### PR TITLE
Harden camera modal display behavior

### DIFF
--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -394,6 +394,7 @@ script:
   - id: backlight_schedule_display_off
     mode: restart
     then:
+      - lambda: 'backlight_close_modals_for_display_takeover();'
       - if:
           condition:
             lambda: 'return !id(home_screen_idle_suspended) || id(screen_schedule_asleep);'
@@ -421,6 +422,7 @@ script:
   - id: screen_schedule_manual_sleep
     mode: restart
     then:
+      - lambda: 'backlight_close_modals_for_display_takeover();'
       - script.stop: screensaver_idle_check
       - globals.set:
           id: display_asleep

--- a/common/addon/backlight_schedule.yaml
+++ b/common/addon/backlight_schedule.yaml
@@ -472,6 +472,7 @@ script:
   - id: screen_schedule_sleep
     mode: restart
     then:
+      - lambda: 'backlight_close_modals_for_display_takeover();'
       - script.stop: screensaver_idle_check
       - script.stop: home_screen_idle_check
       - script.stop: screen_schedule_wake_timeout_check
@@ -585,6 +586,7 @@ script:
   - id: screen_schedule_show_clock
     mode: restart
     then:
+      - lambda: 'backlight_close_modals_for_display_takeover();'
       - script.stop: screensaver_idle_check
       - script.stop: home_screen_idle_check
       - script.stop: screen_schedule_wake_timeout_check

--- a/components/espcontrol/backlight.h
+++ b/components/espcontrol/backlight.h
@@ -25,6 +25,22 @@
 #include <esp_system.h>
 #endif
 
