### PR TITLE
Reduce self-hosted runner disk usage

### DIFF
--- a/.github/workflows/nightly-firmware.yml
+++ b/.github/workflows/nightly-firmware.yml
@@ -8,9 +8,6 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ESPHOME_VERSION: 2026.5.3
-  ESPCONTROL_ESPHOME_CACHE_MAX_MB: 6144
-  ESPCONTROL_PLATFORMIO_CACHE_MAX_MB: 4096
-  ESPCONTROL_BUILD_CACHE_MAX_MB: 1024
   ESPCONTROL_DOCKER_BUILD_CACHE_KEEP: 2GB
 
 concurrency:
@@ -46,7 +43,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 2
       matrix: ${{ fromJSON(needs.device-matrix.outputs.matrix) }}
     steps:
       - name: Prepare self-hosted workspace
@@ -76,19 +73,17 @@ jobs:
         working-directory: espcontrol-${{ matrix.slug }}
         run: bash scripts/reclaim_actions_disk.sh
 
-      - name: Prepare local ESPHome cache
+      - name: Prepare isolated ESPHome cache
         working-directory: espcontrol-${{ matrix.slug }}
         run: |
-          CACHE_ROOT="${HOME}/.cache/espcontrol-actions/esphome/${{ matrix.slug }}"
-          PLATFORMIO_CACHE="${CACHE_ROOT}/platformio-${ESPHOME_VERSION}"
-          RUN_CACHE_ROOT="${CACHE_ROOT}/nightly/${{ github.run_id }}-${{ github.run_attempt }}"
+          RUN_CACHE_ROOT="${RUNNER_TEMP}/espcontrol-esphome/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.slug }}"
+          PLATFORMIO_CACHE="${RUN_CACHE_ROOT}/platformio-${ESPHOME_VERSION}"
           BUILD_CACHE="${RUN_CACHE_ROOT}/build"
+          rm -rf "${RUN_CACHE_ROOT}"
           mkdir -p "${PLATFORMIO_CACHE}" "${BUILD_CACHE}" builds
-          bash scripts/prune_actions_cache.sh "${CACHE_ROOT}" "${ESPCONTROL_ESPHOME_CACHE_MAX_MB}" --protect "${PLATFORMIO_CACHE}" --protect "${RUN_CACHE_ROOT}"
-          bash scripts/prune_actions_cache.sh "${CACHE_ROOT}/nightly" "${ESPCONTROL_BUILD_CACHE_MAX_MB}" --protect "${RUN_CACHE_ROOT}"
-          bash scripts/prune_actions_cache.sh "${PLATFORMIO_CACHE}" "${ESPCONTROL_PLATFORMIO_CACHE_MAX_MB}" --strategy reset
           rm -rf .esphome
           rm -rf builds/.esphome
+          echo "RUN_CACHE_ROOT=${RUN_CACHE_ROOT}" >> "$GITHUB_ENV"
           echo "PLATFORMIO_CACHE=${PLATFORMIO_CACHE}" >> "$GITHUB_ENV"
           echo "BUILD_CACHE=${BUILD_CACHE}" >> "$GITHUB_ENV"
 
@@ -110,13 +105,9 @@ jobs:
         if: always()
         working-directory: espcontrol-${{ matrix.slug }}
         run: |
-          if [ -z "${BUILD_CACHE:-}" ] || [ -z "${PLATFORMIO_CACHE:-}" ]; then
+          if [ -z "${RUN_CACHE_ROOT:-}" ] || [ -z "${BUILD_CACHE:-}" ] || [ -z "${PLATFORMIO_CACHE:-}" ]; then
             echo "No firmware cache paths were prepared."
             exit 0
           fi
-          rm -rf "${BUILD_CACHE}"
-          RUN_CACHE_ROOT="$(dirname "${BUILD_CACHE}")"
-          bash scripts/prune_actions_cache.sh "${PLATFORMIO_CACHE}" "${ESPCONTROL_PLATFORMIO_CACHE_MAX_MB}" --strategy reset
-          bash scripts/prune_actions_cache.sh "$(dirname "${RUN_CACHE_ROOT}")" "${ESPCONTROL_BUILD_CACHE_MAX_MB}" --protect "${RUN_CACHE_ROOT}"
-          bash scripts/prune_actions_cache.sh "${HOME}/.cache/espcontrol-actions/esphome/${{ matrix.slug }}" "${ESPCONTROL_ESPHOME_CACHE_MAX_MB}" --protect "${PLATFORMIO_CACHE}"
+          rm -rf "${RUN_CACHE_ROOT}"
           bash scripts/reclaim_actions_disk.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,6 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ESPHOME_VERSION: 2026.5.3
-  ESPCONTROL_ESPHOME_CACHE_MAX_MB: 6144
-  ESPCONTROL_PLATFORMIO_CACHE_MAX_MB: 4096
-  ESPCONTROL_BUILD_CACHE_MAX_MB: 1024
   ESPCONTROL_DOCKER_BUILD_CACHE_KEEP: 2GB
 
 jobs:
