### PR TITLE
Fix cover art resume proxy download

### DIFF
--- a/components/artwork_image/artwork_image.cpp
+++ b/components/artwork_image/artwork_image.cpp
@@ -42,9 +42,13 @@ static std::string sanitize_artwork_url_for_log(const std::string &url) {
   return url.substr(0, query) + "?...";
 }
 
+static bool is_ha_media_proxy_url(const std::string &url) {
+  return url.find("/api/media_player_proxy/") != std::string::npos;
+}
+
 static const char *classify_artwork_url_for_log(const std::string &url) {
   if (url.find("mzstatic.com") != std::string::npos) return "apple-cdn";
-  if (url.find("/api/media_player_proxy/") != std::string::npos) return "ha-media-proxy";
+  if (is_ha_media_proxy_url(url)) return "ha-media-proxy";
   if (url.rfind("http://", 0) == 0) return "http";
   if (url.rfind("https://", 0) == 0) return "https";
   return "unknown";
@@ -473,6 +477,10 @@ std::shared_ptr<http_request::HttpContainer> ArtworkImage::get_local_idf_(
   container->set_content_length_known(content_length > 0);
   container->set_chunked(esp_http_client_is_chunked_response(client));
   container->status_code = esp_http_client_get_status_code(client);
+  if (container->status_code <= 0 && is_ha_media_proxy_url(url)) {
+    ESP_LOGW(TAG, "Home Assistant media proxy returned an unknown HTTP status; trying artwork bytes anyway");
+    container->status_code = HTTP_CODE_OK;
+  }
   container->duration_ms = millis() - start;
   return container;
 #else

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -867,6 +867,12 @@ def firmware_artwork_image_auth_errors(path: Path, root: Path) -> list[str]:
         )
     if "config.auth_type = HTTP_AUTH_TYPE_NONE;" not in text:
         errors.append(f"{rel}: explicitly disable HTTP auth for local artwork requests")
+    if (
+        'container->status_code <= 0 && is_ha_media_proxy_url(url)' not in text
+        or "trying artwork bytes anyway" not in text
+        or "container->status_code = HTTP_CODE_OK;" not in text
+    ):
+        errors.append(f"{rel}: allow Home Assistant media proxy artwork to fall back to image-byte detection")
     return errors
 
 
@@ -3014,6 +3020,10 @@ def run_self_test() -> int:
         "    const std::string &url, const std::vector<http_request::Header> &headers) {\n"
         "  esp_http_client_config_t config = {};\n"
         "  config.auth_type = HTTP_AUTH_TYPE_BASIC;\n"
+        "  if (container->status_code <= 0 && is_ha_media_proxy_url(url)) {\n"
+        "    ESP_LOGW(TAG, \"Home Assistant media proxy returned an unknown HTTP status; trying artwork bytes anyway\");\n"
+        "    container->status_code = HTTP_CODE_OK;\n"
+        "  }\n"
         "}\n",
         (
             "keep local Home Assistant image proxy requests off HTTP Basic auth",
@@ -3026,8 +3036,21 @@ def run_self_test() -> int:
         "    const std::string &url, const std::vector<http_request::Header> &headers) {\n"
         "  esp_http_client_config_t config = {};\n"
         "  config.auth_type = HTTP_AUTH_TYPE_NONE;\n"
+        "  if (container->status_code <= 0 && is_ha_media_proxy_url(url)) {\n"
+        "    ESP_LOGW(TAG, \"Home Assistant media proxy returned an unknown HTTP status; trying artwork bytes anyway\");\n"
+        "    container->status_code = HTTP_CODE_OK;\n"
+        "  }\n"
         "}\n",
         (),
+    )
+    expect_artwork_image_auth_errors(
+        "local artwork image request rejects unknown HA media proxy status",
+        "std::shared_ptr<http_request::HttpContainer> ArtworkImage::get_local_idf_(\n"
+        "    const std::string &url, const std::vector<http_request::Header> &headers) {\n"
+        "  esp_http_client_config_t config = {};\n"
+        "  config.auth_type = HTTP_AUTH_TYPE_NONE;\n"
+        "}\n",
+        ("allow Home Assistant media proxy artwork to fall back to image-byte detection",),
     )
     expect_climate_step_errors(
         "climate ignores whole-number display step",


### PR DESCRIPTION
## Purpose
Fixes #457 by letting Home Assistant media proxy artwork continue to image-byte detection when the local HTTP client opens the response but reports an unknown status after playback resumes.

## Practical impact
When Music Assistant or another Home Assistant media player resumes playback after a pause, cover art should have another chance to load instead of immediately failing because the proxy response has no usable status/content-type metadata.

## What changed
- Detect Home Assistant `/api/media_player_proxy/` artwork URLs with a shared helper.
- For those proxy URLs only, treat an unknown local HTTP status as OK so the existing JPEG/PNG magic-byte detection can inspect the returned bytes.
- Added a firmware guard self-test so this fallback stays in place.

## Checks
- `npm run check:firmware-ha-bindings`
- `npm run check:fast`

## Device testing
Flash this branch to a display that uses media cover art, play media through Music Assistant, pause playback, then resume. The album art should reappear without needing to skip tracks.