### PR TITLE
Add Hebrew glyph and right-to-left text support

### DIFF
--- a/common/assets/fonts.yaml
+++ b/common/assets/fonts.yaml
@@ -42,12 +42,18 @@ font:
     size: 22
     bpp: 4
     glyphs: !include text_glyphs.yaml
+    extras:
+      - file: "gfonts://Heebo"
+        glyphs: !include hebrew_glyphs.yaml
 
   # Top bar: clock and temperature
   - file: "gfonts://Roboto"
     id: clockbar_font
     size: 20
     bpp: 4
+    extras:
+      - file: "gfonts://Heebo"
+        glyphs: !include hebrew_glyphs.yaml
 
   # Setup screens: titles (40px light)
   - file: "gfonts://Roboto@Light"
@@ -57,6 +63,9 @@ font:
     glyphs: >-
       !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
       ¡¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ—–…·°•€£¥¢
+    extras:
+      - file: "gfonts://Heebo@Light"
+        glyphs: !include hebrew_glyphs.yaml
 
   # Setup screens: body text (24px)
   - file: "gfonts://Roboto"
@@ -66,3 +75,6 @@ font:
     glyphs: >-
       !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
       ¡¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ—–…·°•€£¥¢
+    extras:
+      - file: "gfonts://Heebo"
+        glyphs: !include hebrew_glyphs.yaml

--- a/common/assets/hebrew_glyphs.yaml
+++ b/common/assets/hebrew_glyphs.yaml
@@ -1,0 +1,62 @@
+# strings coming from Home Assistant render on the panel.
+# Listed as one codepoint per entry to avoid YAML combining-mark
+
+# Letters (U+05D0..U+05EA: alef..tav, with the 5 final forms in place)
+- "א"  # alef
+- "ב"  # bet
+- "ג"  # gimel
+- "ד"  # dalet
+- "ה"  # he
+- "ו"  # vav
+- "ז"  # zayin
+- "ח"  # het
+- "ט"  # tet
+- "י"  # yod
+- "ך"  # final kaf
+- "כ"  # kaf
+- "ל"  # lamed
+- "ם"  # final mem
+- "מ"  # mem
+- "ן"  # final nun
+- "נ"  # nun
+- "ס"  # samekh
+- "ע"  # ayin
+- "ף"  # final pe
+- "פ"  # pe
+- "ץ"  # final tsadi
+- "צ"  # tsadi
+- "ק"  # qof
+- "ר"  # resh
+- "ש"  # shin
+- "ת"  # tav
+
+# Yiddish digraphs (U+05F0..U+05F2)
+- "װ"  # double vav
+- "ױ"  # vav-yod
+- "ײ"  # double yod
+
+# Niqud / vowel marks covered by Heebo (U+05B0..U+05BC, U+05BF, U+05C1,
+# U+05C2, U+05C7). Cantillation marks like meteg (U+05BD) are not
+# present in Heebo, so they are intentionally omitted.
+- "ְ"  # sheva
+- "ֱ"  # hataf segol
+- "ֲ"  # hataf patah
+- "ֳ"  # hataf qamats
+- "ִ"  # hiriq
+- "ֵ"  # tsere
+- "ֶ"  # segol
+- "ַ"  # patah
+- "ָ"  # qamats
+- "ֹ"  # holam
+- "ֺ"  # holam haser for vav
+- "ֻ"  # qubuts
+- "ּ"  # dagesh / shuruq dot
+- "ֿ"  # rafe
+- "ׁ"  # shin dot
+- "ׂ"  # sin dot
+- "ׇ"  # qamats qatan
+
+# Punctuation present in Heebo (maqaf, geresh, gershayim).
+- "־"  # maqaf
+- "׳"  # geresh
+- "״"  # gershayim

--- a/common/device/core_infra.yaml
+++ b/common/device/core_infra.yaml
@@ -5,6 +5,13 @@
 # identical across all hardware targets.
 # =============================================================================
 
+esphome:
+  # Enable LVGL's bidirectional text algorithm so right-to-left scripts
+  # (Hebrew, Arabic) render in visual order.
+  platformio_options:
+    build_flags:
+      - "-DLV_USE_BIDI=1"
+
 api:
   reboot_timeout: 0s
   homeassistant_states: true

