### PR TITLE
Fix stale media cover art refresh

### DIFF
--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -12,6 +12,9 @@ globals:
   - id: cover_art_url
     type: std::string
     initial_value: '""'
+  - id: cover_art_download_url
+    type: std::string
+    initial_value: '""'
   - id: cover_art_pending_remote_url
     type: std::string
     initial_value: '""'
@@ -33,6 +36,9 @@ globals:
   - id: cover_art_loaded_url
     type: std::string
     initial_value: '""'
+  - id: cover_art_refresh_needed
+    type: bool
+    initial_value: 'false'
   - id: cover_art_retry_url
     type: std::string
     initial_value: '""'
@@ -52,6 +58,9 @@ globals:
     type: std::string
     initial_value: '""'
   - id: cover_art_artist
+    type: std::string
+    initial_value: '""'
+  - id: cover_art_album
     type: std::string
     initial_value: '""'
   - id: cover_art_media_source
@@ -449,9 +458,12 @@ script:
       - if:
           condition:
             lambda: |-
+              std::string expected_url = id(cover_art_download_url).empty()
+                  ? id(cover_art_url)
+                  : id(cover_art_download_url);
               return id(cover_art_screensaver_enabled).state &&
                      !id(cover_art_url).empty() &&
-                     id(cover_art_downloaded_image)->get_url() == id(cover_art_url);
+                     id(cover_art_downloaded_image)->get_url() == expected_url;
           then:
             - script.stop: cover_art_retry_download
             - script.stop: cover_art_deferred_download
@@ -459,7 +471,9 @@ script:
                 id: cover_art_image_available
                 value: 'true'
             - lambda: |-
-                id(cover_art_loaded_url) = id(cover_art_downloaded_image)->get_url();
+                id(cover_art_loaded_url) = id(cover_art_url);
+                id(cover_art_download_url).clear();
+                id(cover_art_refresh_needed) = false;
                 id(cover_art_retry_url) = id(cover_art_url);
                 id(cover_art_retry_count) = 0;
                 auto *img = id(cover_art_downloaded_image);
@@ -664,6 +678,7 @@ script:
           value: 'false'
       - lambda: |-
           id(cover_art_url).clear();
+          id(cover_art_download_url).clear();
           id(cover_art_pending_remote_url).clear();
           id(cover_art_pending_local_url).clear();
           id(cover_art_cached_remote_url).clear();
@@ -671,11 +686,13 @@ script:
           id(cover_art_artwork_pending_count) = 0;
           id(cover_art_request_id)++;
           id(cover_art_loaded_url).clear();
+          id(cover_art_refresh_needed) = false;
           id(cover_art_retry_url).clear();
           id(cover_art_fallback_url).clear();
           id(cover_art_retry_count) = 0;
           id(cover_art_title).clear();
           id(cover_art_artist).clear();
+          id(cover_art_album).clear();
           id(cover_art_media_source).clear();
           id(cover_art_external_input_active) = false;
           id(cover_art_last_playback_state).clear();
@@ -713,13 +730,26 @@ script:
                   id(cover_art_retry_url) = id(cover_art_url);
                   id(cover_art_retry_count) = 0;
                 }
-                ESP_LOGI("cover_art", "Downloading artwork URL (%u chars, active=%s, image_available=%s)",
+                auto refresh_ha_media_proxy_url = [](const std::string &url) -> std::string {
+                  if (url.find("/api/media_player_proxy/") == std::string::npos) {
+                    return url;
+                  }
+                  std::string refreshed = url;
+                  refreshed += refreshed.find('?') == std::string::npos ? "?time=" : "&time=";
+                  refreshed += std::to_string(esphome::millis());
+                  return refreshed;
+                };
+                id(cover_art_download_url) = id(cover_art_refresh_needed)
+                    ? refresh_ha_media_proxy_url(id(cover_art_url))
+                    : id(cover_art_url);
+                ESP_LOGI("cover_art", "Downloading artwork URL (%u chars, download %u chars, active=%s, image_available=%s, refresh_needed=%s)",
                          (unsigned) id(cover_art_url).size(),
+                         (unsigned) id(cover_art_download_url).size(),
                          id(cover_art_screensaver_active) ? "true" : "false",
-                         id(cover_art_image_available) ? "true" : "false");
-            - artwork_image.set_url:
-                id: cover_art_downloaded_image
-                url: !lambda 'return id(cover_art_url);'
+                         id(cover_art_image_available) ? "true" : "false",
+                         id(cover_art_refresh_needed) ? "true" : "false");
+                id(cover_art_download_url) =
+                    id(cover_art_downloaded_image)->request_update_url(id(cover_art_download_url));
 
   - id: cover_art_deferred_download
     mode: restart
