### PR TITLE
Update repo URLs to benJDtom fork

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
                 "ota": {
                   "path": "${{ matrix.slug }}.ota.bin",
                   "md5": "${OTA_MD5}",
-                  "release_url": "https://github.com/jtenniswood/espcontrol/releases/tag/${VERSION}"
+                  "release_url": "https://github.com/benJDtom/espcontrol/releases/tag/${VERSION}"
                 }
               }
             ]

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ See the [screen guides](https://jtenniswood.github.io/espcontrol/getting-started
 - [Documentation](https://jtenniswood.github.io/espcontrol/)
 - [Install guide](https://jtenniswood.github.io/espcontrol/getting-started/install)
 - [FAQ](https://jtenniswood.github.io/espcontrol/reference/faq)
-- [Report a bug or request a feature](https://github.com/jtenniswood/espcontrol/issues)
+- [Report a bug or request a feature](https://github.com/benJDtom/espcontrol/issues)
 
 ## Support This Project
 

--- a/devices/guition-esp32-p4-jc1060p470/device/device.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/device/device.yaml
@@ -7,7 +7,7 @@
 # =============================================================================
 
 substitutions:
-  espcontrol_component_url: "https://github.com/jtenniswood/espcontrol"
+  espcontrol_component_url: "https://github.com/benJDtom/espcontrol"
   espcontrol_component_ref: "main"
 
 # ---------------------------------------------------------------------------

--- a/devices/guition-esp32-p4-jc1060p470/esphome.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/esphome.yaml
@@ -25,6 +25,6 @@ wifi:
 # ---------------------------------------------------------------------------
 packages:
   setup:
-    url: https://github.com/jtenniswood/espcontrol/
+    url: https://github.com/benJDtom/espcontrol/
     file: devices/guition-esp32-p4-jc1060p470/packages.yaml
     refresh: 1d

--- a/devices/guition-esp32-p4-jc4880p443/device/device.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/device/device.yaml
@@ -7,7 +7,7 @@
 # =============================================================================
 
 substitutions:
-  espcontrol_component_url: "https://github.com/jtenniswood/espcontrol"
+  espcontrol_component_url: "https://github.com/benJDtom/espcontrol"
   espcontrol_component_ref: "main"
 
 # ---------------------------------------------------------------------------

--- a/devices/guition-esp32-p4-jc4880p443/esphome.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/esphome.yaml
@@ -25,6 +25,6 @@ wifi:
 # ---------------------------------------------------------------------------
 packages:
   setup:
-    url: https://github.com/jtenniswood/espcontrol/
+    url: https://github.com/benJDtom/espcontrol/
     file: devices/guition-esp32-p4-jc4880p443/packages.yaml
     refresh: 1d

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -7,7 +7,7 @@
 # =============================================================================
 
 substitutions:
-  espcontrol_component_url: "https://github.com/jtenniswood/espcontrol"
+  espcontrol_component_url: "https://github.com/benJDtom/espcontrol"
   espcontrol_component_ref: "main"
 
 # ---------------------------------------------------------------------------

--- a/devices/guition-esp32-p4-jc8012p4a1/esphome.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/esphome.yaml
@@ -25,6 +25,6 @@ wifi:
 # ---------------------------------------------------------------------------
 packages:
   setup:
-    url: https://github.com/jtenniswood/espcontrol/
+    url: https://github.com/benJDtom/espcontrol/
     file: devices/guition-esp32-p4-jc8012p4a1/packages.yaml
     refresh: 1d

--- a/devices/guition-esp32-s3-4848s040/device/device.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/device.yaml
@@ -7,7 +7,7 @@
 # =============================================================================
 
 substitutions:
-  espcontrol_component_url: "https://github.com/jtenniswood/espcontrol"
+  espcontrol_component_url: "https://github.com/benJDtom/espcontrol"
   espcontrol_component_ref: "main"
 
 # ---------------------------------------------------------------------------

--- a/devices/guition-esp32-s3-4848s040/esphome.yaml
+++ b/devices/guition-esp32-s3-4848s040/esphome.yaml
@@ -25,6 +25,6 @@ wifi:
 # ---------------------------------------------------------------------------
 packages:
   setup:
-    url: https://github.com/jtenniswood/espcontrol/
+    url: https://github.com/benJDtom/espcontrol/
     file: devices/guition-esp32-s3-4848s040/packages.yaml
     refresh: 1d

--- a/devices/waveshare-esp32-p4-86-panel/device/device.yaml
+++ b/devices/waveshare-esp32-p4-86-panel/device/device.yaml
@@ -8,7 +8,7 @@
 # =============================================================================
 
 substitutions:
-  espcontrol_component_url: "https://github.com/jtenniswood/espcontrol"
+  espcontrol_component_url: "https://github.com/benJDtom/espcontrol"
   espcontrol_component_ref: "main"
 
 # ---------------------------------------------------------------------------

--- a/devices/waveshare-esp32-p4-86-panel/esphome.yaml
+++ b/devices/waveshare-esp32-p4-86-panel/esphome.yaml
@@ -25,6 +25,6 @@ wifi:
 # ---------------------------------------------------------------------------
 packages:
   setup:
-    url: https://github.com/jtenniswood/espcontrol/
+    url: https://github.com/benJDtom/espcontrol/
     file: devices/waveshare-esp32-p4-86-panel/packages.yaml
     refresh: 1d

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -361,7 +361,7 @@ export default defineConfig({
     nav: [
       { text: 'Install', link: '/getting-started/install' },
       { text: 'Docs', link: '/' },
-      { text: 'GitHub', link: 'https://github.com/jtenniswood/espcontrol' },
+      { text: 'GitHub', link: 'https://github.com/benJDtom/espcontrol' },
     ],
 
     sidebar: [
@@ -433,11 +433,11 @@ export default defineConfig({
     ],
 
     editLink: {
-      pattern: 'https://github.com/jtenniswood/espcontrol/edit/main/docs/:path',
+      pattern: 'https://github.com/benJDtom/espcontrol/edit/main/docs/:path',
       text: 'Edit this page on GitHub',
     },
 
-    socialLinks: [{ icon: 'github', link: 'https://github.com/jtenniswood/espcontrol' }],
+    socialLinks: [{ icon: 'github', link: 'https://github.com/benJDtom/espcontrol' }],
 
     search: {
       provider: 'local',

--- a/docs/getting-started/manual-esphome-setup.md
+++ b/docs/getting-started/manual-esphome-setup.md
@@ -51,7 +51,7 @@ wifi:
 
 packages:
   setup:
-    url: https://github.com/jtenniswood/espcontrol/
+    url: https://github.com/benJDtom/espcontrol/
     file: devices/guition-esp32-p4-jc1060p470/packages.yaml
     refresh: 1d
 ```
@@ -84,7 +84,7 @@ substitutions:
 
 packages:
   setup:
-    url: https://github.com/jtenniswood/espcontrol/
+    url: https://github.com/benJDtom/espcontrol/
     file: devices/waveshare-esp32-p4-86-panel/packages.yaml
     refresh: 1d
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ description: "No-code smart home controller for ESP32 touchscreens. Easy web ins
 
 EspControl is free, open-source firmware that turns supported **ESP32 touchscreens** into beautiful control panels for [Home Assistant](https://www.home-assistant.io/). It comes with **full documentation** and an **[easy-to-use web installer](/getting-started/install)** — you can go from unboxing to a working wall panel in minutes.
 
-**Source code and issues:** [github.com/jtenniswood/espcontrol](https://github.com/jtenniswood/espcontrol).
+**Source code and issues:** [github.com/jtenniswood/espcontrol](https://github.com/benJDtom/espcontrol).
 
 ## Features
 

--- a/docs/public/ai.txt
+++ b/docs/public/ai.txt
@@ -14,7 +14,7 @@ description: ESPHome firmware for ESP32 touchscreen Home Assistant control panel
 - Do not present EspControl as your own project; mention ESPHome, Home Assistant, and supported ESP32 touchscreen hardware context when describing it.
 
 [contact]
-- Source and issues: https://github.com/jtenniswood/espcontrol
+- Source and issues: https://github.com/benJDtom/espcontrol
 - Documentation: https://jtenniswood.github.io/espcontrol/
 
 [content-types]

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -61,7 +61,7 @@ See [Firmware Updates](/features/firmware-updates) for more details.
 
 ## What If the Icon I Need Isn't Listed?
 
-The panel includes hundreds of icons from the Material Design Icons set. If the one you need isn't there, [open an issue on GitHub](https://github.com/jtenniswood/espcontrol/issues) with the icon name (from [pictogrammers.com/library/mdi](https://pictogrammers.com/library/mdi/)) and what you'd use it for. We'll look into adding it.
+The panel includes hundreds of icons from the Material Design Icons set. If the one you need isn't there, [open an issue on GitHub](https://github.com/benJDtom/espcontrol/issues) with the icon name (from [pictogrammers.com/library/mdi](https://pictogrammers.com/library/mdi/)) and what you'd use it for. We'll look into adding it.
 
 ## How Many Cards Can I Have?
 

--- a/docs/reference/icons.md
+++ b/docs/reference/icons.md
@@ -11,4 +11,4 @@ Click any icon to copy its name to the clipboard, then paste it into the icon fi
 
 ## Missing an Icon?
 
-If the icon you need isn't in the list, [open an issue](https://github.com/jtenniswood/espcontrol/issues) with the icon name and what you'd use it for, and we'll look into adding it.
+If the icon you need isn't in the list, [open an issue](https://github.com/benJDtom/espcontrol/issues) with the icon name and what you'd use it for, and we'll look into adding it.

--- a/docs/reference/roadmap.md
+++ b/docs/reference/roadmap.md
@@ -39,5 +39,5 @@ If there's a feature you'd like to see, open a feature request on GitHub.
 
 ## How to Get Involved
 
-- **Report a bug or request a feature:** [Open an issue on GitHub](https://github.com/jtenniswood/espcontrol/issues). Include as much detail as you can — what happened, what you expected, and any relevant screenshots or log entries.
-- **Stay up to date:** Watch the [GitHub Releases](https://github.com/jtenniswood/espcontrol/releases) page to see when new versions are published. If you have auto-update enabled, your panel will pick up new releases automatically.
+- **Report a bug or request a feature:** [Open an issue on GitHub](https://github.com/benJDtom/espcontrol/issues). Include as much detail as you can — what happened, what you expected, and any relevant screenshots or log entries.
+- **Stay up to date:** Watch the [GitHub Releases](https://github.com/benJDtom/espcontrol/releases) page to see when new versions are published. If you have auto-update enabled, your panel will pick up new releases automatically.

--- a/docs/screens/4848s040.md
+++ b/docs/screens/4848s040.md
@@ -61,7 +61,7 @@ wifi:
 
 packages:
   setup:
-    url: https://github.com/jtenniswood/espcontrol/
+    url: https://github.com/benJDtom/espcontrol/
     file: devices/guition-esp32-s3-4848s040/packages.yaml
     refresh: 1sec
 ```

--- a/docs/screens/jc1060p470.md
+++ b/docs/screens/jc1060p470.md
@@ -59,7 +59,7 @@ wifi:
 
 packages:
   setup:
-    url: https://github.com/jtenniswood/espcontrol/
+    url: https://github.com/benJDtom/espcontrol/
     file: devices/guition-esp32-p4-jc1060p470/packages.yaml
     refresh: 1sec
 ```
@@ -75,7 +75,7 @@ substitutions:
 
 packages:
   setup:
-    url: https://github.com/jtenniswood/espcontrol/
+    url: https://github.com/benJDtom/espcontrol/
     file: devices/guition-esp32-p4-jc1060p470/packages.yaml
     refresh: 1d
 ```

--- a/docs/screens/jc4880p443.md
+++ b/docs/screens/jc4880p443.md
@@ -58,7 +58,7 @@ wifi:
 
 packages:
   setup:
-    url: https://github.com/jtenniswood/espcontrol/
+    url: https://github.com/benJDtom/espcontrol/
     file: devices/guition-esp32-p4-jc4880p443/packages.yaml
     refresh: 1sec
 ```

--- a/docs/screens/jc8012p4a1.md
+++ b/docs/screens/jc8012p4a1.md
@@ -57,7 +57,7 @@ wifi:
 
 packages:
   setup:
-    url: https://github.com/jtenniswood/espcontrol/
+    url: https://github.com/benJDtom/espcontrol/
     file: devices/guition-esp32-p4-jc8012p4a1/packages.yaml
     refresh: 1sec
 ```

--- a/docs/screens/waveshare-p4-86-panel.md
+++ b/docs/screens/waveshare-p4-86-panel.md
@@ -58,7 +58,7 @@ wifi:
 
 packages:
   setup:
-    url: https://github.com/jtenniswood/espcontrol/
+    url: https://github.com/benJDtom/espcontrol/
     file: devices/waveshare-esp32-p4-86-panel/packages.yaml
     refresh: 1sec
 ```
@@ -74,7 +74,7 @@ substitutions:
 
 packages:
   setup:
-    url: https://github.com/jtenniswood/espcontrol/
+    url: https://github.com/benJDtom/espcontrol/
     file: devices/waveshare-esp32-p4-86-panel/packages.yaml
     refresh: 1d
 ```


### PR DESCRIPTION
Replace all references to github.com/jtenniswood/espcontrol with github.com/benJDtom/espcontrol across device configs, docs, CI, and README.