### PR TITLE
Remove inverted setting from relay definitions

### DIFF
--- a/devices/guition-esp32-s3-4848s040/device/device.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/device.yaml
@@ -164,7 +164,6 @@ switch:
     icon: mdi:electric-switch
     pin:
       number: GPIO40
-      inverted: true
     restore_mode: RESTORE_DEFAULT_OFF
     on_turn_on:
       then:
@@ -179,7 +178,6 @@ switch:
     icon: mdi:electric-switch
     pin:
       number: GPIO2
-      inverted: true
     restore_mode: RESTORE_DEFAULT_OFF
     on_turn_on:
       then:
@@ -194,7 +192,6 @@ switch:
     icon: mdi:electric-switch
     pin:
       number: GPIO1
-      inverted: true
     restore_mode: RESTORE_DEFAULT_OFF
     on_turn_on:
       then:


### PR DESCRIPTION
Removed 'inverted: true' from relay configurations, because on my device, the relays are not reverted.

Would solve issue #96 