### PR TITLE
Server the Web UI directly from the device. 

### DIFF
--- a/builds/esp32-p4-86.yaml
+++ b/builds/esp32-p4-86.yaml
@@ -21,3 +21,6 @@ wifi:
     ssid: "${friendly_name}"
 
 captive_portal:
+
+web_server:
+  js_include: "../docs/public/webserver/${device_slug}/www.js"

--- a/builds/guition-esp32-p4-jc1060p470.yaml
+++ b/builds/guition-esp32-p4-jc1060p470.yaml
@@ -23,3 +23,6 @@ wifi:
     ssid: "${friendly_name}"
 
 captive_portal:
+
+web_server:
+  js_include: "../docs/public/webserver/${device_slug}/www.js"

--- a/builds/guition-esp32-p4-jc4880p443.yaml
+++ b/builds/guition-esp32-p4-jc4880p443.yaml
@@ -21,3 +21,6 @@ wifi:
     ssid: "${friendly_name}"
 
 captive_portal:
+
+web_server:
+  js_include: "../docs/public/webserver/${device_slug}/www.js"

--- a/builds/guition-esp32-p4-jc8012p4a1.yaml
+++ b/builds/guition-esp32-p4-jc8012p4a1.yaml
@@ -23,3 +23,6 @@ wifi:
     ssid: "${friendly_name}"
 
 captive_portal:
+
+web_server:
+  js_include: "../docs/public/webserver/${device_slug}/www.js"

--- a/builds/guition-esp32-s3-4848s040.yaml
+++ b/builds/guition-esp32-s3-4848s040.yaml
@@ -21,3 +21,6 @@ wifi:
     ssid: "${friendly_name}"
 
 captive_portal:
+
+web_server:
+  js_include: "../docs/public/webserver/${device_slug}/www.js"

--- a/common/device/core_infra.yaml
+++ b/common/device/core_infra.yaml
@@ -43,7 +43,7 @@ web_server:
   port: 80
   version: 3
   include_internal: true
-  js_url: https://jtenniswood.github.io/espcontrol/webserver/${device_slug}/www.js
+  js_url: ""
   sorting_groups:
     - id: sg_button
       name: "Button Configuration"

--- a/devices/esp32-p4-86/packages.yaml
+++ b/devices/esp32-p4-86/packages.yaml
@@ -38,6 +38,9 @@ substitutions:
   firmware_update_package_suffix: ${ "_disabled" if disable_updates == "true" else "" }
   backlight_pwm_frequency: ${ "20000Hz" if network_transport == "ethernet" else "100Hz" }
 
+web_server:
+  js_include: "../../docs/public/webserver/${device_slug}/www.js"
+
 packages:
   # ---------------------------------------------------------------------------
   # Device, assets, and LVGL base

--- a/devices/guition-esp32-p4-jc1060p470/packages.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/packages.yaml
@@ -38,6 +38,9 @@ substitutions:
   firmware_update_package_suffix: ${ "_disabled" if disable_updates == "true" else "" }
   backlight_pwm_frequency: ${ "20000Hz" if network_transport == "ethernet" else "1000Hz" }
 
+web_server:
+  js_include: "../../docs/public/webserver/${device_slug}/www.js"
+
 packages:
   # ---------------------------------------------------------------------------
   # Device, assets, and LVGL base

--- a/devices/guition-esp32-p4-jc4880p443/packages.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/packages.yaml
@@ -33,6 +33,9 @@ substitutions:
   clock_cx: "240"
   clock_cy: "400"
 
+web_server:
+  js_include: "../../docs/public/webserver/${device_slug}/www.js"
+
 packages:
   # ---------------------------------------------------------------------------
   # Device, assets, and LVGL base

--- a/devices/guition-esp32-p4-jc8012p4a1/packages.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/packages.yaml
@@ -33,6 +33,9 @@ substitutions:
   clock_cx: "640"
   clock_cy: "400"
 
+web_server:
+  js_include: "../../docs/public/webserver/${device_slug}/www.js"
+
 packages:
   # ---------------------------------------------------------------------------
   # Device, assets, and LVGL base

--- a/devices/guition-esp32-s3-4848s040/packages.yaml
+++ b/devices/guition-esp32-s3-4848s040/packages.yaml
@@ -33,6 +33,9 @@ substitutions:
   clock_cx: "240"
   clock_cy: "240"
 
