### PR TITLE
Reduce repeated firmware lambda allocations

### DIFF
--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -78,12 +78,25 @@ globals:
     type: bool
     restore_value: true
     initial_value: 'false'
+  - id: screensaver_action_clock
+    type: bool
+    initial_value: 'false'
+  - id: screensaver_action_dimmed
+    type: bool
+    initial_value: 'false'
 
 esphome:
   on_boot:
     priority: -240
     then:
       - lambda: |-
+          auto update_screensaver_action_cache = []() {
+            std::string action = id(screensaver_action).current_option();
+            id(screensaver_action_clock) = screensaver_action_clock_mode(action);
+            id(screensaver_action_dimmed) = screensaver_action_dimmed_mode(action);
+          };
+          update_screensaver_action_cache();
+
           if (!id(screensaver_action_migrated)) {
             if (id(clock_screensaver_enabled).state) {
               auto action_call = id(screensaver_action).make_call();
@@ -93,6 +106,7 @@ esphome:
             id(screensaver_action_migrated) = true;
             global_preferences->sync();
           }
+          update_screensaver_action_cache();
 
           auto clamp_clock_pct = [](float pct, float fallback) -> float {
             if (std::isnan(pct) || pct <= 0.0f) pct = fallback;
@@ -194,7 +208,7 @@ script:
                   - lambda: 'navigation_return_home(id(main_page)->obj);'
                   - if:
                       condition:
-                        lambda: 'return screensaver_action_clock_mode(id(screensaver_action).current_option());'
+                        lambda: 'return id(screensaver_action_clock);'
                       then:
                         - globals.set:
                             id: display_asleep
@@ -204,7 +218,7 @@ script:
                         - script.execute: hide_cover_art_view
                         - if:
                             condition:
-                              lambda: 'return screensaver_action_dimmed_mode(id(screensaver_action).current_option());'
+                              lambda: 'return id(screensaver_action_dimmed);'
                             then:
                               - script.execute: show_dimmed_view
                             else:
@@ -268,7 +282,7 @@ script:
                           now.is_valid() ? now.hour : 0,
                           (int) id(schedule_on_hour).state,
                           (int) id(schedule_off_hour).state)) return true;
-                    return screen_schedule_always_on_mode(id(schedule_mode).current_option());
+                    return id(schedule_mode_always_on);
                 then:
                   - script.execute: screensaver_wake
                 else:
@@ -493,7 +507,7 @@ script:
           condition:
             lambda: |-
               return (id(screen_schedule_asleep) &&
-                      !screen_schedule_clock_mode(id(schedule_mode).current_option())) ||
+                      !id(schedule_mode_clock)) ||
                      screen_schedule_waiting_for_time(
                        id(screen_schedule_trigger).state,
                        id(schedule_enabled).state,
@@ -558,9 +572,8 @@ script:
               now.is_valid() ? now.hour : 0,
               (int) id(schedule_on_hour).state,
               (int) id(schedule_off_hour).state);
-            std::string mode = id(schedule_mode).current_option();
             id(manual_wake_ms) =
-              (schedule_night && !screen_schedule_always_on_mode(mode)) ? millis() : 0;
+              (schedule_night && !id(schedule_mode_always_on)) ? millis() : 0;
           }
       - if:
           condition:
