### PR TITLE
Reduce climate card icon glyph set

### DIFF
--- a/common/assets/README.md
+++ b/common/assets/README.md
@@ -13,7 +13,7 @@ the right size on every device.
 | Style ID | Intended use |
 | --- | --- |
 | `font_icon_main` | Main action icons and setup icons |
-| `font_icon_card` | Smaller card-level icons |
+| `font_icon_card` | Smaller fixed climate option chip icons |
 | `font_icon_status` | Status, network, and subpage indicator icons |
 | `font_text_body` | Labels, setup body copy, and normal UI text |
 | `font_text_small` | Compact supporting text on small displays, only where needed |
@@ -31,6 +31,11 @@ The old shared common font package was removed from normal device builds. Each
 device defines the style IDs it needs in `devices/*/device/fonts.yaml`, using
 device-specific sizes behind the same generic names. This avoids loading setup
 fonts that duplicate fonts already available on the device.
+
+Some icon roles intentionally use smaller glyph sets. `font_icon_main` carries
+the user-selectable icon picker glyphs. `font_icon_card` carries only the fixed
+climate option chip icons; user-selected climate card icons still render through
+`font_icon_main`.
 
 ### Shared ratios
 

--- a/common/assets/climate_card_icon_glyphs.yaml
+++ b/common/assets/climate_card_icon_glyphs.yaml
@@ -1,0 +1,12 @@
+# Climate option chip icons used by font_icon_card.
+# User-selectable climate card icons use font_icon_main.
+- "\U000F0D43"  # mdi-air-filter
+- "\U000F0210"  # mdi-fan
+- "\U000F0238"  # mdi-fire
+- "\U000F0425"  # mdi-power
+- "\U000F0717"  # mdi-snowflake
+- "\U000F04E1"  # mdi-swap-horizontal
+- "\U000F050F"  # mdi-thermometer
+- "\U000F0393"  # mdi-thermostat
+- "\U000F1B17"  # mdi-thermostat-auto
+- "\U000F058C"  # mdi-water

--- a/devices/esp32-p4-86/device/fonts.yaml
+++ b/devices/esp32-p4-86/device/fonts.yaml
@@ -18,7 +18,7 @@ font:
     id: font_icon_card
     size: 50
     bpp: 4
-    glyphs: !include ../../../common/assets/icon_glyphs.yaml
+    glyphs: !include ../../../common/assets/climate_card_icon_glyphs.yaml
 
   # Status, network, and subpage icons
   - file: 'https://github.com/Templarian/MaterialDesign-Webfont/raw/v7.4.47/fonts/materialdesignicons-webfont.ttf'

--- a/devices/guition-esp32-p4-jc1060p470/device/fonts.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/device/fonts.yaml
@@ -18,7 +18,7 @@ font:
     id: font_icon_card
     size: 41
     bpp: 4
-    glyphs: !include ../../../common/assets/icon_glyphs.yaml
+    glyphs: !include ../../../common/assets/climate_card_icon_glyphs.yaml
 
   # Status, network, and subpage icons
   - file: 'https://github.com/Templarian/MaterialDesign-Webfont/raw/v7.4.47/fonts/materialdesignicons-webfont.ttf'

--- a/devices/guition-esp32-p4-jc4880p443/device/fonts.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/device/fonts.yaml
@@ -18,7 +18,7 @@ font:
     id: font_icon_card
     size: 47
     bpp: 4
-    glyphs: !include ../../../common/assets/icon_glyphs.yaml
+    glyphs: !include ../../../common/assets/climate_card_icon_glyphs.yaml
 
   # Status, network, and subpage icons
   - file: 'https://github.com/Templarian/MaterialDesign-Webfont/raw/v7.4.47/fonts/materialdesignicons-webfont.ttf'

--- a/devices/guition-esp32-p4-jc8012p4a1/device/fonts.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/fonts.yaml
@@ -18,7 +18,7 @@ font:
     id: font_icon_card
     size: 42
     bpp: 4
-    glyphs: !include ../../../common/assets/icon_glyphs.yaml
+    glyphs: !include ../../../common/assets/climate_card_icon_glyphs.yaml
 
   # Status, network, and subpage icons
   - file: 'https://github.com/Templarian/MaterialDesign-Webfont/raw/v7.4.47/fonts/materialdesignicons-webfont.ttf'

