### PR TITLE
Remove unavailable Home Assistant state retry

### DIFF
--- a/common/addon/firmware_update.yaml
+++ b/common/addon/firmware_update.yaml
@@ -36,9 +36,6 @@ esphome:
                   return NETWORK_STATUS_UPDATE_HIDDEN;
               }
             };
-            network_status_set_update_callback([]() {
-              id(firmware_update_from_screen).execute();
-            });
             network_status_set_update_check_callback([]() {
               id(firmware_update_check_for_network_status).execute();
             });

--- a/common/addon/firmware_update.yaml
+++ b/common/addon/firmware_update.yaml
@@ -20,29 +20,6 @@ esphome:
         - text_sensor.template.publish:
             id: firmware_version_sensor
             state: "${firmware_version}"
-    - priority: 190
-      then:
-        - lambda: |-
-            auto network_status_firmware_update_state = []() -> NetworkStatusUpdateState {
-              switch (id(firmware_update).state) {
-                case esphome::update::UPDATE_STATE_NO_UPDATE:
-                  return NETWORK_STATUS_UPDATE_LATEST;
-                case esphome::update::UPDATE_STATE_AVAILABLE:
-                  return NETWORK_STATUS_UPDATE_AVAILABLE;
-                case esphome::update::UPDATE_STATE_INSTALLING:
-                  return NETWORK_STATUS_UPDATE_INSTALLING;
-                case esphome::update::UPDATE_STATE_UNKNOWN:
-                default:
-                  return NETWORK_STATUS_UPDATE_HIDDEN;
-              }
-            };
-            network_status_set_update_check_callback([]() {
-              id(firmware_update_check_for_network_status).execute();
-            });
-            network_status_set_update_state(network_status_firmware_update_state());
-            id(firmware_update).add_on_state_callback([network_status_firmware_update_state]() {
-              network_status_set_update_state(network_status_firmware_update_state());
-            });
     - priority: -50
       then:
         - if:
@@ -167,7 +144,7 @@ script:
       - delay: 8s
       - script.execute: navigate_after_api
 
-  - id: firmware_update_from_screen
+  - id: firmware_install_update
     mode: single
     then:
       - lambda: 'id(manual_check_only) = true;'
@@ -187,20 +164,6 @@ script:
             - update.perform: firmware_update
       - delay: 15s
       - lambda: 'id(manual_check_only) = false;'
-
-  - id: firmware_update_check_for_network_status
-    mode: single
-    then:
-      - lambda: |-
-          id(manual_check_only) = true;
-          network_status_set_update_state(NETWORK_STATUS_UPDATE_CHECKING);
-      - component.update: firmware_update
-      - delay: 15s
-      - lambda: |-
-          id(manual_check_only) = false;
-          if (id(firmware_update).state == esphome::update::UPDATE_STATE_UNKNOWN) {
-            network_status_set_update_state(NETWORK_STATUS_UPDATE_HIDDEN);
-          }
 
 update:
   - platform: http_request
@@ -289,4 +252,4 @@ button:
     web_server:
       sorting_group_id: sg_firmware
     on_press:
-      - script.execute: firmware_update_from_screen
+      - script.execute: firmware_install_update

--- a/common/device/core_infra.yaml
+++ b/common/device/core_infra.yaml
@@ -41,7 +41,6 @@ api:
           refresh_image_cards();
           if (ha_api_state_connected()) {
             apply_registered_ha_control_availability(true);
-            ha_retry_unavailable_states(true);
             refresh_weather_forecast_cards();
             ha_flush_deferred_state_requests();
           }
@@ -51,14 +50,12 @@ api:
         if (ha_api_connected()) refresh_image_cards();
         if (ha_api_state_connected()) {
           ha_flush_deferred_state_requests();
-          ha_retry_unavailable_states(true);
         }
         todo_reload_active_modal();
     - delay: 8s
     - lambda: |-
         if (ha_api_connected()) refresh_image_cards();
         if (ha_api_state_connected()) {
-          ha_retry_unavailable_states(true);
           refresh_weather_forecast_cards();
           ha_flush_deferred_state_requests();
         }