--- a/devices/guition-esp32-p4-jc1060p470/device/fonts.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/device/fonts.yaml
@@ -13,9 +13,15 @@ font:
     size: 22
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
+    extras:
+      - file: "gfonts://Heebo"
+        glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
   # Top bar clock and temperature (20px)
   - file: "gfonts://Roboto"
     id: clockbar_font_lt
     size: 20
     bpp: 4
+    extras:
+      - file: "gfonts://Heebo"
+        glyphs: !include ../../../common/assets/hebrew_glyphs.yaml

--- a/devices/guition-esp32-p4-jc4880p443/device/fonts.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/device/fonts.yaml
@@ -20,6 +20,9 @@ font:
     size: 31
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
+    extras:
+      - file: "gfonts://Heebo"
+        glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
   # Sensor value large number (62px)
   - file: "gfonts://Roboto@Light"
@@ -59,3 +62,6 @@ font:
     id: clockbar_font_lg
     size: 25
     bpp: 4
+    extras:
+      - file: "gfonts://Heebo"
+        glyphs: !include ../../../common/assets/hebrew_glyphs.yaml

--- a/devices/guition-esp32-p4-jc8012p4a1/device/fonts.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/fonts.yaml
@@ -53,9 +53,15 @@ font:
     size: 24
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
+    extras:
+      - file: "gfonts://Heebo"
+        glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
   # Top bar clock and temperature (22px)
   - file: "gfonts://Roboto"
     id: clockbar_font_lt
     size: 22
     bpp: 4
+    extras:
+      - file: "gfonts://Heebo"
+        glyphs: !include ../../../common/assets/hebrew_glyphs.yaml

--- a/devices/guition-esp32-s3-4848s040/device/fonts.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/fonts.yaml
@@ -4,6 +4,8 @@
 # Supplements the common fonts with smaller variants for the main UI.
 # The common fonts (icon_font, label_font, etc.) still load for setup screens;
 # these _sm variants are referenced by the device theme and LVGL config.
+# Hebrew glyphs are pulled from gfonts://Heebo via `extras`, since Roboto
+# does not include the Hebrew block.
 # =============================================================================
 
 font:
@@ -20,6 +22,9 @@ font:
     size: 22
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
+    extras:
+      - file: "gfonts://Heebo"
+        glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
   # Climate detail page: oversized target temperature
   - file: "gfonts://Roboto@Light"
@@ -42,3 +47,6 @@ font:
     id: clockbar_font_sm
     size: 20
     bpp: 4
+    extras:
+      - file: "gfonts://Heebo"
+        glyphs: !include ../../../common/assets/hebrew_glyphs.yaml


### PR DESCRIPTION
## Summary

- Layer Heebo (the Roboto-companion family designed for Hebrew) on top of the existing Roboto label, clockbar and setup fonts via the font `extras` mechanism, so the Hebrew Unicode block is available in every UI surface that shows user-supplied text. Latin glyphs continue to come from Roboto, so existing Western entity labels are unchanged.
- Add `common/assets/hebrew_glyphs.yaml` covering the alef-tav letters and the five final forms, the niqud and Yiddish digraphs that Heebo ships, and the maqaf / geresh / gershayim punctuation. Cantillation marks Heebo does not include are intentionally omitted to keep the build clean.
- Enable LVGL's bidirectional text algorithm with `-DLV_USE_BIDI=1`. ESPHome leaves `LV_USE_BIDI` off by default, which makes Hebrew strings draw in storage order - so a Home Assistant entity named `שלום` rendered on screen as `םולש`. With BIDI on, LVGL's default `LV_BASE_DIR_AUTO` detects the script per label and flips the visual order automatically. Mixed Latin/Hebrew labels also lay out correctly.
- All four supported panels (4848S040, JC4880P443, JC1060P470, JC8012P4A1) get the Heebo extras on their device-specific `label_font_*` and `clockbar_font_*` overrides for parity.

Tested on a JC-S3-4848S040 with Hebrew-named entities; existing Latin-only setups are unaffected.