### PR TITLE
Restore cover art progress bar

### DIFF
--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -90,6 +90,9 @@ globals:
   - id: cover_art_last_position_timestamp
     type: int
     initial_value: '0'
+  - id: cover_art_last_progress_percent
+    type: int
+    initial_value: '-1'
   - id: cover_art_accent_r
     type: int
     initial_value: '0'
@@ -284,6 +287,22 @@ lvgl:
                       text_color: ${cover_art_text_color}
                       text_opa: 80%
                       text_align: left
+            - bar:
+                id: cover_art_progress_bar
+                align: bottom_mid
+                y: 0
+                width: ${cover_art_progress_width}px
+                height: ${cover_art_progress_height}px
+                bg_color: 0x000000
+                bg_opa: 50%
+                radius: 0
+                min_value: 0
+                max_value: 100
+                value: 0
+                hidden: true
+                indicator:
+                  bg_color: ${cover_art_text_color}
+                  radius: 0
       - obj:
           id: cover_art_wake_touch_guard
           x: 0
@@ -354,6 +373,8 @@ script:
             lv_obj_set_size(id(cover_art_screensaver), width, height);
             lv_obj_set_pos(id(cover_art_wake_touch_guard), 0, 0);
             lv_obj_set_size(id(cover_art_wake_touch_guard), width, height);
+            lv_obj_set_size(id(cover_art_progress_bar), width, ${cover_art_progress_height});
+            lv_obj_align(id(cover_art_progress_bar), LV_ALIGN_BOTTOM_MID, 0, 0);
           };
 
           auto apply_split_layout = [](int screen_w, int screen_h,
@@ -365,6 +386,8 @@ script:
             lv_obj_set_size(id(cover_art_screensaver), screen_w, screen_h);
             lv_obj_set_pos(id(cover_art_wake_touch_guard), 0, 0);
             lv_obj_set_size(id(cover_art_wake_touch_guard), screen_w, screen_h);
+            lv_obj_set_size(id(cover_art_progress_bar), screen_w, ${cover_art_progress_height});
+            lv_obj_align(id(cover_art_progress_bar), LV_ALIGN_BOTTOM_MID, 0, 0);
             lv_obj_set_pos(id(cover_art_backdrop), art_x, art_y);
             lv_obj_set_size(id(cover_art_backdrop), art_size, art_size);
             lv_obj_set_pos(id(cover_art_image_widget), art_x, art_y);
@@ -590,9 +613,11 @@ script:
           then:
             - lvgl.widget.show: cover_art_accent_overlay
             - lvgl.widget.show: cover_art_track_panel
+            - lvgl.widget.show: cover_art_progress_bar
           else:
             - lvgl.widget.hide: cover_art_accent_overlay
             - lvgl.widget.hide: cover_art_track_panel
+            - lvgl.widget.hide: cover_art_progress_bar
       - script.execute: cover_art_refresh_progress
 
   - id: cover_art_download_failed
@@ -685,6 +710,8 @@ script:
           id(cover_art_media_duration) = 0.0f;
           id(cover_art_position_anchor_epoch) = 0;
           id(cover_art_last_position_timestamp) = 0;
+          id(cover_art_last_progress_percent) = -1;
+          lv_bar_set_value(id(cover_art_progress_bar), 0, LV_ANIM_OFF);
           lv_label_set_text(id(cover_art_time_label), "0:00  /  0:00");
       - artwork_image.release: cover_art_downloaded_image
       - script.execute: hide_cover_art_view
@@ -957,6 +984,17 @@ script:
           }
           lv_label_set_text(id(cover_art_time_label), label);
 
+          int value = 0;
+          if (duration > 0.0f) {
+            value = (int)((position / duration) * 100.0f + 0.5f);
+          }
+          if (value < 0) value = 0;
+          if (value > 100) value = 100;
+          if (value != id(cover_art_last_progress_percent)) {
+            id(cover_art_last_progress_percent) = value;
+            lv_bar_set_value(id(cover_art_progress_bar), value, LV_ANIM_OFF);
+          }
+
   - id: cover_art_show_track_overlay
     mode: restart
     then:
@@ -965,6 +1003,8 @@ script:
             lambda: 'return id(cover_art_screensaver_active) && id(cover_art_media_playing);'
           then:
             - script.execute: cover_art_sync_track_text
+            - lvgl.widget.show: cover_art_progress_bar
+            - script.execute: cover_art_refresh_progress
             - if:
                 condition:
                   lambda: |-
