### PR TITLE
Fix screensaver clock bar jump

### DIFF
--- a/components/espcontrol/clock_bar.h
+++ b/components/espcontrol/clock_bar.h
@@ -275,15 +275,17 @@ inline ClockBarVisibility clock_bar_resolve_visibility(
     bool display_off_screensaver_active,
     bool dimmed_screensaver_active) {
   ClockBarVisibility result;
-  result.reserve_space = enabled &&
+  // Full-screen screensavers hide the clock bar, but the grid should keep the
+  // same top padding so waking does not briefly resize the cards.
+  result.reserve_space = enabled && !screen_schedule_asleep;
+  result.visible = result.reserve_space &&
       !clock_bar_blocked_by_overlay(
           display_asleep,
           screen_schedule_asleep,
           clock_screensaver_active,
           cover_art_screensaver_active,
           display_off_screensaver_active,
-          dimmed_screensaver_active);
-  result.visible = result.reserve_space &&
+          dimmed_screensaver_active) &&
       clock_bar_active_on_button_grid_page(main_page_obj);
   return result;
 }

--- a/scripts/check_firmware_parser.py
+++ b/scripts/check_firmware_parser.py
@@ -56,6 +56,7 @@ using lv_style_selector_t = int;
 using lv_color_t = int;
 using lv_grid_align_t = int;
 static int lv_obj_move_background_calls = 0;
+static lv_obj_t *lv_active_screen = nullptr;
 inline const char *espcontrol_i18n(const char *text) { return text ? text : ""; }
 inline std::string espcontrol_i18n(const std::string &text) { return text; }
 constexpr int LV_PART_MAIN = 0;
@@ -80,7 +81,7 @@ constexpr int LV_OBJ_FLAG_HIDDEN = 2;
 constexpr int LV_GRAD_DIR_HOR = 1;
 inline int lv_color_hex(uint32_t value) { return static_cast<int>(value); }
 inline int lv_pct(int value) { return value; }
-inline lv_obj_t *lv_scr_act() { return nullptr; }
+inline lv_obj_t *lv_scr_act() { return lv_active_screen; }
 inline void lv_obj_set_style_transform_scale_x(lv_obj_t *, int, int) {}
 inline void lv_obj_set_style_transform_scale_y(lv_obj_t *, int, int) {}
 inline void lv_obj_set_style_bg_color(lv_obj_t *, int, lv_style_selector_t) {}
@@ -155,6 +156,28 @@ int main() {
   assert(clock_bar_grid_track_span_size(1024, 5, 5, 10, 5, 0, 2) == 400);
   assert(clock_bar_grid_track_span_size(1024, 5, 5, 10, 5, 3, 2) == 399);
   assert(clock_bar_grid_track_span_size(600, 42, 5, 10, 3, 0, 2) == 366);
+
+  lv_obj_t main_page;
+  lv_active_screen = &main_page;
+  auto awake_clock_bar = clock_bar_resolve_visibility(
+    true, &main_page, false, false, false, false, false, false);
+  assert(awake_clock_bar.reserve_space);
+  assert(awake_clock_bar.visible);
+
+  auto clock_screensaver_clock_bar = clock_bar_resolve_visibility(
+    true, &main_page, false, false, true, false, false, false);
+  assert(clock_screensaver_clock_bar.reserve_space);
+  assert(!clock_screensaver_clock_bar.visible);
+
+  auto dismissing_screensaver_clock_bar = clock_bar_resolve_visibility(
+    true, &main_page, true, false, false, false, false, false);
+  assert(dismissing_screensaver_clock_bar.reserve_space);
+  assert(!dismissing_screensaver_clock_bar.visible);
+
+  auto screen_schedule_clock_bar = clock_bar_resolve_visibility(
+    true, &main_page, true, true, true, false, false, false);
+  assert(!screen_schedule_clock_bar.reserve_space);
+  assert(!screen_schedule_clock_bar.visible);
 
   auto fallback_clock_bar = parse_clock_bar_layout("bad|unknown:time");
   assert(fallback_clock_bar.section[CLOCK_BAR_ITEM_TEMPERATURE] == CLOCK_BAR_SECTION_LEFT);


### PR DESCRIPTION
## Purpose
Addresses #407 by stopping the button grid from briefly switching to the compact no-clock-bar layout while a screensaver is being dismissed.

## Practical impact
When the clock bar is enabled, the grid keeps the same reserved top space during screensaver wake-up. Full-screen screensavers still hide the clock bar widgets themselves, so the clock/network/status items do not appear over the screensaver overlay.

## Root cause
The shared clock-bar helper used one decision for both layout spacing and widget visibility. During wake-up, screensaver/display-asleep state could hide the clock bar and remove the reserved top padding, then add it back moments later. That caused the visible grid jump.

## Checks
- `python3 scripts/check_firmware_parser.py`
- `python3 scripts/check_firmware_ha_bindings.py`
- `npm run check:fast`

## Device testing
Flash a display with this branch, enable the clock bar, let the screensaver activate, then wake it. The grid should return without the cards resizing or jumping when the clock bar comes back.
