### PR TITLE
Fix S3 timezone memory leak

### DIFF
--- a/common/addon/backlight_schedule.yaml
+++ b/common/addon/backlight_schedule.yaml
@@ -823,9 +823,6 @@ script:
     mode: single
     then:
       - lambda: |-
-          const char *posix = apply_timezone(id(timezone_select).current_option());
-          id(panel_time).set_timezone(posix);
-          id(homeassistant_time).set_timezone(posix);
           auto now = panel_time_or_fallback(id(panel_time).now(), id(homeassistant_time).now());
           if (!now.is_valid()) return;
           bool use_12h = id(clock_format_select).current_option() == "12h";

--- a/common/addon/time.yaml
+++ b/common/addon/time.yaml
@@ -362,8 +362,8 @@ text_sensor:
             }
 
 # ---------------------------------------------------------------------------
-# SNTP primary time source and Home Assistant fallback. Sync triggers clock and
-# sunrise/sunset recalculation.
+# SNTP primary time source and Home Assistant fallback. SNTP sync refreshes
+# sunrise/sunset; Home Assistant sync only refreshes the clock/schedule.
 # ---------------------------------------------------------------------------
 time:
   - platform: sntp
@@ -389,7 +389,6 @@ time:
     update_interval: 1min
     on_time_sync:
       - script.execute: time_update
-      - script.execute: backlight_recalc_sunrise_sunset
       - script.execute: screen_schedule_check
     on_time:
       - minutes: '*'
@@ -414,10 +413,6 @@ script:
 
   - id: time_update
     then:
-      - lambda: |-
-          const char *posix = apply_timezone(id(timezone_select).current_option());
-          id(panel_time).set_timezone(posix);
-          id(homeassistant_time).set_timezone(posix);
       - lvgl.label.update:
           id: display_time
           text: !lambda |-

--- a/components/espcontrol/button_grid_cards.h
+++ b/components/espcontrol/button_grid_cards.h
@@ -282,15 +282,6 @@ inline std::string timezone_city_label(const std::string &tz_option) {
   return city.empty() ? espcontrol_i18n(std::string("World Clock")) : city;
 }
 
