### PR TITLE
[codex] Fix HA state callback crash

### DIFF
--- a/common/device/core_infra.yaml
+++ b/common/device/core_infra.yaml
@@ -41,12 +41,14 @@ api:
             apply_registered_ha_control_availability(true);
             ha_retry_unavailable_states(true);
             refresh_weather_forecast_cards();
+            ha_flush_deferred_state_requests();
           }
         }
     - delay: 2s
     - lambda: |-
         if (ha_api_connected()) refresh_image_cards();
         if (ha_api_state_connected()) {
+          ha_flush_deferred_state_requests();
           ha_retry_unavailable_states(true);
         }
         todo_reload_active_modal();
@@ -56,6 +58,7 @@ api:
         if (ha_api_state_connected()) {
           ha_retry_unavailable_states(true);
           refresh_weather_forecast_cards();
+          ha_flush_deferred_state_requests();
         }
         todo_reload_active_modal();
     - delay: 20s
@@ -64,6 +67,7 @@ api:
         if (ha_api_state_connected()) {
           ha_retry_unavailable_states(true);
           refresh_weather_forecast_cards();
+          ha_flush_deferred_state_requests();
         }
         todo_reload_active_modal();
   on_client_disconnected:
@@ -84,6 +88,7 @@ interval:
       - lambda: |-
           weather_forecast_cancel_stale_requests();
           weather_forecast_send_next_queued();
+          ha_flush_deferred_state_requests();
           ha_retry_unavailable_states();
           todo_retry_waiting_modal();
 

--- a/components/espcontrol/button_grid_config.h
+++ b/components/espcontrol/button_grid_config.h
@@ -1273,6 +1273,9 @@ inline void reset_ha_control_availability_refs() {
 #ifndef ESPCONTROL_HA_RETRY_HELPERS_DEFINED
 inline void ha_reset_unavailable_state_retries() {}
 #endif
+#ifndef ESPCONTROL_HA_DEFERRED_HELPERS_DEFINED
+inline void ha_reset_deferred_state_requests() {}
+#endif
 
 inline uint32_t &ha_subscription_generation() {
   static uint32_t generation = 1;
@@ -1284,6 +1287,7 @@ inline void bump_ha_subscription_generation() {
   generation++;
   if (generation == 0) generation = 1;
   ha_reset_unavailable_state_retries();
+  ha_reset_deferred_state_requests();
 }
 
 inline void register_ha_control_availability(lv_obj_t *visual_obj, lv_obj_t *input_obj,

--- a/components/espcontrol/button_grid_ha.h
+++ b/components/espcontrol/button_grid_ha.h
@@ -69,15 +69,47 @@ struct HaUnavailableStateRetryRef {
   bool unavailable = false;
 };
 
+struct HaDeferredStateRequest {
+  std::string entity_id;
+  std::string attribute;
+  std::shared_ptr<HomeAssistantStateCallback> callback;
+  uint32_t generation = 0;
+  bool has_attribute = false;
+};
+
 inline std::vector<HaUnavailableStateRetryRef> &ha_unavailable_state_retry_refs() {
   static std::vector<HaUnavailableStateRetryRef> refs;
   return refs;
 }
 
+inline std::vector<HaDeferredStateRequest> &ha_deferred_state_requests() {
+  static std::vector<HaDeferredStateRequest> requests;
+  return requests;
+}
+
+inline uint8_t &ha_state_callback_depth() {
+  static uint8_t depth = 0;
+  return depth;
+}
+
 inline void ha_reset_unavailable_state_retries() {
   ha_unavailable_state_retry_refs().clear();
 }
+
+inline void ha_reset_deferred_state_requests() {
+  ha_deferred_state_requests().clear();
+}
 #define ESPCONTROL_HA_RETRY_HELPERS_DEFINED 1
+#define ESPCONTROL_HA_DEFERRED_HELPERS_DEFINED 1
+
+inline void ha_invoke_state_callback(const std::shared_ptr<HomeAssistantStateCallback> &callback,
+                                     esphome::StringRef state) {
+  if (!callback || !*callback) return;
+  uint8_t &depth = ha_state_callback_depth();
+  depth++;
+  (*callback)(state);
+  depth--;
+}
 
 inline void ha_note_state_retry_result(const std::string &entity_id,
                                        esphome::StringRef state,
@@ -124,8 +156,66 @@ inline void ha_retry_unavailable_states(bool force = false) {
       entity_id, {},
       [entity_id, generation, callback](esphome::StringRef state) {
         ha_note_state_retry_result(entity_id, state, generation);
-        if (callback && *callback) (*callback)(state);
+        ha_invoke_state_callback(callback, state);
       });
+  }
+}
+
+inline bool ha_queue_deferred_state_request(const std::string &entity_id,
+                                            const std::string &attribute,
+                                            std::shared_ptr<HomeAssistantStateCallback> callback,
+                                            bool has_attribute) {
+  constexpr size_t HA_DEFERRED_STATE_REQUEST_MAX = 64;
+  if (!callback || !*callback) return false;
+  std::vector<HaDeferredStateRequest> &requests = ha_deferred_state_requests();
+  if (requests.size() >= HA_DEFERRED_STATE_REQUEST_MAX) {
+    ESP_LOGW("ha", "Dropping deferred Home Assistant state request for %s: queue full",
+             entity_id.c_str());
+    return false;
+  }
+  requests.push_back({
+    entity_id,
+    attribute,
+    std::move(callback),
+    ha_subscription_generation(),
+    has_attribute,
+  });
+  return true;
+}
+
+inline void ha_flush_deferred_state_requests(size_t max_requests = 8) {
+  if (ha_state_callback_depth() != 0 || !ha_api_state_connected()) return;
+  std::vector<HaDeferredStateRequest> &requests = ha_deferred_state_requests();
+  size_t processed = 0;
+  while (!requests.empty() && processed < max_requests) {
+    HaDeferredStateRequest request = std::move(requests.front());
+    requests.erase(requests.begin());
+    if (!request.callback || !*request.callback) continue;
+    if (request.generation != ha_subscription_generation()) continue;
+    if (!ha_internal_heap_available("deferred Home Assistant state request",
+                                    HA_READ_INTERNAL_FREE_MIN_BYTES,
+                                    HA_READ_INTERNAL_LARGEST_MIN_BYTES)) {
+      requests.insert(requests.begin(), std::move(request));
+      return;
+    }
+
+    auto callback = request.callback;
+    if (request.has_attribute) {
+      esphome::api::global_api_server->get_home_assistant_state(
+        std::move(request.entity_id),
+        std::move(request.attribute),
+        [callback](esphome::StringRef state) {
+          ha_invoke_state_callback(callback, state);
+        });
+    } else {
+      esphome::api::global_api_server->get_home_assistant_state(
+        std::move(request.entity_id),
+        {},
+        [callback](esphome::StringRef state) {
+          ha_invoke_state_callback(callback, state);
+        });
+    }
+    processed++;
   }
 }
 
@@ -216,7 +306,7 @@ inline bool ha_subscribe_state(const std::string &entity_id,
     entity_id, {},
     [entity_id, callback_ref, generation](esphome::StringRef state) {
       ha_note_state_retry_result(entity_id, state, generation);
-      if (callback_ref && *callback_ref) (*callback_ref)(state);
+      ha_invoke_state_callback(callback_ref, state);
     });
   return true;
 }
@@ -228,10 +318,13 @@ inline bool ha_get_state(const std::string &entity_id,
                                   HA_READ_INTERNAL_FREE_MIN_BYTES,
                                   HA_READ_INTERNAL_LARGEST_MIN_BYTES)) return false;
   auto callback_ref = std::make_shared<HomeAssistantStateCallback>(std::move(callback));
