### PR TITLE
Add invisible LCD burn-in protection

### DIFF
--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -313,6 +313,23 @@ script:
       - output.turn_off: gpio_backlight_pwm
       - lambda: 'id(gpio_backlight_pwm).turn_off();'
 
+  - id: backlight_pause_display_off
+    mode: restart
+    then:
+      - script.execute: backlight_force_display_off
+      - delay: 100ms
+      - if:
+          condition:
+            lambda: |-
+              return id(screen_rotation_select).current_option() == "90" ||
+                     id(screen_rotation_select).current_option() == "270";
+          then:
+            - lvgl.pause:
+          else:
+            - lvgl.pause:
+                show_snow: true
+      - script.execute: backlight_force_display_off
+
   - id: backlight_fade_current_ui_to_black
     mode: restart
     then:
@@ -386,8 +403,7 @@ script:
             - script.execute: clock_bar_hide
             - delay: 50ms
             - script.execute: backlight_force_display_off
-            - lvgl.pause:
-            - script.execute: backlight_force_display_off
+            - script.execute: backlight_pause_display_off
           else:
             - lambda: 'ESP_LOGD("backlight", "Skipping automatic display-off while image modal is active");'
 
@@ -412,8 +428,7 @@ script:
             - script.execute: clock_bar_hide
             - delay: 50ms
             - script.execute: backlight_force_display_off
-            - lvgl.pause:
-            - script.execute: backlight_force_display_off
+            - script.execute: backlight_pause_display_off
           else:
             - lambda: 'ESP_LOGD("backlight", "Skipping non-scheduled display-off while image modal is active");'
 
@@ -493,6 +508,7 @@ script:
       - script.stop: backlight_fade_current_ui_to_black
       - script.stop: backlight_sleep_display_off
       - script.stop: backlight_schedule_display_off
+      - script.stop: backlight_pause_display_off
       - script.stop: screensaver_sleep_timer
       - script.stop: screensaver_sleep_sensor
       - script.stop: screensaver_sleep_display_off
@@ -563,6 +579,12 @@ script:
                   - globals.set:
                       id: screensaver_wake_touch_guard_active
                       value: 'false'
+            - if:
+                condition:
+                  lambda: 'return id(screensaver_display_off_active);'
+                then:
+                  - script.execute: backlight_force_display_off
+                  - script.wait: backlight_force_display_off
             - globals.set:
                 id: screensaver_display_off_active
                 value: 'false'

--- a/docs/features/backlight.md
+++ b/docs/features/backlight.md
@@ -31,11 +31,11 @@ For example, you can set Dawn to `07:00` and Dusk to `22:00` if you want the pan
 
 ## Screensaver
 
-When the screensaver uses **Screen Dimmed**, it keeps the normal screen visible at the saved dim brightness. When the screensaver clock is active, it can use separate daytime and nighttime clock brightness values based on the same automatic or manual day/night times. If the screensaver is set to Display Off, the backlight turns off completely. On wake (touch or presence sensor), brightness returns to the correct level for the current time.
+When the screensaver uses **Screen Dimmed**, it keeps the normal screen visible at the saved dim brightness. When the screensaver clock is active, it can use separate daytime and nighttime clock brightness values based on the same automatic or manual day/night times. If the screensaver is set to Display Off, the backlight turns off completely. While the backlight is off, EspControl can exercise the LCD pixels in the background to reduce burn-in risk without showing that pattern. On wake (touch or presence sensor), brightness returns to the correct level for the current time.
 
 ## Screen Schedule
 
-The [screen schedule](/features/screen-schedule) can turn the physical backlight off, keep the panel dimmed, or show a clock at set hours. **Screen Off** uses the schedule's separate **When Woken** brightness during a temporary wake. **Screen Dimmed** uses its own overnight brightness setting. **Clock** uses its own clock brightness setting.
+The [screen schedule](/features/screen-schedule) can turn the physical backlight off, keep the panel dimmed, or show a clock at set hours. **Screen Off** uses the schedule's separate **When Woken** brightness during a temporary wake and can run the same invisible burn-in protection while dark. **Screen Dimmed** uses its own overnight brightness setting. **Clock** uses its own clock brightness setting.
 
 ## Before Clock Sync
 

--- a/docs/features/screen-schedule.md
+++ b/docs/features/screen-schedule.md
@@ -15,7 +15,7 @@ You will find it in the **Settings** tab on the [Setup](/features/setup) page, u
 - **Night Schedule** - turns automatic night schedule behavior on or off.
 - **Daytime** - the first hour when the screen should be awake. The default is **6:00 AM**.
 - **Night Time** - the first hour when the night schedule starts. The default is **11:00 PM**.
