### PR TITLE
Fix UTF-8 corruption when saving subpage sensor config with non-ASCII units

### DIFF
--- a/src/webserver/model/card.ts
+++ b/src/webserver/model/card.ts
@@ -85,8 +85,16 @@ export function encodeConfigField(value: string | number | boolean | null | unde
 }
 
 export function decodeConfigField(value: string | number | boolean | null | undefined): string {
-  return String(value || "").replace(/%([0-9a-fA-F]{2})/g, (_match, hex: string) => {
-    return String.fromCharCode(parseInt(hex, 16));
+  const str = String(value || "");
+  // Decode %XX sequences as UTF-8 using decodeURIComponent, which correctly
+  // handles multi-byte sequences like %C2%B0 → ° (instead of byte-by-byte
+  // String.fromCharCode which produces Mojibake: Â°).
+  return str.replace(/(%[0-9a-fA-F]{2})+/g, (run) => {
+    try {
+      return decodeURIComponent(run);
+    } catch {
+      return run;
+    }
   });
 }
 

--- a/src/webserver/model/subpage.ts
+++ b/src/webserver/model/subpage.ts
@@ -256,16 +256,44 @@ export function chooseSerializedSubpageConfig(
   return compact.length < legacy.length ? compact : legacy;
 }
 
+function utf8ByteLength(str: string): number {
+  let bytes = 0;
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    if (code < 0x80) bytes += 1;
+    else if (code >= 0xd800 && code <= 0xdbff) { bytes += 4; i += 1; } // surrogate pair → U+10000+
+    else if (code < 0x800) bytes += 2;
+    else bytes += 3;
+  }
+  return bytes;
+}
+
 export function splitSubpageConfigChunks(
   value: string | null | undefined,
   chunkCount: number,
   chunkSize = 255,
 ): string[] | null {
   const full = String(value || "");
-  if (chunkCount < 1 || chunkSize < 1 || full.length > chunkCount * chunkSize) return null;
+  // Device text entities enforce max_length in BYTES, not characters.
+  // Split on character boundaries so each chunk's UTF-8 byte count ≤ chunkSize.
+  if (chunkCount < 1 || chunkSize < 1 || utf8ByteLength(full) > chunkCount * chunkSize) return null;
   const chunks: string[] = [];
+  let charPos = 0;
   for (let i = 0; i < chunkCount; i += 1) {
-    chunks.push(full.substring(i * chunkSize, (i + 1) * chunkSize));
+    let bytes = 0;
+    let end = charPos;
+    while (end < full.length) {
+      const code = full.charCodeAt(end);
+      const charBytes =
+        code < 0x80 ? 1 :
+        (code >= 0xd800 && code <= 0xdbff) ? 4 :
+        code < 0x800 ? 2 : 3;
+      if (bytes + charBytes > chunkSize) break;
+      bytes += charBytes;
+      end += code >= 0xd800 && code <= 0xdbff ? 2 : 1; // surrogate pairs use 2 JS chars
+    }
+    chunks.push(full.substring(charPos, end));
+    charPos = end;
   }
   return chunks;
 }


### PR DESCRIPTION
Two bugs caused silent data corruption for users who configure sensor cards with units like °C, μg/m³ or similar non-ASCII strings via the WebUI:

1. decodeConfigField used String.fromCharCode(parseInt(hex, 16)) to decode each %XX escape individually. This treats every byte as a Unicode code point, so a UTF-8 multi-byte sequence like %C2%B0 (°) was decoded as two separate Latin-1 characters Â and ° instead of the single character °. Fix: use decodeURIComponent() which understands UTF-8 byte sequences and decodes consecutive %XX runs into the correct Unicode characters.

2. splitSubpageConfigChunks split the config string on CHARACTER position 255, but the ESPHome text entity enforces max_length=255 in BYTES. A chunk of 255 characters containing multi-byte UTF-8 characters (e.g. ° = 2 bytes, μ = 2 bytes) can exceed 255 bytes and is then silently rejected by the device (returns HTTP 200 but discards the write), causing the subpage config to revert to the previous value without any error shown to the user. Fix: add utf8ByteLength() and rewrite the splitter to track byte count and split on character boundaries so each chunk stays within the byte limit.