### PR TITLE
Reduce P4 LVGL display buffers

### DIFF
--- a/devices/esp32-p4-86/device/device.yaml
+++ b/devices/esp32-p4-86/device/device.yaml
@@ -282,7 +282,7 @@ display:
 # ---------------------------------------------------------------------------
 lvgl:
   id: main_lvgl
-  buffer_size: 100%
+  buffer_size: 26%
   displays: my_display
   rotation: 0
   byte_order: little_endian

--- a/devices/guition-esp32-p4-jc4880p443/device/device.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/device/device.yaml
@@ -263,7 +263,7 @@ display:
 # ---------------------------------------------------------------------------
 lvgl:
   id: main_lvgl
-  buffer_size: 100%
+  buffer_size: 26%
   displays: my_display
   rotation: 180
   byte_order: little_endian


### PR DESCRIPTION
## Purpose

Reduce the LVGL display buffer size on the two ESP32-P4 display profiles from `100%` to `26%`.

## Practical impact

This keeps the P4 LVGL buffers above ESPHome's 25% PSRAM threshold while reducing the amount of PSRAM reserved for the display buffer compared with a full-screen `100%` buffer.

Affected devices:

- `esp32-p4-86`
- `guition-esp32-p4-jc4880p443`

The existing ESP32-S3 `12%` setting is unchanged.

## Checks run

- `npm run check:device-profiles`
- `npm run check:device-matrix`

## Testing notes

Flash/test this branch on the affected P4 panels and compare:

- free PSRAM after boot
- free internal heap after boot
- page-change responsiveness
- whether redraws show any tearing, lag, or partial-update artifacts

No full ESPHome firmware compile was run for this small YAML-only change.