@@ -740,7 +753,7 @@ script:
 
           float pct = ${screen_saver_clock_default_brightness}.0f;
           if (id(screen_schedule_asleep) &&
-              screen_schedule_clock_mode(id(schedule_mode).current_option())) {
+              id(schedule_mode_clock)) {
             pct = id(schedule_clock_brightness).state;
             if (std::isnan(pct) || pct <= 0.0f) {
               pct = ${screen_schedule_clock_default_brightness}.0f;
@@ -818,7 +831,7 @@ script:
                 auto time = panel_time_or_fallback(id(panel_time).now(), id(homeassistant_time).now());
                 if (time.is_valid()) {
                   char buf[8];
-                  bool use_12h = id(clock_format_select).current_option() == "12h";
+                  bool use_12h = id(clock_format_12h);
                   format_clock_time_without_suffix(buf, sizeof(buf),
                                                    time.hour, time.minute, use_12h);
                   lv_label_set_text(id(clock_label), buf);
@@ -925,7 +938,7 @@ interval:
           auto time = panel_time_or_fallback(id(panel_time).now(), id(homeassistant_time).now());
           if (!time.is_valid()) return;
           char buf[8];
-          bool use_12h = id(clock_format_select).current_option() == "12h";
+          bool use_12h = id(clock_format_12h);
           format_clock_time_without_suffix(buf, sizeof(buf),
                                            time.hour, time.minute, use_12h);
           lv_label_set_text(id(clock_label), buf);

--- a/common/addon/backlight_schedule.yaml
+++ b/common/addon/backlight_schedule.yaml
@@ -25,6 +25,12 @@ globals:
   - id: sunrise_sunset_valid
     type: bool
     initial_value: 'false'
+  - id: schedule_mode_always_on
+    type: bool
+    initial_value: 'false'
+  - id: schedule_mode_clock
+    type: bool
+    initial_value: 'false'
 
 # =============================================================================
 # SUNRISE / SUNSET DISPLAY
@@ -53,6 +59,10 @@ esphome:
   on_boot:
     priority: -250
     then:
+      - lambda: |-
+          std::string mode = id(schedule_mode).current_option();
+          id(schedule_mode_always_on) = screen_schedule_always_on_mode(mode);
+          id(schedule_mode_clock) = screen_schedule_clock_mode(mode);
       - if:
           condition:
             lambda: 'return id(schedule_enabled).state && screen_schedule_disabled_trigger(id(screen_schedule_trigger).state);'
@@ -143,6 +153,10 @@ select:
       sorting_group_id: sg_brightness
     on_value:
       then:
+        - lambda: |-
+            std::string mode = id(schedule_mode).current_option();
+            id(schedule_mode_always_on) = screen_schedule_always_on_mode(mode);
+            id(schedule_mode_clock) = screen_schedule_clock_mode(mode);
         - script.execute: screen_schedule_check
 
 text:
@@ -346,7 +360,7 @@ number:
                          now.is_valid() ? now.hour : 0,
                          (int) id(schedule_on_hour).state,
                          (int) id(schedule_off_hour).state) &&
-                       screen_schedule_always_on_mode(id(schedule_mode).current_option());
+                       id(schedule_mode_always_on);
             then:
               - script.execute: backlight_apply_brightness
 
@@ -439,10 +453,8 @@ script:
                        (int) id(schedule_on_hour).state,
                        (int) id(schedule_off_hour).state);
               if (!waiting_for_time && !night_active) return false;
-              std::string mode = id(schedule_mode).current_option();
               return waiting_for_time ||
-                     (!screen_schedule_always_on_mode(mode) &&
-                      !screen_schedule_clock_mode(mode));
+                     (!id(schedule_mode_always_on) && !id(schedule_mode_clock));
           then:
             - globals.set:
                 id: display_asleep
@@ -651,8 +663,7 @@ script:
             return;
           }
 
