### PR TITLE
Restore image card loading overlay

### DIFF
--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -23,9 +23,6 @@ constexpr int IMAGE_CARD_MODAL_MAX_TARGET_SIDE_PX = 800;
 constexpr size_t IMAGE_CARD_MEMORY_HEADROOM_BYTES = 96 * 1024;
 constexpr lv_coord_t IMAGE_CARD_JC4880P443_MODAL_BACK_BUTTON_REF_PX = 58;
 constexpr const char *IMAGE_CARD_LOADING_ICON = "\U000F02E9";
-constexpr lv_coord_t IMAGE_CARD_MODAL_LOADING_MIN_W = 132;
-constexpr lv_coord_t IMAGE_CARD_MODAL_LOADING_MAX_W = 220;
-constexpr lv_coord_t IMAGE_CARD_MODAL_LOADING_H = 48;
 
 struct ImageCardCtx {
   lv_obj_t *widget = nullptr;
@@ -352,28 +349,19 @@ inline void image_card_layout_modal_loading(ImageCardCtx *ctx) {
   lv_coord_t width = lv_obj_get_width(ui.panel);
   lv_coord_t height = lv_obj_get_height(ui.panel);
   if (width <= 0 || height <= 0) return;
-  lv_coord_t margin = width < 260 ? 8 : 12;
-  lv_coord_t available_w = width - margin * 2;
-  if (available_w <= 0) return;
-  lv_coord_t indicator_w = width / 2;
-  if (indicator_w < IMAGE_CARD_MODAL_LOADING_MIN_W) indicator_w = IMAGE_CARD_MODAL_LOADING_MIN_W;
-  if (indicator_w > IMAGE_CARD_MODAL_LOADING_MAX_W) indicator_w = IMAGE_CARD_MODAL_LOADING_MAX_W;
-  if (indicator_w > available_w) indicator_w = available_w;
-  lv_coord_t indicator_h = IMAGE_CARD_MODAL_LOADING_H;
-  if (height < 180) indicator_h = 40;
-  lv_obj_set_size(ui.loading_widget, indicator_w, indicator_h);
-  lv_obj_align(ui.loading_widget, LV_ALIGN_TOP_RIGHT, -margin, margin);
-  lv_obj_set_style_radius(ui.loading_widget, indicator_h / 2, LV_PART_MAIN);
+  lv_obj_set_pos(ui.loading_widget, 0, 0);
+  lv_obj_set_size(ui.loading_widget, width, height);
+  lv_obj_set_style_radius(
+    ui.loading_widget, lv_obj_get_style_radius(ui.panel, LV_PART_MAIN), LV_PART_MAIN);
   lv_obj_set_style_clip_corner(ui.loading_widget, true, LV_PART_MAIN);
   if (lv_obj_get_child_cnt(ui.loading_widget) < 2) return;
   lv_obj_t *icon = lv_obj_get_child(ui.loading_widget, 0);
   lv_obj_t *label = lv_obj_get_child(ui.loading_widget, 1);
-  lv_coord_t inner_pad = 14;
-  lv_coord_t label_x = 44;
-  lv_obj_align(icon, LV_ALIGN_LEFT_MID, inner_pad, 0);
-  lv_obj_set_width(label, indicator_w - label_x - inner_pad);
-  lv_label_set_long_mode(label, LV_LABEL_LONG_DOT);
-  lv_obj_align(label, LV_ALIGN_LEFT_MID, label_x, 0);
+  lv_obj_set_width(label, width);
+  lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
+  lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
+  lv_obj_align(icon, LV_ALIGN_CENTER, 0, -18);
+  lv_obj_align_to(label, icon, LV_ALIGN_OUT_BOTTOM_MID, 0, 8);
 }
 
 inline void image_card_show_modal_loading(ImageCardCtx *ctx, const char *text) {

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -758,8 +758,12 @@ def firmware_image_card_quality_errors(firmware_dir: Path, root: Path) -> list[s
         errors.append(f"{rel}: log image-card modal close events")
     if "image_card_abort_modal_open" not in text or "modal shell setup failed" not in text:
         errors.append(f"{rel}: clean up partially-created image card modals")
-    if "IMAGE_CARD_MODAL_LOADING_MAX_W" not in text or "LV_ALIGN_TOP_RIGHT" not in text:
-        errors.append(f"{rel}: keep image-card modal loading indicator compact")
+    if (
+        "lv_obj_set_size(ui.loading_widget, width, height)" not in text
+        or "lv_obj_align(icon, LV_ALIGN_CENTER" not in text
+        or "LV_ALIGN_OUT_BOTTOM_MID" not in text
+    ):
+        errors.append(f"{rel}: keep image-card modal loading overlay centered")
     if (
         "image_card_show_modal_image(ctx, ctx->image)" not in text
         or "image_card_queue_modal_source_request(ctx)" not in text
@@ -2561,7 +2565,7 @@ def run_self_test() -> int:
             "keep 4.3-inch P4 tile downloads sized to the tile before modal open",
             "log image-card modal close events",
             "clean up partially-created image card modals",
-            "keep image-card modal loading indicator compact",
+            "keep image-card modal loading overlay centered",
             "show the cached image-card tile while modal-quality image loads",
             "clip image card modal content to rounded panel corners",
             "preserve image card rounded corners while pressed",
@@ -2575,7 +2579,6 @@ def run_self_test() -> int:
         "constexpr int IMAGE_CARD_MAX_CONTEXTS = 6;\n"
         "constexpr int IMAGE_CARD_MODAL_MAX_TARGET_SIDE_PX = 800;\n"
         "constexpr size_t IMAGE_CARD_MEMORY_HEADROOM_BYTES = 96 * 1024;\n"
-        "constexpr lv_coord_t IMAGE_CARD_MODAL_LOADING_MAX_W = 220;\n"
         "inline lv_style_selector_t image_card_pressed_selector() { return LV_STATE_PRESSED; }\n"
         "inline void image_card_apply_corner_clip(lv_obj_t *obj, lv_coord_t radius) {}\n"
         "inline bool image_card_memory_available(ImageCardCtx *ctx, const char *stage,\n"
@@ -2593,7 +2596,9 @@ def run_self_test() -> int:
         "inline void image_card_limit_target_size(lv_coord_t source_width, lv_coord_t source_height,\n"
         "                                         int *target_width, int *target_height) {}\n"
         "inline void image_card_layout_modal_loading(ImageCardCtx *ctx) {\n"
-        "  lv_obj_align(ui.loading_widget, LV_ALIGN_TOP_RIGHT, -margin, margin);\n"
+        "  lv_obj_set_size(ui.loading_widget, width, height);\n"
+        "  lv_obj_align(icon, LV_ALIGN_CENTER, 0, -18);\n"
+        "  lv_obj_align_to(label, icon, LV_ALIGN_OUT_BOTTOM_MID, 0, 8);\n"
         "}\n"
         "inline void image_card_request_source_url(ImageCardCtx *ctx) {\n"
         "  ctx->image->set_target_size(width, height);\n"


### PR DESCRIPTION
## Purpose
Restore the image-card modal loading state so it overlays the image area again instead of appearing as a small status indicator in the top-right corner.

## Practical impact
When an expanded image card is loading, the loading icon and message should be centered over the image card, matching the previous behavior.

## Checks run
- npm run check:firmware-ha-bindings
- npm run check:firmware-modals
- git diff --check

## Device testing notes
Flash this branch to a display with an image/camera card, open the image card, and confirm the loading message appears centered over the image area while the image loads.