### PR TITLE
Notifications

### DIFF
--- a/common/device/screen_notification_popup.yaml
+++ b/common/device/screen_notification_popup.yaml
@@ -1,0 +1,133 @@
+# =============================================================================
+# SCREEN: NOTIFICATION POPUP
+# =============================================================================
+# Top-layer overlay for HA-pushed notifications. Two actions are exposed:
+#
+# Persistent (user must tap to dismiss):
+#   action: esphome.<device>_send_notification
+#   data:
+#     message: "Front door camera triggered"
+#     title: "Motion Detected"   # optional — omit or pass "" to hide title
+#     message_id: "motion_front"  # optional, returned in HA events
+#
+# Auto-dismissing:
+#   action: esphome.<device>_send_expiring_notification
+#   data:
+#     message: "Front door camera triggered"
+#     title: "Motion Detected"   # optional
+#     timeout: 15                # seconds until auto-dismiss
+#     message_id: "motion_front"  # optional, returned in HA events
+#
+# The popup fires one of two HA events on close:
+#   esphome.notification_acknowledged  – user tapped to dismiss
+#   esphome.notification_expired       – auto-timeout elapsed unread
+#
+# Both events carry: device_name, message_id
+#
+# Implementation: LVGL top_layer card (always above all pages/screensaver).
+# Background is a semi-transparent dark scrim; there is no GPU blur on ESP32.
+# Tapping anywhere (card or scrim) dismisses the popup.
+# notification_popup.h is auto-included by ESPHome's component resource system.
+# =============================================================================
+
+lvgl:
+  top_layer:
+    widgets:
+      # Full-screen scrim — dark overlay that blocks interaction with UI beneath.
+      # Tapping the scrim (outside the card) dismisses the popup.
+      - obj:
+          id: notification_scrim
+          x: 0
+          y: 0
+          width: ${screen_width}
+          height: ${screen_height}
+          bg_color: 0x000000
+          bg_opa: 75%
+          radius: 0
+          border_width: 0
+          pad_all: 0
+          scrollable: false
+          scrollbar_mode: "off"
+          clickable: true
+          hidden: true
+          on_click:
+            then:
+              - lambda: |-
+                  notification_popup_dismiss(true);
+          widgets:
+            # Notification card — centered dark panel with title + body.
+            # Tapping the card also dismisses (same as tapping the scrim).
+            - obj:
+                id: notification_card
+                align: center
+                width: ${content_width}
+                height: SIZE_CONTENT
+                bg_color: 0x1E1E1E
+                bg_opa: cover
+                radius: 16
+                border_width: 0
+                pad_top: 24
+                pad_bottom: 24
+                pad_left: 24
+                pad_right: 24
+                scrollable: false
+                clickable: true
+                layout:
+                  type: flex
+                  flex_flow: COLUMN
+                  flex_align_main: center
+                  flex_align_cross: start
+                  pad_row: 12
+                on_click:
+                  then:
+                    - lambda: |-
+                        notification_popup_dismiss(true);
+                widgets:
+                  - label:
+                      id: notification_title_lbl
+                      text: ""
+                      text_font: ${setup_body_font_id}
+                      text_color: 0xFFFFFF
+                      long_mode: wrap
+                      width: 100%
+                  - label:
+                      id: notification_body_lbl
+                      text: ""
+                      text_font: ${label_font}
+                      text_color: 0xAAAAAA
+                      long_mode: wrap
+                      width: 100%
+
+api:
+  actions:
+    - action: send_notification
+      variables:
+        message: string
+        title: string
+        message_id: string
+      then:
+        - script.execute: screensaver_wake
+        - lambda: |-
+            notification_popup_show(
+              id(notification_scrim),
+              id(notification_title_lbl),
+              id(notification_body_lbl),
+              title, message,
+              0,
+              message_id);
+    - action: send_expiring_notification
+      variables:
+        message: string
+        title: string
+        timeout: int
+        message_id: string
+      then:
+        - script.execute: screensaver_wake
+        - lambda: |-
+            notification_popup_show(
+              id(notification_scrim),
+              id(notification_title_lbl),
+              id(notification_body_lbl),
+              title, message,
+              timeout,
+              message_id);

