### PR TITLE
Add Check icon to ICON_GROUPS in IconGallery.vue

### DIFF
--- a/docs/.vitepress/theme/components/IconGallery.vue
+++ b/docs/.vitepress/theme/components/IconGallery.vue
@@ -291,6 +291,7 @@ const ICON_GROUPS = {
 
   'Account': 'General',
   'Broom': 'General',
+  'Check': 'General',
   'Clock': 'General',
   'Dog': 'General',
   'Dots Horizontal': 'General',


### PR DESCRIPTION
## Fix missing Check icon group assignment in IconGallery.vue

The `Check` icon was added to `icons.json` in 77ff295 but was never assigned
a group in `ICON_GROUPS` in `IconGallery.vue`, causing the `check_icon_groups.py`
CI check to fail.

**Fix:** Add `'Check': 'General'` to `ICON_GROUPS`.
