### PR TITLE
Prevent upgrade panel config resets

### DIFF
--- a/common/config/display.yaml
+++ b/common/config/display.yaml
@@ -10,10 +10,6 @@ globals:
     type: bool
     restore_value: no
     initial_value: 'false'
-  - id: panel_device_settings_reset_version
-    type: int
-    restore_value: true
-    initial_value: '0'
 
 esphome:
   on_boot:

--- a/devices/esp32-p4-86/device/sensors.yaml
+++ b/devices/esp32-p4-86/device/sensors.yaml
@@ -137,15 +137,6 @@ script:
             id(main_page)->obj);
       - script.execute: clock_bar_apply
 
-  - id: reset_existing_panel_settings_once
-    then:
-      - lambda: |-
-          const int reset_version = 20260611;
-          if (id(panel_device_settings_reset_version) >= reset_version) return;
-          ESP_LOGI("config", "Preserving stored panel settings across firmware update");
-          id(panel_device_settings_reset_version) = reset_version;
-          global_preferences->sync();
-
 esphome:
   on_boot:
     - priority: -100

--- a/devices/guition-esp32-p4-jc1060p470/device/sensors.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/device/sensors.yaml
@@ -146,15 +146,6 @@ script:
             id(main_page)->obj);
       - script.execute: clock_bar_apply
 
-  - id: reset_existing_panel_settings_once
-    then:
-      - lambda: |-
-          const int reset_version = 20260611;
-          if (id(panel_device_settings_reset_version) >= reset_version) return;
-          ESP_LOGI("config", "Preserving stored panel settings across firmware update");
-          id(panel_device_settings_reset_version) = reset_version;
-          global_preferences->sync();
-
 esphome:
   on_boot:
     - priority: -100

--- a/devices/guition-esp32-p4-jc4880p443/device/sensors.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/device/sensors.yaml
@@ -135,15 +135,6 @@ script:
             id(main_page)->obj);
       - script.execute: clock_bar_apply
 
-  - id: reset_existing_panel_settings_once
-    then:
-      - lambda: |-
-          const int reset_version = 20260611;
-          if (id(panel_device_settings_reset_version) >= reset_version) return;
-          ESP_LOGI("config", "Preserving stored panel settings across firmware update");
-          id(panel_device_settings_reset_version) = reset_version;
-          global_preferences->sync();
-
 esphome:
   on_boot:
     - priority: -100

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -109,10 +109,6 @@ esphome:
                 #endif
             then:
               - lambda: |-
-                  ESP_LOGW("jc8012p4a1", "Previous boot crashed; preserving saved panel layout before retry");
-                  id(panel_device_settings_reset_version) = 0;
-              - script.execute: reset_existing_panel_settings_once
-              - lambda: |-
                   #ifdef USE_ESP32_CRASH_HANDLER
                   esphome::esp32::crash_handler_clear();
                   #endif

--- a/devices/guition-esp32-p4-jc8012p4a1/device/sensors.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/sensors.yaml
@@ -152,15 +152,6 @@ script:
             id(main_page)->obj);
       - script.execute: clock_bar_apply
 
-  - id: reset_existing_panel_settings_once
-    then:
-      - lambda: |-
-          const int reset_version = 20260611;
-          if (id(panel_device_settings_reset_version) >= reset_version) return;
-          ESP_LOGI("config", "Preserving stored panel settings across firmware update");
-          id(panel_device_settings_reset_version) = reset_version;
-          global_preferences->sync();
-
 esphome:
   on_boot:
     - priority: -100

--- a/devices/guition-esp32-s3-4848s040/device/sensors.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/sensors.yaml
@@ -118,15 +118,6 @@ script:
             id(main_page)->obj);
       - script.execute: clock_bar_apply
 
-  - id: reset_existing_panel_settings_once
-    then:
-      - lambda: |-
-          const int reset_version = 20260611;
-          if (id(panel_device_settings_reset_version) >= reset_version) return;
-          ESP_LOGI("config", "Preserving stored panel settings across firmware update");
-          id(panel_device_settings_reset_version) = reset_version;
-          global_preferences->sync();
-
 esphome:
   on_boot:
     - priority: -100

