### PR TITLE
Stabilize nightly Docker image pulls

### DIFF
--- a/.github/workflows/firmware-compile.yml
+++ b/.github/workflows/firmware-compile.yml
@@ -121,6 +121,18 @@ jobs:
           echo "PLATFORMIO_CACHE=${PLATFORMIO_CACHE}" >> "$GITHUB_ENV"
           echo "BUILD_CACHE=${BUILD_CACHE}" >> "$GITHUB_ENV"
 
+      - name: Pull ESPHome image
+        working-directory: espcontrol-${{ matrix.slug }}
+        run: |
+          ESPHOME_IMAGE="ghcr.io/esphome/esphome:${ESPHOME_VERSION}"
+          LOCK_FILE="/tmp/espcontrol-esphome-image.lock"
+          if command -v flock >/dev/null 2>&1; then
+            flock "${LOCK_FILE}" ${DOCKER} pull "${ESPHOME_IMAGE}"
+          else
+            ${DOCKER} pull "${ESPHOME_IMAGE}"
+          fi
+          echo "ESPHOME_IMAGE=${ESPHOME_IMAGE}" >> "$GITHUB_ENV"
+
       - name: Compile firmware
         working-directory: espcontrol-${{ matrix.slug }}
         run: >-
@@ -132,7 +144,7 @@ jobs:
           -v "${PWD}:/config"
           -v "${PLATFORMIO_CACHE}:/config/.esphome"
           -v "${BUILD_CACHE}:/config/builds/.esphome"
-          ghcr.io/esphome/esphome:${ESPHOME_VERSION}
+          "${ESPHOME_IMAGE}"
           compile /config/builds/${{ matrix.slug }}.factory.yaml
 
       - name: Clean firmware caches

--- a/.github/workflows/nightly-firmware.yml
+++ b/.github/workflows/nightly-firmware.yml
@@ -87,6 +87,18 @@ jobs:
           echo "PLATFORMIO_CACHE=${PLATFORMIO_CACHE}" >> "$GITHUB_ENV"
           echo "BUILD_CACHE=${BUILD_CACHE}" >> "$GITHUB_ENV"
 
+      - name: Pull ESPHome image
+        working-directory: espcontrol-${{ matrix.slug }}
+        run: |
+          ESPHOME_IMAGE="ghcr.io/esphome/esphome:${ESPHOME_VERSION}"
+          LOCK_FILE="/tmp/espcontrol-esphome-image.lock"
+          if command -v flock >/dev/null 2>&1; then
+            flock "${LOCK_FILE}" ${DOCKER} pull "${ESPHOME_IMAGE}"
+          else
+            ${DOCKER} pull "${ESPHOME_IMAGE}"
+          fi
+          echo "ESPHOME_IMAGE=${ESPHOME_IMAGE}" >> "$GITHUB_ENV"
+
       - name: Compile firmware
         working-directory: espcontrol-${{ matrix.slug }}
         run: >-
@@ -98,7 +110,7 @@ jobs:
           -v "${PWD}:/config"
           -v "${PLATFORMIO_CACHE}:/config/.esphome"
           -v "${BUILD_CACHE}:/config/builds/.esphome"
-          ghcr.io/esphome/esphome:${ESPHOME_VERSION}
+          "${ESPHOME_IMAGE}"
           compile /config/builds/${{ matrix.slug }}.factory.yaml
 
       - name: Clean firmware caches

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,18 @@ jobs:
           echo "PLATFORMIO_CACHE=${PLATFORMIO_CACHE}" >> "$GITHUB_ENV"
           echo "BUILD_CACHE=${BUILD_CACHE}" >> "$GITHUB_ENV"
 
+      - name: Pull ESPHome image
+        working-directory: espcontrol-${{ matrix.slug }}
+        run: |
+          ESPHOME_IMAGE="ghcr.io/esphome/esphome:${ESPHOME_VERSION}"
+          LOCK_FILE="/tmp/espcontrol-esphome-image.lock"
+          if command -v flock >/dev/null 2>&1; then
+            flock "${LOCK_FILE}" ${DOCKER} pull "${ESPHOME_IMAGE}"
+          else
+            ${DOCKER} pull "${ESPHOME_IMAGE}"
+          fi
+          echo "ESPHOME_IMAGE=${ESPHOME_IMAGE}" >> "$GITHUB_ENV"
+
       - name: Compile firmware
         working-directory: espcontrol-${{ matrix.slug }}
         env:
@@ -148,7 +160,7 @@ jobs:
           -v "${PWD}:/config"
           -v "${PLATFORMIO_CACHE}:/config/.esphome"
           -v "${BUILD_CACHE}:/config/builds/.esphome"
