### PR TITLE
Improve camera modal performance

### DIFF
--- a/components/artwork_image/artwork_image.cpp
+++ b/components/artwork_image/artwork_image.cpp
@@ -589,6 +589,24 @@ void ArtworkImage::loop() {
     return;
   }
 
+  if (this->downloader_->is_read_complete()) {
+    if (this->decoder_->has_unknown_download_size()) {
+      this->decoder_->set_download_size(this->downloader_->get_bytes_read());
+      ESP_LOGD(TAG, "HTTP transfer complete; inferred image size: %zu bytes", this->downloader_->get_bytes_read());
+    }
+    if (!this->decode_buffered_data_()) {
+      this->fail_download_();
+      return;
+    }
+    if (this->decoder_->is_finished()) {
+      this->finish_download_();
+      return;
+    }
+    ESP_LOGE(TAG, "HTTP transfer finished before image decoder completed");
+    this->fail_download_();
+    return;
+  }
+
   if (!this->ensure_download_buffer_capacity_()) {
     this->fail_download_();
     return;
@@ -615,24 +633,6 @@ void ArtworkImage::loop() {
 
   if (len < 0) {
     ESP_LOGE(TAG, "Download failed while reading image data: %d", len);
-    this->fail_download_();
-    return;
-  }
-
-  if (this->downloader_->is_read_complete()) {
-    if (this->decoder_->has_unknown_download_size()) {
-      this->decoder_->set_download_size(this->downloader_->get_bytes_read());
-      ESP_LOGD(TAG, "HTTP transfer complete; inferred image size: %zu bytes", this->downloader_->get_bytes_read());
-    }
-    if (!this->decode_buffered_data_()) {
-      this->fail_download_();
-      return;
-    }
-    if (this->decoder_->is_finished()) {
-      this->finish_download_();
-      return;
-    }
-    ESP_LOGE(TAG, "HTTP transfer finished before image decoder completed");
     this->fail_download_();
     return;
   }

--- a/components/artwork_image/artwork_image.cpp
+++ b/components/artwork_image/artwork_image.cpp
@@ -20,6 +20,8 @@ static const char *const TAG = "artwork_image";
 static const char *const CONTENT_TYPE_HEADER_NAME = "content-type";
 static constexpr uint32_t RETIRED_BUFFER_GRACE_MS = 3000;
 static constexpr size_t MAX_DOWNLOAD_BUFFER_SIZE = 2 * 1024 * 1024;
+static constexpr size_t LOOP_READ_BUDGET_BYTES = 4096;
+static constexpr size_t LOOP_DECODE_BUDGET_BYTES = 4096;
 static constexpr int LOCAL_ARTWORK_HTTP_TIMEOUT_MS = 6500;
 
 #include "image_decoder.h"
@@ -516,7 +518,11 @@ void ArtworkImage::loop() {
       return;
     }
 
-    size_t available = std::min(this->download_buffer_.free_capacity(), this->download_buffer_initial_size_);
+    size_t available = std::min({
+      this->download_buffer_.free_capacity(),
+      this->download_buffer_initial_size_,
+      LOOP_READ_BUDGET_BYTES,
+    });
     auto len = this->downloader_->read(this->download_buffer_.append(), available);
     bool transfer_complete = false;
     if (len > 0) {
@@ -564,7 +570,7 @@ void ArtworkImage::loop() {
     ESP_LOGI(TAG, "Downloading image (Size: %zu)", total_size);
 
     // Feed already-buffered data to the newly created decoder
-    if (!this->decode_buffered_data_()) {
+    if (!this->decode_buffered_data_(LOOP_DECODE_BUDGET_BYTES)) {
       this->fail_download_();
       return;
     }
@@ -588,12 +594,16 @@ void ArtworkImage::loop() {
     return;
   }
 
-  size_t available = std::min(this->download_buffer_.free_capacity(), this->download_buffer_initial_size_);
+  size_t available = std::min({
+    this->download_buffer_.free_capacity(),
+    this->download_buffer_initial_size_,
+    LOOP_READ_BUDGET_BYTES,
+  });
   auto len = this->downloader_->read(this->download_buffer_.append(), available);
   if (len > 0) {
     this->download_buffer_.write(len);
     this->last_data_millis_ = millis();
-    if (!this->decode_buffered_data_()) {
+    if (!this->decode_buffered_data_(LOOP_DECODE_BUDGET_BYTES)) {
       this->fail_download_();
       return;
     }
@@ -957,19 +967,23 @@ bool ArtworkImage::ensure_download_buffer_capacity_() {
   return this->download_buffer_.resize(target_size) == target_size;
 }
 
-bool ArtworkImage::decode_buffered_data_() {
+bool ArtworkImage::decode_buffered_data_(size_t max_bytes) {
   if (!this->decoder_ || this->download_buffer_.unread() == 0) {
     return true;
   }
 
   size_t unread = this->download_buffer_.unread();
-  auto fed = this->decoder_->decode(this->download_buffer_.data(), unread);
+  size_t decode_size = unread;
+  if (max_bytes > 0 && decode_size > max_bytes) {
+    decode_size = max_bytes;
+  }
+  auto fed = this->decoder_->decode(this->download_buffer_.data(), decode_size);
   if (fed < 0) {
     ESP_LOGE(TAG, "Error when decoding image.");
     return false;
   }
-  if (static_cast<size_t>(fed) > unread) {
-    ESP_LOGE(TAG, "Decoder consumed %d bytes, but only %zu were buffered", fed, unread);
+  if (static_cast<size_t>(fed) > decode_size) {
+    ESP_LOGE(TAG, "Decoder consumed %d bytes, but only %zu were offered", fed, decode_size);
     return false;
   }
   this->download_buffer_.read(fed);

--- a/components/artwork_image/artwork_image.h
+++ b/components/artwork_image/artwork_image.h
@@ -176,7 +176,7 @@ class ArtworkImage : public PollingComponent,
   void retire_active_buffer_();
   void cleanup_retired_buffers_(bool force);
   bool ensure_download_buffer_capacity_();
-  bool decode_buffered_data_();
+  bool decode_buffered_data_(size_t max_bytes = 0);
   void finish_download_();
   void fail_download_();
 

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -22,7 +22,7 @@ constexpr uint32_t IMAGE_CARD_MODAL_CLEANUP_DELAY_MS = 100;
 constexpr uint32_t IMAGE_CARD_MODAL_CLOSE_GUARD_MS = 350;
 constexpr uint8_t IMAGE_CARD_STARTUP_DOWNLOAD_RETRIES = 10;
 constexpr int IMAGE_CARD_MAX_CONTEXTS = 6;
-constexpr int IMAGE_CARD_MODAL_MAX_TARGET_SIDE_PX = 800;
+constexpr int IMAGE_CARD_MODAL_MAX_TARGET_SIDE_PX = 640;
 constexpr size_t IMAGE_CARD_MEMORY_HEADROOM_BYTES = 96 * 1024;
 constexpr lv_coord_t IMAGE_CARD_JC4880P443_MODAL_BACK_BUTTON_REF_PX = 58;
 constexpr const char *IMAGE_CARD_LOADING_ICON = "\U000F02E9";
@@ -42,6 +42,7 @@ struct ImageCardCtx {
   std::string source_url;
   std::string url;
   std::string modal_url;
+  std::string modal_open_source_url;
   std::string access_token;
   std::function<void()> suspend_display_takeover;
   std::function<void()> resume_display_takeover;
@@ -630,6 +631,7 @@ inline void reset_image_card_pool(const GridConfig &cfg) {
     contexts[i].base_url_provider = nullptr;
     contexts[i].source_url.clear();
     contexts[i].url.clear();
+    contexts[i].modal_open_source_url.clear();
     contexts[i].access_token.clear();
     contexts[i].suspend_display_takeover = nullptr;
     contexts[i].resume_display_takeover = nullptr;
@@ -1426,8 +1428,26 @@ inline void image_card_finish_modal_cleanup(ImageCardCtx *ctx) {
   }
   image_card_apply_widget_geometry(ctx->btn, ctx->widget, ctx->image);
   if (!ctx->source_url.empty()) {
-    image_card_schedule_source_refresh(ctx, IMAGE_CARD_MODAL_REFRESH_DELAY_MS, "tile");
+    uint32_t now = esphome::millis();
+    bool source_changed = !ctx->modal_open_source_url.empty() &&
+                          ctx->source_url != ctx->modal_open_source_url;
+    bool tile_missing = !ctx->image_ready || !ctx->requested_once;
+    bool refresh_due = ctx->refresh_interval_ms > 0 &&
+                       ctx->last_download_completed_ms != 0 &&
+                       (uint32_t)(now - ctx->last_download_completed_ms) >= ctx->refresh_interval_ms;
+    if (source_changed || tile_missing || refresh_due) {
+      const char *reason = source_changed
+        ? "tile source changed"
+        : (tile_missing ? "tile unavailable" : "stale tile");
+      image_card_log_diagnostics(ctx, "modal-close-refresh-scheduled");
+      image_card_schedule_source_refresh(ctx, IMAGE_CARD_MODAL_REFRESH_DELAY_MS, reason);
+    } else {
+      ctx->next_download_retry_ms = 0;
+      image_card_log_diagnostics(ctx, "modal-close-refresh-skipped");
+      ESP_LOGD("image_card", "Skipping tile refresh after modal close for %s", ctx->entity_id.c_str());
+    }
   }
+  ctx->modal_open_source_url.clear();
 }
 
 inline void image_card_modal_cleanup_timer_cb(lv_timer_t *timer) {
@@ -1502,12 +1522,14 @@ inline void image_card_open_modal(ImageCardCtx *ctx) {
     return;
   }
   control_modal_block_close_for(IMAGE_CARD_MODAL_CLOSE_GUARD_MS);
+  image_card_log_diagnostics(ctx, "modal-shell-created");
 
   ImageCardModalUi &ui = image_card_modal_ui();
   ui.active = ctx;
   ui.overlay = shell.overlay;
   ui.panel = shell.panel;
   ui.back_btn = shell.close_btn;
+  ctx->modal_open_source_url = ctx->source_url;
   if (ctx->suspend_display_takeover) ctx->suspend_display_takeover();
   image_card_log_diagnostics(ctx, "modal-display-takeover-suspended");
   image_card_style_modal_back_button(ui.back_btn, shell.layout);

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -1442,9 +1442,13 @@ inline void image_card_finish_modal_cleanup(ImageCardCtx *ctx) {
       image_card_log_diagnostics(ctx, "modal-close-refresh-scheduled");
       image_card_schedule_source_refresh(ctx, IMAGE_CARD_MODAL_REFRESH_DELAY_MS, reason);
     } else {
-      ctx->next_download_retry_ms = 0;
-      image_card_log_diagnostics(ctx, "modal-close-refresh-skipped");
-      ESP_LOGD("image_card", "Skipping tile refresh after modal close for %s", ctx->entity_id.c_str());
+      if (ctx->next_download_retry_ms != 0) {
+        image_card_log_diagnostics(ctx, "modal-close-refresh-preserved");
+        ESP_LOGD("image_card", "Preserving queued tile refresh after modal close for %s", ctx->entity_id.c_str());
+      } else {
+        image_card_log_diagnostics(ctx, "modal-close-refresh-skipped");
+        ESP_LOGD("image_card", "Skipping tile refresh after modal close for %s", ctx->entity_id.c_str());
+      }
     }
   }
   ctx->modal_open_source_url.clear();

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -2656,7 +2656,7 @@ def run_self_test() -> int:
     expect_image_card_quality_errors(
         "image card modal requests capped image",
         "constexpr int IMAGE_CARD_MAX_CONTEXTS = 6;\n"
-        "constexpr int IMAGE_CARD_MODAL_MAX_TARGET_SIDE_PX = 800;\n"
+        "constexpr int IMAGE_CARD_MODAL_MAX_TARGET_SIDE_PX = 640;\n"
         "constexpr size_t IMAGE_CARD_MEMORY_HEADROOM_BYTES = 96 * 1024;\n"
         "inline lv_style_selector_t image_card_pressed_selector() { return LV_STATE_PRESSED; }\n"
         "inline void image_card_apply_corner_clip(lv_obj_t *obj, lv_coord_t radius) {}\n"


### PR DESCRIPTION
## Purpose

Opening the full-screen camera modal was doing too much image work, especially when the modal requested a large image and then refreshed the tile again after closing. This PR reduces that pressure so the modal should feel faster to open and less disruptive after closing.

## What changed

- Reduced the modal image request cap from 800px to 640px on the longest side.
- Stopped automatically refreshing the tile after every modal close. It now refreshes only if the camera source changed, the tile is missing, or the existing tile is stale.
- Limited the image downloader loop to smaller read/decode chunks so a single loop pass does less blocking work.
- Added diagnostics for modal shell creation and whether the close-time tile refresh was scheduled or skipped.

## Practical impact

Camera modals should request less data, decode less image content, and avoid unnecessary refresh work when closing. The image may be slightly lower resolution in full-screen mode, but this is intentional for responsiveness on the displays.

## Checks

- `python3 scripts/check_firmware_ha_bindings.py`
- `python3 scripts/check_firmware_parser.py`
- `python3 scripts/check_firmware_modals.py`
- `npm run check:firmware-ha-bindings`
- `npm run check:firmware-modals`
- `git diff --check`
- ESPHome compile: `guition-esp32-p4-jc1060p470`
- ESPHome compile: `guition-esp32-p4-jc4880p443`
- ESPHome compile: `guition-esp32-s3-4848s040`

## Device testing

Flash this branch to a test display, then open and close a camera tile several times. Please check:

- The full-screen camera modal opens faster than before.
- Closing the modal does not cause a long pause or unnecessary tile reload.
- Reopening the modal still shows the correct camera image.
- The 640px modal image quality is acceptable on the target display.