--- a/devices/guition-esp32-s3-4848s040/device/fonts.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/fonts.yaml
@@ -18,7 +18,7 @@ font:
     id: font_icon_card
     size: 33
     bpp: 4
-    glyphs: !include ../../../common/assets/icon_glyphs.yaml
+    glyphs: !include ../../../common/assets/climate_card_icon_glyphs.yaml
 
   # Status, network, and subpage icons
   - file: 'https://github.com/Templarian/MaterialDesign-Webfont/raw/v7.4.47/fonts/materialdesignicons-webfont.ttf'

--- a/scripts/check_device_profiles.py
+++ b/scripts/check_device_profiles.py
@@ -21,6 +21,18 @@ REQUIRED_SETUP_ICON_GLYPHS = {
     r'"\U000F012C"': "mdi-check",
     r'"\U000F0996"': "mdi-progress-clock",
 }
+REQUIRED_CLIMATE_CARD_ICON_NAMES = {
+    "Air Filter",
+    "Fan",
+    "Fire",
+    "Power",
+    "Snowflake",
+    "Swap Horizontal",
+    "Thermometer",
+    "Thermostat",
+    "Thermostat Auto",
+    "Water",
+}
 
 
 def read_json(path: Path) -> object:
@@ -171,6 +183,29 @@ def test_setup_icon_glyphs() -> None:
     glyphs = (ROOT / "common" / "assets" / "icon_glyphs.yaml").read_text(encoding="utf-8")
     for glyph, icon_name in REQUIRED_SETUP_ICON_GLYPHS.items():
         assert glyph in glyphs, f"shared icon font missing {icon_name} for OTA update screen"
+
+
+def test_climate_card_icon_glyphs() -> None:
+    icons = read_json(ROOT / "common" / "assets" / "icons.json")
+    icon_by_name = {icon["name"]: icon for icon in icons["icons"]}
+    glyphs = (ROOT / "common" / "assets" / "climate_card_icon_glyphs.yaml").read_text(encoding="utf-8")
+
+    for icon_name in sorted(REQUIRED_CLIMATE_CARD_ICON_NAMES):
+        icon = icon_by_name[icon_name]
+        glyph = rf'"\U{icon["codepoint"]:>08s}"'
+        assert glyph in glyphs, f"climate card icon font missing {icon_name}"
+
+    for font_path in sorted((ROOT / "devices").glob("*/device/fonts.yaml")):
+        text = font_path.read_text(encoding="utf-8")
+        rel = font_path.relative_to(ROOT)
+        card_match = re.search(
+            r"id: font_icon_card\n\s*size: \d+\n\s*bpp: \d+\n\s*glyphs: !include (.+)",
+            text,
+        )
+        assert card_match, f"{rel}: missing font_icon_card"
+        assert card_match.group(1).strip().endswith("common/assets/climate_card_icon_glyphs.yaml"), (
+            f"{rel}: font_icon_card should use climate_card_icon_glyphs.yaml"
+        )
 
 
 def test_weather_card_visual_matches_preview() -> None:


### PR DESCRIPTION
## Purpose
Reduce firmware memory use by stopping `font_icon_card` from compiling the full user-selectable Material Design Icons glyph list a second time.

## Practical impact
`font_icon_main` still includes the full icon picker glyph set for user-selected card icons. `font_icon_card` now uses a small 10-glyph climate option chip list instead of the full 313-glyph list.

Affected devices:
- esp32-p4-86
- guition-esp32-p4-jc1060p470
- guition-esp32-p4-jc4880p443
- guition-esp32-p4-jc8012p4a1
- guition-esp32-s3-4848s040

## Checked
- `python3 scripts/check_device_profiles.py`
- `python3 scripts/build.py icons --check`
- `python3 scripts/generate_device_slots.py --check`
- `npm run check:product`
- `npm run check:device-matrix`

## Testing notes
Flash one affected display from this branch and open a climate card modal. Check that the climate option chips still show their icons for target, mode, preset, fan, and swing. Also check a climate card with a custom selected icon to confirm the normal full-size card icon still renders.
