### PR TITLE
Add screen firmware update action

### DIFF
--- a/common/addon/firmware_update.yaml
+++ b/common/addon/firmware_update.yaml
@@ -20,6 +20,12 @@ esphome:
         - text_sensor.template.publish:
             id: firmware_version_sensor
             state: "${firmware_version}"
+    - priority: 190
+      then:
+        - lambda: |-
+            network_status_set_update_callback([]() {
+              id(firmware_update_from_screen).execute();
+            });
     - priority: -50
       then:
         - if:
@@ -144,6 +150,27 @@ script:
       - delay: 8s
       - script.execute: navigate_after_api
 
+  - id: firmware_update_from_screen
+    mode: single
+    then:
+      - lambda: 'id(manual_check_only) = true;'
+      - component.update: firmware_update
+      - wait_until:
+          condition:
+            update.is_available: firmware_update
+          timeout: 30s
+      - if:
+          condition:
+            update.is_available: firmware_update
+          then:
+            - script.execute: show_update_starting
+            - script.wait: show_update_starting
+            - script.execute: show_update_writing
+            - script.wait: show_update_writing
+            - update.perform: firmware_update
+      - delay: 15s
+      - lambda: 'id(manual_check_only) = false;'
+
 update:
   - platform: http_request
     id: firmware_update
@@ -231,20 +258,4 @@ button:
     web_server:
       sorting_group_id: sg_firmware
     on_press:
-      - lambda: 'id(manual_check_only) = true;'
-      - component.update: firmware_update
-      - wait_until:
-          condition:
-            update.is_available: firmware_update
-          timeout: 30s
-      - if:
-          condition:
-            update.is_available: firmware_update
-          then:
-            - script.execute: show_update_starting
-            - script.wait: show_update_starting
-            - script.execute: show_update_writing
-            - script.wait: show_update_writing
-            - update.perform: firmware_update
-      - delay: 15s
-      - lambda: 'id(manual_check_only) = false;'
+      - script.execute: firmware_update_from_screen

--- a/components/espcontrol/network_status.h
+++ b/components/espcontrol/network_status.h
@@ -17,6 +17,9 @@ constexpr const char *NETWORK_ICON_WIFI_3 = "\U000F0925";
 constexpr const char *NETWORK_ICON_WIFI_4 = "\U000F0928";
 constexpr const char *NETWORK_ICON_WIFI_OFF_OUTLINE = "\U000F092E";
 constexpr const char *NETWORK_ICON_ETHERNET = "\U000F0200";
+constexpr const char *NETWORK_ICON_UPDATE = "\U000F06B0";
+
+using NetworkStatusUpdateCallback = void (*)();
 
 struct NetworkStatusModalUi {
   lv_obj_t *overlay = nullptr;
@@ -26,11 +29,22 @@ struct NetworkStatusModalUi {
   lv_obj_t *device_name_lbl = nullptr;
   lv_obj_t *ip_lbl = nullptr;
   lv_obj_t *firmware_lbl = nullptr;
+  lv_obj_t *update_btn = nullptr;
+  NetworkStatusUpdateCallback update_callback = nullptr;
 };
 
 inline NetworkStatusModalUi &network_status_modal_ui() {
   static NetworkStatusModalUi ui;
   return ui;
+}
+
+inline NetworkStatusUpdateCallback &network_status_update_callback_ref() {
+  static NetworkStatusUpdateCallback callback = nullptr;
+  return callback;
+}
+
+inline void network_status_set_update_callback(NetworkStatusUpdateCallback callback) {
+  network_status_update_callback_ref() = callback;
 }
 
 inline const char *network_status_wifi_icon(float pct) {
@@ -110,6 +124,8 @@ inline void network_status_hide_modal() {
   ui.device_name_lbl = nullptr;
   ui.ip_lbl = nullptr;
   ui.firmware_lbl = nullptr;
+  ui.update_btn = nullptr;
+  ui.update_callback = nullptr;
   control_modal_clear_active(ControlModalKind::NETWORK_STATUS);
 }
 
@@ -175,6 +191,22 @@ inline void network_status_open_modal(const std::string &device_name,
     text_font,
     content_w,
     DARK_TEXT_MUTED);
+
+  ui.update_callback = network_status_update_callback_ref();
+  if (ui.update_callback) {
+    lv_coord_t update_size = control_modal_scaled_px(54, layout.short_side);
+    if (update_size < 40) update_size = 40;
+    if (update_size > 64) update_size = 64;
+    ui.update_btn = control_modal_create_round_button(
+      ui.content, update_size, NETWORK_ICON_UPDATE, icon_font,
+      DEFAULT_SLIDER_COLOR, DARK_BACKGROUND_SECONDARY);
+    if (ui.update_btn) {
+      lv_obj_add_event_cb(ui.update_btn, [](lv_event_t *) {
+        NetworkStatusModalUi &ui = network_status_modal_ui();
+        if (ui.update_callback) ui.update_callback();
+      }, LV_EVENT_CLICKED, nullptr);
+    }
+  }
   lv_obj_update_layout(ui.content);
   lv_obj_align(ui.content, LV_ALIGN_CENTER, 0, 0);
 


### PR DESCRIPTION
Relates to #370.

## What changed
- Adds an update icon button to the on-screen network/device info popup when firmware updates are enabled.
- Pressing the button checks the release manifest and installs the latest available firmware using the existing update screens.
- Reuses the same install script for the web/Home Assistant firmware install button and the on-screen button, so both paths behave the same.
- Keeps manual checks from triggering surprise background updates, and leaves builds without firmware updates unchanged.

## Checks run
- `python3 scripts/build.py --check`
- `python3 scripts/check_firmware_modals.py`
- `python3 scripts/check_firmware_ha_bindings.py`
- `esphome -s espcontrol_component_url file:///Users/jtenniswood/Git/espcontrol-firmware-update-from-screen -s espcontrol_component_ref HEAD compile builds/guition-esp32-p4-jc1060p470.yaml`

## Device testing notes
- Flash this branch to a supported display. Compile testing was done against the Guition ESP32-P4 JC1060P470 / EspControl 7inch build.
- Tap the network icon in the top bar to open the device info popup.
- Confirm the update icon appears in the popup.
- Tap the update icon. If a newer release is available, the display should show the existing firmware update flow and restart. If it is already current, it should stay on the current firmware.