### PR TITLE
Fix clock bar rotation layout

### DIFF
--- a/common/config/display.yaml
+++ b/common/config/display.yaml
@@ -77,15 +77,19 @@ script:
           bool visible = visibility.visible;
           bool show_time = visible;
           bool show_network = visible;
+          int clock_bar_screen_width = clock_bar_current_screen_width(${screen_width});
+          int clock_bar_screen_height = clock_bar_current_screen_height(${screen_height});
+          bool clock_bar_480_square =
+              clock_bar_screen_width == 480 && clock_bar_screen_height == 480;
+          bool clock_bar_device_480_square =
+              ${screen_width} == 480 && ${screen_height} == 480;
           int clock_bar_label_y = ${main_page_pad_top} / 5;
           int clock_bar_icon_y =
-              (${screen_width} == 1024 ||
-               (${screen_width} == 480 && ${screen_height} == 480)) ? 1 : clock_bar_label_y;
+              (${screen_width} == 1024 || clock_bar_device_480_square) ? 1 : clock_bar_label_y;
           int clock_bar_item_width = ${clock_bar_item_gap};
           int clock_bar_visual_gap = ${clock_bar_visual_gap};
           int clock_bar_right_x =
-              (${screen_width} == 480 && ${screen_height} == 480) ? 8 :
-              (${screen_width} >= 700 ? 20 : 16);
+              clock_bar_480_square ? 8 : (clock_bar_screen_width >= 700 ? 20 : 16);
           lv_obj_t *temperature_labels[] = {
             id(temperatures),
             id(temperature_2),
@@ -116,8 +120,8 @@ script:
                                  show_network,
                                  visible && id(indoor_temp_enable).state,
                                  visible && id(outdoor_temp_enable).state,
-                                 ${screen_width},
-                                 ${screen_width} >= 700 ? 12 : 8,
+                                 clock_bar_screen_width,
+                                 clock_bar_screen_width >= 700 ? 12 : 8,
                                  clock_bar_label_y,
                                  clock_bar_right_x,
                                  clock_bar_icon_y,

--- a/components/espcontrol/clock_bar.h
+++ b/components/espcontrol/clock_bar.h
@@ -652,6 +652,18 @@ inline int clock_bar_visual_gap_px(int gap) {
   return gap;
 }
 
+inline lv_coord_t clock_bar_current_screen_width(lv_coord_t fallback) {
+  lv_disp_t *disp = lv_disp_get_default();
+  lv_coord_t width = disp ? lv_disp_get_hor_res(disp) : 0;
+  return width > 0 ? width : fallback;
+}
+
+inline lv_coord_t clock_bar_current_screen_height(lv_coord_t fallback) {
+  lv_disp_t *disp = lv_disp_get_default();
+  lv_coord_t height = disp ? lv_disp_get_ver_res(disp) : 0;
+  return height > 0 ? height : fallback;
+}
+
 inline int clock_bar_icon_fallback_width(int item_gap) {
   int width = item_gap / 2;
   if (width < 38) width = 38;

--- a/devices/guition-esp32-p4-jc1060p470/device/sensors.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/device/sensors.yaml
@@ -139,6 +139,7 @@ script:
           grid_refresh_layout(slots, cfg,
             id(button_order).state,
             id(main_page)->obj);
+      - script.execute: clock_bar_apply
 
   - id: reset_existing_panel_settings_once
     then:

--- a/devices/guition-esp32-p4-jc4880p443/device/sensors.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/device/sensors.yaml
@@ -128,6 +128,7 @@ script:
           grid_refresh_layout(slots, cfg,
             id(button_order).state,
             id(main_page)->obj);
+      - script.execute: clock_bar_apply
 
   - id: reset_existing_panel_settings_once
     then:

--- a/devices/guition-esp32-p4-jc8012p4a1/device/sensors.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/sensors.yaml
@@ -144,6 +144,7 @@ script:
           grid_refresh_layout(slots, cfg,
             id(button_order).state,
             id(main_page)->obj);
+      - script.execute: clock_bar_apply
 
   - id: reset_existing_panel_settings_once
     then:

--- a/scripts/check_firmware_parser.py
+++ b/scripts/check_firmware_parser.py
@@ -55,6 +55,10 @@ using lv_coord_t = int;
 using lv_style_selector_t = int;
 using lv_color_t = int;
 using lv_grid_align_t = int;
+static lv_disp_t lv_test_default_disp;
+static bool lv_test_disp_available = false;
+static int lv_test_hor_res = 480;
+static int lv_test_ver_res = 480;
 static int lv_obj_move_background_calls = 0;
 inline const char *espcontrol_i18n(const char *text) { return text ? text : ""; }
 inline std::string espcontrol_i18n(const std::string &text) { return text; }
@@ -108,9 +112,9 @@ inline int lv_obj_get_style_pad_bottom(lv_obj_t *, int) { return 0; }
 inline int lv_obj_get_style_pad_column(lv_obj_t *, int) { return 0; }
 inline int lv_obj_get_style_pad_row(lv_obj_t *, int) { return 0; }
 inline lv_obj_t *lv_obj_get_parent(lv_obj_t *) { return nullptr; }
-inline lv_disp_t *lv_disp_get_default() { return nullptr; }
-inline int lv_disp_get_hor_res(lv_disp_t *) { return 480; }
-inline int lv_disp_get_ver_res(lv_disp_t *) { return 480; }
+inline lv_disp_t *lv_disp_get_default() { return lv_test_disp_available ? &lv_test_default_disp : nullptr; }
+inline int lv_disp_get_hor_res(lv_disp_t *) { return lv_test_hor_res; }
+inline int lv_disp_get_ver_res(lv_disp_t *) { return lv_test_ver_res; }
 inline void lv_label_set_long_mode(lv_obj_t *, int) {}
 inline void lv_obj_set_size(lv_obj_t *, int, int) {}
 inline void lv_obj_set_width(lv_obj_t *, int) {}
@@ -155,6 +159,15 @@ int main() {
   assert(clock_bar_grid_track_span_size(1024, 5, 5, 10, 5, 0, 2) == 400);
   assert(clock_bar_grid_track_span_size(1024, 5, 5, 10, 5, 3, 2) == 399);
   assert(clock_bar_grid_track_span_size(600, 42, 5, 10, 3, 0, 2) == 366);
+  lv_test_disp_available = false;
+  assert(clock_bar_current_screen_width(1024) == 1024);
+  assert(clock_bar_current_screen_height(600) == 600);
+  lv_test_hor_res = 800;
+  lv_test_ver_res = 1280;
+  lv_test_disp_available = true;
+  assert(clock_bar_current_screen_width(1024) == 800);
+  assert(clock_bar_current_screen_height(600) == 1280);
+  lv_test_disp_available = false;
 
   auto fallback_clock_bar = parse_clock_bar_layout("bad|unknown:time");
   assert(fallback_clock_bar.section[CLOCK_BAR_ITEM_TEMPERATURE] == CLOCK_BAR_SECTION_LEFT);

--- a/scripts/generate_device_slots.py
+++ b/scripts/generate_device_slots.py
@@ -644,9 +644,7 @@ def phase2_block(device: dict) -> str:
 
 
 def script_block(device: dict) -> str:
-    after_refresh = []
-    if device["slug"] in {"esp32-p4-86", "guition-esp32-s3-4848s040"}:
-        after_refresh.append("      - script.execute: clock_bar_apply")
+    after_refresh = ["      - script.execute: clock_bar_apply"]
     return "\n".join(
         [
             "script:",


### PR DESCRIPTION
## Purpose

Related issue: #406

The clock bar was still using the device fixed configured width when placing the left, middle, and right sections. On rotated layouts, that meant the time and status items could stay positioned for the original orientation instead of the active screen orientation.

## What changed

- Clock bar layout now reads the active LVGL display width and height when positioning the bar.
- The generated grid refresh script now reapplies the clock bar after rebuilding the layout on the widescreen P4 displays.
- Added a host-side check covering the new live-display-size helper.

## Devices affected

- Guition ESP32-P4 JC1060P470
- Guition ESP32-P4 JC4880P443
- Guition ESP32-P4 JC8012P4A1

## Checks run

- `python3 scripts/generate_device_slots.py --check`
- `npm run check:firmware-parser`
- `npm run check:firmware-display-tokens`

## Device testing notes

Flash this branch to an affected display, enable the clock bar, then switch through the alternate rotations, especially 90 and 270 degrees. The temperature, time, and network status should re-align to the current visible width instead of keeping their old fixed positions.