### PR TITLE
Add 3D printable stands docs page

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -452,6 +452,7 @@ export default defineConfig({
       {
         text: 'Reference',
         items: [
+          { text: '3D Printable Stands', link: '/reference/3d-printable-stands' },
           { text: 'Contributing', link: '/reference/contributing' },
           { text: 'Icon Reference', link: '/reference/icons' },
           { text: 'Language Support', link: '/reference/language-support' },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -377,6 +377,7 @@ export default defineConfig({
           { text: 'Install', link: '/getting-started/install' },
           { text: 'Manual ESPHome Setup', link: '/getting-started/manual-esphome-setup' },
           { text: 'Enable Actions', link: '/getting-started/home-assistant-actions' },
+          { text: '3D Printable Stands', link: '/reference/3d-printable-stands' },
           { text: 'Troubleshooting', link: '/getting-started/troubleshooting' },
         ],
       },
@@ -452,7 +453,6 @@ export default defineConfig({
       {
         text: 'Reference',
         items: [
-          { text: '3D Printable Stands', link: '/reference/3d-printable-stands' },
           { text: 'Contributing', link: '/reference/contributing' },
           { text: 'Icon Reference', link: '/reference/icons' },
           { text: 'Language Support', link: '/reference/language-support' },

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,11 +27,11 @@ EspControl is free, open-source firmware that turns supported **ESP32 touchscree
 
 | Screen | Panel | 3D printable mount |
 |---|---|---|
-| 10.1-inch JC8012P4A1 | [AliExpress ~£40](https://s.click.aliexpress.com/e/_c4W6TYvp) | [MakerWorld](https://makerworld.com/en/models/2490049-guition-p4-10inch-screen-stand#profileId-2736046) |
-| 7-inch JC1060P470 | [AliExpress ~£40](https://s.click.aliexpress.com/e/_c335W0r5) | [MakerWorld](https://makerworld.com/en/models/2387421-guition-esp32p4-jc1060p470-7inch-screen-desk-mount#profileId-2614995) |
+| 10.1-inch JC8012P4A1 | [AliExpress ~£40](https://s.click.aliexpress.com/e/_c4W6TYvp) | [Stand page](/reference/3d-printable-stands) |
+| 7-inch JC1060P470 | [AliExpress ~£40](https://s.click.aliexpress.com/e/_c335W0r5) | [Stand page](/reference/3d-printable-stands) |
 | 4.3-inch JC4880P443 | [AliExpress ~£24](https://s.click.aliexpress.com/e/_c32jr3eN) | - |
-| 4-inch ESP32-P4 86 Panel | [AliExpress ~£45](https://s.click.aliexpress.com/e/_c3O6ndAX) | [MakerWorld](https://makerworld.com/en/models/2720366-waveshare-esp32-p4-smart-86-box-screen-desk-stand#profileId-3013481) |
-| 4-inch 4848S040 | [AliExpress ~£16](https://s.click.aliexpress.com/e/_c3sIhvBv) | [MakerWorld](https://makerworld.com/en/models/2581572-guition-esp32s3-4848s040-case-stand#profileId-2847301) |
+| 4-inch ESP32-P4 86 Panel | [AliExpress ~£45](https://s.click.aliexpress.com/e/_c3O6ndAX) | [Stand page](/reference/3d-printable-stands) |
+| 4-inch 4848S040 | [AliExpress ~£16](https://s.click.aliexpress.com/e/_c3sIhvBv) | [Stand page](/reference/3d-printable-stands) |
 
 ## Support This Project
 

--- a/docs/reference/3d-printable-stands.md
+++ b/docs/reference/3d-printable-stands.md
@@ -1,0 +1,34 @@
+---
+title: 3D Printable Stands
+description:
+  3D printable desk stands and case stands for EspControl supported ESP32 touchscreens, with links to the matching MakerWorld print files.
+---
+
+# 3D Printable Stands
+
+These stands are optional desk mounts for supported EspControl panels. They are useful when you want a display on a desk, shelf, bedside table, or test bench instead of wall mounting it.
+
+Choose the stand that matches your exact screen model. The cases are shaped around the panel body, ports, and cable position, so a stand for one display usually will not fit another display cleanly.
+
+## Available Print Files
+
+| Screen | Stand type | Print file |
+|---|---|---|
+| [10.1-inch JC8012P4A1](/screens/jc8012p4a1) | Desk stand | [MakerWorld](https://makerworld.com/en/models/2490049-guition-p4-10inch-screen-stand#profileId-2736046) |
+| [7-inch JC1060P470](/screens/jc1060p470) | Desk stand | [MakerWorld](https://makerworld.com/en/models/2387421-guition-esp32p4-jc1060p470-7inch-screen-desk-mount#profileId-2614995) |
+| [4-inch ESP32-P4 86 Panel](/screens/p4-86) | Desk stand | [MakerWorld](https://makerworld.com/en/models/2720366-waveshare-esp32-p4-smart-86-box-screen-desk-stand#profileId-3013481) |
+| [4-inch 4848S040](/screens/4848s040) | Case stand | [MakerWorld](https://makerworld.com/en/models/2581572-guition-esp32s3-4848s040-case-stand#profileId-2847301) |
+| [4.3-inch JC4880P443](/screens/jc4880p443) | Not available yet | - |
+
+## Before Printing
+
+- Confirm the screen model printed on the product listing or board matches the stand page.
+- Check that the USB-C cable exits in the direction you need for your desk or shelf.
+- Use a material and print settings suitable for the temperature and sunlight where the display will sit.
+- Test fit the display before forcing clips or tabs into place.
+
+## Related Links
+
+- [Install EspControl](/getting-started/install)
+- [Supported Screens](/screens/jc1060p470)
+- [Request Device Support](/reference/request-device-support)


### PR DESCRIPTION
## What changed

- Added a dedicated docs page for 3D printable stands.
- Linked the new page from the Reference sidebar.
- Updated the home page buying table so stand links point to the dedicated page.

## Practical impact

Users now have one place to find the current MakerWorld stand files for supported EspControl panels, plus basic notes to help them choose the correct print.

## Checks

- `npm run docs:build`
- `npm run check:dev-docs`

## Testing notes

Docs-only change. No firmware flashing is needed. Please check the new 3D Printable Stands page and confirm the MakerWorld links are the ones you want published.