+using BacklightDisplayTakeoverCallback = void (*)();
+
+inline BacklightDisplayTakeoverCallback &backlight_display_takeover_callback() {
+  static BacklightDisplayTakeoverCallback callback = nullptr;
+  return callback;
+}
+
+inline void set_backlight_display_takeover_callback(BacklightDisplayTakeoverCallback callback) {
+  backlight_display_takeover_callback() = callback;
+}
+
+inline void backlight_close_modals_for_display_takeover() {
+  BacklightDisplayTakeoverCallback callback = backlight_display_takeover_callback();
+  if (callback) callback();
+}
+
 // ── Sunrise/sunset recalculation ─────────────────────────────────────
 
 struct SunCalcResult {

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -697,6 +697,7 @@ inline void grid_phase1(
     const std::string &sensor_hex,
     lv_obj_t *main_page_obj = nullptr) {
   ESP_LOGI("sensors", "Phase 1: visual setup start (%lu ms)", esphome::millis());
+  set_backlight_display_takeover_callback(navigation_close_modals_for_display_takeover);
   set_display_temperature_unit(cfg.temperature_unit, cfg.timezone);
   const DisplayProfile display = display_profile_from_grid_config(cfg);
   display_set_width_axis(display);

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -23,6 +23,9 @@ constexpr int IMAGE_CARD_MODAL_MAX_TARGET_SIDE_PX = 800;
 constexpr size_t IMAGE_CARD_MEMORY_HEADROOM_BYTES = 96 * 1024;
 constexpr lv_coord_t IMAGE_CARD_JC4880P443_MODAL_BACK_BUTTON_REF_PX = 58;
 constexpr const char *IMAGE_CARD_LOADING_ICON = "\U000F02E9";
+constexpr lv_coord_t IMAGE_CARD_MODAL_LOADING_MIN_W = 132;
+constexpr lv_coord_t IMAGE_CARD_MODAL_LOADING_MAX_W = 220;
+constexpr lv_coord_t IMAGE_CARD_MODAL_LOADING_H = 48;
 
 struct ImageCardCtx {
   lv_obj_t *widget = nullptr;
@@ -349,16 +352,28 @@ inline void image_card_layout_modal_loading(ImageCardCtx *ctx) {
   lv_coord_t width = lv_obj_get_width(ui.panel);
   lv_coord_t height = lv_obj_get_height(ui.panel);
   if (width <= 0 || height <= 0) return;
-  lv_obj_set_pos(ui.loading_widget, 0, 0);
-  lv_obj_set_size(ui.loading_widget, width, height);
-  lv_obj_set_style_radius(
-    ui.loading_widget, lv_obj_get_style_radius(ui.panel, LV_PART_MAIN), LV_PART_MAIN);
+  lv_coord_t margin = width < 260 ? 8 : 12;
+  lv_coord_t available_w = width - margin * 2;
+  if (available_w <= 0) return;
+  lv_coord_t indicator_w = width / 2;
+  if (indicator_w < IMAGE_CARD_MODAL_LOADING_MIN_W) indicator_w = IMAGE_CARD_MODAL_LOADING_MIN_W;
+  if (indicator_w > IMAGE_CARD_MODAL_LOADING_MAX_W) indicator_w = IMAGE_CARD_MODAL_LOADING_MAX_W;
+  if (indicator_w > available_w) indicator_w = available_w;
+  lv_coord_t indicator_h = IMAGE_CARD_MODAL_LOADING_H;
+  if (height < 180) indicator_h = 40;
+  lv_obj_set_size(ui.loading_widget, indicator_w, indicator_h);
+  lv_obj_align(ui.loading_widget, LV_ALIGN_TOP_RIGHT, -margin, margin);
+  lv_obj_set_style_radius(ui.loading_widget, indicator_h / 2, LV_PART_MAIN);
   lv_obj_set_style_clip_corner(ui.loading_widget, true, LV_PART_MAIN);
   if (lv_obj_get_child_cnt(ui.loading_widget) < 2) return;
   lv_obj_t *icon = lv_obj_get_child(ui.loading_widget, 0);
   lv_obj_t *label = lv_obj_get_child(ui.loading_widget, 1);
-  lv_obj_align(icon, LV_ALIGN_CENTER, 0, -18);
-  lv_obj_align_to(label, icon, LV_ALIGN_OUT_BOTTOM_MID, 0, 8);
+  lv_coord_t inner_pad = 14;
+  lv_coord_t label_x = 44;
+  lv_obj_align(icon, LV_ALIGN_LEFT_MID, inner_pad, 0);
+  lv_obj_set_width(label, indicator_w - label_x - inner_pad);
+  lv_label_set_long_mode(label, LV_LABEL_LONG_DOT);
+  lv_obj_align(label, LV_ALIGN_LEFT_MID, label_x, 0);
 }
 
 inline void image_card_show_modal_loading(ImageCardCtx *ctx, const char *text) {
@@ -373,7 +388,7 @@ inline void image_card_show_modal_loading(ImageCardCtx *ctx, const char *text) {
   }
   lv_obj_clear_flag(ui.loading_widget, LV_OBJ_FLAG_HIDDEN);
   lv_obj_move_foreground(ui.loading_widget);
-  lv_obj_move_foreground(ui.back_btn);
+  if (ui.back_btn) lv_obj_move_foreground(ui.back_btn);
   lv_obj_invalidate(ui.loading_widget);
 }
 
@@ -381,7 +396,7 @@ inline void image_card_hide_modal_loading(ImageCardCtx *ctx) {
   ImageCardModalUi &ui = image_card_modal_ui();
   if (!ctx || ui.active != ctx || !ui.loading_widget) return;
   lv_obj_add_flag(ui.loading_widget, LV_OBJ_FLAG_HIDDEN);
-  lv_obj_move_foreground(ui.back_btn);
+  if (ui.back_btn) lv_obj_move_foreground(ui.back_btn);
 }
 
 inline bool image_card_startup_retry_active(ImageCardCtx *ctx,
@@ -480,11 +495,11 @@ inline void image_card_apply_modal_downloaded(ImageCardCtx *ctx) {
   if (!image_card_modal_active_for(ctx)) return;
   if (ctx->modal_image->get_url() != ctx->modal_url) return;
   ImageCardModalUi &ui = image_card_modal_ui();
-  image_card_apply_modal_geometry(ctx, ctx->modal_image);
+  if (!image_card_apply_modal_geometry(ctx, ctx->modal_image)) return;
   image_card_set_widget_source(ui.image_widget, ctx->modal_image);
   lv_obj_move_background(ui.image_widget);
   image_card_hide_modal_loading(ctx);
-  lv_obj_move_foreground(ui.back_btn);
+  if (ui.back_btn) lv_obj_move_foreground(ui.back_btn);
   if (ui.panel) lv_obj_invalidate(ui.panel);
   notify_dashboard_content_changed();
 }
@@ -495,7 +510,7 @@ inline void image_card_handle_modal_download_error(ImageCardCtx *ctx) {
   if (image_card_modal_active_for(ctx)) {
     ImageCardModalUi &ui = image_card_modal_ui();
     image_card_hide_modal_loading(ctx);
-    lv_obj_move_foreground(ui.back_btn);
+    if (ui.back_btn) lv_obj_move_foreground(ui.back_btn);
   }
 }
 
@@ -693,13 +708,13 @@ inline void image_card_show_modal_image(ImageCardCtx *ctx,
                                         esphome::artwork_image::ArtworkImage *image) {
   ImageCardModalUi &ui = image_card_modal_ui();
   if (!ctx || !image_card_modal_active_for(ctx) || !image) return;
-  image_card_apply_modal_geometry(ctx, image);
+  if (!image_card_apply_modal_geometry(ctx, image)) return;
   image_card_set_widget_source(ui.image_widget, image);
   lv_obj_move_background(ui.image_widget);
   if (ui.loading_widget && !lv_obj_has_flag(ui.loading_widget, LV_OBJ_FLAG_HIDDEN)) {
     lv_obj_move_foreground(ui.loading_widget);
   }
-  lv_obj_move_foreground(ui.back_btn);
+  if (ui.back_btn) lv_obj_move_foreground(ui.back_btn);
   if (ui.panel) lv_obj_invalidate(ui.panel);
 }
 
@@ -1340,6 +1355,19 @@ inline void image_card_schedule_modal_cleanup(ImageCardCtx *ctx) {
   if (!ctx->modal_cleanup_timer) image_card_finish_modal_cleanup(ctx);
 }
 
+inline void image_card_abort_modal_open(ImageCardCtx *ctx, const char *reason) {
+  ESP_LOGW("image_card", "Unable to open image modal for %s: %s",
+           ctx ? ctx->entity_id.c_str() : "(unknown)",
+           reason ? reason : "modal setup failed");
+  ImageCardModalUi &ui = image_card_modal_ui();
+  image_card_cancel_modal_request_timer();
+  image_card_clear_widget_source(ui.image_widget);
+  control_modal_delete_overlay(ControlModalKind::IMAGE_CARD, ui.overlay);
+  ui = ImageCardModalUi();
+  if (ctx && ctx->resume_home_idle) ctx->resume_home_idle();
+  image_card_schedule_modal_cleanup(ctx);
+}
+
 inline void image_card_hide_modal() {
   ImageCardModalUi &ui = image_card_modal_ui();
   ImageCardCtx *ctx = ui.active;
@@ -1370,14 +1398,19 @@ inline void image_card_open_modal(ImageCardCtx *ctx) {
   ControlModalShell shell = control_modal_open_shell(
     ControlModalKind::IMAGE_CARD, ctx->btn, ctx->width_compensation_percent,
     ctx->icon_font, "\U000F0141", false, image_card_hide_modal);
+  if (!shell.overlay || !shell.panel || !shell.close_btn) {
+    ESP_LOGW("image_card", "Unable to open image modal for %s: modal shell setup failed",
+             ctx->entity_id.c_str());
+    return;
+  }
   control_modal_block_close_for(IMAGE_CARD_MODAL_CLOSE_GUARD_MS);
-  if (ctx->pause_home_idle) ctx->pause_home_idle();
 
   ImageCardModalUi &ui = image_card_modal_ui();
   ui.active = ctx;
   ui.overlay = shell.overlay;
   ui.panel = shell.panel;
   ui.back_btn = shell.close_btn;
+  if (ctx->pause_home_idle) ctx->pause_home_idle();
   image_card_style_modal_back_button(ui.back_btn, shell.layout);
 
   lv_obj_set_style_bg_color(ui.panel, lv_color_hex(DARK_OVERLAY), LV_PART_MAIN);
@@ -1389,6 +1422,10 @@ inline void image_card_open_modal(ImageCardCtx *ctx) {
 #else
   ui.image_widget = lv_img_create(ui.panel);
 #endif
+  if (!ui.image_widget) {
+    image_card_abort_modal_open(ctx, "image widget setup failed");
+    return;
+  }
   lv_obj_clear_flag(ui.image_widget, LV_OBJ_FLAG_CLICKABLE);
   lv_obj_clear_flag(ui.image_widget, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_set_style_pad_all(ui.image_widget, 0, LV_PART_MAIN);
@@ -1396,9 +1433,14 @@ inline void image_card_open_modal(ImageCardCtx *ctx) {
   lv_obj_set_style_bg_opa(ui.image_widget, LV_OPA_TRANSP, LV_PART_MAIN);
 
   ui.loading_widget = lv_obj_create(ui.panel);
-  lv_obj_set_style_bg_color(ui.loading_widget, lv_color_hex(DARK_OVERLAY), LV_PART_MAIN);
+  if (!ui.loading_widget) {
+    image_card_abort_modal_open(ctx, "loading widget setup failed");
+    return;
+  }
+  lv_obj_set_style_bg_color(ui.loading_widget, lv_color_hex(DARK_BACKGROUND_SECONDARY), LV_PART_MAIN);
   lv_obj_set_style_bg_opa(ui.loading_widget, LV_OPA_70, LV_PART_MAIN);
-  lv_obj_set_style_border_width(ui.loading_widget, 0, LV_PART_MAIN);
+  lv_obj_set_style_border_color(ui.loading_widget, lv_color_hex(DARK_BORDER), LV_PART_MAIN);
+  lv_obj_set_style_border_width(ui.loading_widget, 1, LV_PART_MAIN);
   lv_obj_set_style_shadow_width(ui.loading_widget, 0, LV_PART_MAIN);
   lv_obj_set_style_pad_all(ui.loading_widget, 0, LV_PART_MAIN);
   lv_obj_clear_flag(ui.loading_widget, LV_OBJ_FLAG_CLICKABLE);
@@ -1406,16 +1448,25 @@ inline void image_card_open_modal(ImageCardCtx *ctx) {
   lv_obj_add_flag(ui.loading_widget, LV_OBJ_FLAG_HIDDEN);
 
   lv_obj_t *loading_icon = lv_label_create(ui.loading_widget);
+  if (!loading_icon) {
+    image_card_abort_modal_open(ctx, "loading icon setup failed");
+    return;
+  }
   if (ctx->icon_font) lv_obj_set_style_text_font(loading_icon, ctx->icon_font, LV_PART_MAIN);
   lv_obj_set_style_text_color(loading_icon, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_opa(loading_icon, LV_OPA_COVER, LV_PART_MAIN);
   lv_label_set_text(loading_icon, IMAGE_CARD_LOADING_ICON);
 
   lv_obj_t *loading_label = lv_label_create(ui.loading_widget);
+  if (!loading_label) {
+    image_card_abort_modal_open(ctx, "loading label setup failed");
+    return;
+  }
   if (ctx->label_font) lv_obj_set_style_text_font(loading_label, ctx->label_font, LV_PART_MAIN);
   lv_obj_set_style_text_color(loading_label, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_opa(loading_label, LV_OPA_COVER, LV_PART_MAIN);
-  lv_obj_set_style_text_align(loading_label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
+  lv_obj_set_style_text_align(loading_label, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN);
+  lv_label_set_long_mode(loading_label, LV_LABEL_LONG_DOT);
   lv_label_set_text(loading_label, espcontrol_i18n("Loading"));
 
   image_card_show_modal_image(ctx, ctx->image);

--- a/components/espcontrol/button_grid_modal.h
+++ b/components/espcontrol/button_grid_modal.h
@@ -79,16 +79,24 @@ inline void control_modal_block_close_for(uint32_t delay_ms) {
   active.close_guard_until_ms = lv_tick_get() + delay_ms;
 }
 
-inline void control_modal_close_active() {
+inline void control_modal_close_active_internal(bool honor_close_guard) {
   ControlModalActive &active = control_modal_active();
   if (active.kind == ControlModalKind::NONE || active.closing) return;
-  if (control_modal_close_guard_active(active)) return;
+  if (honor_close_guard && control_modal_close_guard_active(active)) return;
 
   ControlModalKind closing_kind = active.kind;
   void (*close_callback)() = active.close_callback;
   active.closing = true;
   if (close_callback) close_callback();
   if (control_modal_active().kind == closing_kind) control_modal_reset_active();
+}
+
+inline void control_modal_close_active() {
+  control_modal_close_active_internal(true);
+}
+
+inline void control_modal_force_close_active() {
+  control_modal_close_active_internal(false);
 }
 
 struct ControlModalGridMetrics {
@@ -399,6 +407,7 @@ inline lv_obj_t *control_modal_create_round_button(lv_obj_t *parent, lv_coord_t 
                                                   uint32_t bg_color,
                                                   int width_compensation_percent = 100) {
   lv_obj_t *btn = lv_btn_create(parent);
+  if (!btn) return nullptr;
   lv_obj_set_size(btn, size, size);
   apply_width_compensation(btn, width_compensation_percent);
   lv_obj_set_style_radius(btn, size / 2, LV_PART_MAIN);
@@ -409,6 +418,10 @@ inline lv_obj_t *control_modal_create_round_button(lv_obj_t *parent, lv_coord_t 
   lv_obj_set_style_shadow_width(btn, 0, LV_PART_MAIN);
   control_modal_apply_pressed_fill(btn);
   lv_obj_t *label = lv_label_create(btn);
+  if (!label) {
+    lv_obj_del(btn);
+    return nullptr;
+  }
   lv_label_set_text(label, text);
   lv_obj_set_style_text_color(label, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
@@ -454,9 +467,19 @@ inline ControlModalShell control_modal_open_shell(ControlModalKind kind,
   if (shell.content_w < 120) shell.content_w = shell.layout.panel_w;
 
   shell.overlay = lv_obj_create(lv_layer_top());
+  if (!shell.overlay) {
+    ESP_LOGW("control_modal", "Unable to create modal overlay");
+    return shell;
+  }
   control_modal_style_overlay(shell.overlay);
 
   shell.panel = lv_obj_create(shell.overlay);
+  if (!shell.panel) {
+    ESP_LOGW("control_modal", "Unable to create modal panel");
+    lv_obj_del(shell.overlay);
+    shell.overlay = nullptr;
+    return shell;
+  }
   control_modal_style_panel(shell.panel, radius);
   control_modal_apply_panel_layout(shell.overlay, shell.panel, shell.layout, radius);
 
@@ -464,6 +487,13 @@ inline ControlModalShell control_modal_open_shell(ControlModalKind kind,
     shell.close_btn = control_modal_create_round_button(
       shell.panel, 32, button_text, icon_font,
       DARK_BORDER, DARK_BACKGROUND_TERTIARY, width_compensation_percent);
+    if (!shell.close_btn) {
+      ESP_LOGW("control_modal", "Unable to create modal close button");
+      lv_obj_del(shell.overlay);
+      shell.overlay = nullptr;
+      shell.panel = nullptr;
+      return shell;
+    }
     control_modal_style_chrome_button(shell.close_btn, shell.layout, button_top_right);
     lv_obj_add_event_cb(shell.close_btn, [](lv_event_t *) {
       control_modal_close_active();

--- a/components/espcontrol/button_grid_navigation.h
+++ b/components/espcontrol/button_grid_navigation.h
@@ -54,6 +54,19 @@ inline void navigation_hide_modals() {
   network_status_hide_modal();
 }
 
+inline void navigation_close_modals_for_display_takeover() {
+  control_modal_close_nested_menu();
+  control_modal_force_close_active();
+  image_card_hide_modal();
+  media_volume_hide_modal();
+  climate_control_hide_modal();
+  option_select_hide_modal();
+  switch_confirmation_hide_modal();
+  alarm_pin_hide_modal();
+  alarm_control_hide_modal();
+  network_status_hide_modal();
+}
+
 inline bool navigation_return_home(lv_obj_t *main_page_obj) {
   navigation_hide_modals();
   if (main_page_obj == nullptr) {

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -668,10 +668,29 @@ def firmware_image_card_quality_errors(firmware_dir: Path, root: Path) -> list[s
         errors.append(f"{rel}: release modal image-card buffers when the modal closes")
     if 'image_card_set_loading_state(loading, "Too many")' not in text:
         errors.append(f"{rel}: show a visible image-card limit message when downloaders run out")
-    if "image_card_modal_refresh_supported" not in text or "control_modal_current_is_jc4880p443_size" not in text:
-        errors.append(f"{rel}: avoid extra modal image downloads on the 4.3-inch P4 screen")
+    modal_refresh = re.search(
+        r"inline\s+bool\s+image_card_modal_refresh_supported\s*\(\s*\)\s*\{\s*return\s+true\s*;",
+        text,
+        re.S,
+    )
+    if not modal_refresh:
+        errors.append(f"{rel}: keep modal-quality image refresh enabled on the 4.3-inch P4 screen")
+    if (
+        "image_card_tile_prefetches_modal_quality" not in text
+        or "!control_modal_current_is_jc4880p443_size()" not in text
+    ):
+        errors.append(f"{rel}: keep 4.3-inch P4 tile downloads sized to the tile before modal open")
     if "Closing image modal" not in text:
         errors.append(f"{rel}: log image-card modal close events")
+    if "image_card_abort_modal_open" not in text or "modal shell setup failed" not in text:
+        errors.append(f"{rel}: clean up partially-created image card modals")
+    if "IMAGE_CARD_MODAL_LOADING_MAX_W" not in text or "LV_ALIGN_TOP_RIGHT" not in text:
+        errors.append(f"{rel}: keep image-card modal loading indicator compact")
+    if (
+        "image_card_show_modal_image(ctx, ctx->image)" not in text
+        or "image_card_queue_modal_source_request(ctx)" not in text
+    ):
+        errors.append(f"{rel}: show the cached image-card tile while modal-quality image loads")
     if "lv_obj_set_style_clip_corner(ui.panel, true, LV_PART_MAIN)" not in text:
         errors.append(f"{rel}: clip image card modal content to rounded panel corners")
     if "image_card_apply_corner_clip" not in text:
@@ -2375,8 +2394,12 @@ def run_self_test() -> int:
             "check free memory before image-card downloads",
             "include PSRAM in image-card memory checks",
             "show a visible image-card limit message when downloaders run out",
-            "avoid extra modal image downloads on the 4.3-inch P4 screen",
+            "keep modal-quality image refresh enabled on the 4.3-inch P4 screen",
+            "keep 4.3-inch P4 tile downloads sized to the tile before modal open",
             "log image-card modal close events",
+            "clean up partially-created image card modals",
+            "keep image-card modal loading indicator compact",
+            "show the cached image-card tile while modal-quality image loads",
             "clip image card modal content to rounded panel corners",
             "preserve image card rounded corners while pressed",
             "apply image card corner clipping to the pressed state",
@@ -2389,6 +2412,7 @@ def run_self_test() -> int:
         "constexpr int IMAGE_CARD_MAX_CONTEXTS = 6;\n"
         "constexpr int IMAGE_CARD_MODAL_MAX_TARGET_SIDE_PX = 800;\n"
         "constexpr size_t IMAGE_CARD_MEMORY_HEADROOM_BYTES = 96 * 1024;\n"
+        "constexpr lv_coord_t IMAGE_CARD_MODAL_LOADING_MAX_W = 220;\n"
         "inline lv_style_selector_t image_card_pressed_selector() { return LV_STATE_PRESSED; }\n"
         "inline void image_card_apply_corner_clip(lv_obj_t *obj, lv_coord_t radius) {}\n"
         "inline bool image_card_memory_available(ImageCardCtx *ctx, const char *stage,\n"
@@ -2397,10 +2421,17 @@ def run_self_test() -> int:
         "  return external_largest > 0;\n"
         "}\n"
         "inline bool image_card_modal_refresh_supported() {\n"
-        "  return !control_modal_current_is_jc4880p443_size();\n"
+        "  return true;\n"
+        "}\n"
+        "inline bool image_card_tile_prefetches_modal_quality() {\n"
+        "  return image_card_modal_refresh_supported() &&\n"
+        "         !control_modal_current_is_jc4880p443_size();\n"
         "}\n"
         "inline void image_card_limit_target_size(lv_coord_t source_width, lv_coord_t source_height,\n"
         "                                         int *target_width, int *target_height) {}\n"
+        "inline void image_card_layout_modal_loading(ImageCardCtx *ctx) {\n"
+        "  lv_obj_align(ui.loading_widget, LV_ALIGN_TOP_RIGHT, -margin, margin);\n"
+        "}\n"
         "inline void image_card_request_source_url(ImageCardCtx *ctx) {\n"
         "  ctx->image->set_target_size(width, height);\n"
         "  image_card_tile_request_size(width, height, &request_width, &request_height);\n"
@@ -2420,8 +2451,14 @@ def run_self_test() -> int:
         "inline void image_card_request_modal_source_url(ImageCardCtx *ctx) {\n"
         "  ctx->modal_image->request_update_url(ctx->modal_url, max_source_dim);\n"
         "}\n"
+        "inline void image_card_abort_modal_open(ImageCardCtx *ctx, const char *reason) {\n"
+        "  ESP_LOGW(\"image_card\", \"modal shell setup failed\");\n"
+        "}\n"
         "inline void image_card_open_modal(ImageCardCtx *ctx) {\n"
+        "  ESP_LOGW(\"image_card\", \"modal shell setup failed\");\n"
         "  lv_obj_set_style_clip_corner(ui.panel, true, LV_PART_MAIN);\n"
+        "  image_card_show_modal_image(ctx, ctx->image);\n"
+        "  image_card_queue_modal_source_request(ctx);\n"
         "  image_card_clear_widget_source(ui.image_widget);\n"
         "  image_card_set_widget_source(ui.image_widget, ctx->modal_image);\n"
         "  if (image_card_modal_active_for(ctx)) {\n"

--- a/scripts/check_firmware_modals.py
+++ b/scripts/check_firmware_modals.py
@@ -51,8 +51,78 @@ def firmware_modal_errors(firmware_dir: Path, root: Path) -> list[str]:
     return errors
 
 
+def firmware_modal_sleep_takeover_errors(root: Path) -> list[str]:
+    firmware_dir = root / "components" / "espcontrol"
+    backlight_header_path = firmware_dir / "backlight.h"
+    modal_path = firmware_dir / "button_grid_modal.h"
+    navigation_path = firmware_dir / "button_grid_navigation.h"
+    grid_path = firmware_dir / "button_grid_grid.h"
+    backlight_path = root / "common" / "addon" / "backlight.yaml"
+    schedule_path = root / "common" / "addon" / "backlight_schedule.yaml"
+    errors: list[str] = []
+
+    if not backlight_header_path.exists():
+        errors.append("components/espcontrol/backlight.h: provide early display-takeover hook")
+    else:
+        text = backlight_header_path.read_text(encoding="utf-8")
+        if (
+            "backlight_close_modals_for_display_takeover" not in text
+            or "set_backlight_display_takeover_callback" not in text
+        ):
+            errors.append("components/espcontrol/backlight.h: expose an early display-takeover modal hook")
+
+    if not modal_path.exists():
+        errors.append("components/espcontrol/button_grid_modal.h: provide shared modal lifecycle helpers")
+    else:
+        text = modal_path.read_text(encoding="utf-8")
+        if "control_modal_force_close_active" not in text or "control_modal_close_active_internal(false)" not in text:
+            errors.append(
+                "components/espcontrol/button_grid_modal.h: provide a forced modal close path for display takeover"
+            )
+
+    if not navigation_path.exists():
+        errors.append("components/espcontrol/button_grid_navigation.h: close modals before display takeover")
+    else:
+        text = navigation_path.read_text(encoding="utf-8")
+        if (
+            "navigation_close_modals_for_display_takeover" not in text
+            or "control_modal_force_close_active();" not in text
+        ):
+            errors.append(
+                "components/espcontrol/button_grid_navigation.h: close modals through a display-takeover helper"
+            )
+
+    if not grid_path.exists():
+        errors.append("components/espcontrol/button_grid_grid.h: register the display-takeover modal hook")
+    else:
+        text = grid_path.read_text(encoding="utf-8")
+        if "set_backlight_display_takeover_callback(navigation_close_modals_for_display_takeover)" not in text:
+            errors.append("components/espcontrol/button_grid_grid.h: register the display-takeover modal hook")
+
+    if not backlight_path.exists():
+        errors.append("common/addon/backlight.yaml: keep display-off modal guards")
+    else:
+        text = backlight_path.read_text(encoding="utf-8")
+        if "Skipping automatic display-off while image modal is active" not in text:
+            errors.append("common/addon/backlight.yaml: keep automatic idle display-off blocked by image modals")
+        if "backlight_close_modals_for_display_takeover();" not in text:
+            errors.append("common/addon/backlight.yaml: close modals before manual or scheduled display-off")
+
+    if not schedule_path.exists():
+        errors.append("common/addon/backlight_schedule.yaml: close modals before scheduled takeover")
+    else:
+        text = schedule_path.read_text(encoding="utf-8")
+        if text.count("backlight_close_modals_for_display_takeover();") < 2:
+            errors.append(
+                "common/addon/backlight_schedule.yaml: close modals before scheduled sleep and clock takeover"
+            )
+
+    return errors
+
+
 def run_scan() -> int:
     errors = firmware_modal_errors(FIRMWARE_DIR, ROOT)
+    errors.extend(firmware_modal_sleep_takeover_errors(ROOT))
 
     if errors:
         print("Firmware modal allocation check failed:")
@@ -73,6 +143,21 @@ def expect_errors(name: str, files: dict[str, str], expected: tuple[str, ...]) -
             (firmware_dir / filename).write_text(text, encoding="utf-8")
 
         errors = firmware_modal_errors(firmware_dir, root)
+        for item in expected:
+            assert any(item in error for error in errors), f"{name}: missing {item!r} in {errors!r}"
+        if not expected:
+            assert not errors, f"{name}: expected no errors, got {errors!r}"
+
+
+def expect_sleep_takeover_errors(name: str, files: dict[str, str], expected: tuple[str, ...]) -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        for filename, text in files.items():
+            path = root / filename
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(text, encoding="utf-8")
+
+        errors = firmware_modal_sleep_takeover_errors(root)
         for item in expected:
             assert any(item in error for error in errors), f"{name}: missing {item!r} in {errors!r}"
         if not expected:
@@ -103,6 +188,55 @@ def run_self_test() -> int:
     expect_errors(
         "shared delete helper",
         {"button_grid_media.h": "control_modal_delete_overlay(ControlModalKind::MEDIA_VOLUME, ui.overlay);\n"},
+        (),
+    )
+    expect_sleep_takeover_errors(
+        "missing display takeover close",
+        {
+            "components/espcontrol/backlight.h": "inline void backlight_close_modals_for_display_takeover() {}\n",
+            "components/espcontrol/button_grid_modal.h": "inline void control_modal_close_active() {}\n",
+            "components/espcontrol/button_grid_navigation.h": "inline void navigation_hide_modals() {}\n",
+            "components/espcontrol/button_grid_grid.h": "inline void grid_phase1() {}\n",
+            "common/addon/backlight.yaml": "Skipping automatic display-off while image modal is active\n",
+            "common/addon/backlight_schedule.yaml": "script:\n",
+        },
+        (
+            "expose an early display-takeover modal hook",
+            "provide a forced modal close path for display takeover",
+            "close modals through a display-takeover helper",
+            "register the display-takeover modal hook",
+            "close modals before manual or scheduled display-off",
+            "close modals before scheduled sleep and clock takeover",
+        ),
+    )
+    expect_sleep_takeover_errors(
+        "display takeover close",
+        {
+            "components/espcontrol/backlight.h": (
+                "inline void set_backlight_display_takeover_callback(BacklightDisplayTakeoverCallback callback) {}\n"
+                "inline void backlight_close_modals_for_display_takeover() {}\n"
+            ),
+            "components/espcontrol/button_grid_modal.h": (
+                "inline void control_modal_close_active_internal(bool honor_close_guard) {}\n"
+                "inline void control_modal_force_close_active() { control_modal_close_active_internal(false); }\n"
+            ),
+            "components/espcontrol/button_grid_navigation.h": (
+                "inline void navigation_close_modals_for_display_takeover() {\n"
+                "  control_modal_force_close_active();\n"
+                "}\n"
+            ),
+            "components/espcontrol/button_grid_grid.h": (
+                "set_backlight_display_takeover_callback(navigation_close_modals_for_display_takeover);\n"
+            ),
+            "common/addon/backlight.yaml": (
+                "Skipping automatic display-off while image modal is active\n"
+                "backlight_close_modals_for_display_takeover();\n"
+            ),
+            "common/addon/backlight_schedule.yaml": (
+                "backlight_close_modals_for_display_takeover();\n"
+                "backlight_close_modals_for_display_takeover();\n"
+            ),
+        },
         (),
     )
     print("Firmware modal allocation self-tests passed.")


### PR DESCRIPTION
## Summary
- Hardened camera modal opening/loading so the existing camera image stays visible while the higher-quality modal image refreshes.
- Scheduled/manual screen-off paths now close any open modal first, then turn the screen off.
- Modal setup now fails cleanly if UI object creation fails, leaving the camera card intact.
- Updated firmware guard checks for modal/sleep behavior and 4.3-inch P4 image refresh behavior.

## Verification
- `npm run check:firmware-modals`
- `npm run check:firmware-ha-bindings`
- `npm run check:firmware-card-runtime`
- `npm run check:config`
- ESPHome compile: `guition-esp32-p4-jc1060p470.factory.yaml`
- ESPHome compile: `guition-esp32-p4-jc4880p443.factory.yaml`
- ESPHome compile: `guition-esp32-s3-4848s040.factory.yaml`

## Device Testing Required Before Merge
This PR should stay draft until it is tested on device.

Device checks:
- Camera opens when display is awake.
- First tap wakes if display is already asleep.
- Scheduled/manual sleep closes the modal, then blanks the screen.
- Next tap wakes cleanly.
- Slow/dark camera feed still shows visible modal controls/loading.

No issues are closed by this PR.