+  if (ha_state_callback_depth() != 0) {
+    return ha_queue_deferred_state_request(entity_id, std::string(), callback_ref, false);
+  }
   esphome::api::global_api_server->get_home_assistant_state(
     entity_id, {},
     [callback_ref](esphome::StringRef state) {
-      if (callback_ref && *callback_ref) (*callback_ref)(state);
+      ha_invoke_state_callback(callback_ref, state);
     });
   return true;
 }
@@ -244,7 +337,7 @@ inline bool ha_subscribe_attribute(const std::string &entity_id,
   esphome::api::global_api_server->subscribe_home_assistant_state(
     entity_id, attribute,
     [callback_ref](esphome::StringRef state) {
-      if (callback_ref && *callback_ref) (*callback_ref)(state);
+      ha_invoke_state_callback(callback_ref, state);
     });
   return true;
 }
@@ -257,10 +350,13 @@ inline bool ha_get_attribute(const std::string &entity_id,
                                   HA_READ_INTERNAL_FREE_MIN_BYTES,
                                   HA_READ_INTERNAL_LARGEST_MIN_BYTES)) return false;
   auto callback_ref = std::make_shared<HomeAssistantStateCallback>(std::move(callback));
+  if (ha_state_callback_depth() != 0) {
+    return ha_queue_deferred_state_request(entity_id, attribute, callback_ref, true);
+  }
   esphome::api::global_api_server->get_home_assistant_state(
     entity_id, attribute,
     [callback_ref](esphome::StringRef state) {
-      if (callback_ref && *callback_ref) (*callback_ref)(state);
+      ha_invoke_state_callback(callback_ref, state);
     });
   return true;
 }


### PR DESCRIPTION
## Purpose
Fix a crash risk when Home Assistant state callbacks request more Home Assistant state while another callback is still running.

## Practical impact
The firmware now defers nested Home Assistant state reads instead of making them immediately from inside an active callback. Deferred requests are flushed after API connection/retry events and on the regular Home Assistant retry interval. This should make display state refreshes more stable after reconnects and when entities update in quick succession.

## What changed
- Track active Home Assistant state callback depth.
- Queue nested state and attribute reads, with a bounded queue to avoid runaway memory use.
- Clear queued reads when Home Assistant subscription generation changes.
- Flush deferred reads during existing reconnect and retry paths.

## Checks
- Compared the branch against current `origin/main`.
- Confirmed the branch is already pushed as `origin/codex/fix-ha-state-callback-crash`.
- Firmware compile and device flashing have not been run yet for this PR.

## Testing notes
Please test on a display that previously hit the Home Assistant state callback crash. After flashing this branch, reconnect Home Assistant/API and exercise pages or buttons that request entity states or attributes, especially after Home Assistant restarts or network reconnects.