-- **At Night Time** - what the panel should do overnight. **Screen Off** is the default, **Screen Dimmed** keeps the panel usable at a set brightness, and **Clock** shows the clock instead.
+- **At Night Time** - what the panel should do overnight. **Screen Off** is the default, **Screen Dimmed** keeps the panel usable at a set brightness, and **Clock** shows the clock instead. Screen Off can protect the LCD in the background while the backlight stays off.
 - **When Woken, Idle Time to Screen Off** - shown only for **Screen Off**. It controls how long the screen stays awake after you tap it during scheduled-off hours. The default is **1 minute**.
 - **When Woken, Screen Brightness** - shown only for **Screen Off**. It controls the brightness used for a temporary wake during scheduled-off hours. The default is **10%**.
 - **Dimmed Screen Brightness** - shown only for **Screen Dimmed**. It controls the overnight brightness while the panel stays usable. The default is **10%**.
@@ -40,4 +40,4 @@ Pressing and holding a button on the touchscreen for 3 seconds puts the screen t
 
 ## Brightness
 
-Screen schedule works alongside the daytime and nighttime brightness settings. When the screen is awake during scheduled-on hours, brightness follows the calculated sunrise and sunset for your selected timezone, or the manual Dawn and Dusk times when **Automatic Brightness** is off. **Screen Dimmed** uses its own overnight brightness setting. **Screen Off** turns the physical backlight off, while **Clock** uses its own clock brightness and text colour settings.
+Screen schedule works alongside the daytime and nighttime brightness settings. When the screen is awake during scheduled-on hours, brightness follows the calculated sunrise and sunset for your selected timezone, or the manual Dawn and Dusk times when **Automatic Brightness** is off. **Screen Dimmed** uses its own overnight brightness setting. **Screen Off** turns the physical backlight off and can run invisible burn-in protection while dark, while **Clock** uses its own clock brightness and text colour settings.

--- a/docs/features/screensaver.md
+++ b/docs/features/screensaver.md
@@ -35,7 +35,7 @@ When the screensaver activates, you can choose what happens:
 
 - **Screen Dimmed** — keeps the normal screen visible, but lowers the backlight. The first tap wakes the screen instead of pressing a card.
 - **Clock** — shows a large drifting clock at reduced brightness (the default). The clock repositions itself periodically to prevent burn-in.
-- **Display Off** — switches to a black screen and turns the backlight off completely.
+- **Display Off** — switches to a black screen and turns the backlight off completely. While the backlight is off, EspControl can exercise the LCD pixels in the background to reduce burn-in risk; this should not be visible.
 
 When Screen Dimmed is selected, set **Dimmed Screen Brightness**. When Clock is selected, set separate **Daytime Clock Brightness** and **Nighttime Clock Brightness** values. Clock brightness uses the same sunrise and sunset calculation as the main screen brightness.
 


### PR DESCRIPTION
## Summary
- add invisible LVGL snow burn-in protection behind the existing Display Off / Screen Off paths
- keep the physical backlight forced off before and after starting the snow pattern, and before waking/redrawing the UI
- skip snow for 90/270 degree rotations to avoid the current ESPHome/LVGL rotation crash risk
- document that burn-in protection runs only while the panel appears fully dark

Fixes #405

## Testing
- `git diff --check`
- `npm run check:fast`
- `docker run --rm -v "/Users/jtenniswood/Git/espcontrol:/config" ghcr.io/esphome/esphome:stable compile /config/builds/guition-esp32-p4-jc1060p470.factory.yaml`
- `docker run --rm -v "/Users/jtenniswood/Git/espcontrol:/config" ghcr.io/esphome/esphome:stable compile /config/builds/guition-esp32-p4-jc4880p443.factory.yaml`
- `docker run --rm -v "/Users/jtenniswood/Git/espcontrol:/config" ghcr.io/esphome/esphome:stable compile /config/builds/guition-esp32-p4-jc8012p4a1.factory.yaml`
- `docker run --rm -v "/Users/jtenniswood/Git/espcontrol:/config" ghcr.io/esphome/esphome:stable compile /config/builds/esp32-p4-86.factory.yaml`
- `docker run --rm -v "/Users/jtenniswood/Git/espcontrol:/config" ghcr.io/esphome/esphome:stable compile /config/builds/guition-esp32-s3-4848s040.factory.yaml`

## Device testing needed
Flash a test panel from this branch, set screensaver to **Display Off**, let it sleep, confirm the screen goes fully dark with no visible snow flash, then tap to wake and confirm the normal UI appears before brightness returns.

Also test scheduled **Screen Off** and manual long-press sleep, because those share the same burn-in protection path.
