### PR TITLE
Pin local ESPHome compile image

### DIFF
--- a/.agents/skills/compile/SKILL.md
+++ b/.agents/skills/compile/SKILL.md
@@ -32,7 +32,7 @@ entry point CI uses, so the test matches what a release build would do.
 ```bash
 docker run --rm \
   -v "/Users/jtenniswood/Library/CloudStorage/Dropbox/Git/espcontrol:/config" \
-  ghcr.io/esphome/esphome:stable \
+  ghcr.io/esphome/esphome:2026.5.3 \
   compile /config/builds/<slug>.factory.yaml
 ```
 
@@ -41,10 +41,10 @@ Run devices sequentially because each compile is resource-intensive. Use a
 stalled too early. If a compile backgrounds, poll the terminal output until it
 finishes and read the result.
 
-If `ghcr.io/esphome/esphome:stable` is missing or stale, pull it first:
+If `ghcr.io/esphome/esphome:2026.5.3` is missing, pull it first:
 
 ```bash
-docker pull ghcr.io/esphome/esphome:stable
+docker pull ghcr.io/esphome/esphome:2026.5.3
 ```
 
 ### 2. Interpret Results


### PR DESCRIPTION
## What changed

Pinned the local `/compile` helper to use `ghcr.io/esphome/esphome:2026.5.3` instead of the moving `stable` Docker image tag.

## Practical impact

Future local compile checks will use the same ESPHome version already configured in the GitHub firmware workflows, making local checks more repeatable.

## Checks

- Confirmed the GitHub firmware workflows are already set to `ESPHOME_VERSION: 2026.5.3`.
- Ran `git diff --check`.
- Pulled `ghcr.io/esphome/esphome:2026.5.3` successfully; Docker reported the image is up to date locally.

## Testing notes

This does not change firmware behavior directly. To test it, run `/compile` or manually run the Docker compile command from `.agents/skills/compile/SKILL.md` and confirm it uses the `2026.5.3` image.