### PR TITLE
Fix: ESPHome 2026.5 build failure — `AssertionError: assert "." not in domain`

### DIFF
--- a/devices/guition-esp32-s3-4848s040/packages.yaml
+++ b/devices/guition-esp32-s3-4848s040/packages.yaml
@@ -6,10 +6,8 @@
 # it at startup. Main page (lvgl.yaml) is included after setup screens.
 # =============================================================================
 
-defaults:
-  provisioning_package_suffix: ""
-
 substitutions:
+  provisioning_package_suffix: ""
   device_slug: "guition-esp32-s3-4848s040"
   firmware_manifest_slug: "guition-esp32-s3-4848s040"
   screen_width: "480"


### PR DESCRIPTION
This fixes #256

## What broke

After upgrading to ESPHome 2026.5.1, the `guition-esp32-s3-4848s040` device fails
to compile with the following error in `preload_core_config`:

```
AssertionError: assert "." not in domain
```

## Root cause

ESPHome 2026.5.1 introduced the `defaults:` keyword for package files. When
`defaults:` is present in a `packages.yaml` that is itself included via the older
single-key package syntax (e.g. `packages: espcontrol: !include packages.yaml`),
ESPHome does not strip the `defaults:` block before merging the package into the
top-level config. The dotted key `defaults.provisioning_package_suffix` ends up
at the top level, which triggers the assertion in `preload_core_config` that
validates no domain name contains a dot.

The affected file is `devices/guition-esp32-s3-4848s040/packages.yaml`, which was
updated in a recent commit to use `defaults:` for `provisioning_package_suffix`.

## Fix

Move `provisioning_package_suffix` back into the `substitutions:` block:

```diff
-defaults:
-  provisioning_package_suffix: ""
-
 substitutions:
+  provisioning_package_suffix: ""
   device_slug: "guition-esp32-s3-4848s040"
```

The `vars:` mechanism on `!include` overrides `substitutions:` values, so this
achieves the same optional-override behaviour that `defaults:` was intended to
provide, without triggering the 2026.5 assertion.

## Verification

Compiled successfully with both ESPHome 2026.4.5 and ESPHome 2026.5.1 using the
Docker images `ghcr.io/esphome/esphome:2026.4.5` and
`ghcr.io/esphome/esphome:2026.5.1`.

No other devices are affected — the remaining four device `packages.yaml` files
(`esp32-p4-86`, `guition-esp32-p4-jc1060p470`, `guition-esp32-p4-jc4880p443`,
`guition-esp32-p4-jc8012p4a1`) use `substitutions:` directly and do not have a
`defaults:` block.
