### PR TITLE
Remove firmware compile PR gate

### DIFF
--- a/.github/workflows/firmware-compile.yml
+++ b/.github/workflows/firmware-compile.yml
@@ -2,7 +2,6 @@ name: Firmware Compile
 
 on:
   workflow_dispatch:
-  pull_request:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
## What changed

- Removed the automatic pull request trigger from the `Firmware Compile` workflow.
- Left the manual `workflow_dispatch` trigger in place so firmware compilation can still be run from GitHub when needed.
- Updated the `main` branch ruleset separately so only `CI Gate` is required for merging.

## Practical impact

Pull requests should no longer be blocked by the firmware compile gate. Normal CI remains required, and firmware release/nightly workflows are not changed by this PR.

## Checks

- Confirmed `.github/workflows/firmware-compile.yml` still parses as valid YAML.
- Confirmed the GitHub ruleset for `main` now requires only `CI Gate`.

## Testing notes

Open any PR targeting `main` and confirm GitHub no longer requires `Firmware Compile Gate` before merge. Use the manual `Firmware Compile` workflow only when you specifically want a firmware compile check.
