### PR TITLE
Fix ESPHome select state deprecation

### DIFF
--- a/common/device/core_infra.yaml
+++ b/common/device/core_infra.yaml
@@ -32,7 +32,7 @@ api:
             }
             int port = static_cast<int>(id(cover_art_home_assistant_artwork_port).state);
             id(cover_art_home_assistant_base_url) =
-              id(cover_art_home_assistant_artwork_protocol).state + "://" + host + ":" + std::to_string(port);
+              id(cover_art_home_assistant_artwork_protocol).current_option() + "://" + host + ":" + std::to_string(port);
             ESP_LOGI("api", "Using Home Assistant base URL: %s",
                      id(cover_art_home_assistant_base_url).c_str());
           } else {

--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -138,7 +138,7 @@ api:
         }
         int port = static_cast<int>(id(cover_art_home_assistant_artwork_port).state);
         id(cover_art_home_assistant_base_url) =
-          id(cover_art_home_assistant_artwork_protocol).state + "://" + host + ":" + std::to_string(port);
+          id(cover_art_home_assistant_artwork_protocol).current_option() + "://" + host + ":" + std::to_string(port);
         id(cover_art_api_wait_logged) = false;
         ESP_LOGI("cover_art", "Using Home Assistant artwork base URL: %s",
                  id(cover_art_home_assistant_base_url).c_str());


### PR DESCRIPTION
## Purpose
Replace the deprecated ESPHome select `.state` access used when building the Home Assistant artwork base URL.

## Practical impact
This removes the compile deprecation warning about ESPHome select state access while keeping the artwork URL behavior the same.

## Checks
- Compiled `builds/guition-esp32-p4-jc1060p470.factory.yaml`
- Compiled `builds/guition-esp32-p4-jc4880p443.factory.yaml`
- Compiled `builds/guition-esp32-s3-4848s040.factory.yaml`

## Testing notes
Flash firmware from this branch to a display that uses Home Assistant artwork/media images, then confirm artwork still loads correctly.