### PR TITLE
[codex] Increase P4-86 flash size

### DIFF
--- a/devices/esp32-p4-86/device/device.yaml
+++ b/devices/esp32-p4-86/device/device.yaml
@@ -16,9 +16,8 @@ substitutions:
 # ---------------------------------------------------------------------------
 esp32:
   variant: esp32p4
-  # Keep OTA app slots inside the first 16MB. Some existing ESP32-P4 86
-  # bootloaders cannot boot OTA images that cross the 16MB flash boundary.
-  flash_size: 16MB
+  # Waveshare documents this panel with 32MB external NOR flash.
+  flash_size: 32MB
   cpu_frequency: 360MHZ
   engineering_sample: true
   framework:


### PR DESCRIPTION
## Summary
- Updates the Waveshare ESP32-P4 86 Panel firmware config to use the documented 32MB flash size.
- Removes the old 16MB cap comment so the device definition matches the hardware.

## Practical impact
This gives the ESP32-P4 86 Panel build the full flash size declared by Waveshare, which should help avoid free-space pressure on this device.

## Affected device
- ESP32-P4 86 Panel / Waveshare ESP32-P4-WIFI6-Touch-LCD-4B

## Validation
- `npm run check:device-profiles`
- `npm run check:device-matrix`
- `npm run check:firmware-parser`
- `npm run check:firmware-ha-bindings`
- `esphome -s espcontrol_component_url file:///Users/jtenniswood/Git/espcontrol -s espcontrol_component_ref HEAD compile dev.yaml` from `devices/esp32-p4-86/`

The compile reported `HARDWARE: ESP32P4 360MHz, 500KB RAM, 32MB Flash` and completed successfully.

## Device testing needed
- Flash this branch to an ESP32-P4 86 Panel.
- Confirm the panel boots normally.
- Confirm OTA/update still works from the device UI or Home Assistant.

Refs #409