@@ -979,7 +1019,6 @@ script:
                       lv_obj_set_style_text_line_space(id(cover_art_title_label), ${cover_art_title_line_space}, 0);
                   - lvgl.widget.show: cover_art_accent_overlay
                   - lvgl.widget.show: cover_art_track_panel
-                  - script.execute: cover_art_refresh_progress
                   - if:
                       condition:
                         lambda: 'return ${cover_art_square_overlay} && id(cover_art_track_overlay_duration).state > 0;'
@@ -1069,6 +1108,7 @@ script:
       - lvgl.widget.hide: cover_art_screensaver
       - lvgl.widget.hide: cover_art_accent_overlay
       - lvgl.widget.hide: cover_art_track_panel
+      - lvgl.widget.hide: cover_art_progress_bar
       - if:
           condition:
             lambda: 'return std::string("${device_slug}") == "guition-esp32-s3-4848s040";'
@@ -1347,6 +1387,7 @@ script:
                 id(cover_art_position_anchor) = id(cover_art_media_position);
                 id(cover_art_position_anchor_epoch) = 0;
                 id(cover_art_last_position_timestamp) = now.is_valid() ? now.timestamp : 0;
+                id(cover_art_last_progress_percent) = -1;
                 if (id(cover_art_screensaver_active)) id(cover_art_refresh_progress).execute();
                 id(cover_art_delay_timer).stop();
                 id(cover_art_show_track_overlay).stop();
@@ -1533,6 +1574,7 @@ script:
               float next_duration = value.empty() ? 0.0f : strtof(value.c_str(), nullptr);
               if (std::fabs(next_duration - id(cover_art_media_duration)) < 0.05f) return;
               id(cover_art_media_duration) = next_duration;
+              id(cover_art_last_progress_percent) = -1;
               if (id(cover_art_screensaver_active)) id(cover_art_refresh_progress).execute();
             };
           if (!already_subscribed) ha_subscribe_attribute(cover_entity, std::string("media_duration"), handle_media_duration);
@@ -1554,6 +1596,7 @@ script:
               } else {
                 id(cover_art_last_position_timestamp) = now.is_valid() ? now.timestamp : 0;
               }
+              id(cover_art_last_progress_percent) = -1;
               if (id(cover_art_screensaver_active) && !id(cover_art_media_playing)) {
                 id(cover_art_refresh_progress).execute();
               }
@@ -1581,6 +1624,7 @@ script:
               long days = 365L * y + y / 4 - y / 100 + y / 400 + (153 * (m - 3) + 2) / 5 + dy - 719469;
               id(cover_art_position_anchor_epoch) = (int)(days * 86400L + hr * 3600 + mn * 60 + sc);
               id(cover_art_last_position_timestamp) = id(cover_art_position_anchor_epoch);
+              id(cover_art_last_progress_percent) = -1;
               if (id(cover_art_screensaver_active) && !id(cover_art_media_playing)) {
                 id(cover_art_refresh_progress).execute();
               }
@@ -1616,5 +1660,7 @@ script:
           id(cover_art_media_duration) = 0.0f;
           id(cover_art_position_anchor_epoch) = 0;
           id(cover_art_last_position_timestamp) = 0;
+          id(cover_art_last_progress_percent) = -1;
+          lv_bar_set_value(id(cover_art_progress_bar), 0, LV_ANIM_OFF);
           lv_label_set_text(id(cover_art_time_label), "0:00  /  0:00");
       - script.execute: hide_cover_art_view


### PR DESCRIPTION
## Purpose

Restore the playback progress indicator along the bottom of the media cover-art screensaver.

## Practical impact

The cover-art screen now always shows the bottom progress bar while media is playing. There is no Home Assistant/user-facing setting for it; it is simply part of the cover-art screen again. The bar uses the existing media duration/position tracking and resizes to the active cover-art screen width, including rotated layouts.

## Root cause

The previous cleanup removed the progress bar widget itself, not just the old optional setting. The timing label remained, but the visual bottom bar was no longer present.

## Checks

- `npm run check:config`
- `npm run check:firmware-parser`
- `npm run check:firmware-display-tokens`

## Testing notes

Flash a display that uses the media cover-art screensaver, start playback on the configured media player, and let the cover-art screen appear. The expected result is a thin progress bar along the bottom edge that advances as the track plays. This affects the shared cover-art screen used by the supported displays.