-          ghcr.io/esphome/esphome:${ESPHOME_VERSION}
+          "${ESPHOME_IMAGE}"
           -s firmware_version "${VERSION}"
           compile /config/builds/${{ matrix.slug }}.factory.yaml
 

--- a/.github/workflows/runner-cleanup.yml
+++ b/.github/workflows/runner-cleanup.yml
@@ -39,4 +39,7 @@ jobs:
           fi
 
       - name: Reclaim runner disk
+        env:
+          ESPCONTROL_DOCKER_PRUNE_ALL_IMAGES: true
+          ESPCONTROL_DOCKER_PRUNE_VOLUMES: true
         run: bash scripts/reclaim_actions_disk.sh

--- a/scripts/reclaim_actions_disk.sh
+++ b/scripts/reclaim_actions_disk.sh
@@ -3,9 +3,16 @@ set -euo pipefail
 
 DOCKER_COMMAND=${DOCKER:-docker}
 KEEP_STORAGE=${ESPCONTROL_DOCKER_BUILD_CACHE_KEEP:-2GB}
-PRUNE_VOLUMES=${ESPCONTROL_DOCKER_PRUNE_VOLUMES:-true}
+LOCK_FILE=${ESPCONTROL_DOCKER_LOCK_FILE:-/tmp/espcontrol-esphome-image.lock}
+PRUNE_ALL_IMAGES=${ESPCONTROL_DOCKER_PRUNE_ALL_IMAGES:-false}
+PRUNE_VOLUMES=${ESPCONTROL_DOCKER_PRUNE_VOLUMES:-false}
 CLEAN_RUNNER_UPDATES=${ESPCONTROL_CLEAN_RUNNER_UPDATES:-true}
 CLEAN_LEGACY_ESPHOME_CACHE=${ESPCONTROL_CLEAN_LEGACY_ESPHOME_CACHE:-true}
+
+if [ "${ESPCONTROL_DOCKER_LOCK_HELD:-false}" != "true" ] && command -v flock >/dev/null 2>&1; then
+  export ESPCONTROL_DOCKER_LOCK_HELD=true
+  exec flock "${LOCK_FILE}" bash "$0" "$@"
+fi
 
 disk_report() {
   local label=$1
@@ -17,7 +24,11 @@ disk_report "Disk before cleanup"
 
 if ${DOCKER_COMMAND} info >/dev/null 2>&1; then
   ${DOCKER_COMMAND} container prune -f >/dev/null || true
-  ${DOCKER_COMMAND} image prune -af >/dev/null || true
+  if [ "${PRUNE_ALL_IMAGES}" = "true" ]; then
+    ${DOCKER_COMMAND} image prune -af >/dev/null || true
+  else
+    ${DOCKER_COMMAND} image prune -f >/dev/null || true
+  fi
   ${DOCKER_COMMAND} builder prune -f --keep-storage "${KEEP_STORAGE}" >/dev/null || true
   if [ "${PRUNE_VOLUMES}" = "true" ]; then
     ${DOCKER_COMMAND} volume prune -f >/dev/null || true


### PR DESCRIPTION
## Purpose
Stabilize the self-hosted firmware build workflows after nightly jobs started failing while Docker was pulling the ESPHome image.

## What changed
- Docker cleanup now keeps normal named images by default instead of pruning every unused image during each build job.
- ESPHome image pulls now run under a shared lock, so parallel firmware jobs do not try to pull or mutate the same Docker image state at the same time.
- The scheduled runner cleanup still performs the more aggressive disk reclaim, including unused images and volumes.
- Nightly and release firmware builds still keep `max-parallel: 2`; only the fragile Docker pull/cleanup work is serialized.

## Root cause
The nightly matrix runs parallel self-hosted jobs. Each job was running aggressive Docker cleanup, then Docker was sometimes trying to pull the same ESPHome image concurrently. The failed logs showed Docker/containerd errors such as `lease does not exist` and missing layer digests before ESPHome compilation began.

## Checks
- Parsed all GitHub workflow YAML files with Python.
- Ran `bash -n scripts/reclaim_actions_disk.sh`.
- Ran `git diff --check`.
- Manually ran Nightly Firmware Test Build on this branch: https://github.com/jtenniswood/espcontrol/actions/runs/27609154280. All device compile jobs passed.

## Testing notes
The manual nightly run confirmed the firmware jobs still run in parallel and the Docker image pull step completes reliably. Keep the PR as draft until you are happy with the next scheduled nightly run as well.