### PR TITLE
[codex] Add small-branch PR workflow guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+-
+
+## Testing
+
+- [ ] I checked the change locally where practical.
+- [ ] User testing is still needed before merge.
+- [ ] Affected display/device, if applicable:
+
+## Notes for testing
+
+-
+
+## Issue handling
+
+- [ ] Do not close related issues until the user confirms the fix works.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Communication
+
+- The user is technical but not development-oriented. Explain changes in approachable terms and avoid unnecessary implementation detail.
+- Keep final updates concise: what changed, how it was checked, and what the user needs to test.
+
+## Development workflow
+
+- Treat `main` as the stable branch.
+- For normal code, firmware, configuration, UI, or documentation changes, create a short-lived branch from the latest `main`.
+- Use branch names like `codex/fix-display-timeout` or `codex/update-pr-workflow`.
+- Keep each branch focused on one bug fix, feature, device change, cleanup, or documentation change.
+- Commit completed changes and push the branch.
+- Open a draft pull request for user testing instead of merging directly to `main`.
+- Leave the pull request open until the user confirms they have tested it.
+- Do not close related GitHub issues until the user confirms the fix works.
+- Only work directly on `main` when the user explicitly asks for it, or for a tiny emergency/documentation-only change where a PR would add no value.
+
+## Pull requests
+
+- PR descriptions should explain the purpose of the change, the practical impact, and how it was checked.
+- Include clear testing notes so the user can test the branch independently of `main`.
+- If firmware needs flashing, name the affected display or device in the PR body.


### PR DESCRIPTION
## Summary

- Adds repo-level Codex instructions in `AGENTS.md` so future sessions default to short-lived branches and draft PRs.
- Adds a pull request template with testing notes and an issue-handling reminder.
- Separately, the repository now has an active GitHub ruleset requiring pull requests for changes to `main`.

## Testing

- [x] Checked the markdown diff for whitespace issues with `git diff --cached --check`.
- [x] Confirmed the new GitHub ruleset is active for the default branch.
- [ ] User testing is still needed before merge.
- [ ] Affected display/device, if applicable: none

## Notes for testing

- Open this PR and confirm the template and guidance match how you want Codex to work going forward.
- Once merged, future Codex sessions in this repo should automatically load `AGENTS.md`.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.
