### PR TITLE
Remove small climate fonts

### DIFF
--- a/devices/guition-esp32-p4-jc4880p443/device/fonts.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/device/fonts.yaml
@@ -37,16 +37,6 @@ font:
       - file: "gfonts://Heebo"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
-  # Compact supporting text
-  - file: "gfonts://Roboto"
-    id: font_text_small
-    size: 26
-    bpp: 4
-    glyphs: !include ../../../common/assets/text_glyphs.yaml
-    extras:
-      - file: "gfonts://Heebo"
-        glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
-
   # Headings and media titles
   - file: "gfonts://Roboto@Light"
     id: font_text_title

--- a/devices/guition-esp32-p4-jc4880p443/device/sensors.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/device/sensors.yaml
@@ -48,7 +48,7 @@ script:
           cfg.climate_card_icon_font = id(font_icon_card)->get_lv_font();
           cfg.subpage_chevron_font = id(font_icon_status)->get_lv_font();
           cfg.climate_option_title_font = id(font_text_body)->get_lv_font();
-          cfg.climate_option_value_font = id(font_text_small)->get_lv_font();
+          cfg.climate_option_value_font = id(font_text_body)->get_lv_font();
           cfg.temperature_unit = id(temperature_unit_select).current_option();
           cfg.timezone = id(timezone_select).current_option();
           cfg.suspend_display_takeover = []() {
@@ -171,7 +171,7 @@ esphome:
             cfg.climate_card_icon_font = id(font_icon_card)->get_lv_font();
             cfg.subpage_chevron_font = id(font_icon_status)->get_lv_font();
             cfg.climate_option_title_font = id(font_text_body)->get_lv_font();
-            cfg.climate_option_value_font = id(font_text_small)->get_lv_font();
+            cfg.climate_option_value_font = id(font_text_body)->get_lv_font();
             cfg.temperature_unit = id(temperature_unit_select).current_option();
             cfg.timezone = id(timezone_select).current_option();
             cfg.suspend_display_takeover = []() {
@@ -341,7 +341,7 @@ esphome:
             cfg.climate_card_icon_font = id(font_icon_card)->get_lv_font();
             cfg.subpage_chevron_font = id(font_icon_status)->get_lv_font();
             cfg.climate_option_title_font = id(font_text_body)->get_lv_font();
-            cfg.climate_option_value_font = id(font_text_small)->get_lv_font();
+            cfg.climate_option_value_font = id(font_text_body)->get_lv_font();
             cfg.temperature_unit = id(temperature_unit_select).current_option();
             cfg.timezone = id(timezone_select).current_option();
             cfg.suspend_display_takeover = []() {

--- a/devices/guition-esp32-s3-4848s040/device/fonts.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/fonts.yaml
@@ -37,16 +37,6 @@ font:
       - file: "gfonts://Heebo"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
-  # Compact supporting text
-  - file: "gfonts://Roboto"
-    id: font_text_small
-    size: 18
-    bpp: 4
-    glyphs: !include ../../../common/assets/text_glyphs.yaml
-    extras:
-      - file: "gfonts://Heebo"
-        glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
-
   # Headings and media titles
   - file: "gfonts://Roboto@Light"
     id: font_text_title

--- a/devices/guition-esp32-s3-4848s040/device/sensors.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/sensors.yaml
@@ -50,7 +50,7 @@ script:
           cfg.climate_card_icon_font = id(font_icon_card)->get_lv_font();
           cfg.subpage_chevron_font = id(font_icon_status)->get_lv_font();
           cfg.climate_option_title_font = id(font_text_body)->get_lv_font();
-          cfg.climate_option_value_font = id(font_text_small)->get_lv_font();
+          cfg.climate_option_value_font = id(font_text_body)->get_lv_font();
           cfg.temperature_unit = id(temperature_unit_select).current_option();
           cfg.timezone = id(timezone_select).current_option();
           cfg.suspend_display_takeover = []() {
@@ -156,7 +156,7 @@ esphome:
             cfg.climate_card_icon_font = id(font_icon_card)->get_lv_font();
             cfg.subpage_chevron_font = id(font_icon_status)->get_lv_font();
             cfg.climate_option_title_font = id(font_text_body)->get_lv_font();
-            cfg.climate_option_value_font = id(font_text_small)->get_lv_font();
+            cfg.climate_option_value_font = id(font_text_body)->get_lv_font();
             cfg.temperature_unit = id(temperature_unit_select).current_option();
             cfg.timezone = id(timezone_select).current_option();
             cfg.suspend_display_takeover = []() {
@@ -289,7 +289,7 @@ esphome:
             cfg.climate_card_icon_font = id(font_icon_card)->get_lv_font();
             cfg.subpage_chevron_font = id(font_icon_status)->get_lv_font();
             cfg.climate_option_title_font = id(font_text_body)->get_lv_font();
-            cfg.climate_option_value_font = id(font_text_small)->get_lv_font();
+            cfg.climate_option_value_font = id(font_text_body)->get_lv_font();
             cfg.temperature_unit = id(temperature_unit_select).current_option();
             cfg.timezone = id(timezone_select).current_option();
             cfg.suspend_display_takeover = []() {

--- a/devices/manifest.json
+++ b/devices/manifest.json
@@ -236,7 +236,7 @@
           "climateCardIcon": "font_icon_card",
           "subpageChevron": "font_icon_status",
           "climateOptionTitle": "font_text_body",
-          "climateOptionValue": "font_text_small"
+          "climateOptionValue": "font_text_body"
         },
         "display": {
           "wrapTallLabels": false,
@@ -667,7 +667,7 @@
           "climateCardIcon": "font_icon_card",
           "subpageChevron": "font_icon_status",
           "climateOptionTitle": "font_text_body",
-          "climateOptionValue": "font_text_small"
+          "climateOptionValue": "font_text_body"
         },
         "display": {
           "wrapTallLabels": false,


### PR DESCRIPTION
## Summary
- removes the separate `font_text_small` compiled font from the 480x800 P4 and 480x480 S3 displays
- reuses `font_text_body` for Climate modal option values on those two devices
- regenerates the affected device slot YAML so firmware config uses the body font

## Practical impact
This saves one compiled firmware font on each affected smaller display. The intended behavior is unchanged, but the Climate modal option value text will be slightly larger because it now uses the existing body font.

## Checks run
- `python3 scripts/generate_device_slots.py`
- `python3 scripts/generate_device_slots.py --check`
- `npm run check:device-profiles`
- `npm run check:device-matrix`
- `npm run check:product`
- Docker ESPHome compile: `builds/guition-esp32-p4-jc4880p443.factory.yaml`
- Docker ESPHome compile: `builds/guition-esp32-s3-4848s040.factory.yaml`
- search confirmed no `font_text_small` remains under the two affected device folders

## Device testing needed
Please flash/test both affected displays and open a Climate card modal. Check the Mode and Preset option chips for clipping, overlap, or cramped text. Slightly larger text is expected and acceptable if the layout remains readable.