+web_server:
+  js_include: "../../docs/public/webserver/${device_slug}/www.js"
+
 packages:
   # ---------------------------------------------------------------------------
   # Device, assets, and LVGL base


### PR DESCRIPTION
## Summary 

This branch implements the **"Embed www.js in firmware"** option from [#183](https://github.com/jtenniswood/espcontrol/issues/183), addressing both problems raised there.

---

### Limitations Addresses

This addresses several limitations in the current architecture.

**Version mismatch:** The `js_url` pointed at GitHub Pages HEAD, meaning every device silently loaded whatever JS was current at page-load time regardless of firmware age. With `js_include`, the web UI is compiled into the firmware at build time. The UI version is now locked to the firmware version — the same guarantee users get from every other part of the binary. A device running 3-month-old firmware serves 3-month-old UI. No silent drift, no broken UI when the remote changes out from under it.

**Cloud dependency:** `js_url` caused the browser to make an outbound request to `jtenniswood.github.io` on every  web UI access. That call is gone. The device now serves `www.js` directly from its own flash. The configuration interface works offline — but with full embedding of all external component (see below) there could be no internet, no GitHub Pages, no CDN, no privacy exposure.

---

### What changed

- `common/device/core_infra.yaml` — `js_url` cleared to `""`
- `devices/*/packages.yaml` and `builds/*.yaml` — `js_include` added pointing at the per-device `docs/public/webserver/${device_slug}/www.js` build output
- ESPHome gzip-compresses the file at build time and serves it with  `Content-Encoding: gzip` — no runtime overhead

---

### Remaining cloud dependencies

This change embeds the `www.js`only, but the web UI still makes **5 outbound requests** on every page open:

| Resource | Host | Transfer size |
|---|---|---|
| MDI icon CSS | `cdn.jsdelivr.net` | 52.7 KB |
| MDI icon webfont | `cdn.jsdelivr.net` | 403.2 KB |
| Inter font (woff2, all weights/subsets) | `fonts.gstatic.com` | 213.8 KB |
| Roboto font (woff2, all weights/subsets) | `fonts.gstatic.com` | 187.7 KB |
| Buy Me a Coffee button | `cdn.buymeacoffee.com` | 4.8 KB |

Fully embedding all of these would add a further **~851 KB** to flash on top of the `www.js` embedding already done. The flash headroom exists on every device (see utilization figures below), so this is viable for a full offline operation

| Device | State | Used | % Flash | Remaining | Δ vs Remote |
|---|---|---|---|---|---|
| s3-4848s040 | Remote | 2,200.8 KB | 27.7% | 5,735.2 KB | — |
| | www.js only | 2,257.6 KB | 28.4% | 5,678.4 KB | +56.8 KB |
| | Full embed | 3,109.0 KB | 39.2% | 4,827.0 KB | +908.2 KB |
| p4-jc4880p443 | Remote | 2,553.9 KB | 32.2% | 5,382.1 KB | — |
| | www.js only | 2,610.6 KB | 32.9% | 5,325.4 KB | +56.7 KB |
| | Full embed | 3,462.0 KB | 43.6% | 4,474.0 KB | +908.2 KB |
| p4-jc1060p470 | Remote | 2,363.5 KB | 29.8% | 5,572.5 KB | — |
| | www.js only | 2,420.4 KB | 30.5% | 5,515.6 KB | +56.9 KB |
| | Full embed | 3,271.8 KB | 41.2% | 4,664.2 KB | +908.3 KB |
| p4-86 | Remote | 2,802.7 KB | 17.4% | 13,325.3 KB | — |
| | www.js only | 2,859.4 KB | 17.7% | 13,268.6 KB | +56.7 KB |
| | Full embed | 3,710.8 KB | 23.0% | 12,417.2 KB | +908.2 KB |

The www.js embedding is a near-zero cost at +57 KB. Full embedding of all fonts and icons costs +908 KB across the board but every device still has >4.4 GB remaining — well within safe headroom on the 8 MB and 16 MB OTA partitions.

---

### Memory impact of www.js only embedding

Compiled on `base` (before) and `base-local-ui` (after) for all devices.

#### guition-esp32-s3-4848s040
*ESP32-S3 · 16 MB flash · internal DRAM/IRAM*

| Section | base | base-local-ui | Δ |
|---|---|---|---|
| Flash Code `.text` | 1,150,696 | 1,150,868 | +172 |
| Flash Data `.rodata` | 997,256 | 1,055,208 | **+57,952** |
| DIRAM | 286,187 (83.74%) | 286,187 (83.74%) | 0 |
| IRAM | 16,384 (100.0%) | 16,384 (100.0%) | 0 |
| Total image | 2,254,007 | 2,312,131 | +58,124 |
| Flash used | 27.7% | 28.4% | +0.7% |
| RAM used | 66.4% | 66.4% | **0** |

#### guition-esp32-p4-jc4880p443
*ESP32-P4 + C6 · 16 MB flash · execute_from_psram*

| Section | base | base-local-ui | Δ |
|---|---|---|---|
| Flash Code `.text` | 1,095,904 | 1,096,032 | +128 |
| Flash Data `.rodata` | 1,445,356 | 1,503,324 | **+57,968** |
| DIRAM | 262,058 (45.46%) | 262,062 (45.46%) | +4 |
| Total image | 2,616,006 | 2,674,118 | +58,112 |
| Flash used | 32.2% | 32.9% | +0.7% |
| RAM used | 21.4% | 21.4% | **0** |

#### guition-esp32-p4-jc1060p470
*ESP32-P4 + C6 · 16 MB flash · execute_from_psram*

| Section | base | base-local-ui | Δ |
|---|---|---|---|
| Flash Code `.text` | 1,120,224 | 1,120,480 | +256 |
| Flash Data `.rodata` | 1,226,108 | 1,284,076 | **+57,968** |
| DIRAM | 268,026 (46.49%) | 268,030 (46.50%) | +4 |
| Total image | 2,421,062 | 2,479,302 | +58,240 |
| Flash used | 29.8% | 30.5% | +0.7% |
| RAM used | 22.5% | 22.5% | **0** |

#### esp32-p4-86
*ESP32-P4 + C6 · 32 MB flash · execute_from_psram*

| Section | base | base-local-ui | Δ |
|---|---|---|---|
| Flash Code `.text` | 1,116,768 | 1,116,896 | +128 |
| Flash Data `.rodata` | 1,679,036 | 1,736,988 | **+57,952** |
| DIRAM | 264,960 (45.96%) | 264,964 (45.96%) | +4 |
| Total image | 2,870,688 | 2,928,800 | +58,112 |
| Flash used | 17.4% | 17.7% | +0.3% |
| RAM used | 22.0% | 22.0% | **0** |

> `guition-esp32-p4-jc8012p4a1` was not measured — its build requires a
> third-party `gsl3680` touchscreen driver cloned from GitHub which is
> unavailable in the Docker compile environment.

#### Cross-device summary

| | Value |
|---|---|
| `.rodata` increase (all devices) | **~56.6 KB** (+57,952 – +57,968 bytes) |
| `.text` increase | +128 – +256 bytes (negligible) |
| RAM impact | **zero** on all platforms |
| Flash utilization increase | **+0.7%** on 16 MB · **+0.3%** on 32 MB |

The ~56.6 KB is the gzip-compressed `www.js` blob (source is ~227 KB uncompressed). It is identical across every device. The ESP-IDF HTTP server streams it directly from flash to the TCP socket via the instruction cache — no heap allocation, no copy into SRAM. Runtime RAM is completely unaffected on all platforms.

On the S3, DIRAM stays at 83.74% in both builds. On P4 devices, `execute_from_psram` already moves code execution to PSRAM so DIRAM is nearly empty for data; the embedding adds nothing to that budget (+4 bytes, rounding noise from alignment).

If the remaining ~851 KB of fonts and icons were also embedded, the projected flash utilization after full embedding would be:

| Device | After `www.js` | After full embed | Flash total |
|---|---|---|---|
| guition-esp32-s3-4848s040 | 28.4% | ~38.9% | 16 MB |
| guition-esp32-p4-jc4880p443 | 32.9% | ~43.4% | 16 MB |
| guition-esp32-p4-jc1060p470 | 30.5% | ~41.0% | 16 MB |
| esp32-p4-86 | 17.7% | ~28.2% | 32 MB |

All devices retain substantial flash headroom even under full embedding.