--- a/components/espcontrol/notification_popup.h
+++ b/components/espcontrol/notification_popup.h
@@ -1,0 +1,96 @@
+// =============================================================================
+// NOTIFICATION POPUP - Top-layer overlay driven by HA notify action
+// =============================================================================
+// Called from screen_notification_popup.yaml. Manages show/hide, the
+// auto-dismiss LVGL timer, and firing acknowledgement events back to HA.
+//
+// show: replaces any active popup; resets/starts the timeout timer.
+// dismiss: cancels the timer, hides the scrim, fires the appropriate event.
+// =============================================================================
+#pragma once
+#include <string>
+#include "esphome/components/api/homeassistant_service.h"
+
+// --------------------------------------------------------------------------
+// Module-level state (one popup at a time)
+// --------------------------------------------------------------------------
+static lv_timer_t  *s_notification_timer   = nullptr;
+static std::string  s_notification_msg_id;
+static lv_obj_t    *s_notification_scrim   = nullptr;
+
+// --------------------------------------------------------------------------
+// Fire a HA event with device_name + message_id payload
+// --------------------------------------------------------------------------
+inline void notification_fire_event(const char *event_name, const std::string &message_id) {
+  if (esphome::api::global_api_server == nullptr) return;
+  esphome::api::HomeassistantActionRequest req;
+  req.service  = decltype(req.service)(event_name);
+  req.is_event = true;
+  req.data.init(2);
+  auto &kv1   = req.data.emplace_back();
+  kv1.key     = decltype(kv1.key)("device_name");
+  kv1.value   = decltype(kv1.value)(esphome::App.get_name().c_str());
+  auto &kv2   = req.data.emplace_back();
+  kv2.key     = decltype(kv2.key)("message_id");
+  kv2.value   = decltype(kv2.value)(message_id.c_str());
+  esphome::api::global_api_server->send_homeassistant_action(req);
+}
+
+// --------------------------------------------------------------------------
+// Auto-dismiss timer callback (fires when timeout elapses unread)
+// --------------------------------------------------------------------------
+static void notification_timer_cb(lv_timer_t *timer) {
+  lv_timer_pause(timer);
+  if (s_notification_scrim)
+    lv_obj_add_flag(s_notification_scrim, LV_OBJ_FLAG_HIDDEN);
+  notification_fire_event("esphome.notification_expired", s_notification_msg_id);
+}
+
+// --------------------------------------------------------------------------
+// Dismiss the popup (user_tapped = true → acknowledged, false → expired)
+// --------------------------------------------------------------------------
+inline void notification_popup_dismiss(bool user_tapped) {
+  if (s_notification_timer)
+    lv_timer_pause(s_notification_timer);
+  if (s_notification_scrim)
+    lv_obj_add_flag(s_notification_scrim, LV_OBJ_FLAG_HIDDEN);
+  notification_fire_event(
+    user_tapped ? "esphome.notification_acknowledged" : "esphome.notification_expired",
+    s_notification_msg_id);
+}
+
+// --------------------------------------------------------------------------
+// Show a popup. Call after screensaver_wake to ensure display is on.
+// timeout_sec == 0 → manual dismiss only (no auto-dismiss).
+// --------------------------------------------------------------------------
+inline void notification_popup_show(
+    lv_obj_t *scrim, lv_obj_t *title_lbl, lv_obj_t *body_lbl,
+    const std::string &title, const std::string &body,
+    int timeout_sec, const std::string &message_id) {
+  s_notification_scrim  = scrim;
+  s_notification_msg_id = message_id;
+
+  if (title.empty()) {
+    lv_obj_add_flag(title_lbl, LV_OBJ_FLAG_HIDDEN);
+  } else {
+    lv_label_set_text(title_lbl, title.c_str());
+    lv_obj_clear_flag(title_lbl, LV_OBJ_FLAG_HIDDEN);
+  }
+  lv_label_set_text(body_lbl, body.c_str());
+  lv_obj_clear_flag(scrim, LV_OBJ_FLAG_HIDDEN);
+
+  if (timeout_sec > 0) {
+    uint32_t period_ms = (uint32_t)timeout_sec * 1000u;
+    if (!s_notification_timer) {
+      s_notification_timer = lv_timer_create(notification_timer_cb, period_ms, nullptr);
+    } else {
+      lv_timer_set_period(s_notification_timer, period_ms);
+      lv_timer_reset(s_notification_timer);
+      lv_timer_resume(s_notification_timer);
+    }
+  } else {
+    // No auto-dismiss; pause any running timer from a previous popup.
+    if (s_notification_timer)
+      lv_timer_pause(s_notification_timer);
+  }
+}

--- a/devices/esp32-p4-86/packages.yaml
+++ b/devices/esp32-p4-86/packages.yaml
@@ -85,6 +85,7 @@ packages:
   screen_ha_act:   !include ../../common/device/screen_ha_actions.yaml
   screen_setup:    !include ../../common/device/screen_button_setup.yaml
   screen_clock:    !include ../../common/device/screen_clock.yaml
+  screen_notification: !include ../../common/device/screen_notification_popup.yaml
   # ---------------------------------------------------------------------------
   # Main page and dynamic sensor subscriptions (after setup screens)
   # ---------------------------------------------------------------------------