@@ -67,7 +64,6 @@ api:
     - lambda: |-
         if (ha_api_connected()) refresh_image_cards();
         if (ha_api_state_connected()) {
-          ha_retry_unavailable_states(true);
           refresh_weather_forecast_cards();
           ha_flush_deferred_state_requests();
         }
@@ -91,7 +87,6 @@ interval:
           weather_forecast_cancel_stale_requests();
           weather_forecast_send_next_queued();
           ha_flush_deferred_state_requests();
-          ha_retry_unavailable_states();
           todo_retry_waiting_modal();
 
   - interval: 1h

--- a/components/espcontrol/button_grid_config.h
+++ b/components/espcontrol/button_grid_config.h
@@ -1270,9 +1270,6 @@ inline void reset_ha_control_availability_refs() {
   ha_control_availability_refs().clear();
 }
 
-#ifndef ESPCONTROL_HA_RETRY_HELPERS_DEFINED
-inline void ha_reset_unavailable_state_retries() {}
-#endif
 #ifndef ESPCONTROL_HA_DEFERRED_HELPERS_DEFINED
 inline void ha_reset_deferred_state_requests() {}
 #endif
@@ -1286,7 +1283,6 @@ inline void bump_ha_subscription_generation() {
   uint32_t &generation = ha_subscription_generation();
   generation++;
   if (generation == 0) generation = 1;
-  ha_reset_unavailable_state_retries();
   ha_reset_deferred_state_requests();
 }
 

--- a/components/espcontrol/button_grid_ha.h
+++ b/components/espcontrol/button_grid_ha.h
@@ -17,8 +17,6 @@ using HomeAssistantStateCallback = std::function<void(esphome::StringRef)>;
 using HomeAssistantActionResponseCallback =
   std::function<void(const esphome::api::ActionResponse &)>;
 
