### PR TITLE
Fix clock bar text alignment type

### DIFF
--- a/components/espcontrol/clock_bar.h
+++ b/components/espcontrol/clock_bar.h
@@ -712,7 +712,7 @@ inline void clock_bar_add_layout_box(ClockBarLayoutBox *boxes,
 
 inline void clock_bar_align_box_text(const ClockBarLayoutBox &box) {
   if (!box.obj || box.item == CLOCK_BAR_ITEM_NETWORK) return;
-  int align = LV_TEXT_ALIGN_CENTER;
+  lv_text_align_t align = LV_TEXT_ALIGN_CENTER;
   if (box.section == CLOCK_BAR_SECTION_LEFT) align = LV_TEXT_ALIGN_LEFT;
   else if (box.section == CLOCK_BAR_SECTION_RIGHT) align = LV_TEXT_ALIGN_RIGHT;
   lv_obj_set_style_text_align(box.obj, align, LV_PART_MAIN);

--- a/scripts/check_firmware_parser.py
+++ b/scripts/check_firmware_parser.py
@@ -55,6 +55,7 @@ using lv_coord_t = int;
 using lv_style_selector_t = int;
 using lv_color_t = int;
 using lv_grid_align_t = int;
+using lv_text_align_t = int;
 static lv_disp_t lv_test_default_disp;
 static bool lv_test_disp_available = false;
 static int lv_test_hor_res = 480;


### PR DESCRIPTION
## Purpose
Fix a compile error in the shared clock bar component that blocked firmware builds.

## Practical impact
This changes the internal text alignment variable to the correct LVGL type. It should not change how the clock bar looks, but it allows the firmware to compile cleanly again.

## Root cause
The clock bar text alignment value was stored as a plain integer, then passed to LVGL where a `lv_text_align_t` value is expected. The stricter compiler rejected that conversion.

## Checked
- Built and OTA flashed 7-inch P4 at 192.168.6.102
- Built and OTA flashed 10-inch P4 at 192.168.6.103
- Built and OTA flashed 4-inch P4 / P4-86 at 192.168.10.52
- Built and OTA flashed 4.3-inch P4 at 192.168.6.101
- Built and OTA flashed 4-inch S3 at 192.168.10.226
- Confirmed each display came back online with ping after reboot

## Testing notes
The firmware has already been flashed to all known display types using the normal OTA targets. Please visually check the clock bar on each display before merging.