### PR TITLE
Remove heap min free memory sensor

### DIFF
--- a/common/addon/memory_diagnostics.yaml
+++ b/common/addon/memory_diagnostics.yaml
@@ -1,9 +1,9 @@
 # =============================================================================
 # MEMORY DIAGNOSTICS - Device memory exposed to Home Assistant
 # =============================================================================
-# Current free internal heap, minimum free internal heap since boot, and free
-# PSRAM exposed as percentages. Raw byte sensors are internal and update once
-# per minute through ESPHome's debug component.
+# Current free internal heap and free PSRAM exposed as percentages. Raw byte
+# sensors are internal and update once per minute through ESPHome's debug
+# component.
 # =============================================================================
 
 debug:
@@ -14,11 +14,6 @@ sensor:
     free:
       name: "Memory: Heap Free Bytes"
       id: memory_heap_free_bytes
-      entity_category: diagnostic
-      internal: true
-    min_free:
-      name: "Memory: Heap Min Free Bytes"
-      id: memory_heap_min_free_bytes
       entity_category: diagnostic
       internal: true
     psram:
@@ -41,21 +36,6 @@ sensor:
         return NAN;
       }
       return id(memory_heap_free_bytes).state * 100.0f / total;
-
-  - platform: template
-    name: "Memory: Heap Min Free"
-    id: memory_heap_min_free_percent
-    icon: mdi:memory
-    unit_of_measurement: "%"
-    accuracy_decimals: 1
-    entity_category: diagnostic
-    update_interval: 60s
-    lambda: |-
-      const float total = heap_caps_get_total_size(MALLOC_CAP_INTERNAL);
-      if (total <= 0.0f || isnan(id(memory_heap_min_free_bytes).state)) {
-        return NAN;
-      }
-      return id(memory_heap_min_free_bytes).state * 100.0f / total;
 
   - platform: template
     name: "Memory: PSRAM Free"


### PR DESCRIPTION
## Purpose
Remove the `Memory: Heap Min Free` diagnostic sensor from Home Assistant.

## Practical impact
After flashing this branch, devices should still report the current heap free memory and PSRAM free memory diagnostics, but Home Assistant should no longer get the minimum-free heap sensor.

## What changed
- Removed the hidden raw `Memory: Heap Min Free Bytes` debug sensor.
- Removed the visible `Memory: Heap Min Free` percentage template sensor.
- Updated the memory diagnostics comment to match the remaining sensors.

## Checks
- `npm run check:firmware-parser`
- `npm run check:firmware-ha-bindings`

## Device testing notes
Flash a device from this branch and check Home Assistant after the device reconnects. The `Memory: Heap Min Free` entity should be gone or become unavailable depending on Home Assistant's entity history, while the other memory diagnostics should continue updating.