-          std::string mode = id(schedule_mode).current_option();
-          if (screen_schedule_always_on_mode(mode)) {
+          if (id(schedule_mode_always_on)) {
             id(manual_wake_ms) = 0;
             if (id(backlight_manual_off)) {
               id(backlight_schedule_display_off).execute();
@@ -662,7 +673,7 @@ script:
             return;
           }
 
-          if (screen_schedule_clock_mode(mode)) {
+          if (id(schedule_mode_clock)) {
             if (id(backlight_manual_off)) {
               id(backlight_schedule_display_off).execute();
               return;
@@ -746,7 +757,7 @@ script:
           uint32_t elapsed = (uint32_t) (millis() - id(manual_wake_ms));
           if (elapsed >= timeout_ms && !id(screen_schedule_asleep)) {
             id(manual_wake_ms) = 0;
-            if (screen_schedule_clock_mode(id(schedule_mode).current_option())) {
+            if (id(schedule_mode_clock)) {
               id(screen_schedule_show_clock).execute();
             } else {
               id(screen_schedule_sleep).execute();
@@ -763,7 +774,7 @@ script:
           if (id(display_asleep) && !id(cover_art_screensaver_active)) return;
           auto now = panel_time_or_fallback(id(panel_time).now(), id(homeassistant_time).now());
           if (id(screen_schedule_asleep)) {
-            if (screen_schedule_clock_mode(id(schedule_mode).current_option())) return;
+            if (id(schedule_mode_clock)) return;
             id(backlight_force_display_off).execute();
             return;
           }
@@ -788,7 +799,7 @@ script:
                        now.is_valid() ? now.hour : 0,
                        (int) id(schedule_on_hour).state,
                        (int) id(schedule_off_hour).state) &&
-                     screen_schedule_always_on_mode(id(schedule_mode).current_option())) {
+                     id(schedule_mode_always_on)) {
             pct = id(schedule_dimmed_brightness).state;
             if (std::isnan(pct) || pct <= 0) pct = 10;
             if (pct < 1) pct = 1;
@@ -825,7 +836,7 @@ script:
       - lambda: |-
           auto now = panel_time_or_fallback(id(panel_time).now(), id(homeassistant_time).now());
           if (!now.is_valid()) return;
-          bool use_12h = id(clock_format_select).current_option() == "12h";
+          bool use_12h = id(clock_format_12h);
           auto r = recalc_sunrise_sunset(now.year, now.month, now.day_of_month,
                                          id(timezone_select).current_option(),
                                          use_12h);
@@ -851,7 +862,7 @@ interval:
           condition:
             lambda: |-
               return (id(screen_schedule_asleep) &&
-                      !screen_schedule_clock_mode(id(schedule_mode).current_option())) ||
+                      !id(schedule_mode_clock)) ||
                      screen_schedule_waiting_for_time(
                        id(screen_schedule_trigger).state,
                        id(schedule_enabled).state,

--- a/common/addon/time.yaml
+++ b/common/addon/time.yaml
@@ -6,11 +6,17 @@
 # lat/lon for on-device sunrise/sunset calculation (sun_calc.h).
 # =============================================================================
 
+globals:
+  - id: clock_format_12h
+    type: bool
+    initial_value: 'false'
+
 esphome:
   on_boot:
     priority: -100
     then:
       - lambda: |-
+          id(clock_format_12h) = id(clock_format_select).current_option() == "12h";
           const char *posix = apply_timezone(id(timezone_select).current_option());
           set_espcontrol_language(id(language_select).current_option());
           id(panel_time).set_timezone(posix);
@@ -226,6 +232,7 @@ select:
       sorting_group_id: sg_brightness
     on_value:
       then:
+        - lambda: 'id(clock_format_12h) = id(clock_format_select).current_option() == "12h";'
         - script.execute: time_update
         - script.execute: backlight_recalc_sunrise_sunset
 
@@ -420,16 +427,14 @@ script:
             auto now = panel_time_or_fallback(id(panel_time).now(),
                                               id(homeassistant_time).now());
             if (!now.is_valid()) return "--:--";
-            bool use_12h =
-                id(clock_format_select).current_option() == "12h";
+            bool use_12h = id(clock_format_12h);
             format_clock_time_without_suffix(time_buf, sizeof(time_buf),
                                              now.hour, now.minute, use_12h);
             return time_buf;
       - lambda: |-
           auto now = panel_time_or_fallback(id(panel_time).now(),
                                             id(homeassistant_time).now());
-          bool use_12h =
-              id(clock_format_select).current_option() == "12h";
+          bool use_12h = id(clock_format_12h);
           if (now.is_valid()) {
             static char date_buf[11];
             snprintf(date_buf, sizeof(date_buf), "%04d-%02d-%02d",

--- a/common/config/display.yaml
+++ b/common/config/display.yaml
@@ -359,7 +359,7 @@ switch:
     on_turn_on:
       - if:
           condition:
-            lambda: 'return !screensaver_action_clock_mode(id(screensaver_action).current_option());'
+            lambda: 'return !id(screensaver_action_clock);'
           then:
             - select.set:
                 id: screensaver_action
@@ -372,7 +372,7 @@ switch:
     on_turn_off:
       - if:
           condition:
-            lambda: 'return screensaver_action_clock_mode(id(screensaver_action).current_option());'
+            lambda: 'return id(screensaver_action_clock);'
           then:
             - select.set:
                 id: screensaver_action
@@ -455,18 +455,20 @@ select:
       sorting_group_id: sg_screensaver
     on_value:
       then:
+        - lambda: |-
+            std::string action = id(screensaver_action).current_option();
+            id(screensaver_action_clock) = screensaver_action_clock_mode(action);
+            id(screensaver_action_dimmed) = screensaver_action_dimmed_mode(action);
         - if:
             condition:
               lambda: |-
-                return screensaver_action_clock_mode(id(screensaver_action).current_option()) &&
-                       !id(clock_screensaver_enabled).state;
+                return id(screensaver_action_clock) && !id(clock_screensaver_enabled).state;
             then:
               - switch.turn_on: clock_screensaver_enabled
         - if:
             condition:
               lambda: |-
-                return !screensaver_action_clock_mode(id(screensaver_action).current_option()) &&
-                       id(clock_screensaver_enabled).state;
+                return !id(screensaver_action_clock) && id(clock_screensaver_enabled).state;
             then:
               - switch.turn_off: clock_screensaver_enabled
         - if:

--- a/components/espcontrol/button_grid_alarm.h
+++ b/components/espcontrol/button_grid_alarm.h
@@ -1194,9 +1194,10 @@ inline void alarm_configure_page_grid(lv_obj_t *page, int num_slots, int cols) {
   if (col_count > MAX_GRID_SLOTS) col_count = MAX_GRID_SLOTS;
   int row_count = (slot_count + col_count - 1) / col_count;
   if (row_count < 1) row_count = 1;
+  if (row_count > MAX_GRID_SLOTS) row_count = MAX_GRID_SLOTS;
 
-  lv_coord_t *col_dsc = new lv_coord_t[col_count + 1];
-  lv_coord_t *row_dsc = new lv_coord_t[row_count + 1];
+  static lv_coord_t col_dsc[MAX_GRID_SLOTS + 1];
+  static lv_coord_t row_dsc[MAX_GRID_SLOTS + 1];
   for (int i = 0; i < col_count; i++) col_dsc[i] = LV_GRID_FR(1);
   col_dsc[col_count] = LV_GRID_TEMPLATE_LAST;
   for (int i = 0; i < row_count; i++) row_dsc[i] = LV_GRID_FR(1);

--- a/components/espcontrol/button_grid_config.h
+++ b/components/espcontrol/button_grid_config.h
@@ -248,11 +248,14 @@ inline int hex_digit(char c) {
   return -1;
 }
 
-inline std::string decode_compact_field(const std::string &value) {
+inline std::string decode_compact_field(const std::string &value, size_t start, size_t len) {
+  if (start > value.size()) return "";
+  size_t end = start + len;
+  if (end < start || end > value.size()) end = value.size();
   std::string out;
-  out.reserve(value.size());
-  for (size_t i = 0; i < value.size(); i++) {
-    if (value[i] == '%' && i + 2 < value.size()) {
+  out.reserve(end - start);
+  for (size_t i = start; i < end; i++) {
+    if (value[i] == '%' && i + 2 < end) {
       int hi = hex_digit(value[i + 1]);
       int lo = hex_digit(value[i + 2]);
       if (hi >= 0 && lo >= 0) {
@@ -264,6 +267,10 @@ inline std::string decode_compact_field(const std::string &value) {
     out.push_back(value[i]);
   }
   return out;
+}
+
+inline std::string decode_compact_field(const std::string &value) {
+  return decode_compact_field(value, 0, value.size());
 }
 
 inline char compact_hex_char(uint8_t value) {

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -709,6 +709,7 @@ inline void grid_phase1(
   display_set_width_axis(display);
   int NS = bounded_grid_slots(cfg.num_slots);
   int COLS = cfg.cols > 0 ? cfg.cols : 1;
+  if (COLS > MAX_GRID_SLOTS) COLS = MAX_GRID_SLOTS;
   for (int i = 0; i < NS; i++)
     lv_obj_add_flag(slots[i].btn, LV_OBJ_FLAG_HIDDEN);
   configure_grid_layout(main_page_obj, NS, COLS);
@@ -1252,11 +1253,10 @@ inline void grid_phase2(
   if (cfg.info_only) return;
 
   // --- Subpage creation ---
-  // Heap-allocated grid descriptors (never freed -- display lifetime)
-  lv_coord_t *sp_col_dsc = new lv_coord_t[COLS + 1];
+  static lv_coord_t sp_col_dsc[MAX_GRID_SLOTS + 1];
   for (int i = 0; i < COLS; i++) sp_col_dsc[i] = LV_GRID_FR(1);
   sp_col_dsc[COLS] = LV_GRID_TEMPLATE_LAST;
-  lv_coord_t *sp_row_dsc = new lv_coord_t[ROWS + 1];
+  static lv_coord_t sp_row_dsc[MAX_GRID_SLOTS + 1];
   for (int i = 0; i < ROWS; i++) sp_row_dsc[i] = LV_GRID_FR(1);
   sp_row_dsc[ROWS] = LV_GRID_TEMPLATE_LAST;
 

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -1102,14 +1102,19 @@ inline std::string image_card_cache_bust_url(const std::string &url) {
 inline bool image_card_query_has_param(const std::string &url, const std::string &param) {
   size_t query = url.find('?');
   if (query == std::string::npos) return false;
-  std::string token = param + "=";
-  size_t pos = url.find(token, query + 1);
-  while (pos != std::string::npos) {
-    if ((pos == query + 1 || url[pos - 1] == '&') &&
-        (url.find('#') == std::string::npos || pos < url.find('#'))) {
+  size_t fragment = url.find('#', query + 1);
+  if (fragment == std::string::npos) fragment = url.size();
+  size_t pos = query + 1;
+  while (pos < fragment) {
+    size_t next = url.find('&', pos);
+    if (next == std::string::npos || next > fragment) next = fragment;
+    size_t eq = url.find('=', pos);
+    if (eq != std::string::npos && eq < next &&
+        eq - pos == param.size() &&
+        url.compare(pos, param.size(), param) == 0) {
       return true;
     }
-    pos = url.find(token, pos + 1);
+    pos = next + 1;
   }
   return false;
 }
@@ -1751,11 +1756,14 @@ inline bool bind_image_card(BtnSlot &s, const ParsedCfg &p, const GridConfig &cf
     }, LV_EVENT_CLICKED, ctx);
   }
 
+  const std::string image_card_entity_id = p.entity;
+  const uint32_t image_card_generation = ha_subscription_generation();
   ha_subscribe_attribute(
-    p.entity,
+    image_card_entity_id,
     std::string("entity_picture"),
     std::function<void(esphome::StringRef)>(
-      [ctx](esphome::StringRef picture) {
+      [ctx, image_card_entity_id, image_card_generation](esphome::StringRef picture) {
+        if (!image_card_context_current(ctx, image_card_entity_id, image_card_generation)) return;
         image_card_handle_picture(ctx, picture);
       })
   );

--- a/components/espcontrol/button_grid_layout.h
+++ b/components/espcontrol/button_grid_layout.h
@@ -119,6 +119,19 @@ inline bool grid_token_has_span_suffix(char suffix) {
     suffix == CARD_SIZE_EXTRA_WIDE_TOKEN;
 }
 
+inline int parse_positive_int_span(const std::string &value, size_t start, size_t end) {
+  while (start < end && std::isspace(static_cast<unsigned char>(value[start]))) start++;
+  int result = 0;
+  bool has_digit = false;
+  for (size_t i = start; i < end; i++) {
+    char ch = value[i];
+    if (ch < '0' || ch > '9') break;
+    has_digit = true;
+    result = result * 10 + (ch - '0');
+  }
+  return has_digit ? result : 0;
+}
+
 // Parse "1,2d,3w,4b,5t,6x,..." into positions + row/column spans
 inline void parse_order_string(const std::string &order_str, int num_slots, OrderResult &result) {
   memset(result.positions, 0, sizeof(result.positions));
@@ -133,13 +146,16 @@ inline void parse_order_string(const std::string &order_str, int num_slots, Orde
     size_t comma = order_str.find(',', start);
     if (comma == std::string::npos) comma = order_str.length();
     if (comma > start) {
-      std::string token = order_str.substr(start, comma - start);
+      size_t token_end = comma;
       int row_span = 1, col_span = 1;
-      if (!token.empty() && grid_token_has_span_suffix(token.back())) {
-        grid_token_spans(token.back(), row_span, col_span);
-        token.pop_back();
+      while (token_end > start && std::isspace(static_cast<unsigned char>(order_str[token_end - 1]))) {
+        token_end--;
       }
-      int v = atoi(token.c_str());
+      if (token_end > start && grid_token_has_span_suffix(order_str[token_end - 1])) {
+        grid_token_spans(order_str[token_end - 1], row_span, col_span);
+        token_end--;
+      }
+      int v = parse_positive_int_span(order_str, start, token_end);
       if (v >= 1 && v <= slot_limit) {
         result.positions[gpos] = v;
         result.row_span[v - 1] = row_span;

--- a/components/espcontrol/button_grid_subpages.h
+++ b/components/espcontrol/button_grid_subpages.h
@@ -37,6 +37,10 @@ inline std::string decode_compact_subpage_field(const std::string &value) {
   return decode_compact_field(value);
 }
 
+inline std::string decode_compact_subpage_field(const std::string &value, size_t start, size_t len) {
+  return decode_compact_field(value, start, len);
+}
+
 inline SubpageBtn normalize_subpage_btn(SubpageBtn b) {
   if (brightness_slider_type(b.type) && !b.sensor.empty()) b.sensor.clear();
   if (fan_card_type(b.type)) {
@@ -349,17 +353,19 @@ inline std::string get_subpage_order(const std::string &sp_cfg) {
   return sp_cfg.substr(start, pe - start);
 }
 
-inline std::string subpage_back_token_base(std::string token) {
-  size_t eq = token.find('=');
-  if (eq != std::string::npos) token = token.substr(0, eq);
-  return token;
-}
-
-inline std::string subpage_back_label_from_order_token(const std::string &token) {
-  size_t eq = token.find('=');
-  if (eq == std::string::npos) return espcontrol_i18n(std::string("Back"));
-  std::string label = decode_compact_subpage_field(token.substr(eq + 1));
-  return label.empty() ? espcontrol_i18n(std::string("Back")) : label;
+inline bool subpage_back_token_span(const std::string &order_str, size_t start, size_t end, char &suffix,
+                                    size_t *label_start = nullptr) {
+  while (start < end && std::isspace(static_cast<unsigned char>(order_str[start]))) start++;
+  while (end > start && std::isspace(static_cast<unsigned char>(order_str[end - 1]))) end--;
+  size_t eq = order_str.find('=', start);
+  size_t base_end = (eq == std::string::npos || eq > end) ? end : eq;
+  while (base_end > start && std::isspace(static_cast<unsigned char>(order_str[base_end - 1]))) base_end--;
+  size_t len = base_end - start;
+  if (len < 1 || len > 2 || order_str[start] != 'B') return false;
+  suffix = len == 2 ? order_str[start + 1] : '\0';
+  if (suffix != '\0' && !grid_token_has_span_suffix(suffix)) return false;
+  if (label_start) *label_start = (eq == std::string::npos || eq >= end) ? std::string::npos : eq + 1;
+  return true;
 }
 
 inline std::string get_subpage_back_label(const std::string &order_str) {
@@ -369,11 +375,14 @@ inline std::string get_subpage_back_label(const std::string &order_str) {
     size_t cm = order_str.find(',', st);
     if (cm == std::string::npos) cm = order_str.length();
     if (cm > st) {
-      std::string tk = order_str.substr(st, cm - st);
-      std::string base = subpage_back_token_base(tk);
-      if (base == "B" || base == "Bd" || base == "Bw" || base == "Bb" ||
-          base == "Bt" || base == "Bx") {
-        return subpage_back_label_from_order_token(tk);
+      char suffix = '\0';
+      size_t label_start = std::string::npos;
+      if (subpage_back_token_span(order_str, st, cm, suffix, &label_start)) {
+        if (label_start != std::string::npos) {
+          std::string label = decode_compact_subpage_field(order_str, label_start, cm - label_start);
+          return label.empty() ? espcontrol_i18n(std::string("Back")) : label;
+        }
+        return espcontrol_i18n(std::string("Back"));
       }
     }
     st = cm + 1;
@@ -500,19 +509,22 @@ inline void parse_subpage_order(const std::string &order_str, int num_slots, int
     size_t cm = order_str.find(',', st2);
     if (cm == std::string::npos) cm = order_str.length();
     if (cm > st2) {
-      std::string tk = order_str.substr(st2, cm - st2);
-      tk = subpage_back_token_base(tk);
-      if (tk == "B" || tk == "Bd" || tk == "Bw" || tk == "Bb" || tk == "Bt" || tk == "Bx") {
+      char back_suffix = '\0';
+      if (subpage_back_token_span(order_str, st2, cm, back_suffix)) {
         result.back_pos = gp2;
-        grid_token_spans(tk.length() > 1 ? tk[1] : '\0', result.back_row_span, result.back_col_span);
+        grid_token_spans(back_suffix, result.back_row_span, result.back_col_span);
         result.has_back_token = true;
       } else {
+        size_t token_end = cm;
         int row_span = 1, col_span = 1;
-        if (!tk.empty() && grid_token_has_span_suffix(tk.back())) {
-          grid_token_spans(tk.back(), row_span, col_span);
-          tk.pop_back();
+        while (token_end > st2 && std::isspace(static_cast<unsigned char>(order_str[token_end - 1]))) {
+          token_end--;
         }
-        int v = atoi(tk.c_str());
+        if (token_end > st2 && grid_token_has_span_suffix(order_str[token_end - 1])) {
+          grid_token_spans(order_str[token_end - 1], row_span, col_span);
+          token_end--;
+        }
+        int v = parse_positive_int_span(order_str, st2, token_end);
         if (v >= 1 && v <= btn_limit) {
           result.positions[gp2] = v;
           result.row_span[v - 1] = row_span;

--- a/components/espcontrol/clock_bar.h
+++ b/components/espcontrol/clock_bar.h
@@ -515,6 +515,9 @@ enum ClockBarSectionId {
   CLOCK_BAR_SECTION_COUNT = 3,
 };
 
+inline int clock_bar_section_id(const std::string &value, size_t start, size_t end);
+inline int clock_bar_item_id(const std::string &value, size_t start, size_t end);
+
 struct ClockBarParsedLayout {
   int section[CLOCK_BAR_ITEM_COUNT];
   int order[CLOCK_BAR_ITEM_COUNT];
@@ -530,29 +533,49 @@ inline void clock_bar_clear_layout(ClockBarParsedLayout &layout) {
 }
 
 inline int clock_bar_section_id(const std::string &value) {
-  std::string token = clock_bar_trim(value);
-  if (token == "left") return CLOCK_BAR_SECTION_LEFT;
-  if (token == "middle") return CLOCK_BAR_SECTION_MIDDLE;
-  if (token == "right") return CLOCK_BAR_SECTION_RIGHT;
+  return clock_bar_section_id(value, 0, value.size());
+}
+
+inline void clock_bar_trim_span(const std::string &value, size_t &start, size_t &end) {
+  while (start < end && std::isspace(static_cast<unsigned char>(value[start]))) start++;
+  while (end > start && std::isspace(static_cast<unsigned char>(value[end - 1]))) end--;
+}
+
+inline bool clock_bar_span_equals(const std::string &value, size_t start, size_t end, const char *text) {
+  clock_bar_trim_span(value, start, end);
+  const size_t len = strlen(text);
+  return end - start == len && value.compare(start, len, text) == 0;
+}
+
+inline int clock_bar_section_id(const std::string &value, size_t start, size_t end) {
+  if (clock_bar_span_equals(value, start, end, "left")) return CLOCK_BAR_SECTION_LEFT;
+  if (clock_bar_span_equals(value, start, end, "middle")) return CLOCK_BAR_SECTION_MIDDLE;
+  if (clock_bar_span_equals(value, start, end, "right")) return CLOCK_BAR_SECTION_RIGHT;
   return -1;
 }
 
 inline int clock_bar_item_id(const std::string &value) {
-  std::string token = clock_bar_trim(value);
-  if (token == "temperature") return CLOCK_BAR_ITEM_TEMPERATURE;
-  const std::string prefix = "temperature_";
-  if (token.compare(0, prefix.size(), prefix) == 0) {
-    int slot = 0;
-    for (size_t i = prefix.size(); i < token.size(); i++) {
-      if (token[i] < '0' || token[i] > '9') return -1;
-      slot = slot * 10 + (token[i] - '0');
-    }
-    if (slot >= 2 && slot <= (int) CLOCK_BAR_TEMPERATURE_SLOT_COUNT) {
-      return CLOCK_BAR_ITEM_TEMPERATURE + slot - 1;
-    }
+  return clock_bar_item_id(value, 0, value.size());
+}
+
+inline int clock_bar_item_id(const std::string &value, size_t start, size_t end) {
+  if (clock_bar_span_equals(value, start, end, "temperature")) return CLOCK_BAR_ITEM_TEMPERATURE;
+  if (clock_bar_span_equals(value, start, end, "time")) return CLOCK_BAR_ITEM_TIME;
+  if (clock_bar_span_equals(value, start, end, "network")) return CLOCK_BAR_ITEM_NETWORK;
+
+  clock_bar_trim_span(value, start, end);
+  static const char prefix[] = "temperature_";
+  const size_t prefix_len = sizeof(prefix) - 1;
+  if (end - start <= prefix_len || value.compare(start, prefix_len, prefix) != 0) return -1;
+
+  int slot = 0;
+  for (size_t i = start + prefix_len; i < end; i++) {
+    if (value[i] < '0' || value[i] > '9') return -1;
+    slot = slot * 10 + (value[i] - '0');
   }
-  if (token == "time") return CLOCK_BAR_ITEM_TIME;
-  if (token == "network") return CLOCK_BAR_ITEM_NETWORK;
+  if (slot >= 2 && slot <= (int) CLOCK_BAR_TEMPERATURE_SLOT_COUNT) {
+    return CLOCK_BAR_ITEM_TEMPERATURE + slot - 1;
+  }
   return -1;
 }
 
@@ -580,19 +603,18 @@ inline ClockBarParsedLayout parse_clock_bar_layout(const std::string &layout_tex
   while (segment_start <= layout_text.size()) {
     size_t segment_end = layout_text.find('|', segment_start);
     if (segment_end == std::string::npos) segment_end = layout_text.size();
-    std::string segment = layout_text.substr(segment_start, segment_end - segment_start);
-    size_t colon = segment.find(':');
-    if (colon != std::string::npos) {
-      int section = clock_bar_section_id(segment.substr(0, colon));
+    size_t colon = layout_text.find(':', segment_start);
+    if (colon != std::string::npos && colon < segment_end) {
+      int section = clock_bar_section_id(layout_text, segment_start, colon);
       size_t item_start = colon + 1;
-      while (section >= 0 && item_start <= segment.size()) {
-        size_t item_end = segment.find(',', item_start);
-        if (item_end == std::string::npos) item_end = segment.size();
+      while (section >= 0 && item_start <= segment_end) {
+        size_t item_end = layout_text.find(',', item_start);
+        if (item_end == std::string::npos || item_end > segment_end) item_end = segment_end;
         clock_bar_add_item(
             layout,
             section,
-            clock_bar_item_id(segment.substr(item_start, item_end - item_start)));
-        if (item_end == segment.size()) break;
+            clock_bar_item_id(layout_text, item_start, item_end));
+        if (item_end == segment_end) break;
         item_start = item_end + 1;
       }
     }

--- a/devices/esp32-p4-86/device/device.yaml
+++ b/devices/esp32-p4-86/device/device.yaml
@@ -194,7 +194,7 @@ light:
               lambda: |-
                 auto now = panel_time_or_fallback(id(panel_time).now(), id(homeassistant_time).now());
                 return (id(screen_schedule_asleep) &&
-                        !screen_schedule_clock_mode(id(schedule_mode).current_option())) ||
+                        !id(schedule_mode_clock)) ||
                        screen_schedule_waiting_for_time(
                          id(screen_schedule_trigger).state,
                          id(schedule_enabled).state,

--- a/devices/guition-esp32-p4-jc1060p470/device/device.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/device/device.yaml
@@ -224,7 +224,7 @@ light:
               lambda: |-
                 auto now = panel_time_or_fallback(id(panel_time).now(), id(homeassistant_time).now());
                 return (id(screen_schedule_asleep) &&
-                        !screen_schedule_clock_mode(id(schedule_mode).current_option())) ||
+                        !id(schedule_mode_clock)) ||
                        screen_schedule_waiting_for_time(
                          id(screen_schedule_trigger).state,
                          id(schedule_enabled).state,

--- a/devices/guition-esp32-p4-jc4880p443/device/device.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/device/device.yaml
@@ -207,7 +207,7 @@ light:
               lambda: |-
                 auto now = panel_time_or_fallback(id(panel_time).now(), id(homeassistant_time).now());
                 return (id(screen_schedule_asleep) &&
-                        !screen_schedule_clock_mode(id(schedule_mode).current_option())) ||
+                        !id(schedule_mode_clock)) ||
                        screen_schedule_waiting_for_time(
                          id(screen_schedule_trigger).state,
                          id(schedule_enabled).state,

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -230,7 +230,7 @@ light:
               lambda: |-
                 auto now = panel_time_or_fallback(id(panel_time).now(), id(homeassistant_time).now());
                 return (id(screen_schedule_asleep) &&
-                        !screen_schedule_clock_mode(id(schedule_mode).current_option())) ||
+                        !id(schedule_mode_clock)) ||
                        screen_schedule_waiting_for_time(
                          id(screen_schedule_trigger).state,
                          id(schedule_enabled).state,

--- a/devices/guition-esp32-s3-4848s040/device/device.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/device.yaml
@@ -227,7 +227,7 @@ light:
               lambda: |-
                 auto now = panel_time_or_fallback(id(panel_time).now(), id(homeassistant_time).now());
                 return (id(screen_schedule_asleep) &&
-                        !screen_schedule_clock_mode(id(schedule_mode).current_option())) ||
+                        !id(schedule_mode_clock)) ||
                        screen_schedule_waiting_for_time(
                          id(screen_schedule_trigger).state,
                          id(schedule_enabled).state,


### PR DESCRIPTION
## Purpose
Reduce repeated temporary string/object allocations in firmware paths that run often, especially schedule/backlight checks and button/clock layout parsing.

## Practical impact
- Caches select-state booleans for schedule mode, clock format, and screensaver action instead of rebuilding/comparing strings repeatedly.
- Parses clock bar, button grid order, and subpage layout tokens from existing strings where possible.
- Uses fixed LVGL descriptor arrays for grid/alarm layouts instead of allocating descriptor arrays repeatedly.
- Avoids a small query-parameter temporary string in image-card URL checks.

## Checks
- `git diff --check`
- Focused scan for repeated allocation patterns
- `docker run --rm -v "/Users/jtenniswood/Git/espcontrol:/config" ghcr.io/esphome/esphome:2026.5.3 compile /config/builds/guition-esp32-p4-jc1060p470.factory.yaml`
- `/Users/jtenniswood/.local/bin/esphome -s espcontrol_component_url file:///Users/jtenniswood/Git/espcontrol compile builds/guition-esp32-p4-jc4880p443.factory.yaml`
- `/Users/jtenniswood/.local/bin/esphome -s espcontrol_component_url file:///Users/jtenniswood/Git/espcontrol compile builds/guition-esp32-s3-4848s040.factory.yaml`
- `/Users/jtenniswood/.local/bin/esphome -s espcontrol_component_url file:///Users/jtenniswood/Git/espcontrol compile builds/guition-esp32-p4-jc8012p4a1.factory.yaml`
- `/Users/jtenniswood/.local/bin/esphome -s espcontrol_component_url file:///Users/jtenniswood/Git/espcontrol compile builds/esp32-p4-86.factory.yaml`

Note: Docker Desktop became unavailable after the first compile, so the remaining targets were checked with the local ESPHome 2026.5.3 install and the local component URL override.

## Device testing
Flash and test affected display branches before merge: 10.1-inch P4, 4.3-inch P4, 7-inch P4, 4-inch S3, and 8.6-inch P4.