### PR TITLE
feat: add sensor_chart card type (live value + LVGL sparkline history)

### DIFF
--- a/components/espcontrol/__init__.py
+++ b/components/espcontrol/__init__.py
@@ -10,6 +10,16 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 import os
 
+# Enable LV_USE_CHART in the generated lv_conf.h so that sensor_chart cards
+# can create lv_chart sparkline widgets at runtime.  This must run at import
+# time (before any to_code() is called) so that the LVGL component sees the
+# flag when it writes lv_conf.h.
+try:
+    from esphome.components.lvgl.helpers import add_lv_use
+    add_lv_use("CHART")
+except Exception:
+    pass
+
 CODEOWNERS = ["@jtenniswood"]
 
 CONF_ACTION_RESPONSES = "action_responses"

--- a/components/espcontrol/button_grid_cards.h
+++ b/components/espcontrol/button_grid_cards.h
@@ -678,3 +678,62 @@ inline void setup_subpage_parent_state_card(BtnSlot &s, const ParsedCfg &p,
     s, subpage_chevron_enabled, subpage_chevron_x, subpage_chevron_y,
     subpage_chevron_text_width_percent);
 }
+
+// ── Sensor chart card ──────────────────────────────────────────────────────────
+// Like sensor card, but adds an lv_chart sparkline at the bottom of the button.
+// Chart height and bottom margin are fixed in pixels; the value + label use the
+// same positions as a regular sensor card.
+
+constexpr int SENSOR_CHART_HEIGHT_PX = 40;
+constexpr int SENSOR_CHART_BOTTOM_MARGIN_PX = 16; // gap for text_lbl
+
+inline void setup_sensor_chart_card(BtnSlot &s, const ParsedCfg &p,
+                                    bool has_sensor_color, uint32_t sensor_val) {
+  if (has_sensor_color) {
+    lv_obj_set_style_bg_color(s.btn, lv_color_hex(sensor_val),
+      static_cast<lv_style_selector_t>(LV_PART_MAIN) | static_cast<lv_style_selector_t>(LV_STATE_DEFAULT));
+  }
+  lv_obj_clear_flag(s.btn, LV_OBJ_FLAG_CLICKABLE);
+  lv_obj_add_flag(s.icon_lbl, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_clear_flag(s.sensor_container, LV_OBJ_FLAG_HIDDEN);
+
+  if (!p.unit.empty())
+    lv_label_set_text(s.unit_lbl, trim_display_unit(p.unit).c_str());
+  if (!p.label.empty())
+    lv_label_set_text(s.text_lbl, p.label.c_str());
+
+  // Sparkline chart
+  lv_obj_t *chart = lv_chart_create(s.btn);
+  lv_obj_set_size(chart, lv_pct(100), SENSOR_CHART_HEIGHT_PX);
+  lv_obj_align(chart, LV_ALIGN_BOTTOM_LEFT, 0, -SENSOR_CHART_BOTTOM_MARGIN_PX);
+  lv_obj_clear_flag(chart, LV_OBJ_FLAG_CLICKABLE);
+
+  lv_chart_set_type(chart, LV_CHART_TYPE_LINE);
+  lv_chart_set_update_mode(chart, LV_CHART_UPDATE_MODE_SHIFT);
+  lv_chart_set_point_count(chart, sensor_chart_point_count(p));
+  lv_chart_set_div_line_count(chart, 0, 0);
+  lv_chart_set_range(chart, LV_CHART_AXIS_PRIMARY_Y, 0, 100);
+
+  // Transparent background, no border, no padding
+  lv_obj_set_style_bg_opa(chart, LV_OPA_TRANSP, LV_PART_MAIN);
+  lv_obj_set_style_border_width(chart, 0, LV_PART_MAIN);
+  lv_obj_set_style_pad_all(chart, 0, LV_PART_MAIN);
+
+  // Line: 2 px wide, always DEFAULT_CHART_COLOR (sensor_val is the button background,
+  // not the chart line — using it here made the line match the bg and become invisible).
+  lv_color_t chart_color = lv_color_hex(DEFAULT_CHART_COLOR);
+  lv_obj_set_style_line_color(chart, chart_color, LV_PART_ITEMS);
+  lv_obj_set_style_line_width(chart, 2, LV_PART_ITEMS);
+  lv_obj_set_style_size(chart, 0, 0, LV_PART_INDICATOR);
+
+  lv_chart_series_t *series = lv_chart_add_series(
+    chart, chart_color, LV_CHART_AXIS_PRIMARY_Y);
+  lv_chart_set_all_value(chart, series, LV_CHART_POINT_NONE);
+
+  // Z-order: ensure chart is drawn above sibling widgets (text label, sensor container).
+  // Without this, LVGL may layer them above the chart after layout/reflow.
+  lv_obj_move_foreground(chart);
+
+  s.chart = chart;
+  s.chart_series = series;
+}

--- a/components/espcontrol/button_grid_config.h
+++ b/components/espcontrol/button_grid_config.h
@@ -51,6 +51,7 @@ static_assert(correct_display_color(0xF0F0F0, 200, 200, 200) == 0xFFFFFF,
               "colour correction must clamp channels at 255");
 
 constexpr uint32_t DEFAULT_SLIDER_COLOR = correct_display_color(0xFF8C00);
+constexpr uint32_t DEFAULT_CHART_COLOR = correct_display_color(0xFF8C00);
 constexpr uint32_t DEFAULT_OFF_COLOR = correct_display_color(0x313131);
 constexpr uint32_t DEFAULT_TERTIARY_COLOR = correct_display_color(0x212121);
 constexpr uint32_t DARK_BACKGROUND_SECONDARY = DEFAULT_OFF_COLOR;
@@ -96,6 +97,8 @@ struct BtnSlot {
   lv_obj_t *sensor_lbl;             // numeric sensor value
   lv_obj_t *unit_lbl;               // unit suffix (°C, %, etc.)
   lv_obj_t *subpage_lbl = nullptr;  // small chevron marker for subpage cards
+  lv_obj_t *chart = nullptr;          // sparkline chart widget (sensor_chart cards only)
+  lv_chart_series_t *chart_series = nullptr; // chart data series (sensor_chart cards only)
 };
 
 inline void set_card_checked_state(lv_obj_t *btn, bool checked);
@@ -394,6 +397,17 @@ inline bool todo_card_label_shows_count(const ParsedCfg &p) {
 inline bool todo_card_shows_completed_items(const ParsedCfg &p) {
   (void) p;
   return false;
+}
+
+inline std::string sensor_chart_normalize_options(const std::string &options) {
+  std::string out;
+  std::string interval = cfg_option_value(options, "interval");
+  std::string mode     = cfg_option_value(options, "mode");
+  std::string points   = cfg_option_value(options, "points");
+  if (!interval.empty()) out += "interval=" + interval;
+  if (!mode.empty())     { if (!out.empty()) out += ","; out += "mode=" + mode; }
+  if (!points.empty())   { if (!out.empty()) out += ","; out += "points=" + points; }
+  return out;
 }
 
 inline std::string normalize_climate_label_display(const std::string &value) {
@@ -723,11 +737,14 @@ inline ParsedCfg normalize_parsed_cfg(ParsedCfg p) {
     if (p.icon_on.empty() || p.icon_on == "Auto") p.icon_on = "Motion Sensor";
     p.options = presence_card_options_normalized(p.options);
   }
-  if (!p.type.empty() && p.type != "action" && p.type != "alarm" && p.type != "alarm_action" && p.type != "climate" && p.type != "garage" && p.type != "webhook" && p.type != "todo" && p.type != "sensor" && p.type != "door_window" && p.type != "presence" && p.type != "media" && p.type != "subpage" && !fan_card_type(p.type) && !card_large_numbers_supported(p)) {
+  if (!p.type.empty() && p.type != "action" && p.type != "alarm" && p.type != "alarm_action" && p.type != "climate" && p.type != "garage" && p.type != "webhook" && p.type != "todo" && p.type != "sensor" && p.type != "sensor_chart" && p.type != "door_window" && p.type != "presence" && p.type != "media" && p.type != "subpage" && !fan_card_type(p.type) && !card_large_numbers_supported(p)) {
     p.options.clear();
   }
   if (p.type == "sensor") {
     p.options = sensor_card_options_normalized(p.options, p.precision);
+  }
+  if (p.type == "sensor_chart") {
+    p.options = sensor_chart_normalize_options(p.options);
   }
   return p;
 }
@@ -2321,4 +2338,29 @@ inline void transient_status_label_show_if_changed(TransientStatusLabel *ctx,
       lv_timer_pause(ctx->revert_timer);
     }
   }
+}
+
+// ── sensor_chart card config helpers ──────────────────────────────────────────
+
+inline uint8_t sensor_chart_mode_index(const ParsedCfg &p) {
+  std::string val = cfg_option_value(p.options, "mode");
+  if (val == "max") return 1;
+  if (val == "min") return 2;
+  if (val == "last") return 3;
+  return 0; // avg (default)
+}
+
+inline uint32_t sensor_chart_interval_ms(const ParsedCfg &p) {
+  std::string val = cfg_option_value(p.options, "interval");
+  uint32_t seconds = val.empty() ? 3600u : (uint32_t)atoi(val.c_str());
+  if (seconds == 0u) seconds = 3600u;
+  return seconds * 1000u;
+}
+
+inline int sensor_chart_point_count(const ParsedCfg &p) {
+  std::string val = cfg_option_value(p.options, "points");
+  int count = val.empty() ? 24 : atoi(val.c_str());
+  if (count < 2) count = 2;
+  if (count > 60) count = 60;
+  return count;
 }

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -84,6 +84,16 @@ inline DisplayProfile display_profile_from_grid_config(const GridConfig &cfg) {
   return profile;
 }
 
+inline lv_obj_t *find_chart_in_btn(lv_obj_t *btn) {
+  if (!btn) return nullptr;
+  uint32_t cnt = lv_obj_get_child_cnt(btn);
+  for (uint32_t i = 0; i < cnt; i++) {
+    lv_obj_t *child = lv_obj_get_child(btn, i);
+    if (lv_obj_check_type(child, &lv_chart_class)) return child;
+  }
+  return nullptr;
+}
+
 inline void configure_grid_layout(lv_obj_t *page, int num_slots, int cols) {
   if (!page) return;
   int slot_count = bounded_grid_slots(num_slots);
@@ -248,6 +258,11 @@ inline void setup_card_visual(BtnSlot &s, const ParsedCfg &p,
       apply_large_sensor_number_style(
         s, display_large_sensor_font(display), display_large_sensor_unit_offset_percent(display));
     }
+    return;
+  }
+  if (p.type == "sensor_chart") {
+    if (p.sensor.empty()) return;
+    setup_sensor_chart_card(s, p, palette.has_sensor_color, palette.sensor_val);
     return;
   }
   if (p.type == "door_window") {
@@ -828,6 +843,18 @@ inline void grid_phase2(
     bool is_1x1_card = row_span == 1 && col_span == 1;
     if (cfg.info_only && info_only_hidden_card_type(p)) continue;
     if (p.type == "push") continue;
+    if (p.type == "sensor_chart") {
+      if (p.sensor.empty()) continue;
+      lv_obj_t *sc_chart = find_chart_in_btn(s.btn);
+      lv_chart_series_t *sc_series = sc_chart ? lv_chart_get_series_next(sc_chart, NULL) : nullptr;
+      if (!sc_chart || !sc_series) continue;
+      subscribe_sensor_chart(s.sensor_lbl, sc_chart, sc_series, p.sensor,
+        parse_precision(p.precision), s.unit_lbl, p.unit,
+        sensor_chart_interval_ms(p), sensor_chart_mode_index(p));
+      if (p.label.empty())
+        subscribe_friendly_name(s.text_lbl, p.sensor);
+      continue;
+    }
     if (bind_basic_sensor_card(s, p, palette)) continue;
     if (bind_passive_card_sources(s, p)) continue;
     if (p.type == "garage") {
@@ -1351,6 +1378,18 @@ inline void grid_phase2(
       display_apply_slot_text_width(sub_slot, display);
       setup_card_visual(sub_slot, sb_cfg, cfg, palette, rs, cs);
 
+      if (sb_cfg.type == "sensor_chart") {
+        if (sb_cfg.sensor.empty()) continue;
+        lv_obj_t *sc_chart = find_chart_in_btn(sub_slot.btn);
+        lv_chart_series_t *sc_series = sc_chart ? lv_chart_get_series_next(sc_chart, NULL) : nullptr;
+        if (!sc_chart || !sc_series) continue;
+        subscribe_sensor_chart(sub_slot.sensor_lbl, sc_chart, sc_series,
+          sb_cfg.sensor, parse_precision(sb_cfg.precision), sub_slot.unit_lbl, sb_cfg.unit,
+          sensor_chart_interval_ms(sb_cfg), sensor_chart_mode_index(sb_cfg));
+        if (sb_cfg.label.empty())
+          subscribe_friendly_name(sub_slot.text_lbl, sb_cfg.sensor);
+        continue;
+      }
       if (bind_basic_sensor_card(sub_slot, sb_cfg, palette)) continue;
       if (bind_passive_card_sources(sub_slot, sb_cfg)) continue;
       if (sb_cfg.type == "cover" && cover_command_mode(sb_cfg.sensor)) {

--- a/components/espcontrol/button_grid_subscriptions.h
+++ b/components/espcontrol/button_grid_subscriptions.h
@@ -475,6 +475,133 @@ inline void apply_action_card_display_value(ActionCardStateCtx *ctx,
   }
 }
 
+inline void subscribe_action_card_target_availability(ActionCardStateCtx *ctx,
+                                                      const std::string &entity_id) {
+  if (!ctx || entity_id.empty()) return;
+  esphome::api::global_api_server->subscribe_home_assistant_state(
+    entity_id, {},
+    std::function<void(esphome::StringRef)>([ctx](esphome::StringRef state) {
+      ctx->state_available = !ha_state_unavailable_ref(state);
+      apply_action_card_availability(ctx);
+    })
+  );
+}
+
+// ── Sensor chart subscription ──────────────────────────────────────────────────
+// Subscribes to a HA sensor entity, updates the live value label, and
+// accumulates samples over a configurable interval. At each interval boundary,
+// computes a single aggregated value (avg/max/min/last) and pushes it to the
+// lv_chart sparkline, then auto-scales the Y axis to the current data range.
+
+struct SensorChartAcc {
+  lv_obj_t *chart;
+  lv_chart_series_t *series;
+  float acc_sum;
+  int acc_count;
+  float acc_min;
+  float acc_max;
+  float acc_last;
+  uint32_t last_push_ms;
+  uint32_t interval_ms;
+  uint8_t mode; // 0=avg 1=max 2=min 3=last
+  bool seeded; // true once chart has been pre-filled with the first received value
+};
+
+inline void sensor_chart_push(SensorChartAcc *acc, float val) {
+  lv_coord_t chart_val = (lv_coord_t)roundf(val * 10.0f);
+  lv_chart_set_next_value(acc->chart, acc->series, chart_val);
+
+  // Recompute Y range from the full data buffer
+  lv_coord_t *y_arr = lv_chart_get_y_array(acc->chart, acc->series);
+  uint16_t cnt = lv_chart_get_point_count(acc->chart);
+  lv_coord_t y_min = chart_val, y_max = chart_val;
+  for (uint16_t i = 0; i < cnt; i++) {
+    if (y_arr[i] != LV_CHART_POINT_NONE) {
+      if (y_arr[i] < y_min) y_min = y_arr[i];
+      if (y_arr[i] > y_max) y_max = y_arr[i];
+    }
+  }
+  lv_coord_t pad = (y_max - y_min) / 4;
+  if (pad < 2) pad = 2;
+  lv_chart_set_range(acc->chart, LV_CHART_AXIS_PRIMARY_Y, y_min - pad, y_max + pad);
+  lv_chart_refresh(acc->chart);
+}
+
+inline void sensor_chart_flush_interval(SensorChartAcc *acc) {
+  if (acc->acc_count == 0) return;
+  float val;
+  switch (acc->mode) {
+    case 1: val = acc->acc_max; break;
+    case 2: val = acc->acc_min; break;
+    case 3: val = acc->acc_last; break;
+    default: val = acc->acc_sum / (float)acc->acc_count; break;
+  }
+  sensor_chart_push(acc, val);
+  acc->acc_sum = 0.0f;
+  acc->acc_count = 0;
+  acc->acc_min = 1e30f;
+  acc->acc_max = -1e30f;
+}
+
+inline void subscribe_sensor_chart(lv_obj_t *sensor_lbl, lv_obj_t *chart,
+                                   lv_chart_series_t *series,
+                                   const std::string &sensor_id,
+                                   int precision, lv_obj_t *unit_lbl,
+                                   const std::string &unit,
+                                   uint32_t interval_ms, uint8_t mode) {
+  std::string display_unit = trim_display_unit(unit);
+  SensorChartAcc *acc = new SensorChartAcc{};
+  acc->chart = chart;
+  acc->series = series;
+  acc->acc_sum = 0.0f;
+  acc->acc_count = 0;
+  acc->acc_min = 1e30f;
+  acc->acc_max = -1e30f;
+  acc->acc_last = 0.0f;
+  acc->last_push_ms = esphome::millis();
+  acc->interval_ms = interval_ms;
+  acc->mode = mode;
+  acc->seeded = false;
+
+  esphome::api::global_api_server->subscribe_home_assistant_state(
+    sensor_id, {},
+    std::function<void(esphome::StringRef)>(
+      [sensor_lbl, precision, unit_lbl, display_unit, acc](esphome::StringRef state) {
+        bool unavailable = ha_state_unavailable_ref(state);
+        float val = 0.0f;
+        if (!unavailable && parse_float_ref(state, val) && std::isfinite(val)) {
+          char buf[16];
+          format_fixed_decimal(buf, sizeof(buf), val, precision);
+          lv_label_set_text(sensor_lbl, buf);
+          if (unit_lbl) lv_label_set_text(unit_lbl, display_unit.c_str());
+
+          acc->acc_sum += val;
+          acc->acc_count++;
+          if (val < acc->acc_min) acc->acc_min = val;
+          if (val > acc->acc_max) acc->acc_max = val;
+          acc->acc_last = val;
+
+          uint32_t now = esphome::millis();
+          if (!acc->seeded) {
+            // First value ever: pre-fill all points so a flat line is immediately visible.
+            lv_coord_t cv = (lv_coord_t)roundf(val * 10.0f);
+            lv_chart_set_all_value(acc->chart, acc->series, cv);
+            lv_chart_set_range(acc->chart, LV_CHART_AXIS_PRIMARY_Y, cv - 2, cv + 2);
+            lv_chart_refresh(acc->chart);
+            acc->last_push_ms = now;
+            acc->seeded = true;
+          } else if ((now - acc->last_push_ms) >= acc->interval_ms) {
+            sensor_chart_flush_interval(acc);
+            acc->last_push_ms = now;
+          }
+        } else {
+          lv_label_set_text(sensor_lbl, "");
+          if (unit_lbl) lv_label_set_text(unit_lbl, "");
+        }
+      })
+  );
+}
+
 inline void subscribe_action_card_display_state(ActionCardStateCtx *ctx,
                                                 const std::string &entity_id) {
   if (!ctx || entity_id.empty()) return;

--- a/src/webserver/modules/config_codec.js
+++ b/src/webserver/modules/config_codec.js
@@ -146,6 +146,8 @@ function normalizeButtonConfig(b) {
     if (!b.icon || b.icon === "Auto") b.icon = "Motion Sensor Off";
     if (!b.icon_on || b.icon_on === "Auto") b.icon_on = "Motion Sensor";
     b.options = normalizePresenceOptions(b.options);
+  } else if (b && b.type === "sensor_chart") {
+    // preserve sensor_chart options (interval, mode, points)
   } else if (b && b.type !== "action" && b.type !== "alarm" && b.type !== "alarm_action" && b.type !== "climate" && b.type !== "garage" && b.type !== "webhook" && b.type !== "media" && b.type !== "presence" && b.type !== "subpage" && !cardLargeNumbersSupported(b)) {
     b.options = "";
   }
@@ -1059,7 +1061,7 @@ function buttonConfigFields(b) {
     options = normalizePresenceOptions(options);
   } else if (isActionOptionSelect || isFanCardType(type)) {
     options = "";
-  } else if (type !== "action" && type !== "alarm_action" && type !== "garage" && type !== "webhook" && type !== "media" && type !== "presence" && !cardLargeNumbersSupported({ type: type, precision: precision })) {
+  } else if (type !== "action" && type !== "alarm_action" && type !== "garage" && type !== "webhook" && type !== "media" && type !== "presence" && type !== "sensor_chart" && !cardLargeNumbersSupported({ type: type, precision: precision })) {
     options = "";
   }
   if (type === "door_window") {

--- a/src/webserver/modules/styles.js
+++ b/src/webserver/modules/styles.js
@@ -101,6 +101,8 @@ var CSS =
   ".sp-forecast-preview{white-space:nowrap;gap:0}" +
   ".sp-sensor-value{font-size:var(--btn-icon);line-height:1;font-weight:300}" +
   ".sp-sensor-unit{font-size:var(--btn-label);line-height:1;color:#fff}" +
+  ".sp-chart-sparkline{position:absolute;bottom:calc(var(--btn-pad) + 1.4em);" +
+  "left:var(--btn-pad);right:var(--btn-pad);height:32%;pointer-events:none}" +
   ".sp-slider-preview{position:absolute;inset:0;border-radius:var(--r);overflow:hidden;pointer-events:none}" +
   ".sp-slider-track{width:100%;height:100%;position:relative}" +
   ".sp-slider-fill{position:absolute;left:0;bottom:0;width:100%;height:80%;background:var(--accent);" +

--- a/src/webserver/types/sensor_chart.js
+++ b/src/webserver/types/sensor_chart.js
@@ -1,0 +1,125 @@
+// Sensor chart card: displays a live numeric value with a sparkline history chart.
+// The chart accumulates samples over a configurable interval (seconds) and plots
+// one aggregated point (avg / max / min / last) per interval.
+registerButtonType("sensor_chart", {
+  label: "Sensor + Chart",
+  allowInSubpage: true,
+  hideLabel: true,
+  onSelect: function (b) {
+    b.entity = "";
+    b.icon = "Auto";
+    b.icon_on = "Auto";
+    if (!b.precision) b.precision = "";
+    if (!b.options) b.options = "";
+    b.options = sensorChartNormalizeOptions(b.options);
+  },
+  renderSettings: function (panel, b, slot, helpers) {
+    var sensorField = helpers.entityField(
+      "Sensor Entity", helpers.idPrefix + "sensor", b.sensor,
+      "e.g. sensor.living_room_temperature",
+      ["sensor", "binary_sensor", "text_sensor"], "sensor", true,
+      "Add a sensor entity before saving.");
+    panel.appendChild(sensorField.field);
+
+    var labelField = helpers.textField(
+      "Label", helpers.idPrefix + "label", b.label, "e.g. Température", "label", true);
+    panel.appendChild(labelField.field);
+
+    var unitField = helpers.textField(
+      "Unit", helpers.idPrefix + "unit", b.unit, "e.g. °C", "unit", true);
+    panel.appendChild(unitField.field);
+
+    var precisionField = helpers.precisionField(helpers.idPrefix + "precision",
+      b.precision || "0", function () {
+        b.precision = this.value === "0" ? "" : this.value;
+        helpers.saveField("precision", b.precision);
+      });
+    panel.appendChild(precisionField.field);
+
+    // Interval select
+    var intervalSel = document.createElement("select");
+    intervalSel.className = "sp-select";
+    var intervals = [
+      ["1", "1 s (test)"], ["300", "5 min"], ["900", "15 min"], ["1800", "30 min"],
+      ["3600", "1 h"], ["7200", "2 h"], ["21600", "6 h"],
+      ["43200", "12 h"], ["86400", "24 h"]
+    ];
+    var curInterval = configOptionValue(b.options, "interval") || "3600";
+    intervals.forEach(function (iv) {
+      var opt = document.createElement("option");
+      opt.value = iv[0];
+      opt.textContent = iv[1];
+      if (iv[0] === curInterval) opt.selected = true;
+      intervalSel.appendChild(opt);
+    });
+    intervalSel.addEventListener("change", function () {
+      b.options = setConfigOptionValue(b.options, "interval", this.value);
+      helpers.saveField("options", b.options);
+    });
+    panel.appendChild(helpers.fieldWithControl("Interval", null, intervalSel));
+
+    // Mode segment
+    var curMode = configOptionValue(b.options, "mode") || "avg";
+    var mode = helpers.segmentControl([
+      ["avg", "Avg"], ["max", "Max"], ["min", "Min"], ["last", "Last"]
+    ], curMode, function (value) {
+      b.options = setConfigOptionValue(b.options, "mode", value);
+      helpers.saveField("options", b.options);
+    });
+    panel.appendChild(helpers.fieldWithControl("Mode", null, mode.segment));
+
+    // Points field
+    var curPoints = configOptionValue(b.options, "points") || "24";
+    var pointsField = helpers.textField(
+      "Points", helpers.idPrefix + "points", curPoints, "2–60", null, true);
+    pointsField.input.addEventListener("change", function () {
+      var v = parseInt(this.value, 10);
+      if (isNaN(v) || v < 2) v = 2;
+      if (v > 60) v = 60;
+      this.value = String(v);
+      b.options = setConfigOptionValue(b.options, "points", String(v));
+      helpers.saveField("options", b.options);
+    });
+    panel.appendChild(pointsField.field);
+  },
+  renderPreview: function (b, helpers) {
+    var label = b.label || b.sensor || "Sensor";
+    var unit = b.unit ? helpers.escHtml(b.unit) : "";
+    var prec = parseInt(b.precision || "0", 10) || 0;
+    var sampleVal = (0).toFixed(prec);
+    var sparkline =
+      '<svg class="sp-chart-sparkline" viewBox="0 0 60 20" preserveAspectRatio="none"' +
+      ' xmlns="http://www.w3.org/2000/svg">' +
+      '<defs><linearGradient id="scg" x1="0" y1="0" x2="0" y2="1">' +
+      '<stop offset="0%" stop-color="#42A5F5" stop-opacity=".35"/>' +
+      '<stop offset="100%" stop-color="#42A5F5" stop-opacity=".05"/>' +
+      '</linearGradient></defs>' +
+      '<polygon points="0,20 0,16 10,13 20,11 30,7 40,9 50,5 60,3 60,20"' +
+      ' fill="url(#scg)"/>' +
+      '<polyline points="0,16 10,13 20,11 30,7 40,9 50,5 60,3"' +
+      ' fill="none" stroke="#42A5F5" stroke-width="1.5" stroke-linejoin="round"/>' +
+      '</svg>';
+    return {
+      iconHtml:
+        '<span class="sp-sensor-preview">' +
+          '<span class="sp-sensor-value">' + sampleVal + '</span>' +
+          '<span class="sp-sensor-unit">' + unit + '</span>' +
+        '</span>' + sparkline,
+      labelHtml:
+        '<span class="sp-btn-label-row"><span class="sp-btn-label">' +
+        helpers.escHtml(label) + '</span>' +
+        '<span class="sp-type-badge mdi mdi-chart-line"></span></span>',
+    };
+  },
+});
+
+function sensorChartNormalizeOptions(options) {
+  var interval = configOptionValue(options, "interval") || "3600";
+  var mode = configOptionValue(options, "mode") || "avg";
+  var points = configOptionValue(options, "points") || "24";
+  var out = "";
+  out = setConfigOptionValue(out, "interval", interval);
+  out = setConfigOptionValue(out, "mode", mode);
+  out = setConfigOptionValue(out, "points", points);
+  return out;
+}


### PR DESCRIPTION
## Summary

<img width="3072" height="4080" alt="PXL_20260607_123852817 PORTRAIT" src="https://github.com/user-attachments/assets/38c933d1-dd7a-4ed5-87c6-9e53344adc4c" />

Adds a new `sensor_chart` card type that displays a live numeric sensor value
alongside a scrolling sparkline history chart built on LVGL's `lv_chart`
widget. The chart accumulates HA state updates over a configurable interval
and plots one aggregated point (avg / max / min / last) per interval.

## Architecture

### C++ side

**`button_grid_config.h`** — new `sensor_chart` config helpers:
- `sensor_chart_normalize_options()` — round-trips `interval`, `mode`,
  `points` from the stored options string
- `sensor_chart_interval_ms()`, `sensor_chart_mode_index()`,
  `sensor_chart_point_count()` — accessors with safe defaults

Two new fields added to `BtnSlot`: `chart` (`lv_obj_t*`) and `chart_series`
(`lv_chart_series_t*`), both initialised to `nullptr`.

**`button_grid_cards.h`** — `setup_sensor_chart_card()` creates the
`lv_chart` widget at phase-1 grid setup. Key decisions:
- `LV_CHART_TYPE_LINE` + `LV_CHART_UPDATE_MODE_SHIFT`: new points push the
  history left
- All points initialised to `LV_CHART_POINT_NONE` so the line only appears
  where real data exists
- `lv_obj_move_foreground(chart)` is required: the sensor text label uses
  `LV_OBJ_FLAG_OVERFLOW_VISIBLE` + wrapping, which causes LVGL to place it
  above later-created siblings in the draw order. Without the foreground
  call the chart is hidden behind the label.
- Line colour is always `DEFAULT_CHART_COLOR` (0xFF8C00). Do **not** use
  `palette.sensor_val` — that is the button background colour and makes the
  line invisible.
- `lv_obj_set_style_size(chart, 0, 0, LV_PART_INDICATOR)` — LVGL 9 requires
  **four** arguments here (width, height, selector); three-arg calls silently
  do nothing and leave visible data-point dots.

**`button_grid_subscriptions.h`** — `SensorChartAcc` accumulator + callback:
- On the **first** HA state update: all existing chart points are pre-filled
  with the current value (`lv_chart_set_all_value`) and the Y range is
  centred on it. This avoids an initial flat line at 0.
- The "already seeded" state is tracked with a `bool seeded` flag on the
  accumulator struct. Do **not** use `acc_count == 1` for this check:
  `acc_count` resets to 0 after every flush, so that condition would
  re-seed (and erase history) on every single post-flush update.
- On each flush: one aggregated point is pushed, and the Y axis range is
  auto-scaled to `[data_min − margin, data_max + margin]`.
- The accumulator is heap-allocated (`new SensorChartAcc{}`) and intentionally
  not freed — consistent with the existing pattern for other subscription
  contexts in this codebase.

**`__init__.py`** — calls `add_lv_use("CHART")` at import time to set
`LV_USE_CHART 1` in the generated `lv_conf.h`. Without this, ESPHome's LVGL
component leaves the chart widget disabled and `lv_chart_create()` returns
`nullptr` silently at runtime.

**`button_grid_grid.h`** — `find_chart_in_btn()` helper: phase-2 recovers
the chart widget by walking the button's LVGL children, because phase-1 and
phase-2 each build a fresh local `BtnSlot` array. The `s.chart` pointer set
in phase-1 is gone by phase-2, so child-scanning is the only reliable way to
find the widget.

### JS / web UI side

**`src/webserver/types/sensor_chart.js`** — new card type registration with:
- Interval select (1 s test / 5 min / 15 min / 30 min / 1 h / 2 h / 6 h /
  12 h / 24 h)
- Mode segment (Avg / Max / Min / Last)
- Points field (2–60, default 24)
- SVG sparkline preview in the web UI editor

**`src/webserver/modules/config_codec.js`**:
- `normalizeButtonConfig`: `sensor_chart` branch preserves options unchanged
  (the surrounding else-if chain would otherwise clear them)
- `buttonConfigFields`: `sensor_chart` excluded from the options-clearing
  condition, consistent with `action`, `garage`, etc.

> **Note**: the subpage serialization path (`serializeLegacySubpageConfig` /
> `serializeCompactSubpageConfig`) also required the same `sensor_chart`
> exclusion. In the current codebase both functions delegate to
> `buttonConfigFields` via `subpageLegacyButtonFields` /
> `subpageCompactButtonFields`, so the fix is in one place. An earlier
> version of this code had the exclusion missing from the inline subpage
> serializers, causing options to silently reset to defaults for cards placed
> inside subpages.

## Known limitations / not included

- **Area fill** (`LV_PART_ITEMS` background): not rendered on this
  display/LVGL build regardless of `bg_opa` value. The fill code was removed;
  the root cause was not investigated.
- The `"1 s (test)"` interval option is intentionally left in the UI for
  development convenience. It should be removed before a stable release.
- Y-axis auto-scaling uses a fixed ±2-unit margin around the data range —
  adequate for typical sensor values but not ideal for very noisy or
  near-zero signals.

## Testing

Tested on JC3248W535 (ESP32-S3, LVGL 9) with a power sensor updating every
few seconds. Chart history, Y-axis scaling, interval/mode/points persistence
(main screen and subpages), and device reboot all verified.