### PR TITLE
Increase firmware rollback options

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -88,7 +88,7 @@ jobs:
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases?per_page=30")
-          STABLE_RELEASES_JSON=$(printf '%s' "${RELEASES_JSON}" | jq -c '[.[] | select((.draft | not) and (.prerelease | not))][0:3]')
+          STABLE_RELEASES_JSON=$(printf '%s' "${RELEASES_JSON}" | jq -c '[.[] | select((.draft | not) and (.prerelease | not))][0:5]')
           RELEASE_COUNT=$(printf '%s' "${STABLE_RELEASES_JSON}" | jq 'length')
 
           if [ "${RELEASE_COUNT}" -eq 0 ]; then

--- a/docs/features/firmware-updates.md
+++ b/docs/features/firmware-updates.md
@@ -15,7 +15,7 @@ These are configured from the **Settings** tab in the [Setup](/features/setup) u
 - **Version** — the firmware version currently running on your panel (read-only).
 - **Auto Update** — turn this on to let the panel install new versions automatically. When off, you'll need to trigger updates manually.
 - **Update Frequency** — how often the panel checks for updates: **Hourly**, **Daily**, **Weekly**, or **Monthly**.
-- **Install Version** — choose the latest stable firmware or one of the previous stable versions when more than one version is available.
+- **Install Version** — choose the latest stable firmware or one of up to four previous stable versions when more than one version is available.
 - **Check for Update** — press this button to check for a new version right now, regardless of the automatic schedule.
 
 ## What Happens During an Update
@@ -29,7 +29,7 @@ The update usually takes a minute or two. The display may show an update or load
 
 ## Installing an Older Version
 
-When older stable firmware is available, the **Install Version** selector lets you choose the version to install. This is intended for rolling back to a recent stable version if you need to test or recover from a problem.
+When older stable firmware is available, the **Install Version** selector lets you choose the version to install. This is intended for rolling back to one of the four most recent previous stable versions if you need to test or recover from a problem.
 
 ## Compatibility Notes
 

--- a/scripts/check_public_firmware.py
+++ b/scripts/check_public_firmware.py
@@ -104,8 +104,8 @@ def verify_versions_index(base_url: str, slug: str, latest_version: str) -> None
     entries = data.get("versions")
     if not isinstance(entries, list) or not entries:
         raise PublicFirmwareError(f"{url} must contain a non-empty versions list")
-    if len(entries) > 3:
-        raise PublicFirmwareError(f"{url} must contain at most latest plus two previous versions")
+    if len(entries) > 5:
+        raise PublicFirmwareError(f"{url} must contain at most latest plus four previous versions")
 
     seen: set[str] = set()
     for idx, entry in enumerate(entries):


### PR DESCRIPTION
## Purpose
Increase the public firmware rollback list from 3 total stable versions to 5 total stable versions.

## Practical impact
The firmware update page can now offer the latest stable firmware plus up to four previous stable versions for rollback/testing, instead of only the latest plus two previous versions.

## Checks
- npm run check:public-firmware-script
- npm run docs:build

## Testing notes
After this is merged and the Pages workflow publishes, check a display's Firmware settings and confirm the Install Version selector can show up to five stable firmware choices when enough releases exist.