### PR TITLE
[codex] Fix 10-inch boot wake after time sync

### DIFF
--- a/common/addon/time.yaml
+++ b/common/addon/time.yaml
@@ -32,6 +32,8 @@ api:
         if (ha_api_state_connected()) id(homeassistant_time).update();
     - delay: 1s
     - script.execute: time_update
+    - script.execute: backlight_recalc_sunrise_sunset
+    - script.execute: screen_schedule_check
 
 # ---------------------------------------------------------------------------
 # Timezone selector (drives sunrise/sunset calculation via sun_calc.h)

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -337,6 +337,16 @@ def firmware_time_reconnect_errors(time_path: Path, root: Path) -> list[str]:
         errors.append(f"{rel}: wait for Home Assistant state readiness before reconnect time sync")
     if "on_client_connected:" in text and "delay: 2s" not in text:
         errors.append(f"{rel}: defer Home Assistant time sync after API reconnect")
+    api_connect_match = re.search(
+        r"(?ms)^api:\n\s+on_client_connected:\n(?P<body>.*?)(?:^#|^select:|^text:|^text_sensor:|^time:|^script:|\Z)",
+        text,
+    )
+    if api_connect_match:
+        api_connect_body = api_connect_match.group("body")
+        if "script.execute: backlight_recalc_sunrise_sunset" not in api_connect_body:
+            errors.append(f"{rel}: recalculate sunrise and sunset after reconnect time sync")
+        if "script.execute: screen_schedule_check" not in api_connect_body:
+            errors.append(f"{rel}: recheck the screen schedule after reconnect time sync")
     return errors
 
 
@@ -2001,7 +2011,13 @@ def run_self_test() -> int:
         "  on_client_connected:\n"
         "    - lambda: |-\n"
         "        id(homeassistant_time).update();\n",
-        ("guard Home Assistant time updates", "wait for Home Assistant state readiness", "defer Home Assistant time sync"),
+        (
+            "guard Home Assistant time updates",
+            "wait for Home Assistant state readiness",
+            "defer Home Assistant time sync",
+            "recalculate sunrise and sunset",
+            "recheck the screen schedule",
+        ),
     )
     expect_time_reconnect_errors(
         "home assistant time sync waits for state readiness",
@@ -2010,6 +2026,10 @@ def run_self_test() -> int:
         "    - delay: 2s\n"
         "    - lambda: |-\n"
         "        if (ha_api_state_connected()) id(homeassistant_time).update();\n"
+        "    - delay: 1s\n"
+        "    - script.execute: time_update\n"
+        "    - script.execute: backlight_recalc_sunrise_sunset\n"
+        "    - script.execute: screen_schedule_check\n"
         "script:\n"
         "  - id: time_update\n"
         "    then:\n"


### PR DESCRIPTION
## What changed

- Re-runs sunrise/sunset calculation after Home Assistant time is refreshed on API reconnect.
- Rechecks the screen schedule immediately after that time refresh.
- Adds a guardrail so future reconnect-time changes must keep the schedule recheck.

## Why

The screen schedule boot guard can intentionally keep the backlight off while the panel is waiting for valid time. On the 10-inch panel, Home Assistant time is requested after reconnect, but that reconnect path only refreshed the visible clock/date state. It did not re-run the schedule decision, so the panel could remain blank until touch triggered the normal wake script.

## Validation

- `python3 scripts/check_firmware_ha_bindings.py --self-test`
- `python3 scripts/check_firmware_ha_bindings.py`
- `python3 scripts/check_firmware_parser.py`
- `npm test -- --runInBand`
- `docker run ... ghcr.io/esphome/esphome:2026.5.3 compile /config/builds/guition-esp32-p4-jc8012p4a1.factory.yaml`