### PR TITLE
Set firmware logging to warning level

### DIFF
--- a/common/device/core_infra.yaml
+++ b/common/device/core_infra.yaml
@@ -95,9 +95,7 @@ interval:
           refresh_weather_forecast_cards();
 
 logger:
-  logs:
-    light: WARN
-    script: INFO
+  level: WARN
 
 http_request:
   id: http_req


### PR DESCRIPTION
## What changed
- Set the shared ESPHome logger level to `WARN`.
- Removed the `script: INFO` override so normal informational script logs are no longer emitted.

## Practical impact
This keeps warnings and errors visible, but cuts out routine debug/info logging from the firmware. It should reduce log noise and may slightly reduce firmware memory/size, though it is not expected to be a large RAM saving.

## Checks
- `npm run check:product`

## Testing notes
Flash one affected display from this branch and confirm normal startup, Home Assistant connection, and web setup still work. Check logs only if troubleshooting; routine info messages should no longer appear.