--- a/scripts/check_device_profiles.py
+++ b/scripts/check_device_profiles.py
@@ -118,6 +118,26 @@ def test_generated_yaml(profiles: dict[str, dict]) -> None:
             assert "cfg.info_only = true;" in sensors, f"{slug}: sensors.yaml missing info-only grid flag"
 
 
+def test_upgrades_do_not_reset_saved_panel_config() -> None:
+    display = (ROOT / "common" / "config" / "display.yaml").read_text(encoding="utf-8")
+    generator = (ROOT / "scripts" / "generate_device_slots.py").read_text(encoding="utf-8")
+    assert "panel_device_settings_reset_version" not in display, (
+        "firmware upgrades must not add a stored reset marker for panel config"
+    )
+    assert "reset_existing_panel_settings" not in generator, (
+        "generated device YAML must not include a boot-time panel config reset script"
+    )
+
+    for sensor_path in sorted((ROOT / "devices").glob("*/device/sensors.yaml")):
+        text = sensor_path.read_text(encoding="utf-8")
+        rel = sensor_path.relative_to(ROOT)
+        assert "reset_existing_panel_settings" not in text, f"{rel}: must not reset saved panel config on boot"
+        assert "id(button_order).publish_state(\"\")" not in text, f"{rel}: must not clear saved button order"
+        assert not re.search(r"id\((?:button|subpage)_\d+_config(?:_ext(?:_\d+)?)?\)\.publish_state\(\"\"\)", text), (
+            f"{rel}: must not clear saved button or subpage config"
+        )
+
+
 def test_square_s3_reapplies_clock_bar_layout() -> None:
     slug = "guition-esp32-s3-4848s040"
     sensors = (ROOT / "devices" / slug / "device" / "sensors.yaml").read_text(encoding="utf-8")
@@ -415,6 +435,7 @@ def main() -> int:
     test_public_device_capabilities(profile_slugs)
     test_generated_web(profiles)
     test_generated_yaml(profiles)
+    test_upgrades_do_not_reset_saved_panel_config()
     test_square_s3_reapplies_clock_bar_layout()
     test_setup_icon_glyphs()
     test_weather_card_visual_matches_preview()

--- a/scripts/generate_device_slots.py
+++ b/scripts/generate_device_slots.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from product_schema import slot_devices
 
 ROOT = Path(__file__).resolve().parents[1]
-PANEL_DEVICE_SETTINGS_RESET_VERSION = 20260611
 
 
 PACKAGE_HEADER = """# =============================================================================
@@ -664,24 +663,8 @@ def script_block(device: dict) -> str:
             "            id(main_page)->obj);",
             *after_refresh,
             "",
-            reset_existing_panel_settings_script(device),
-            "",
         ]
     )
-
-
-def reset_existing_panel_settings_script(device: dict) -> str:
-    lines = [
-        "  - id: reset_existing_panel_settings_once",
-        "    then:",
-        "      - lambda: |-",
-        f"          const int reset_version = {PANEL_DEVICE_SETTINGS_RESET_VERSION};",
-        "          if (id(panel_device_settings_reset_version) >= reset_version) return;",
-        '          ESP_LOGI("config", "Preserving stored panel settings across firmware update");',
-        "          id(panel_device_settings_reset_version) = reset_version;",
-        "          global_preferences->sync();",
-    ]
-    return "\n".join(lines)
 
 
 def replace_phase(text: str, phase: int, block: str, call: str, slug: str) -> str:


### PR DESCRIPTION
## Purpose
Prevent firmware upgrades from touching saved panel card/layout configuration during boot. This specifically protects people upgrading from older releases such as v2.2.3 to a newer build.

## Practical impact
- Removes the generated boot-time panel config reset script from all supported display firmware YAML.
- Removes the stored reset marker that could cause an unnecessary preferences write during upgrade.
- Stops the 10.1-inch crash recovery path from invoking the reset script.
- Adds a regression check so future generated firmware cannot clear button order, button config, or subpage config during boot.

## Checked
- npm run check:fast
- python3 scripts/generate_device_slots.py --check

## Device testing notes
Flash this PR build to a panel that is already configured on v2.2.3, then confirm the existing cards, subpages, button order, colours, clock bar, and display settings are still present after the upgrade and reboot.