### PR TITLE
Run release firmware builds in parallel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 5
       matrix: ${{ fromJSON(needs.device-matrix.outputs.matrix) }}
     steps:
       - name: Prepare self-hosted workspace


### PR DESCRIPTION
## Purpose
Allow the Build Release workflow to compile all release firmware targets in parallel instead of one device at a time.

## Practical impact
Release builds should complete faster when enough self-hosted runner capacity is available. Firmware output is unchanged; this only changes GitHub Actions scheduling.

## Checked
- npm run check:firmware-release
- python3 scripts/check_device_matrix.py

## Testing notes
After this is merged, the next release run should show the five Build <device> jobs starting together or as runner capacity allows.