-inline void set_posix_timezone_for_epoch(const std::string &tz_option, time_t epoch) {
-  std::string tz_id = timezone_id_from_option(tz_option);
-  struct tm utc_tm;
-  gmtime_r(&epoch, &utc_tm);
-  const char *posix = resolve_posix_tz_at_utc(tz_id, utc_point_from_tm(utc_tm));
-  setenv("TZ", posix, 1);
-  tzset();
-}
-
 inline bool timezone_localtime(const std::string &tz_option, time_t epoch, struct tm &out) {
   int offset_minutes = 0;
   if (!timezone_offset_minutes_at_utc(tz_option, epoch, offset_minutes)) return false;
@@ -349,10 +340,6 @@ inline void update_timezone_cards(bool valid,
   int count = timezone_card_count();
   for (int i = 0; i < count; i++) {
     apply_timezone_card_text(refs[i], valid, epoch, active_timezone, use_12h);
-  }
-  if (count > 0) {
-    if (valid) set_posix_timezone_for_epoch(active_timezone, epoch);
-    else apply_timezone(active_timezone);
   }
 }
 

--- a/components/espcontrol/sun_calc.h
+++ b/components/espcontrol/sun_calc.h
@@ -22,8 +22,8 @@
 // Timezone coordinate and POSIX TZ lookup table
 // ============================================================================
 // Representative city lat/lon for sunrise/sunset calculation, plus POSIX TZ
-// strings for DST-aware local time via setenv("TZ")/tzset(). Keep the POSIX
-// names alphabetic and DST offsets explicit for embedded C library compatibility.
+// strings for DST-aware local time. Keep the POSIX names alphabetic and DST
+// offsets explicit for embedded parser compatibility.
 
 struct TzCoord { const char* tz; float lat; float lon; const char* posix_tz; };
 struct TzUtcPoint { int year; int month; int day; int hour; int minute; };
@@ -517,46 +517,22 @@ inline void apply_ntp_servers(const std::string &server_1,
 #endif
 }
 
-inline float utc_offset_hours_at(time_t t) {
-  struct tm utc_tm, local_tm;
-  gmtime_r(&t, &utc_tm);
-  localtime_r(&t, &local_tm);
-  int diff_min = (local_tm.tm_hour - utc_tm.tm_hour) * 60
-               + (local_tm.tm_min - utc_tm.tm_min);
-  int day_diff = local_tm.tm_mday - utc_tm.tm_mday;
-  if (day_diff > 1) day_diff = -1;
-  else if (day_diff < -1) day_diff = 1;
-  diff_min += day_diff * 1440;
-  return diff_min / 60.0f;
-}
-
-inline float current_utc_offset_hours() {
-  return utc_offset_hours_at(time(nullptr));
-}
-
 inline float utc_offset_hours_for_date(
     int year, int month, int day, const std::string &tz_option) {
-  std::string tz_id = timezone_id_from_option(tz_option);
-  setenv("TZ", lookup_posix_tz(tz_id), 1);
-  tzset();
-
-  struct tm local_noon = {};
-  local_noon.tm_year = year - 1900;
-  local_noon.tm_mon = month - 1;
-  local_noon.tm_mday = day;
-  local_noon.tm_hour = 12;
-  local_noon.tm_isdst = -1;
-  time_t noon_epoch = mktime(&local_noon);
-  float offset = utc_offset_hours_at(noon_epoch);
-
-  if (tz_id == "Africa/Casablanca") {
-    struct tm utc_tm;
-    gmtime_r(&noon_epoch, &utc_tm);
-    offset = casablanca_pause_at_utc(utc_point_from_tm(utc_tm)) ? 0.0f : 1.0f;
+  int64_t local_noon = tz_epoch_utc(year, month, day, 12 * 3600);
+  int offset_minutes = 0;
+  if (!timezone_offset_minutes_at_utc(
+          tz_option, static_cast<time_t>(local_noon), offset_minutes)) {
+    return 0.0f;
   }
 
-  apply_timezone(tz_option);
-  return offset;
+  time_t utc_noon = static_cast<time_t>(
+      local_noon - static_cast<int64_t>(offset_minutes) * 60);
+  int refined_offset_minutes = offset_minutes;
+  if (timezone_offset_minutes_at_utc(tz_option, utc_noon, refined_offset_minutes)) {
+    offset_minutes = refined_offset_minutes;
+  }
+  return offset_minutes / 60.0f;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Stops minute-by-minute timezone reapplication in the clock update path.
- Removes repeated timezone mutation from sunrise/sunset recalculation.
- Keeps sunrise/sunset recalculation on boot/API connect, SNTP sync, timezone changes, and the existing midnight check.
- Updates timezone/world-clock cards to calculate local display time without mutating global `TZ`.

## Root Cause
References #489.

The 4-inch S3 logs showed internal heap steadily falling until the ESPHome API disconnected and the device later hit a `LoadProhibited` crash. The recurring time/sunrise paths were repeatedly writing global timezone state with `setenv("TZ", ...)`/`tzset()`. On the memory-constrained S3 target, that repeated timezone/environment churn is the likely internal heap leak source.

## Testing
- Targeted source search confirms recurring paths no longer call `setenv("TZ", ...)` or `tzset()`; the remaining calls are only inside `apply_timezone()`, now reached from boot and explicit timezone changes.
- Compiled `builds/guition-esp32-s3-4848s040.factory.yaml` successfully.
- Compiled `builds/guition-esp32-p4-jc1060p470.factory.yaml` successfully.
- Compiled `builds/guition-esp32-p4-jc4880p443.factory.yaml` successfully.

## Device Test Plan
Flash this branch to the 4-inch S3 / 4848S040 and monitor `Memory: Heap Free` for at least 2 hours.

Expected result:
- Internal heap should not steadily fall toward 3%.
- PSRAM should remain stable.
- API should stay connected.
- No `LoadProhibited` crash should appear after reboot.
- Clock/date cards should still update each minute.
- Sunrise/sunset brightness should still work after boot, timezone change, and midnight.
- Timezone/world-clock cards, if configured, should still show correct local time.

Do not close #489 until this has been flashed and confirmed stable on a real device.