@@ -734,7 +764,8 @@ script:
                        id(cover_art_external_input_active)) &&
                      !id(cover_art_url).empty() &&
                      (!id(cover_art_image_available) ||
-                      id(cover_art_url) != id(cover_art_loaded_url));
+                      id(cover_art_url) != id(cover_art_loaded_url) ||
+                      id(cover_art_refresh_needed));
           then:
             - script.execute: cover_art_download
 
@@ -798,10 +829,12 @@ script:
 
           id(cover_art_fallback_url) = fallback;
           if (chosen == id(cover_art_url)) {
-            ESP_LOGI("cover_art", "Cached artwork matches current URL; image_available=%s active=%s",
+            ESP_LOGI("cover_art", "Cached artwork matches current URL; image_available=%s active=%s refresh_needed=%s",
                      id(cover_art_image_available) ? "true" : "false",
-                     id(cover_art_screensaver_active) ? "true" : "false");
-            if (id(cover_art_screensaver_active) && !id(cover_art_image_available)) {
+                     id(cover_art_screensaver_active) ? "true" : "false",
+                     id(cover_art_refresh_needed) ? "true" : "false");
+            if (id(cover_art_screensaver_active) &&
+                (!id(cover_art_image_available) || id(cover_art_refresh_needed))) {
               id(cover_art_deferred_download).execute();
             }
             return;
@@ -830,7 +863,8 @@ script:
                      !(id(cover_art_hide_external_input_enabled).state &&
                        id(cover_art_external_input_active)) &&
                      (!id(cover_art_image_available) ||
-                      id(cover_art_url) != id(cover_art_loaded_url));
+                      id(cover_art_url) != id(cover_art_loaded_url) ||
+                      id(cover_art_refresh_needed));
           then:
             - if:
                 condition:
@@ -888,9 +922,7 @@ script:
                   - lambda: |-
                       id(cover_art_retry_count)++;
                       ESP_LOGI("cover_art", "Retrying artwork download %d/5", id(cover_art_retry_count));
-                  - artwork_image.set_url:
-                      id: cover_art_downloaded_image
-                      url: !lambda 'return id(cover_art_url);'
+                  - script.execute: cover_art_download
           else:
             - lambda: |-
                 if (!id(cover_art_url).empty()) {
@@ -1237,7 +1269,12 @@ script:
             }
 
             if (chosen == id(cover_art_url)) {
-              if (!id(cover_art_image_available)) id(cover_art_deferred_download).execute();
+              ESP_LOGI("cover_art", "Artwork URL unchanged; image_available=%s refresh_needed=%s",
+                       id(cover_art_image_available) ? "true" : "false",
+                       id(cover_art_refresh_needed) ? "true" : "false");
+              if (!id(cover_art_image_available) || id(cover_art_refresh_needed)) {
+                id(cover_art_deferred_download).execute();
+              }
               id(cover_art_show_track_overlay).execute();
               return;
             }
@@ -1306,12 +1343,19 @@ script:
             id(cover_art_subscribed_entity) = cover_entity;
             id(cover_art_last_playback_state).clear();
             id(cover_art_media_source).clear();
+            id(cover_art_album).clear();
             id(cover_art_external_input_active) = false;
             ESP_LOGI("cover_art", "Subscribing to artwork entity: %s", cover_entity.c_str());
           } else {
             ESP_LOGI("cover_art", "Refreshing artwork entity: %s", cover_entity.c_str());
           }
           const int subscription_generation = id(cover_art_subscription_generation);
