### PR TITLE
Fix image card memory retention

### DIFF
--- a/components/artwork_image/artwork_image.cpp
+++ b/components/artwork_image/artwork_image.cpp
@@ -1071,6 +1071,7 @@ void ArtworkImage::end_connection_() {
   this->decoder_.reset();
   this->discard_decode_buffer_();
   this->download_buffer_.reset();
+  this->download_buffer_.shrink_to(this->download_buffer_initial_size_);
 }
 
 bool ArtworkImage::validate_url_(const std::string &url) {

--- a/components/artwork_image/image_decoder.cpp
+++ b/components/artwork_image/image_decoder.cpp
@@ -146,5 +146,24 @@ size_t DownloadBuffer::resize(size_t size) {
   }
 }
 
+void DownloadBuffer::shrink_to(size_t size) {
+  this->reset();
+  if (this->size_ <= size) {
+    return;
+  }
+  this->allocator_.deallocate(this->buffer_, this->size_);
+  this->buffer_ = nullptr;
+  this->size_ = 0;
+  if (size == 0) {
+    return;
+  }
+  this->buffer_ = this->allocator_.allocate(size);
+  if (!this->buffer_) {
+    ESP_LOGW(TAG, "allocation of shrunken download buffer failed: %zu bytes", size);
+    return;
+  }
+  this->size_ = size;
+}
+
 }  // namespace artwork_image
 }  // namespace esphome

--- a/components/artwork_image/image_decoder.h
+++ b/components/artwork_image/image_decoder.h
@@ -127,6 +127,7 @@ class DownloadBuffer {
   void reset() { this->unread_ = 0; }
 
   size_t resize(size_t size);
+  void shrink_to(size_t size);
 
  protected:
   RAMAllocator<uint8_t> allocator_{};

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -1751,11 +1751,14 @@ inline bool bind_image_card(BtnSlot &s, const ParsedCfg &p, const GridConfig &cf
     }, LV_EVENT_CLICKED, ctx);
   }
 
+  const std::string image_card_entity_id = p.entity;
+  const uint32_t image_card_generation = ha_subscription_generation();
   ha_subscribe_attribute(
-    p.entity,
+    image_card_entity_id,
     std::string("entity_picture"),
     std::function<void(esphome::StringRef)>(
-      [ctx](esphome::StringRef picture) {
+      [ctx, image_card_entity_id, image_card_generation](esphome::StringRef picture) {
+        if (!image_card_context_current(ctx, image_card_entity_id, image_card_generation)) return;
         image_card_handle_picture(ctx, picture);
       })
   );

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -840,6 +840,11 @@ def firmware_image_card_startup_errors(
     if "image_card_context_current" not in text or "generation == ha_subscription_generation()" not in text:
         errors.append(f"{rel}: ignore stale image-card callbacks after grid rebuild")
     if (
+        "image_card_generation" not in text
+        or "image_card_context_current(ctx, image_card_entity_id, image_card_generation)" not in text
+    ):
+        errors.append(f"{rel}: ignore stale image-card entity_picture callbacks after grid rebuild")
+    if (
         ("image_card_tile_request_size(width, height" not in text and
          "image_card_tile_request_size(decode_width, decode_height" not in text)
         or "image_card_high_quality_request_size" not in text
@@ -878,6 +883,8 @@ def firmware_artwork_image_auth_errors(path: Path, root: Path) -> list[str]:
         or "container->status_code = HTTP_CODE_OK;" not in text
     ):
         errors.append(f"{rel}: allow Home Assistant media proxy artwork to fall back to image-byte detection")
+    if "download_buffer_.shrink_to(this->download_buffer_initial_size_)" not in text:
+        errors.append(f"{rel}: release oversized artwork download buffers after image requests")
     return errors
 
 
@@ -2787,6 +2794,7 @@ def run_self_test() -> int:
             "request image-card attributes once the Home Assistant API is connected",
             "refresh image cards when the camera/image entity state changes",
             "ignore stale image-card callbacks after grid rebuild",
+            "ignore stale image-card entity_picture callbacks after grid rebuild",
             "request high-quality Home Assistant image card source downloads",
             "request bounded Home Assistant image card proxy downloads",
             "recognize Home Assistant camera and image proxy URLs",
@@ -2823,6 +2831,13 @@ def run_self_test() -> int:
         "inline void subscribe_image_card_entity_state(ImageCardCtx *ctx,\n"
         "                                              const std::string &entity_id) {\n"
         "  ha_subscribe_state(entity_id, callback);\n"
+        "}\n"
+        "inline bool bind_image_card(BtnSlot &s, const ParsedCfg &p, const GridConfig &cfg) {\n"
+        "  const std::string image_card_entity_id = p.entity;\n"
+        "  const uint32_t image_card_generation = ha_subscription_generation();\n"
+        "  ha_subscribe_attribute(image_card_entity_id, std::string(\"entity_picture\"), callback);\n"
+        "  image_card_context_current(ctx, image_card_entity_id, image_card_generation);\n"
+        "  return true;\n"
         "}\n"
         "inline void image_card_request_source_url(ImageCardCtx *ctx) {\n"
         "  image_card_tile_request_size(width, height, &request_width, &request_height);\n"
@@ -3130,6 +3145,9 @@ def run_self_test() -> int:
         "    ESP_LOGW(TAG, \"Home Assistant media proxy returned an unknown HTTP status; trying artwork bytes anyway\");\n"
         "    container->status_code = HTTP_CODE_OK;\n"
         "  }\n"
+        "}\n"
+        "void ArtworkImage::end_connection_() {\n"
+        "  this->download_buffer_.shrink_to(this->download_buffer_initial_size_);\n"
         "}\n",
         (),
     )


### PR DESCRIPTION
## What changed

- Shrinks the reusable artwork download buffer back to its configured starting size after each image request finishes, fails, or is cancelled.
- Guards image-card `entity_picture` callbacks with the current Home Assistant subscription generation and entity id, so stale callbacks from a rebuilt grid cannot trigger extra camera downloads on a reused card context.
- Extends the firmware binding guard checks to cover both behaviours.

## Why

Large camera JPEG downloads could expand an image-card downloader buffer and keep that larger allocation for the rest of the session. That looked like a memory leak on devices after viewing or refreshing camera cards. A separate unguarded camera callback could also survive a grid rebuild and cause old callbacks to act on a reused image-card slot.

## Device testing notes

Please test with one or more camera/image cards on a device branch build:

- Load camera cards and confirm images still appear.
- Open and close an expanded camera image modal.
- Rebuild or reload the grid/config, then confirm camera cards still refresh normally.
- Watch memory diagnostics if available; memory should recover after large camera image downloads instead of staying permanently reduced by the enlarged download buffer.

## Checks run

- `python3 scripts/check_firmware_ha_bindings.py`
- `python3 scripts/check_firmware_ha_bindings.py --self-test`
- `python3 scripts/check_firmware_card_runtime.py`
- `node scripts/check_config_formats.js`