@@ -74,7 +71,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 2
       matrix: ${{ fromJSON(needs.device-matrix.outputs.matrix) }}
     steps:
       - name: Prepare self-hosted workspace
@@ -103,17 +100,14 @@ jobs:
         working-directory: espcontrol-${{ matrix.slug }}
         run: bash scripts/reclaim_actions_disk.sh
 
-      - name: Prepare local ESPHome cache
+      - name: Prepare isolated ESPHome cache
         working-directory: espcontrol-${{ matrix.slug }}
         run: |
-          CACHE_ROOT="${HOME}/.cache/espcontrol-actions/esphome/${{ matrix.slug }}"
-          PLATFORMIO_CACHE="${CACHE_ROOT}/platformio-${ESPHOME_VERSION}"
-          RUN_CACHE_ROOT="${CACHE_ROOT}/release/${{ github.run_id }}-${{ github.run_attempt }}"
+          RUN_CACHE_ROOT="${RUNNER_TEMP}/espcontrol-esphome/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.slug }}"
+          PLATFORMIO_CACHE="${RUN_CACHE_ROOT}/platformio-${ESPHOME_VERSION}"
           BUILD_CACHE="${RUN_CACHE_ROOT}/build"
+          rm -rf "${RUN_CACHE_ROOT}"
           mkdir -p "${PLATFORMIO_CACHE}" "${BUILD_CACHE}" builds
-          bash scripts/prune_actions_cache.sh "${CACHE_ROOT}" "${ESPCONTROL_ESPHOME_CACHE_MAX_MB}" --protect "${PLATFORMIO_CACHE}" --protect "${RUN_CACHE_ROOT}"
-          bash scripts/prune_actions_cache.sh "${CACHE_ROOT}/release" "${ESPCONTROL_BUILD_CACHE_MAX_MB}" --protect "${RUN_CACHE_ROOT}"
-          bash scripts/prune_actions_cache.sh "${PLATFORMIO_CACHE}" "${ESPCONTROL_PLATFORMIO_CACHE_MAX_MB}" --strategy reset
           export PLATFORMIO_CACHE
           python3 - <<'PY'
           import json
@@ -137,6 +131,7 @@ jobs:
           PY
           rm -rf .esphome
           rm -rf builds/.esphome
+          echo "RUN_CACHE_ROOT=${RUN_CACHE_ROOT}" >> "$GITHUB_ENV"
           echo "PLATFORMIO_CACHE=${PLATFORMIO_CACHE}" >> "$GITHUB_ENV"
           echo "BUILD_CACHE=${BUILD_CACHE}" >> "$GITHUB_ENV"
 
@@ -197,15 +192,11 @@ jobs:
         if: always()
         working-directory: espcontrol-${{ matrix.slug }}
         run: |
-          if [ -z "${BUILD_CACHE:-}" ] || [ -z "${PLATFORMIO_CACHE:-}" ]; then
+          if [ -z "${RUN_CACHE_ROOT:-}" ] || [ -z "${BUILD_CACHE:-}" ] || [ -z "${PLATFORMIO_CACHE:-}" ]; then
             echo "No firmware cache paths were prepared."
             exit 0
           fi
-          rm -rf "${BUILD_CACHE}"
-          RUN_CACHE_ROOT="$(dirname "${BUILD_CACHE}")"
-          bash scripts/prune_actions_cache.sh "${PLATFORMIO_CACHE}" "${ESPCONTROL_PLATFORMIO_CACHE_MAX_MB}" --strategy reset
-          bash scripts/prune_actions_cache.sh "$(dirname "${RUN_CACHE_ROOT}")" "${ESPCONTROL_BUILD_CACHE_MAX_MB}" --protect "${RUN_CACHE_ROOT}"
-          bash scripts/prune_actions_cache.sh "${HOME}/.cache/espcontrol-actions/esphome/${{ matrix.slug }}" "${ESPCONTROL_ESPHOME_CACHE_MAX_MB}" --protect "${PLATFORMIO_CACHE}"
+          rm -rf "${RUN_CACHE_ROOT}"
           bash scripts/reclaim_actions_disk.sh
 
   publish:

--- a/.github/workflows/runner-cleanup.yml
+++ b/.github/workflows/runner-cleanup.yml
@@ -1,0 +1,42 @@
+name: Runner Disk Cleanup
+
+on:
+  schedule:
+    - cron: '15 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runner-disk-cleanup
+  cancel-in-progress: true
+
+jobs:
+  cleanup:
+    name: Reclaim Runner Disk
+    runs-on: self-hosted
+    steps:
+      - name: Prepare self-hosted workspace
+        run: |
+          rm -rf "${GITHUB_WORKSPACE:?}/"* "${GITHUB_WORKSPACE:?}/".[!.]* "${GITHUB_WORKSPACE:?}/"..?* 2>/dev/null ||
+            sudo rm -rf "${GITHUB_WORKSPACE:?}/"* "${GITHUB_WORKSPACE:?}/".[!.]* "${GITHUB_WORKSPACE:?}/"..?*
+
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            scripts/reclaim_actions_disk.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Select Docker command
+        run: |
+          if docker info >/dev/null 2>&1; then
+            echo "DOCKER=docker" >> "$GITHUB_ENV"
+          elif sudo -n docker info >/dev/null 2>&1; then
+            echo "DOCKER=sudo docker" >> "$GITHUB_ENV"
+          else
+            echo "Docker is not available to the self-hosted runner user."
+          fi
+
+      - name: Reclaim runner disk
+        run: bash scripts/reclaim_actions_disk.sh