+
+          std::function<void()> mark_artwork_refresh_needed = []() {
+            id(cover_art_refresh_needed) = true;
+            id(cover_art_retry_url).clear();
+            id(cover_art_retry_count) = 0;
+          };
 
           std::function<void(esphome::StringRef)> handle_playback_state =
             [cover_entity, subscription_generation](esphome::StringRef state) {
@@ -1366,7 +1410,7 @@ script:
                    state_requested ? "requested" : "failed", cover_entity.c_str());
 
           std::function<void(esphome::StringRef)> handle_media_title =
-            [cover_entity, subscription_generation](esphome::StringRef title) {
+            [cover_entity, subscription_generation, mark_artwork_refresh_needed](esphome::StringRef title) {
               if (!id(cover_art_screensaver_enabled).state ||
                   subscription_generation != id(cover_art_subscription_generation) ||
                   cover_entity != id(cover_art_media_player_entity).state) return;
@@ -1374,6 +1418,7 @@ script:
               if (next == "unknown" || next == "unavailable") next.clear();
               if (next == id(cover_art_title)) return;
               id(cover_art_title) = next;
+              mark_artwork_refresh_needed();
               id(cover_art_sync_track_text).execute();
               if (id(cover_art_screensaver_active)) {
                 id(cover_art_show_track_overlay).execute();
@@ -1381,8 +1426,6 @@ script:
               } else {
                 ESP_LOGI("cover_art", "Track title changed while inactive (%u chars); deferring download",
                          (unsigned) next.size());
-                id(cover_art_retry_url).clear();
-                id(cover_art_retry_count) = 0;
                 if (id(cover_art_loaded_url).empty()) {
                   id(cover_art_image_available) = false;
                 }
@@ -1396,7 +1439,7 @@ script:
           ESP_LOGI("cover_art", "Title refresh %s", title_requested ? "requested" : "failed");
 
           std::function<void(esphome::StringRef)> handle_media_artist =
-            [cover_entity, subscription_generation](esphome::StringRef artist) {
+            [cover_entity, subscription_generation, mark_artwork_refresh_needed](esphome::StringRef artist) {
               if (!id(cover_art_screensaver_enabled).state ||
                   subscription_generation != id(cover_art_subscription_generation) ||
                   cover_entity != id(cover_art_media_player_entity).state) return;
@@ -1404,7 +1447,15 @@ script:
               if (next == "unknown" || next == "unavailable") next.clear();
               if (next == id(cover_art_artist)) return;
               id(cover_art_artist) = next;
+              mark_artwork_refresh_needed();
               id(cover_art_sync_track_text).execute();
+              if (id(cover_art_screensaver_active)) {
+                id(cover_art_show_track_overlay).execute();
+                id(cover_art_request_artwork).execute();
+              } else {
+                ESP_LOGI("cover_art", "Track artist changed while inactive (%u chars); deferring download",
+                         (unsigned) next.size());
+              }
             };
           if (!already_subscribed) {
             bool artist_subscribed = ha_subscribe_attribute(cover_entity, std::string("media_artist"), handle_media_artist);
@@ -1413,8 +1464,32 @@ script:
           bool artist_requested = ha_get_attribute(cover_entity, std::string("media_artist"), handle_media_artist);
           ESP_LOGI("cover_art", "Artist refresh %s", artist_requested ? "requested" : "failed");
 
+          std::function<void(esphome::StringRef)> handle_media_album =
+            [cover_entity, subscription_generation, mark_artwork_refresh_needed](esphome::StringRef album) {
+              if (!id(cover_art_screensaver_enabled).state ||
+                  subscription_generation != id(cover_art_subscription_generation) ||
+                  cover_entity != id(cover_art_media_player_entity).state) return;
+              std::string next = string_ref_limited(album, HA_STATE_TEXT_MAX_LEN);
+              if (next == "unknown" || next == "unavailable") next.clear();
+              if (next == id(cover_art_album)) return;
+              id(cover_art_album) = next;
+              mark_artwork_refresh_needed();
+              if (id(cover_art_screensaver_active)) {
+                id(cover_art_request_artwork).execute();
+              } else {
+                ESP_LOGI("cover_art", "Album changed while inactive (%u chars); deferring download",
+                         (unsigned) next.size());
+              }
+            };
+          if (!already_subscribed) {
+            bool album_subscribed = ha_subscribe_attribute(cover_entity, std::string("media_album_name"), handle_media_album);
+            ESP_LOGI("cover_art", "Album subscription %s", album_subscribed ? "ready" : "failed");
+          }
+          bool album_requested = ha_get_attribute(cover_entity, std::string("media_album_name"), handle_media_album);
+          ESP_LOGI("cover_art", "Album refresh %s", album_requested ? "requested" : "failed");
+
           std::function<void(esphome::StringRef)> handle_media_source =
-            [cover_entity, subscription_generation](esphome::StringRef source) {
+            [cover_entity, subscription_generation, mark_artwork_refresh_needed](esphome::StringRef source) {
               if (!id(cover_art_screensaver_enabled).state ||
                   subscription_generation != id(cover_art_subscription_generation) ||
                   cover_entity != id(cover_art_media_player_entity).state) return;
@@ -1427,9 +1502,15 @@ script:
                   external == id(cover_art_external_input_active)) return;
               id(cover_art_media_source) = next;
               id(cover_art_external_input_active) = external;
+              mark_artwork_refresh_needed();
               ESP_LOGI("cover_art", "Media source for %s: '%s' (external=%s)",
                        cover_entity.c_str(), next.c_str(), external ? "true" : "false");
               id(cover_art_apply_external_input_policy).execute();
+              if (id(cover_art_screensaver_active) &&
+                  !(id(cover_art_hide_external_input_enabled).state &&
+                    id(cover_art_external_input_active))) {
+                id(cover_art_request_artwork).execute();
+              }
             };
           if (!already_subscribed) {
             bool source_subscribed = ha_subscribe_attribute(cover_entity, std::string("source"), handle_media_source);

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -600,6 +600,70 @@ def firmware_cover_art_stale_image_errors(path: Path, root: Path) -> list[str]:
     return errors
 
 
+def firmware_cover_art_refresh_errors(path: Path, root: Path) -> list[str]:
+    if not path.exists():
+        return []
+    rel = path.relative_to(root)
+    text = path.read_text(encoding="utf-8")
+    errors: list[str] = []
+
+    required_state = (
+        ("cover_art_refresh_needed", "track/source metadata changes as stale artwork"),
+        ("cover_art_download_url", "keep source artwork URLs separate from downloader URLs"),
+        ("cover_art_album", "track album names for artwork refresh decisions"),
+    )
+    for token, message in required_state:
+        if token not in text:
+            errors.append(f"{rel}: {message}")
+
+    download_body = yaml_script_body(text, "cover_art_download")
+    if not download_body:
+        errors.append(f"{rel}: missing cover_art_download script")
+    else:
+        if "/api/media_player_proxy/" not in download_body:
+            errors.append(f"{rel}: only cache-bust Home Assistant media proxy artwork URLs")
+        if "?time=" not in download_body or "&time=" not in download_body:
+            errors.append(f"{rel}: add a refresh marker that preserves existing artwork query strings")
+        if "request_update_url(id(cover_art_download_url))" not in download_body:
+            errors.append(f"{rel}: download through the refresh-aware artwork URL")
+
+    for script_id in ("cover_art_deferred_download", "cover_art_prepare_download"):
+        body = yaml_script_body(text, script_id)
+        if not body:
+            errors.append(f"{rel}: missing {script_id} script")
+        elif "id(cover_art_refresh_needed)" not in body:
+            errors.append(f"{rel}: let {script_id} refresh unchanged artwork URLs after metadata changes")
+
+    for script_id in ("cover_art_use_cached_artwork", "cover_art_request_artwork"):
+        body = yaml_script_body(text, script_id)
+        if not body:
+            errors.append(f"{rel}: missing {script_id} script")
+        elif (
+            "chosen == id(cover_art_url)" not in body
+            or "!id(cover_art_image_available) || id(cover_art_refresh_needed)" not in body
+        ):
+            errors.append(f"{rel}: do not exit early from {script_id} when stale artwork needs refresh")
+
+    apply_body = yaml_script_body(text, "cover_art_apply_downloaded_image")
+    if not apply_body:
+        errors.append(f"{rel}: missing cover_art_apply_downloaded_image script")
+    else:
+        if "expected_url" not in apply_body or "id(cover_art_download_url)" not in apply_body:
+            errors.append(f"{rel}: accept the refresh-aware downloader URL when artwork finishes")
+        if "id(cover_art_loaded_url) = id(cover_art_url)" not in apply_body:
+            errors.append(f"{rel}: remember the clean source artwork URL after a download")
+        if "id(cover_art_refresh_needed) = false" not in apply_body:
+            errors.append(f"{rel}: clear stale artwork state only after a replacement image applies")
+
+    if text.count("mark_artwork_refresh_needed();") < 4:
+        errors.append(f"{rel}: mark title, artist, album, and source changes as artwork refresh triggers")
+    if 'std::string("media_album_name"), handle_media_album' not in text:
+        errors.append(f"{rel}: subscribe to and refresh the media_album_name attribute")
+    if "id(cover_art_refresh_needed) = true" not in text:
+        errors.append(f"{rel}: set stale artwork state when track/source metadata changes")
+    return errors
+
+
 def firmware_image_card_entity_errors(firmware_dir: Path, root: Path) -> list[str]:
     path = firmware_dir / "button_grid_image.h"
     if not path.exists():
@@ -1096,6 +1160,7 @@ def run_scan() -> int:
     errors.extend(firmware_cover_request_errors(FIRMWARE_DIR, CORE_INFRA_PATH, ROOT))
     errors.extend(firmware_cover_art_external_input_errors(COVER_ART_PATH, ROOT))
     errors.extend(firmware_cover_art_stale_image_errors(COVER_ART_PATH, ROOT))
+    errors.extend(firmware_cover_art_refresh_errors(COVER_ART_PATH, ROOT))
     errors.extend(firmware_image_card_entity_errors(FIRMWARE_DIR, ROOT))
     errors.extend(firmware_image_card_base_url_errors(FIRMWARE_DIR, ROOT))
     errors.extend(firmware_image_card_quality_errors(FIRMWARE_DIR, ROOT))
@@ -1363,6 +1428,20 @@ def expect_cover_art_stale_image_errors(name: str, text: str, expected: tuple[st
         path.write_text(text, encoding="utf-8")
 
         errors = firmware_cover_art_stale_image_errors(path, root)
+        for item in expected:
+            assert any(item in error for error in errors), f"{name}: missing {item!r} in {errors!r}"
+        if not expected:
+            assert not errors, f"{name}: expected no errors, got {errors!r}"
+
+
+def expect_cover_art_refresh_errors(name: str, text: str, expected: tuple[str, ...]) -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        path = root / "common" / "device" / "screen_cover_art.yaml"
+        path.parent.mkdir(parents=True)
+        path.write_text(text, encoding="utf-8")
+
+        errors = firmware_cover_art_refresh_errors(path, root)
         for item in expected:
             assert any(item in error for error in errors), f"{name}: missing {item!r} in {errors!r}"
         if not expected:
@@ -2339,6 +2418,70 @@ def run_self_test() -> int:
         "    then:\n"
         "      - lvgl.widget.hide: cover_art_image_widget\n",
         ("do not show an unavailable cover art message",),
+    )
+    expect_cover_art_refresh_errors(
+        "missing stale cover refresh guard",
+        "script:\n"
+        "  - id: cover_art_download\n"
+        "    then:\n"
+        "      - lambda: |-\n"
+        "          id(cover_art_url);\n",
+        (
+            "track/source metadata changes as stale artwork",
+            "subscribe to and refresh the media_album_name attribute",
+        ),
+    )
+    expect_cover_art_refresh_errors(
+        "stale cover refresh guard present",
+        "globals:\n"
+        "  - id: cover_art_refresh_needed\n"
+        "  - id: cover_art_download_url\n"
+        "  - id: cover_art_album\n"
+        "script:\n"
+        "  - id: cover_art_download\n"
+        "    then:\n"
+        "      - lambda: |-\n"
+        "          if (url.find(\"/api/media_player_proxy/\") != std::string::npos) {\n"
+        "            url += url.find('?') == std::string::npos ? \"?time=\" : \"&time=\";\n"
+        "          }\n"
+        "          id(cover_art_download_url) = id(cover_art_downloaded_image)->request_update_url(id(cover_art_download_url));\n"
+        "  - id: cover_art_deferred_download\n"
+        "    then:\n"
+        "      - lambda: |-\n"
+        "          id(cover_art_refresh_needed);\n"
+        "  - id: cover_art_prepare_download\n"
+        "    then:\n"
+        "      - lambda: |-\n"
+        "          id(cover_art_refresh_needed);\n"
+        "  - id: cover_art_use_cached_artwork\n"
+        "    then:\n"
+        "      - lambda: |-\n"
+        "          if (chosen == id(cover_art_url)) {\n"
+        "            if (!id(cover_art_image_available) || id(cover_art_refresh_needed)) {}\n"
+        "          }\n"
+        "  - id: cover_art_request_artwork\n"
+        "    then:\n"
+        "      - lambda: |-\n"
+        "          if (chosen == id(cover_art_url)) {\n"
+        "            if (!id(cover_art_image_available) || id(cover_art_refresh_needed)) {}\n"
+        "          }\n"
+        "  - id: cover_art_apply_downloaded_image\n"
+        "    then:\n"
+        "      - lambda: |-\n"
+        "          std::string expected_url = id(cover_art_download_url);\n"
+        "          id(cover_art_loaded_url) = id(cover_art_url);\n"
+        "          id(cover_art_refresh_needed) = false;\n"
+        "  - id: cover_art_resubscribe\n"
+        "    then:\n"
+        "      - lambda: |-\n"
+        "          id(cover_art_refresh_needed) = true;\n"
+        "          mark_artwork_refresh_needed();\n"
+        "          mark_artwork_refresh_needed();\n"
+        "          mark_artwork_refresh_needed();\n"
+        "          mark_artwork_refresh_needed();\n"
+        "          ha_subscribe_attribute(cover_entity, std::string(\"media_album_name\"), handle_media_album);\n"
+        "          ha_get_attribute(cover_entity, std::string(\"media_album_name\"), handle_media_album);\n",
+        (),
     )
     expect_image_card_entity_errors(
         "legacy camera-only image card guard",


### PR DESCRIPTION
## Purpose
Fix stale cover art on the cover-art screensaver when Home Assistant keeps reporting the same artwork URL string after the track, album, artist, or source changes.

## Practical impact
- Track/source changes can now force a fresh artwork request even when the visible Home Assistant artwork URL is unchanged.
- Home Assistant media proxy artwork URLs get a short refresh marker for the actual download request.
- Third-party artwork/CDN URLs are left unchanged.
- The previous cover remains visible while the replacement downloads, so normal track changes should not flash black.
- Existing "Hide for external sources" behaviour is unchanged.

## Affected firmware
Shared cover-art screensaver firmware used by all supported displays.

## Checks run
- `python3 scripts/check_firmware_ha_bindings.py`
- `python3 scripts/check_firmware_ha_bindings.py --self-test`
- `npm run check:config`
- `npm run check:backup-contract`
- `npm run check:model-contract`
- `npm run check:generated`
- `npm run check:card-contract-outputs`
- `python3 scripts/generate_device_slots.py --check`
- `git diff --check`
- Full ESPHome compile passed for:
  - `builds/esp32-p4-86.factory.yaml`
  - `builds/guition-esp32-p4-jc1060p470.factory.yaml`
  - `builds/guition-esp32-p4-jc4880p443.factory.yaml`
  - `builds/guition-esp32-p4-jc8012p4a1.factory.yaml`
  - `builds/guition-esp32-s3-4848s040.factory.yaml`

## Manual device test notes
- Start Music Assistant playback and confirm title, artist, and art appear.
- Switch to a Cast source from a phone and confirm title and cover both update.
- Disconnect Cast and start a different Music Assistant album; confirm the old cover is replaced.
- Repeat with "Hide for external sources" enabled to confirm TV/Line-in handling still hides as before.