--- a/devices/guition-esp32-p4-jc1060p470/packages.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/packages.yaml
@@ -91,6 +91,7 @@ packages:
   screen_ha_act:   !include ../../common/device/screen_ha_actions.yaml
   screen_setup:    !include ../../common/device/screen_button_setup.yaml
   screen_clock:    !include ../../common/device/screen_clock.yaml
+  screen_notification: !include ../../common/device/screen_notification_popup.yaml
   # ---------------------------------------------------------------------------
   # Main page and dynamic sensor subscriptions (after setup screens)
   # ---------------------------------------------------------------------------

--- a/devices/guition-esp32-p4-jc4880p443/packages.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/packages.yaml
@@ -76,6 +76,7 @@ packages:
   screen_ha_act:   !include ../../common/device/screen_ha_actions.yaml
   screen_setup:    !include ../../common/device/screen_button_setup.yaml
   screen_clock:    !include ../../common/device/screen_clock.yaml
+  screen_notification: !include ../../common/device/screen_notification_popup.yaml
   # ---------------------------------------------------------------------------
   # Main page and dynamic sensor subscriptions (after setup screens)
   # ---------------------------------------------------------------------------

--- a/devices/guition-esp32-p4-jc8012p4a1/packages.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/packages.yaml
@@ -90,6 +90,7 @@ packages:
   screen_ha_act:   !include ../../common/device/screen_ha_actions.yaml
   screen_setup:    !include ../../common/device/screen_button_setup.yaml
   screen_clock:    !include ../../common/device/screen_clock.yaml
+  screen_notification: !include ../../common/device/screen_notification_popup.yaml
   # ---------------------------------------------------------------------------
   # Main page and dynamic sensor subscriptions (after setup screens)
   # ---------------------------------------------------------------------------

--- a/devices/guition-esp32-s3-4848s040/packages.yaml
+++ b/devices/guition-esp32-s3-4848s040/packages.yaml
@@ -80,6 +80,7 @@ packages:
   screen_ha_act:   !include ../../common/device/screen_ha_actions.yaml
   screen_setup:    !include ../../common/device/screen_button_setup.yaml
   screen_clock:    !include ../../common/device/screen_clock.yaml
+  screen_notification: !include ../../common/device/screen_notification_popup.yaml
   # ---------------------------------------------------------------------------
   # Main page and dynamic sensor subscriptions (after setup screens)
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Add HA-driven notification popup feature
<img width="640" height="606" alt="IMG_1941" src="https://github.com/user-attachments/assets/8e49fbce-3ca2-4dc5-8c48-588af281a7de" />

## Summary
This adds a top-layer LVGL overlay that Home Assistant can push notifications to via two ESPHome API actions.  The actions are ESPHome Native api actions to all devices for pushing notification popups from Home Assistant — one persistent and one auto-dismissing — with an optional title and a message ID for tracking. The popup renders as a full-screen overlay that wakes the screensaver and blocks interaction with the UI beneath. When dismissed, either by the user or by timeout, the device fires a corresponding event back to Home Assistant carrying the message ID so automations can tell the difference between a read and an unread notification.

## Design decisions
### Two actions instead of one with an optional timeout field

ESPHome API action variables have no concept of defaults — every defined variable is required from HA's perspective. Using a single action with a timeout field meant users always had to supply it. Splitting into send_notification (no timeout) and send_expiring_notification (requires timeout) makes the intent explicit and removes ambiguity at the call site.

### Top-layer overlay instead of a new LVGL page

The notification renders on LVGL's top_layer, which sits above all pages. This means the popup appears correctly over the main grid, subpages, and the clock screensaver without any page navigation. The screensaver is woken automatically before the popup is shown.

### Touch blocking on the background

The full-screen scrim is clickable: true and consumes all touches, preventing accidental button presses on the main grid while reading a notification. Tapping anywhere — card or scrim — dismisses the popup.

### Distinct acknowledged vs. expired events

The device fires _esphome.notification_acknowledged_ on user tap and _esphome.notification_expired_ on auto-timeout. This lets HA automations distinguish between "user saw it" and "it timed out unread" — useful for critical alerts that should escalate if ignored.

## New API actions
* _send_notification_ — persistent, user must tap to dismiss

Variables: message, title , message_id

* _send_expiring_notification_ — auto-dismisses after timeout seconds

Variables: message, title, timeout (seconds), message_id

## HA events fired on close
_esphome.notification_acknowledged_ — user tapped to dismiss
_esphome.notification_expired_ — auto-timeout elapsed unread
Both events carry device_name and message_id for automation correlation.