-inline bool ha_entity_state_unavailable_ref(const std::string &entity_id,
-                                            esphome::StringRef state);
 inline uint32_t &ha_subscription_generation();
 
 inline bool ha_api_available() {
@@ -33,8 +31,6 @@ inline bool ha_api_state_connected() {
   return ha_api_available() && esphome::api::global_api_server->is_connected_with_state_subscription();
 }
 
-constexpr uint32_t HA_UNAVAILABLE_STATE_RETRY_INTERVAL_MS = 5000;
-constexpr uint32_t HA_UNAVAILABLE_STATE_RETRY_RESPONSE_TIMEOUT_MS = 10000;
 constexpr size_t HA_READ_INTERNAL_FREE_MIN_BYTES = 8 * 1024;
 constexpr size_t HA_READ_INTERNAL_LARGEST_MIN_BYTES = 4 * 1024;
 constexpr size_t HA_ACTION_INTERNAL_FREE_MIN_BYTES = 12 * 1024;
@@ -60,15 +56,6 @@ inline bool ha_internal_heap_available(const char *stage,
   return true;
 }
 
-struct HaUnavailableStateRetryRef {
-  std::string entity_id;
-  std::shared_ptr<HomeAssistantStateCallback> callback;
-  uint32_t generation = 0;
-  uint32_t last_request_ms = 0;
-  bool waiting_for_response = false;
-  bool unavailable = false;
-};
-
 struct HaDeferredStateRequest {
   std::string entity_id;
   std::string attribute;
@@ -76,11 +63,6 @@ struct HaDeferredStateRequest {
   uint32_t generation = 0;
   bool has_attribute = false;
 };
-
-inline std::vector<HaUnavailableStateRetryRef> &ha_unavailable_state_retry_refs() {
-  static std::vector<HaUnavailableStateRetryRef> refs;
-  return refs;
-}
 
 inline std::vector<HaDeferredStateRequest> &ha_deferred_state_requests() {
   static std::vector<HaDeferredStateRequest> requests;
@@ -92,14 +74,9 @@ inline uint8_t &ha_state_callback_depth() {
   return depth;
 }
 
-inline void ha_reset_unavailable_state_retries() {
-  ha_unavailable_state_retry_refs().clear();
-}
-
 inline void ha_reset_deferred_state_requests() {
   ha_deferred_state_requests().clear();
 }
-#define ESPCONTROL_HA_RETRY_HELPERS_DEFINED 1
 #define ESPCONTROL_HA_DEFERRED_HELPERS_DEFINED 1
 
 inline void ha_invoke_state_callback(const std::shared_ptr<HomeAssistantStateCallback> &callback,
@@ -109,56 +86,6 @@ inline void ha_invoke_state_callback(const std::shared_ptr<HomeAssistantStateCal
   depth++;
   (*callback)(state);
   depth--;
-}
-
-inline void ha_note_state_retry_result(const std::string &entity_id,
-                                       esphome::StringRef state,
-                                       uint32_t generation) {
-  std::vector<HaUnavailableStateRetryRef> &refs = ha_unavailable_state_retry_refs();
-  for (auto &ref : refs) {
-    if (ref.generation != generation || ref.entity_id != entity_id) continue;
-    ref.unavailable = ha_entity_state_unavailable_ref(entity_id, state);
-    ref.waiting_for_response = false;
-  }
-}
-
-inline void ha_retry_unavailable_states(bool force = false) {
-  if (!ha_api_state_connected()) return;
-  const uint32_t now = esphome::millis();
-  const uint32_t active_generation = ha_subscription_generation();
-  std::vector<HaUnavailableStateRetryRef> &refs = ha_unavailable_state_retry_refs();
-
-  for (auto &ref : refs) {
-    if (ref.generation != active_generation || !ref.unavailable || !ref.callback) continue;
-    if (ref.waiting_for_response) {
-      if (ref.last_request_ms != 0 &&
-          now - ref.last_request_ms < HA_UNAVAILABLE_STATE_RETRY_RESPONSE_TIMEOUT_MS) {
-        continue;
-      }
-      ref.waiting_for_response = false;
-    }
-    if (!force) {
-      if (ref.last_request_ms != 0 &&
-          now - ref.last_request_ms < HA_UNAVAILABLE_STATE_RETRY_INTERVAL_MS) {
-        continue;
-      }
-    }
-
-    if (!ha_internal_heap_available("Home Assistant state retry",
-                                    HA_READ_INTERNAL_FREE_MIN_BYTES,
-                                    HA_READ_INTERNAL_LARGEST_MIN_BYTES)) continue;
-    ref.waiting_for_response = true;
-    ref.last_request_ms = now;
-    const std::string entity_id = ref.entity_id;
-    const uint32_t generation = ref.generation;
-    auto callback = ref.callback;
-    esphome::api::global_api_server->get_home_assistant_state(
-      entity_id, {},
-      [entity_id, generation, callback](esphome::StringRef state) {
-        ha_note_state_retry_result(entity_id, state, generation);
-        ha_invoke_state_callback(callback, state);
-      });
-  }
 }
 
 inline bool ha_queue_deferred_state_request(const std::string &entity_id,
@@ -293,19 +220,9 @@ inline bool ha_subscribe_state(const std::string &entity_id,
                                HomeAssistantStateCallback callback) {
   if (!ha_api_available() || entity_id.empty() || !callback) return false;
   auto callback_ref = std::make_shared<HomeAssistantStateCallback>(std::move(callback));
-  const uint32_t generation = ha_subscription_generation();
-  ha_unavailable_state_retry_refs().push_back({
-    entity_id,
-    callback_ref,
-    generation,
-    0,
-    false,
-    false,
-  });
   esphome::api::global_api_server->subscribe_home_assistant_state(
     entity_id, {},
-    [entity_id, callback_ref, generation](esphome::StringRef state) {
-      ha_note_state_retry_result(entity_id, state, generation);
+    [callback_ref](esphome::StringRef state) {
       ha_invoke_state_callback(callback_ref, state);
     });
   return true;

--- a/components/espcontrol/network_status.h
+++ b/components/espcontrol/network_status.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <cmath>
-#include <cstdint>
 #include <cstdlib>
 #include <string>
 #include "esphome/components/network/ip_address.h"
@@ -19,17 +18,6 @@ constexpr const char *NETWORK_ICON_WIFI_4 = "\U000F0928";
 constexpr const char *NETWORK_ICON_WIFI_OFF_OUTLINE = "\U000F092E";
 constexpr const char *NETWORK_ICON_ETHERNET = "\U000F0200";
 
-using NetworkStatusUpdateCallback = void (*)();
-using NetworkStatusUpdateCheckCallback = void (*)();
-
-enum NetworkStatusUpdateState : uint8_t {
-  NETWORK_STATUS_UPDATE_HIDDEN,
-  NETWORK_STATUS_UPDATE_CHECKING,
-  NETWORK_STATUS_UPDATE_LATEST,
-  NETWORK_STATUS_UPDATE_AVAILABLE,
-  NETWORK_STATUS_UPDATE_INSTALLING,
-};
-
 struct NetworkStatusModalUi {
   lv_obj_t *overlay = nullptr;
   lv_obj_t *panel = nullptr;
@@ -38,79 +26,11 @@ struct NetworkStatusModalUi {
   lv_obj_t *device_name_lbl = nullptr;
   lv_obj_t *ip_lbl = nullptr;
   lv_obj_t *firmware_lbl = nullptr;
-  lv_obj_t *update_status_lbl = nullptr;
-  lv_obj_t *update_btn = nullptr;
-  NetworkStatusUpdateCallback update_callback = nullptr;
 };
 
 inline NetworkStatusModalUi &network_status_modal_ui() {
   static NetworkStatusModalUi ui;
   return ui;
-}
-
-inline NetworkStatusUpdateCallback &network_status_update_callback_ref() {
-  static NetworkStatusUpdateCallback callback = nullptr;
-  return callback;
-}
-
-inline NetworkStatusUpdateCheckCallback &network_status_update_check_callback_ref() {
-  static NetworkStatusUpdateCheckCallback callback = nullptr;
-  return callback;
-}
-
-inline NetworkStatusUpdateState &network_status_update_state_ref() {
-  static NetworkStatusUpdateState state = NETWORK_STATUS_UPDATE_HIDDEN;
-  return state;
-}
-
-inline void network_status_set_update_callback(NetworkStatusUpdateCallback callback) {
-  network_status_update_callback_ref() = callback;
-}
-
-inline void network_status_set_update_check_callback(NetworkStatusUpdateCheckCallback callback) {
-  network_status_update_check_callback_ref() = callback;
-}
-
-inline const char *network_status_update_status_text(NetworkStatusUpdateState state) {
-  switch (state) {
-    case NETWORK_STATUS_UPDATE_CHECKING:
-      return espcontrol_i18n("Checking for updates");
-    case NETWORK_STATUS_UPDATE_LATEST:
-      return espcontrol_i18n("Latest installed");
-    case NETWORK_STATUS_UPDATE_AVAILABLE:
-      return espcontrol_i18n("Update available");
-    case NETWORK_STATUS_UPDATE_INSTALLING:
-      return espcontrol_i18n("Installing update");
-    case NETWORK_STATUS_UPDATE_HIDDEN:
-    default:
-      return "";
-  }
-}
-
-inline void network_status_apply_update_state() {
-  NetworkStatusModalUi &ui = network_status_modal_ui();
-  NetworkStatusUpdateState state = network_status_update_state_ref();
-  bool show_status = state != NETWORK_STATUS_UPDATE_HIDDEN;
-  bool show_button = state == NETWORK_STATUS_UPDATE_AVAILABLE && ui.update_callback != nullptr;
-
-  if (ui.update_status_lbl) {
-    lv_label_set_text(ui.update_status_lbl, network_status_update_status_text(state));
-    if (show_status) lv_obj_clear_flag(ui.update_status_lbl, LV_OBJ_FLAG_HIDDEN);
-    else lv_obj_add_flag(ui.update_status_lbl, LV_OBJ_FLAG_HIDDEN);
-  }
-  if (ui.update_btn) {
-    if (show_button) lv_obj_clear_flag(ui.update_btn, LV_OBJ_FLAG_HIDDEN);
-    else lv_obj_add_flag(ui.update_btn, LV_OBJ_FLAG_HIDDEN);
-  }
-  if (ui.content) {
-    lv_obj_update_layout(ui.content);
-    lv_obj_align(ui.content, LV_ALIGN_CENTER, 0, 0);
-  }
-}
-
-inline void network_status_set_update_state(NetworkStatusUpdateState state) {
-  network_status_update_state_ref() = state;
-  network_status_apply_update_state();
 }
 
 inline const char *network_status_wifi_icon(float pct) {
@@ -190,9 +110,6 @@ inline void network_status_hide_modal() {
   ui.device_name_lbl = nullptr;
   ui.ip_lbl = nullptr;
   ui.firmware_lbl = nullptr;
-  ui.update_status_lbl = nullptr;
-  ui.update_btn = nullptr;
-  ui.update_callback = nullptr;
   control_modal_clear_active(ControlModalKind::NETWORK_STATUS);
 }
 
@@ -258,49 +175,9 @@ inline void network_status_open_modal(const std::string &device_name,
     text_font,
     content_w,
     DARK_TEXT_MUTED);
-
-  ui.update_callback = network_status_update_callback_ref();
-  bool update_ui_enabled = ui.update_callback != nullptr ||
-                           network_status_update_check_callback_ref() != nullptr ||
-                           network_status_update_state_ref() != NETWORK_STATUS_UPDATE_HIDDEN;
-  if (update_ui_enabled) {
-    ui.update_status_lbl = network_status_add_center_label(
-      ui.content,
-      network_status_update_status_text(network_status_update_state_ref()),
-      text_font,
-      content_w,
-      DARK_TEXT_MUTED);
-  }
-  if (ui.update_callback) {
-    lv_coord_t update_h = control_modal_scaled_px(52, layout.short_side);
-    if (update_h < 38) update_h = 38;
-    if (update_h > 62) update_h = 62;
-    lv_coord_t update_max_w = content_w;
-    lv_coord_t preferred_max_w = control_modal_scaled_px(280, layout.short_side);
-    if (preferred_max_w > 0 && update_max_w > preferred_max_w) update_max_w = preferred_max_w;
-    lv_coord_t update_min_w = control_modal_scaled_px(180, layout.short_side);
-    if (update_min_w < 128) update_min_w = 128;
-    if (update_min_w > update_max_w) update_min_w = update_max_w;
-    ui.update_btn = control_modal_create_text_button(
-      ui.content, espcontrol_i18n(std::string("Update firmware")),
-      update_max_w, update_min_w, update_h, update_h / 2,
-      DEFAULT_SLIDER_COLOR, text_font);
-    if (ui.update_btn) {
-      lv_obj_add_event_cb(ui.update_btn, [](lv_event_t *) {
-        NetworkStatusModalUi &ui = network_status_modal_ui();
-        if (ui.update_callback) ui.update_callback();
-      }, LV_EVENT_CLICKED, nullptr);
-    }
-  }
-  network_status_apply_update_state();
+  lv_obj_update_layout(ui.content);
+  lv_obj_align(ui.content, LV_ALIGN_CENTER, 0, 0);
 
   lv_obj_move_foreground(ui.close_btn);
   lv_obj_move_foreground(ui.overlay);
-
-  NetworkStatusUpdateCheckCallback check_callback = network_status_update_check_callback_ref();
-  NetworkStatusUpdateState state = network_status_update_state_ref();
-  if (check_callback && state != NETWORK_STATUS_UPDATE_INSTALLING &&
-      state != NETWORK_STATUS_UPDATE_AVAILABLE) {
-    check_callback();
-  }
 }

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -112,22 +112,17 @@ def firmware_ha_boundary_errors(firmware_dir: Path, root: Path) -> list[str]:
         errors.append(f"{rel}: missing ha_subscribe_state helper")
     elif "heap_available" in state_helper.group("body"):
         errors.append(f"{rel}: keep core HA state subscriptions off the low-heap guard")
-    elif "ha_note_state_retry_result" not in state_helper.group("body"):
-        errors.append(f"{rel}: track unavailable subscribed states for reconnect retries")
 
-    if (
-        "ha_retry_unavailable_states" not in text
-        or "ha_unavailable_state_retry_refs" not in text
-        or "HA_UNAVAILABLE_STATE_RETRY_INTERVAL_MS" not in text
-        or "HA_UNAVAILABLE_STATE_RETRY_RESPONSE_TIMEOUT_MS" not in text
-    ):
-        errors.append(f"{rel}: retry unavailable subscribed states after Home Assistant finishes startup")
-    if "waiting_for_response = false" not in text:
-        errors.append(f"{rel}: expire unanswered unavailable-state retries after Home Assistant startup")
-    if "ha_entity_state_unavailable_ref(entity_id, state)" not in text:
-        errors.append(f"{rel}: use entity-aware unavailable checks for subscribed state retries")
-    if "ha_reset_unavailable_state_retries" not in text:
-        errors.append(f"{rel}: expose a helper to clear stale unavailable state retries")
+    retry_symbols = (
+        "HaUnavailableStateRetryRef",
+        "ha_unavailable_state_retry_refs",
+        "ha_note_state_retry_result",
+        "ha_retry_unavailable_states",
+        "ha_reset_unavailable_state_retries",
+        "HA_UNAVAILABLE_STATE_RETRY",
+    )
+    if any(symbol in text for symbol in retry_symbols):
+        errors.append(f"{rel}: do not reintroduce unavailable HA state retry polling")
 
     attribute_helper = ATTRIBUTE_HELPER_PATTERN.search(text)
     if not attribute_helper:
@@ -169,20 +164,16 @@ def firmware_unavailable_retry_errors(
             config_text,
             re.DOTALL,
         )
-        if not bump_match or "ha_reset_unavailable_state_retries()" not in bump_match.group("body"):
-            errors.append(f"{config_rel}: clear stale unavailable state retries when subscriptions are rebuilt")
+        if bump_match and "ha_reset_unavailable_state_retries" in bump_match.group("body"):
+            errors.append(f"{config_rel}: do not reset removed unavailable HA state retries")
+        if "ha_reset_unavailable_state_retries" in config_text:
+            errors.append(f"{config_rel}: do not keep removed unavailable HA state retry helpers")
 
     if core_infra_path.exists():
         core_rel = core_infra_path.relative_to(root)
         core_text = core_infra_path.read_text(encoding="utf-8")
-        if "ha_retry_unavailable_states" not in core_text:
-            errors.append(f"{core_rel}: retry unavailable HA states after reconnects and during maintenance")
-        interval_match = re.search(
-            r"(?ms)^interval:\n(?P<body>.*?)(?:^logger:|\Z)",
-            core_text,
-        )
-        if not interval_match or "ha_retry_unavailable_states();" not in interval_match.group("body"):
-            errors.append(f"{core_rel}: periodically retry unavailable HA states")
+        if "ha_retry_unavailable_states" in core_text:
+            errors.append(f"{core_rel}: do not retry unavailable HA states after reconnects or during maintenance")
     return errors
 
 
@@ -1267,6 +1258,28 @@ def expect_ha_boundary_errors(name: str, files: dict[str, str], expected: tuple[
             assert not errors, f"{name}: expected no errors, got {errors!r}"
 
 
+def expect_unavailable_retry_errors(
+    name: str,
+    config_text: str,
+    core_text: str,
+    expected: tuple[str, ...],
+) -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        firmware_dir = root / "components" / "espcontrol"
+        core_path = root / "common" / "device" / "core_infra.yaml"
+        firmware_dir.mkdir(parents=True)
+        core_path.parent.mkdir(parents=True)
+        (firmware_dir / "button_grid_config.h").write_text(config_text, encoding="utf-8")
+        core_path.write_text(core_text, encoding="utf-8")
+
+        errors = firmware_unavailable_retry_errors(firmware_dir, core_path, root)
+        for item in expected:
+            assert any(item in error for error in errors), f"{name}: missing {item!r} in {errors!r}"
+        if not expected:
+            assert not errors, f"{name}: expected no errors, got {errors!r}"
+
+
 def expect_todo_request_errors(name: str, text: str, expected: tuple[str, ...]) -> None:
     with TemporaryDirectory() as tmp:
         root = Path(tmp)
@@ -1760,6 +1773,38 @@ def run_self_test() -> int:
             )
         },
         ("send Home Assistant actions only after state subscription is ready",),
+    )
+    expect_ha_boundary_errors(
+        "unavailable retry helper symbols",
+        {
+            "button_grid_ha.h": (
+                "struct HaUnavailableStateRetryRef {};\n"
+                "inline bool ha_subscribe_state() {\n  return true;\n}\n"
+                "inline bool ha_subscribe_attribute() {\n  return true;\n}\n"
+                "inline bool ha_cancel_action_response_callback() {\n  handle_action_response(); return true;\n}\n"
+                "inline bool ha_action_send() {\n"
+                "  return ha_api_state_connected() && HA_ACTION_INTERNAL_FREE_MIN_BYTES;\n"
+                "}\n"
+            )
+        },
+        ("do not reintroduce unavailable HA state retry polling",),
+    )
+    expect_unavailable_retry_errors(
+        "unavailable retry reset and interval",
+        "inline void bump_ha_subscription_generation() {\n"
+        "  ha_reset_unavailable_state_retries();\n"
+        "  ha_reset_deferred_state_requests();\n"
+        "}\n",
+        "interval:\n"
+        "  - interval: 5s\n"
+        "    then:\n"
+        "      - lambda: |-\n"
+        "          ha_retry_unavailable_states();\n",
+        (
+            "do not reset removed unavailable HA state retries",
+            "do not keep removed unavailable HA state retry helpers",
+            "do not retry unavailable HA states",
+        ),
     )
     with TemporaryDirectory() as tmp:
         root = Path(tmp)


### PR DESCRIPTION
## Summary
- Removes the unavailable Home Assistant card state retry loop that repeatedly called `get_home_assistant_state()`.
- Simplifies HA state subscriptions to rely on normal Home Assistant subscription updates.
- Updates the firmware HA binding guard so the removed retry polling is not reintroduced.

## Root Cause
Fixes #507.

The crash log showed `ha_retry_unavailable_states()` calling ESPHome `get_home_assistant_state()`, which appends a one-shot Home Assistant state subscription. When an entity remains unavailable, the 5-second retry loop can keep adding subscriptions until allocation fails and the device aborts.

## Testing
- `npm run check:firmware-ha-bindings`
- `npm run check:fast`
- `docker run --rm -v "/Users/jtenniswood/Git/espcontrol-remove-ha-unavailable-retry:/config" -v "/Users/jtenniswood/Git:/Users/jtenniswood/Git" ghcr.io/esphome/esphome:stable compile /config/builds/guition-esp32-s3-4848s040.factory.yaml`
- `docker run --rm -v "/Users/jtenniswood/Git/espcontrol-remove-ha-unavailable-retry:/config" -v "/Users/jtenniswood/Git:/Users/jtenniswood/Git" ghcr.io/esphome/esphome:stable compile /config/builds/guition-esp32-p4-jc1060p470.factory.yaml`

## Device Test Plan
Flash this branch to the 4-inch S3 / 4848S040 and configure at least one HA-backed card with a permanently unavailable entity.

Expected result:
- No repeated unavailable-state retry logs.
- No `get_home_assistant_state()` allocation crash.
- No reboot after at least 30 minutes of monitoring.
- Unavailable cards still show unavailable.
- If the entity later becomes available, it should recover through normal HA subscription updates or after a reconnect/reload.