### PR TITLE
Inset left clock bar temperature

### DIFF
--- a/common/config/display.yaml
+++ b/common/config/display.yaml
@@ -121,7 +121,7 @@ script:
                                  visible && id(indoor_temp_enable).state,
                                  visible && id(outdoor_temp_enable).state,
                                  clock_bar_screen_width,
-                                 clock_bar_screen_width >= 700 ? 4 : 3,
+                                 clock_bar_screen_width >= 700 ? 8 : 6,
                                  clock_bar_label_y,
                                  clock_bar_right_x,
                                  clock_bar_icon_y,

--- a/devices/guition-esp32-p4-jc1060p470/device/lvgl.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/device/lvgl.yaml
@@ -20,7 +20,7 @@ lvgl:
           id: temperatures
           text_font: font_text_body
           align: top_left
-          x: 4
+          x: 8
           y: 8
           text_color: 0xFFFFFF
           hidden: true


### PR DESCRIPTION
## Purpose
Move the left clock-bar temperature slightly inward so it is not as close to the screen edge.

## Practical impact
- The shared clock-bar layout now places left-side temperature text 8 px from the edge on wider displays and 6 px on smaller displays.
- The 7-inch P4 static LVGL starting position now matches the new 8 px inset.

## Checked
- Ran `python3 scripts/check_firmware_parser.py` successfully.

## Device testing
Flash a test build for the affected display and check the home screen clock bar. Confirm the left temperature has a little more space from the left edge and the clock/network items still look aligned.