### PR TITLE
Fix clock bar text alignment compile

### DIFF
--- a/components/espcontrol/clock_bar.h
+++ b/components/espcontrol/clock_bar.h
@@ -712,7 +712,7 @@ inline void clock_bar_add_layout_box(ClockBarLayoutBox *boxes,
 
 inline void clock_bar_align_box_text(const ClockBarLayoutBox &box) {
   if (!box.obj || box.item == CLOCK_BAR_ITEM_NETWORK) return;
-  int align = LV_TEXT_ALIGN_CENTER;
+  auto align = LV_TEXT_ALIGN_CENTER;
   if (box.section == CLOCK_BAR_SECTION_LEFT) align = LV_TEXT_ALIGN_LEFT;
   else if (box.section == CLOCK_BAR_SECTION_RIGHT) align = LV_TEXT_ALIGN_RIGHT;
   lv_obj_set_style_text_align(box.obj, align, LV_PART_MAIN);


### PR DESCRIPTION
## Purpose
Fix the firmware compile failure from release run 27435788557. The clock bar layout code stored an LVGL text alignment value in a plain integer, but the ESPHome/LVGL compiler expects the specific lv_text_align_t type.

## Practical impact
This keeps the clock bar left/center/right text alignment behavior the same, but lets the firmware compile cleanly on the current ESPHome 2026.5.3 release workflow.

## Checked
- Confirmed the release workflow pins remain on ESPHome 2026.5.3.
- Locally compiled builds/guition-esp32-p4-jc1060p470.factory.yaml with ghcr.io/esphome/esphome:2026.5.3 successfully.

## Testing notes
Please let the PR checks run. This fix touches shared clock bar firmware code, so the GitHub firmware compile matrix should confirm the remaining display targets.