--- a/scripts/reclaim_actions_disk.sh
+++ b/scripts/reclaim_actions_disk.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 DOCKER_COMMAND=${DOCKER:-docker}
 KEEP_STORAGE=${ESPCONTROL_DOCKER_BUILD_CACHE_KEEP:-2GB}
+PRUNE_VOLUMES=${ESPCONTROL_DOCKER_PRUNE_VOLUMES:-true}
+CLEAN_RUNNER_UPDATES=${ESPCONTROL_CLEAN_RUNNER_UPDATES:-true}
+CLEAN_LEGACY_ESPHOME_CACHE=${ESPCONTROL_CLEAN_LEGACY_ESPHOME_CACHE:-true}
 
 disk_report() {
   local label=$1
@@ -10,14 +13,34 @@ disk_report() {
   df -h "${GITHUB_WORKSPACE:-$PWD}" "$HOME" 2>/dev/null || true
 }
 
-if ! ${DOCKER_COMMAND} info >/dev/null 2>&1; then
+disk_report "Disk before cleanup"
+
+if ${DOCKER_COMMAND} info >/dev/null 2>&1; then
+  ${DOCKER_COMMAND} container prune -f >/dev/null || true
+  ${DOCKER_COMMAND} image prune -af >/dev/null || true
+  ${DOCKER_COMMAND} builder prune -f --keep-storage "${KEEP_STORAGE}" >/dev/null || true
+  if [ "${PRUNE_VOLUMES}" = "true" ]; then
+    ${DOCKER_COMMAND} volume prune -f >/dev/null || true
+  fi
+  ${DOCKER_COMMAND} system df || true
+else
   echo "Docker is not available; skipping Docker disk cleanup."
-  exit 0
 fi
 
-disk_report "Disk before cleanup"
-${DOCKER_COMMAND} container prune -f >/dev/null || true
-${DOCKER_COMMAND} image prune -f >/dev/null || true
-${DOCKER_COMMAND} builder prune -f --keep-storage "${KEEP_STORAGE}" >/dev/null || true
-${DOCKER_COMMAND} system df || true
+if [ "${CLEAN_RUNNER_UPDATES}" = "true" ]; then
+  for update_dir in "$HOME"/actions-runner*/_work/_update; do
+    [ -d "${update_dir}" ] || continue
+    echo "Removing stale runner update directory: ${update_dir}"
+    rm -rf "${update_dir}" || sudo rm -rf "${update_dir}" || true
+  done
+fi
+
+if [ "${CLEAN_LEGACY_ESPHOME_CACHE}" = "true" ]; then
+  legacy_cache="${HOME}/.cache/espcontrol-actions/esphome"
+  if [ -d "${legacy_cache}" ]; then
+    echo "Removing legacy persistent ESPHome cache: ${legacy_cache}"
+    rm -rf "${legacy_cache}" || sudo rm -rf "${legacy_cache}" || true
+  fi
+fi
+
 disk_report "Disk after cleanup"


### PR DESCRIPTION
## Purpose
Reduce disk pressure on the self-hosted GitHub Actions runner by stopping firmware jobs from keeping large ESPHome/PlatformIO caches between runs, and by adding a reusable runner cleanup workflow.

## Practical impact
- Nightly and release firmware builds now use isolated per-run ESPHome caches under the runner temp directory and delete them after each matrix job.
- Nightly/release firmware builds are limited to 2 parallel self-hosted jobs to lower peak disk usage.
- Runner cleanup now prunes unused Docker images more aggressively, prunes unused Docker volumes, removes stale runner `_update` directories, and removes the old persistent ESPHome cache at `~/.cache/espcontrol-actions/esphome`.
- Added a manual and scheduled **Runner Disk Cleanup** workflow so disk cleanup can be run without waiting for a firmware build.

## Checks run
- `bash -n scripts/reclaim_actions_disk.sh scripts/prune_actions_cache.sh`
- `git diff --check`
- Parsed all `.github/workflows/*.yml` files with PyYAML

`actionlint` was not installed locally, so I could not run the dedicated GitHub Actions linter.

## Testing notes
1. Run the new **Runner Disk Cleanup** workflow manually from GitHub Actions.
2. Confirm the runner frees space from Docker and `~/.cache/espcontrol-actions/esphome`.
3. Run **Firmware Compile** against this branch to confirm firmware still compiles with isolated caches.
4. After one nightly/release run, confirm the runner temp ESPHome cache is removed at job cleanup.