### PR TITLE
Tune S3 display refresh and backlight

### DIFF
--- a/devices/guition-esp32-s3-4848s040/device/device.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/device.yaml
@@ -205,8 +205,9 @@ output:
     pin: GPIO38
     id: gpio_backlight_pwm
     # The 4848S040 backlight driver needs a low PWM rate; high rates make
-    # brightness levels below roughly 85% appear off on some boards.
-    frequency: 100Hz
+    # brightness levels below roughly 85% appear off on some boards. Keep the
+    # pulses long, but avoid the more visible shimmer seen at 100Hz.
+    frequency: 150Hz
     min_power: 0.01
     zero_means_zero: true
 
@@ -370,10 +371,10 @@ display:
     # Start WiFi before the RGB panel allocates its frame buffers; otherwise the
     # WiFi driver can fail to claim enough internal RX buffers on fresh boots.
     setup_priority: 240
-    # Keep the S3 RGB clock at the weekend release's stable value. Faster clocks
-    # can starve the PSRAM-backed frame buffer when the web server adds WiFi,
-    # flash, and memory traffic, causing visible screen shifts and pixel breakup.
-    pclk_frequency: 8MHz
+    # Keep the S3 RGB clock conservative while lifting the panel scan rate above
+    # the visibly shimmery 8MHz setting. Higher clocks have caused screen shifts
+    # and pixel breakup when WiFi, flash, and web traffic compete for PSRAM.
+    pclk_frequency: 10MHz
     update_interval: never
     auto_clear_enabled: False
     # Keep the ST7701S panel init sequence on the non-mirrored path. The


### PR DESCRIPTION
## What changed

- Raised the 4848S040 backlight PWM from 100Hz to 150Hz to reduce visible low-brightness shimmer without returning to the 20kHz setting that broke dim levels on some boards.
- Raised the S3 RGB pixel clock from 8MHz to 10MHz to lift the panel scan rate while staying below the faster settings that previously caused screen shifts and pixel breakup under WiFi/web traffic.

## Why

The current S3 settings are very conservative. They protect the panel from display breakup, but the lower scan/backlight rates can make the screen look like it is slightly shimmering.

## Validation

- `npm run check:device-profiles`
- `npm run check:device-matrix`
- `npm run check:config`
- `npm run check:firmware-parser` (passes with existing unused-variable warnings)
- `docker run --rm -v /Users/jtenniswood/Git/espcontrol:/config -w /config ghcr.io/esphome/esphome:2026.5.3 compile builds/guition-esp32-s3-4848s040.yaml`