### PR TITLE
Fix screensaver sensor wake

### DIFF
--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -243,6 +243,7 @@ script:
             - if:
                 condition:
                   lambda: |-
+                    if (!id(schedule_enabled).state) return true;
                     auto now = panel_time_or_fallback(id(panel_time).now(), id(homeassistant_time).now());
                     if (screen_schedule_normal_active(
                           id(screen_schedule_trigger).state,

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -1025,6 +1025,12 @@ def firmware_screen_schedule_screensaver_override_errors(backlight_path: Path, r
         )
         if wake_index == -1 or any(token not in pre_wake_body for token in required_tokens):
             errors.append(f"{rel}: let the night screen schedule override sensor screensaver wake")
+        disabled_wake_index = pre_wake_body.rfind("if (!id(schedule_enabled).state) return true;")
+        schedule_check_index = pre_wake_body.find("id(screen_schedule_check).execute();")
+        if disabled_wake_index == -1 or (
+            schedule_check_index != -1 and disabled_wake_index < schedule_check_index
+        ):
+            errors.append(f"{rel}: let sensor screensaver wake when the screen schedule is disabled")
 
     return errors
 
@@ -2913,6 +2919,19 @@ def run_self_test() -> int:
         "              }\n"
         "              return id(screensaver_mode).state == \"sensor\";\n"
         "          then:\n"
+        "            - if:\n"
+        "                condition:\n"
+        "                  lambda: |-\n"
+        "                    if (!id(schedule_enabled).state) return true;\n"
+        "                    return screen_schedule_normal_active(\n"
+        "                      id(screen_schedule_trigger).state,\n"
+        "                      id(schedule_enabled).state,\n"
+        "                      id(presence_detected),\n"
+        "                      now.is_valid(),\n"
+        "                      now.is_valid() ? now.hour : 0,\n"
+        "                      (int) id(schedule_on_hour).state,\n"
+        "                      (int) id(schedule_off_hour).state);\n"
+        "                then:\n"
         "            - script.execute: screensaver_wake\n"
     )
     expect_screen_schedule_screensaver_override_errors(
@@ -2957,6 +2976,15 @@ def run_self_test() -> int:
             1,
         ),
         ("override sensor screensaver wake",),
+    )
+    expect_screen_schedule_screensaver_override_errors(
+        "sensor screensaver wake ignores disabled schedule",
+        valid_schedule_screensaver_override.replace(
+            "                    if (!id(schedule_enabled).state) return true;\n",
+            "",
+            1,
+        ),
+        ("wake when the screen schedule is disabled",),
     )
     expect_artwork_image_auth_errors(
         "local artwork image request uses Basic auth",


### PR DESCRIPTION
## Summary
- Restores sensor-controlled screensaver wake when the separate screen schedule is disabled.
- Keeps the newer night schedule override in place when screen schedules are enabled.
- Adds a firmware guardrail so this disabled-schedule wake path is checked in future changes.

## Root cause
The wake path checked the screen schedule override before waking. With the screen schedule disabled, the outer check could continue, but the final wake decision still treated the schedule as inactive and routed to `screen_schedule_check` instead of `screensaver_wake`.

## Testing
- `python3 scripts/check_firmware_ha_bindings.py`
- `python3 scripts/check_firmware_ha_bindings.py --self-test`
- `npm run check:firmware-ha-bindings`
- `docker run ... ghcr.io/esphome/esphome:2026.5.3 compile /config/builds/guition-esp32-s3-4848s040.factory.yaml`

## Device testing notes
Please test on an affected display, especially 4848S040 if available:

1. Flash this PR build.
2. Set Screensaver mode to sensor.
3. Set Screensaver action to Clock and/or Screen Dimmed.
4. Leave Screen schedule disabled.
5. Set Presence Sensor Entity to the existing Home Assistant motion/presence sensor.

Expected result: when the sensor clears, the screen can enter the screensaver; when the sensor detects again, the display wakes without needing a touch.

Addresses #437.