### PR TITLE
Fix Home Assistant artwork URL settings

### DIFF
--- a/common/device/core_infra.yaml
+++ b/common/device/core_infra.yaml
@@ -30,7 +30,9 @@ api:
             } else if (host.find(':') != std::string::npos && host.front() != '[') {
               host = "[" + host + "]";
             }
-            id(cover_art_home_assistant_base_url) = "http://" + host + ":8123";
+            int port = static_cast<int>(id(cover_art_home_assistant_artwork_port).state);
+            id(cover_art_home_assistant_base_url) =
+              id(cover_art_home_assistant_artwork_protocol).state + "://" + host + ":" + std::to_string(port);
             ESP_LOGI("api", "Using Home Assistant base URL: %s",
                      id(cover_art_home_assistant_base_url).c_str());
           } else {
@@ -160,3 +162,42 @@ switch:
     icon: "mdi:flask-outline"
     web_server:
       sorting_group_id: sg_developer
+
+select:
+  - platform: template
+    name: "Home Assistant Artwork Protocol"
+    internal: true
+    id: cover_art_home_assistant_artwork_protocol
+    entity_category: config
+    icon: "mdi:protocol"
+    optimistic: true
+    restore_value: true
+    initial_option: "http"
+    options:
+      - "http"
+      - "https"
+    web_server:
+      sorting_group_id: sg_connectivity
+    set_action:
+      - lambda: |-
+          refresh_image_cards();
+
+number:
+  - platform: template
+    name: "Home Assistant Artwork Port"
+    internal: true
+    id: cover_art_home_assistant_artwork_port
+    entity_category: config
+    icon: "mdi:lan-connect"
+    optimistic: true
+    restore_value: true
+    initial_value: 8123
+    min_value: 1
+    max_value: 65535
+    step: 1
+    mode: box
+    web_server:
+      sorting_group_id: sg_connectivity
+    set_action:
+      - lambda: |-
+          refresh_image_cards();

--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -133,7 +133,9 @@ api:
         } else if (host.find(':') != std::string::npos && host.front() != '[') {
           host = "[" + host + "]";
         }
-        id(cover_art_home_assistant_base_url) = "http://" + host + ":8123";
+        int port = static_cast<int>(id(cover_art_home_assistant_artwork_port).state);
+        id(cover_art_home_assistant_base_url) =
+          id(cover_art_home_assistant_artwork_protocol).state + "://" + host + ":" + std::to_string(port);
         id(cover_art_api_wait_logged) = false;
         ESP_LOGI("cover_art", "Using Home Assistant artwork base URL: %s",
                  id(cover_art_home_assistant_base_url).c_str());


### PR DESCRIPTION
## Summary
- Adds device web settings for the Home Assistant artwork protocol and port.
- Keeps the existing default as `http` on port `8123`, so current installs should behave the same after update.
- Uses the selected protocol and port when building the artwork proxy base URL, instead of hardcoding `http://<host>:8123`.

## Why
Some Home Assistant installs serve HTTPS on port 443 or use another custom port. The artwork downloader was always trying `http://<host>:8123`, which meant media artwork could not load on those setups.

## Testing
- `npm run check:fast`
- Docker ESPHome compile: `builds/esp32-p4-86.factory.yaml`

## Device testing notes
Flash this branch to an affected display, then set:
- Home Assistant Artwork Protocol: `https`
- Home Assistant Artwork Port: `443`

After applying/rebooting, start media playback and confirm the cover artwork loads.

Related to #473