### PR TITLE
Fix P4 artwork image memory leak

### DIFF
--- a/common/addon/memory_diagnostics.yaml
+++ b/common/addon/memory_diagnostics.yaml
@@ -38,6 +38,17 @@ sensor:
       return id(memory_heap_free_bytes).state * 100.0f / total;
 
   - platform: template
+    name: "Memory: Heap Largest Block"
+    id: memory_heap_largest_block_bytes
+    icon: mdi:memory
+    unit_of_measurement: "B"
+    accuracy_decimals: 0
+    entity_category: diagnostic
+    update_interval: 60s
+    lambda: |-
+      return (float) heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
+
+  - platform: template
     name: "Memory: PSRAM Free"
     id: memory_psram_free_percent
     icon: mdi:memory
@@ -51,3 +62,14 @@ sensor:
         return NAN;
       }
       return id(memory_psram_free_bytes).state * 100.0f / total;
+
+  - platform: template
+    name: "Memory: PSRAM Largest Block"
+    id: memory_psram_largest_block_bytes
+    icon: mdi:memory
+    unit_of_measurement: "B"
+    accuracy_decimals: 0
+    entity_category: diagnostic
+    update_interval: 60s
+    lambda: |-
+      return (float) heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);

--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -940,13 +940,6 @@ script:
             alternate = id(cover_art_cached_remote_url);
           }
 
-          if (chosen.empty()) return;
-          if (!id(cover_art_active_download_source_url).empty() &&
-              !id(cover_art_download_url).empty()) {
-            ESP_LOGI("cover_art", "Cached artwork update received during active download; keeping current request");
-            return;
-          }
-
           std::string fallback;
           std::string capped = esphome::artwork_image::cap_artwork_url(chosen, ${cover_art_decode_size});
           if (capped != chosen) {
@@ -959,6 +952,38 @@ script:
           }
 
           id(cover_art_fallback_url) = fallback;
+          if (chosen.empty()) {
+            if (!id(cover_art_url).empty() || id(cover_art_image_available)) {
+              ESP_LOGI("cover_art", "Cached artwork is empty; clearing current artwork");
+              id(cover_art_url).clear();
+              id(cover_art_download_url).clear();
+              id(cover_art_active_download_source_url).clear();
+              id(cover_art_loaded_url).clear();
+              id(cover_art_refresh_needed) = false;
+              id(cover_art_retry_url).clear();
+              id(cover_art_retry_count) = 0;
+              id(cover_art_image_available) = false;
+              if (id(cover_art_screensaver_active)) {
+                id(cover_art_show_black_screen).execute();
+              }
+            }
+            return;
+          }
+
+          if (!id(cover_art_active_download_source_url).empty() &&
+              !id(cover_art_download_url).empty()) {
+            if (chosen != id(cover_art_url)) {
+              ESP_LOGI("cover_art", "Cached artwork changed during active download; queueing follow-up refresh");
+              id(cover_art_url) = chosen;
+              id(cover_art_refresh_needed) = true;
+              id(cover_art_retry_url).clear();
+              id(cover_art_retry_count) = 0;
+            } else {
+              ESP_LOGI("cover_art", "Cached artwork update received during active download; keeping current request");
+            }
+            return;
+          }
+
           if (chosen == id(cover_art_url)) {
             ESP_LOGI("cover_art", "Cached artwork matches current URL; image_available=%s active=%s refresh_needed=%s",
                      id(cover_art_image_available) ? "true" : "false",
@@ -1351,6 +1376,20 @@ script:
             return;
           }
 
+          if (id(cover_art_refresh_needed) && !id(cover_art_url).empty()) {
+            ESP_LOGI("cover_art", "No artwork URL available for refreshed track; clearing current artwork");
+            id(cover_art_url).clear();
+            id(cover_art_download_url).clear();
+            id(cover_art_active_download_source_url).clear();
+            id(cover_art_loaded_url).clear();
+            id(cover_art_refresh_needed) = false;
+            id(cover_art_retry_url).clear();
+            id(cover_art_retry_count) = 0;
+            id(cover_art_image_available) = false;
+            id(cover_art_show_black_screen).execute();
+            return;
+          }
+
           std::string chosen = id(cover_art_url);
           if (chosen == id(cover_art_url) && !chosen.empty()) {
             ESP_LOGI("cover_art", "Keeping existing artwork URL while waiting for subscription update");
@@ -1460,10 +1499,10 @@ script:
             bool state_subscribed = ha_subscribe_state(cover_entity, handle_playback_state);
             ESP_LOGI("cover_art", "Playback state subscription %s for %s",
                      state_subscribed ? "ready" : "failed", cover_entity.c_str());
-            bool state_requested = ha_get_state(cover_entity, handle_playback_state);
-            ESP_LOGI("cover_art", "Playback state refresh %s for %s",
-                     state_requested ? "requested" : "failed", cover_entity.c_str());
           }
+          bool state_requested = ha_get_state(cover_entity, handle_playback_state);
+          ESP_LOGI("cover_art", "Playback state refresh %s for %s",
+                   state_requested ? "requested" : "failed", cover_entity.c_str());
 
           std::function<void(esphome::StringRef)> handle_media_title =
             [cover_entity, subscription_generation, mark_artwork_refresh_needed](esphome::StringRef title) {
@@ -1490,9 +1529,9 @@ script:
           if (!already_subscribed) {
             bool title_subscribed = ha_subscribe_attribute(cover_entity, std::string("media_title"), handle_media_title);
             ESP_LOGI("cover_art", "Title subscription %s", title_subscribed ? "ready" : "failed");
-            bool title_requested = ha_get_attribute(cover_entity, std::string("media_title"), handle_media_title);
-            ESP_LOGI("cover_art", "Title refresh %s", title_requested ? "requested" : "failed");
           }
+          bool title_requested = ha_get_attribute(cover_entity, std::string("media_title"), handle_media_title);
+          ESP_LOGI("cover_art", "Title refresh %s", title_requested ? "requested" : "failed");
 
           std::function<void(esphome::StringRef)> handle_media_artist =
             [cover_entity, subscription_generation, mark_artwork_refresh_needed](esphome::StringRef artist) {
@@ -1516,9 +1555,9 @@ script:
           if (!already_subscribed) {
             bool artist_subscribed = ha_subscribe_attribute(cover_entity, std::string("media_artist"), handle_media_artist);
             ESP_LOGI("cover_art", "Artist subscription %s", artist_subscribed ? "ready" : "failed");
-            bool artist_requested = ha_get_attribute(cover_entity, std::string("media_artist"), handle_media_artist);
-            ESP_LOGI("cover_art", "Artist refresh %s", artist_requested ? "requested" : "failed");
           }
+          bool artist_requested = ha_get_attribute(cover_entity, std::string("media_artist"), handle_media_artist);
+          ESP_LOGI("cover_art", "Artist refresh %s", artist_requested ? "requested" : "failed");
 
           std::function<void(esphome::StringRef)> handle_media_album =
             [cover_entity, subscription_generation, mark_artwork_refresh_needed](esphome::StringRef album) {
@@ -1540,9 +1579,9 @@ script:
           if (!already_subscribed) {
             bool album_subscribed = ha_subscribe_attribute(cover_entity, std::string("media_album_name"), handle_media_album);
             ESP_LOGI("cover_art", "Album subscription %s", album_subscribed ? "ready" : "failed");
-            bool album_requested = ha_get_attribute(cover_entity, std::string("media_album_name"), handle_media_album);
-            ESP_LOGI("cover_art", "Album refresh %s", album_requested ? "requested" : "failed");
           }
+          bool album_requested = ha_get_attribute(cover_entity, std::string("media_album_name"), handle_media_album);
+          ESP_LOGI("cover_art", "Album refresh %s", album_requested ? "requested" : "failed");
 
           std::function<void(esphome::StringRef)> handle_media_source =
             [cover_entity, subscription_generation, mark_artwork_refresh_needed](esphome::StringRef source) {
@@ -1572,9 +1611,9 @@ script:
           if (!already_subscribed) {
             bool source_subscribed = ha_subscribe_attribute(cover_entity, std::string("source"), handle_media_source);
             ESP_LOGI("cover_art", "Source subscription %s", source_subscribed ? "ready" : "failed");
-            bool source_requested = ha_get_attribute(cover_entity, std::string("source"), handle_media_source);
-            ESP_LOGI("cover_art", "Source refresh %s", source_requested ? "requested" : "failed");
           }
+          bool source_requested = ha_get_attribute(cover_entity, std::string("source"), handle_media_source);
+          ESP_LOGI("cover_art", "Source refresh %s", source_requested ? "requested" : "failed");
 
           auto parse_cover_art_conditions = []() {
             std::vector<std::pair<std::string, std::string>> conditions;
@@ -1676,10 +1715,10 @@ script:
               );
               ESP_LOGI("cover_art", "Attribute condition subscription %s for %s",
                        condition_subscribed ? "ready" : "failed", attribute_name.c_str());
-              bool condition_requested = ha_get_attribute(cover_entity, attribute_name, handle_condition);
-              ESP_LOGI("cover_art", "Attribute condition refresh %s for %s",
-                       condition_requested ? "requested" : "failed", attribute_name.c_str());
             }
+            bool condition_requested = ha_get_attribute(cover_entity, attribute_name, handle_condition);
+            ESP_LOGI("cover_art", "Attribute condition refresh %s for %s",
+                     condition_requested ? "requested" : "failed", attribute_name.c_str());
           }
 
           auto handle_picture_change =
@@ -1747,26 +1786,26 @@ script:
             ESP_LOGI("cover_art", "Artwork subscriptions entity_picture=%s entity_picture_local=%s",
                      picture_subscribed ? "ready" : "failed",
                      local_picture_subscribed ? "ready" : "failed");
-            bool picture_requested = ha_get_attribute(
-              cover_entity,
-              std::string("entity_picture"),
-              std::function<void(esphome::StringRef)>(
-                [handle_picture_change](esphome::StringRef picture) {
-                  handle_picture_change(picture, false);
-                })
-            );
-            bool local_picture_requested = ha_get_attribute(
-              cover_entity,
-              std::string("entity_picture_local"),
-              std::function<void(esphome::StringRef)>(
-                [handle_picture_change](esphome::StringRef picture) {
-                  handle_picture_change(picture, true);
-                })
-            );
-            ESP_LOGI("cover_art", "Initial artwork refresh entity_picture=%s entity_picture_local=%s",
-                     picture_requested ? "requested" : "failed",
-                     local_picture_requested ? "requested" : "failed");
           }
+          bool picture_requested = ha_get_attribute(
+            cover_entity,
+            std::string("entity_picture"),
+            std::function<void(esphome::StringRef)>(
+              [handle_picture_change](esphome::StringRef picture) {
+                handle_picture_change(picture, false);
+              })
+          );
+          bool local_picture_requested = ha_get_attribute(
+            cover_entity,
+            std::string("entity_picture_local"),
+            std::function<void(esphome::StringRef)>(
+              [handle_picture_change](esphome::StringRef picture) {
+                handle_picture_change(picture, true);
+              })
+          );
+          ESP_LOGI("cover_art", "Artwork refresh entity_picture=%s entity_picture_local=%s",
+                   picture_requested ? "requested" : "failed",
+                   local_picture_requested ? "requested" : "failed");
 
           std::function<void(esphome::StringRef)> handle_media_duration =
             [cover_entity, subscription_generation](esphome::StringRef duration) {
@@ -1782,8 +1821,8 @@ script:
             };
           if (!already_subscribed) {
             ha_subscribe_attribute(cover_entity, std::string("media_duration"), handle_media_duration);
-            ha_get_attribute(cover_entity, std::string("media_duration"), handle_media_duration);
           }
+          ha_get_attribute(cover_entity, std::string("media_duration"), handle_media_duration);
 
           std::function<void(esphome::StringRef)> handle_media_position =
             [cover_entity, subscription_generation](esphome::StringRef position) {
@@ -1808,8 +1847,8 @@ script:
             };
           if (!already_subscribed) {
             ha_subscribe_attribute(cover_entity, std::string("media_position"), handle_media_position);
-            ha_get_attribute(cover_entity, std::string("media_position"), handle_media_position);
           }
+          ha_get_attribute(cover_entity, std::string("media_position"), handle_media_position);
 
           std::function<void(esphome::StringRef)> handle_media_position_updated_at =
             [cover_entity, subscription_generation](esphome::StringRef updated_at) {
@@ -1838,8 +1877,8 @@ script:
             };
           if (!already_subscribed) {
             ha_subscribe_attribute(cover_entity, std::string("media_position_updated_at"), handle_media_position_updated_at);
-            ha_get_attribute(cover_entity, std::string("media_position_updated_at"), handle_media_position_updated_at);
           }
+          ha_get_attribute(cover_entity, std::string("media_position_updated_at"), handle_media_position_updated_at);
 
   - id: cover_art_playback_started
     mode: restart

--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -1279,123 +1279,30 @@ script:
           }
           const std::string cover_entity = id(cover_art_media_player_entity).state;
           if (cover_entity.empty()) return;
-          const int request_id = ++id(cover_art_request_id);
-          id(cover_art_artwork_pending_count) = 2;
+          ++id(cover_art_request_id);
+          id(cover_art_artwork_pending_count) = 0;
           id(cover_art_pending_remote_url).clear();
           id(cover_art_pending_local_url).clear();
           id(cover_art_fallback_url).clear();
 
-          auto normalize_picture_url = [](esphome::StringRef picture) -> std::string {
-            constexpr size_t COVER_ART_URL_MAX_LEN = 4096;
-            std::string path = string_ref_limited(picture, COVER_ART_URL_MAX_LEN);
-            if (path.empty() || path == "unknown" || path == "unavailable") return "";
-            if (path.rfind("http://", 0) == 0 || path.rfind("https://", 0) == 0) return path;
-            std::string base = id(cover_art_home_assistant_base_url);
-            if (base.empty()) return "";
-            while (!base.empty() && base.back() == '/') base.pop_back();
-            return base + path;
-          };
+          if (!id(cover_art_cached_local_url).empty() ||
+              !id(cover_art_cached_remote_url).empty()) {
+            id(cover_art_use_cached_artwork).execute();
+            return;
+          }
 
-          auto handle_picture = [cover_entity, request_id, normalize_picture_url](esphome::StringRef picture, bool local) {
-            if (!id(cover_art_screensaver_enabled).state ||
-                !id(cover_art_screensaver_active) ||
-                cover_entity != id(cover_art_media_player_entity).state ||
-                request_id != id(cover_art_request_id)) {
-              return;
+          if (!id(cover_art_url).empty()) {
+            ESP_LOGI("cover_art", "Keeping existing artwork URL while waiting for subscription update");
+            if (!id(cover_art_image_available) || id(cover_art_refresh_needed)) {
+              id(cover_art_deferred_download).execute();
             }
-            constexpr size_t COVER_ART_URL_MAX_LEN = 4096;
-            std::string path = string_ref_limited(picture, COVER_ART_URL_MAX_LEN);
-            std::string url = normalize_picture_url(picture);
-            if (local) {
-              id(cover_art_pending_local_url) = url;
-            } else {
-              id(cover_art_pending_remote_url) = url;
-            }
-            if (id(cover_art_artwork_pending_count) > 0) {
-              id(cover_art_artwork_pending_count)--;
-            }
-
-            std::string chosen = id(cover_art_pending_local_url);
-            std::string alternate;
-            const bool waiting_for_pair = id(cover_art_artwork_pending_count) > 0;
-            if (chosen.empty()) {
-              chosen = id(cover_art_pending_remote_url);
-            } else if (!id(cover_art_pending_remote_url).empty() &&
-                       id(cover_art_pending_remote_url) != chosen) {
-              alternate = id(cover_art_pending_remote_url);
-            }
-            if (!chosen.empty()) {
-              std::string fallback;
-              std::string capped = esphome::artwork_image::cap_artwork_url(chosen, ${cover_art_decode_size});
-              if (capped != chosen) {
-                ESP_LOGI("cover_art", "Using capped JPEG artwork URL (%u chars)",
-                         (unsigned) capped.size());
-                fallback = chosen;
-                chosen = capped;
-              }
-              if (fallback.empty() && !alternate.empty()) {
-                fallback = esphome::artwork_image::cap_artwork_url(alternate, ${cover_art_decode_size});
-                if (fallback == chosen) fallback.clear();
-              }
-              id(cover_art_fallback_url) = fallback;
-            }
-
-            if (chosen.empty()) {
-              if (!waiting_for_pair) {
-                ESP_LOGI("cover_art", "Artwork attributes unavailable");
-                id(cover_art_url).clear();
-                id(cover_art_loaded_url).clear();
-                id(cover_art_retry_url).clear();
-                id(cover_art_fallback_url).clear();
-                id(cover_art_retry_count) = 0;
-                id(cover_art_image_available) = false;
-                id(cover_art_retry_download).stop();
-                id(cover_art_show_black_screen).execute();
-              }
-              return;
-            }
-
-            if (chosen == id(cover_art_url)) {
-              ESP_LOGI("cover_art", "Artwork URL unchanged; image_available=%s refresh_needed=%s",
-                       id(cover_art_image_available) ? "true" : "false",
-                       id(cover_art_refresh_needed) ? "true" : "false");
-              if (!id(cover_art_image_available) || id(cover_art_refresh_needed)) {
-                id(cover_art_deferred_download).execute();
-              }
-              id(cover_art_show_track_overlay).execute();
-              return;
-            }
-            ESP_LOGI("cover_art", "Artwork %s received (%u chars, url %u chars)",
-                     local ? "entity_picture_local" : "entity_picture",
-                     (unsigned) path.size(), (unsigned) chosen.size());
-            if (picture.size() > COVER_ART_URL_MAX_LEN) {
-              ESP_LOGW("cover_art", "Artwork %s URL exceeded %u chars and was truncated",
-                       local ? "local" : "", (unsigned) COVER_ART_URL_MAX_LEN);
-            }
-            if (!local && path.size() >= HA_TEXT_SENSOR_STATE_MAX_LEN) {
-              ESP_LOGI("cover_art", "Artwork URL is longer than the normal text-sensor limit");
-            }
-            id(cover_art_url) = chosen;
-            id(cover_art_deferred_download).execute();
             id(cover_art_show_track_overlay).execute();
-          };
+            return;
+          }
 
-          ha_get_attribute(
-            cover_entity,
-            std::string("entity_picture"),
-            std::function<void(esphome::StringRef)>(
-              [handle_picture](esphome::StringRef picture) {
-                handle_picture(picture, false);
-              })
-          );
-          ha_get_attribute(
-            cover_entity,
-            std::string("entity_picture_local"),
-            std::function<void(esphome::StringRef)>(
-              [handle_picture](esphome::StringRef picture) {
-                handle_picture(picture, true);
-              })
-          );
+          ESP_LOGI("cover_art", "Waiting for subscribed artwork attributes for %s",
+                   cover_entity.c_str());
+          id(cover_art_deferred_request_artwork).execute();
 
   - id: cover_art_resubscribe
     mode: restart
@@ -1492,10 +1399,10 @@ script:
             bool state_subscribed = ha_subscribe_state(cover_entity, handle_playback_state);
             ESP_LOGI("cover_art", "Playback state subscription %s for %s",
                      state_subscribed ? "ready" : "failed", cover_entity.c_str());
+            bool state_requested = ha_get_state(cover_entity, handle_playback_state);
+            ESP_LOGI("cover_art", "Playback state refresh %s for %s",
+                     state_requested ? "requested" : "failed", cover_entity.c_str());
           }
-          bool state_requested = ha_get_state(cover_entity, handle_playback_state);
-          ESP_LOGI("cover_art", "Playback state refresh %s for %s",
-                   state_requested ? "requested" : "failed", cover_entity.c_str());
 
           std::function<void(esphome::StringRef)> handle_media_title =
             [cover_entity, subscription_generation, mark_artwork_refresh_needed](esphome::StringRef title) {
@@ -1522,9 +1429,9 @@ script:
           if (!already_subscribed) {
             bool title_subscribed = ha_subscribe_attribute(cover_entity, std::string("media_title"), handle_media_title);
             ESP_LOGI("cover_art", "Title subscription %s", title_subscribed ? "ready" : "failed");
+            bool title_requested = ha_get_attribute(cover_entity, std::string("media_title"), handle_media_title);
+            ESP_LOGI("cover_art", "Title refresh %s", title_requested ? "requested" : "failed");
           }
-          bool title_requested = ha_get_attribute(cover_entity, std::string("media_title"), handle_media_title);
-          ESP_LOGI("cover_art", "Title refresh %s", title_requested ? "requested" : "failed");
 
           std::function<void(esphome::StringRef)> handle_media_artist =
             [cover_entity, subscription_generation, mark_artwork_refresh_needed](esphome::StringRef artist) {
@@ -1548,9 +1455,9 @@ script:
           if (!already_subscribed) {
             bool artist_subscribed = ha_subscribe_attribute(cover_entity, std::string("media_artist"), handle_media_artist);
             ESP_LOGI("cover_art", "Artist subscription %s", artist_subscribed ? "ready" : "failed");
+            bool artist_requested = ha_get_attribute(cover_entity, std::string("media_artist"), handle_media_artist);
+            ESP_LOGI("cover_art", "Artist refresh %s", artist_requested ? "requested" : "failed");
           }
-          bool artist_requested = ha_get_attribute(cover_entity, std::string("media_artist"), handle_media_artist);
-          ESP_LOGI("cover_art", "Artist refresh %s", artist_requested ? "requested" : "failed");
 
           std::function<void(esphome::StringRef)> handle_media_album =
             [cover_entity, subscription_generation, mark_artwork_refresh_needed](esphome::StringRef album) {
@@ -1572,9 +1479,9 @@ script:
           if (!already_subscribed) {
             bool album_subscribed = ha_subscribe_attribute(cover_entity, std::string("media_album_name"), handle_media_album);
             ESP_LOGI("cover_art", "Album subscription %s", album_subscribed ? "ready" : "failed");
+            bool album_requested = ha_get_attribute(cover_entity, std::string("media_album_name"), handle_media_album);
+            ESP_LOGI("cover_art", "Album refresh %s", album_requested ? "requested" : "failed");
           }
-          bool album_requested = ha_get_attribute(cover_entity, std::string("media_album_name"), handle_media_album);
-          ESP_LOGI("cover_art", "Album refresh %s", album_requested ? "requested" : "failed");
 
           std::function<void(esphome::StringRef)> handle_media_source =
             [cover_entity, subscription_generation, mark_artwork_refresh_needed](esphome::StringRef source) {
@@ -1604,9 +1511,9 @@ script:
           if (!already_subscribed) {
             bool source_subscribed = ha_subscribe_attribute(cover_entity, std::string("source"), handle_media_source);
             ESP_LOGI("cover_art", "Source subscription %s", source_subscribed ? "ready" : "failed");
+            bool source_requested = ha_get_attribute(cover_entity, std::string("source"), handle_media_source);
+            ESP_LOGI("cover_art", "Source refresh %s", source_requested ? "requested" : "failed");
           }
-          bool source_requested = ha_get_attribute(cover_entity, std::string("source"), handle_media_source);
-          ESP_LOGI("cover_art", "Source refresh %s", source_requested ? "requested" : "failed");
 
           auto parse_cover_art_conditions = []() {
             std::vector<std::pair<std::string, std::string>> conditions;
@@ -1708,10 +1615,10 @@ script:
               );
               ESP_LOGI("cover_art", "Attribute condition subscription %s for %s",
                        condition_subscribed ? "ready" : "failed", attribute_name.c_str());
+              bool condition_requested = ha_get_attribute(cover_entity, attribute_name, handle_condition);
+              ESP_LOGI("cover_art", "Attribute condition refresh %s for %s",
+                       condition_requested ? "requested" : "failed", attribute_name.c_str());
             }
-            bool condition_requested = ha_get_attribute(cover_entity, attribute_name, handle_condition);
-            ESP_LOGI("cover_art", "Attribute condition refresh %s for %s",
-                     condition_requested ? "requested" : "failed", attribute_name.c_str());
           }
 
           auto handle_picture_change =
@@ -1779,26 +1686,26 @@ script:
             ESP_LOGI("cover_art", "Artwork subscriptions entity_picture=%s entity_picture_local=%s",
                      picture_subscribed ? "ready" : "failed",
                      local_picture_subscribed ? "ready" : "failed");
+            bool picture_requested = ha_get_attribute(
+              cover_entity,
+              std::string("entity_picture"),
+              std::function<void(esphome::StringRef)>(
+                [handle_picture_change](esphome::StringRef picture) {
+                  handle_picture_change(picture, false);
+                })
+            );
+            bool local_picture_requested = ha_get_attribute(
+              cover_entity,
+              std::string("entity_picture_local"),
+              std::function<void(esphome::StringRef)>(
+                [handle_picture_change](esphome::StringRef picture) {
+                  handle_picture_change(picture, true);
+                })
+            );
+            ESP_LOGI("cover_art", "Initial artwork refresh entity_picture=%s entity_picture_local=%s",
+                     picture_requested ? "requested" : "failed",
+                     local_picture_requested ? "requested" : "failed");
           }
-          bool picture_requested = ha_get_attribute(
-            cover_entity,
-            std::string("entity_picture"),
-            std::function<void(esphome::StringRef)>(
-              [handle_picture_change](esphome::StringRef picture) {
-                handle_picture_change(picture, false);
-              })
-          );
-          bool local_picture_requested = ha_get_attribute(
-            cover_entity,
-            std::string("entity_picture_local"),
-            std::function<void(esphome::StringRef)>(
-              [handle_picture_change](esphome::StringRef picture) {
-                handle_picture_change(picture, true);
-              })
-          );
-          ESP_LOGI("cover_art", "Artwork refresh entity_picture=%s entity_picture_local=%s",
-                   picture_requested ? "requested" : "failed",
-                   local_picture_requested ? "requested" : "failed");
 
           std::function<void(esphome::StringRef)> handle_media_duration =
             [cover_entity, subscription_generation](esphome::StringRef duration) {
@@ -1812,8 +1719,10 @@ script:
               id(cover_art_last_progress_percent) = -1;
               if (id(cover_art_screensaver_active)) id(cover_art_refresh_progress).execute();
             };
-          if (!already_subscribed) ha_subscribe_attribute(cover_entity, std::string("media_duration"), handle_media_duration);
-          ha_get_attribute(cover_entity, std::string("media_duration"), handle_media_duration);
+          if (!already_subscribed) {
+            ha_subscribe_attribute(cover_entity, std::string("media_duration"), handle_media_duration);
+            ha_get_attribute(cover_entity, std::string("media_duration"), handle_media_duration);
+          }
 
           std::function<void(esphome::StringRef)> handle_media_position =
             [cover_entity, subscription_generation](esphome::StringRef position) {
@@ -1836,8 +1745,10 @@ script:
                 id(cover_art_refresh_progress).execute();
               }
             };
-          if (!already_subscribed) ha_subscribe_attribute(cover_entity, std::string("media_position"), handle_media_position);
-          ha_get_attribute(cover_entity, std::string("media_position"), handle_media_position);
+          if (!already_subscribed) {
+            ha_subscribe_attribute(cover_entity, std::string("media_position"), handle_media_position);
+            ha_get_attribute(cover_entity, std::string("media_position"), handle_media_position);
+          }
 
           std::function<void(esphome::StringRef)> handle_media_position_updated_at =
             [cover_entity, subscription_generation](esphome::StringRef updated_at) {
@@ -1864,8 +1775,10 @@ script:
                 id(cover_art_refresh_progress).execute();
               }
             };
-          if (!already_subscribed) ha_subscribe_attribute(cover_entity, std::string("media_position_updated_at"), handle_media_position_updated_at);
-          ha_get_attribute(cover_entity, std::string("media_position_updated_at"), handle_media_position_updated_at);
+          if (!already_subscribed) {
+            ha_subscribe_attribute(cover_entity, std::string("media_position_updated_at"), handle_media_position_updated_at);
+            ha_get_attribute(cover_entity, std::string("media_position_updated_at"), handle_media_position_updated_at);
+          }
 
   - id: cover_art_playback_started
     mode: restart

--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -529,10 +529,15 @@ script:
                     ? id(cover_art_url)
                     : id(cover_art_active_download_source_url);
                 bool applied_current_url = applied_url == id(cover_art_url);
-                id(cover_art_loaded_url) = applied_url;
+                if (applied_current_url) {
+                  id(cover_art_loaded_url) = id(cover_art_url);
+                  id(cover_art_refresh_needed) = false;
+                } else {
+                  id(cover_art_loaded_url) = applied_url;
+                  id(cover_art_refresh_needed) = true;
+                }
                 id(cover_art_download_url).clear();
                 id(cover_art_active_download_source_url).clear();
-                id(cover_art_refresh_needed) = !applied_current_url;
                 id(cover_art_retry_url) = applied_current_url ? id(cover_art_url) : std::string();
                 id(cover_art_retry_count) = 0;
                 auto *img = id(cover_art_downloaded_image);
@@ -1346,7 +1351,8 @@ script:
             return;
           }
 
-          if (!id(cover_art_url).empty()) {
+          std::string chosen = id(cover_art_url);
+          if (chosen == id(cover_art_url) && !chosen.empty()) {
             ESP_LOGI("cover_art", "Keeping existing artwork URL while waiting for subscription update");
             if (!id(cover_art_image_available) || id(cover_art_refresh_needed)) {
               id(cover_art_deferred_download).execute();

--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -645,6 +645,17 @@ script:
           lv_obj_set_style_bg_color(id(cover_art_backdrop), dark_accent, 0);
           lv_obj_set_style_bg_color(id(cover_art_accent_overlay), dark_accent, 0);
 
+  - id: cover_art_clear_image_source
+    mode: restart
+    then:
+      - lambda: |-
+          #if ESPHOME_VERSION_CODE >= VERSION_CODE(2026, 4, 0)
+          ::lv_image_set_src(id(cover_art_image_widget), static_cast<const void *>(nullptr));
+          #else
+          ::lv_img_set_src(id(cover_art_image_widget), static_cast<const void *>(nullptr));
+          #endif
+          lv_obj_invalidate(id(cover_art_image_widget));
+
   - id: cover_art_show_black_screen
     mode: restart
     then:
@@ -657,6 +668,8 @@ script:
           lv_color_t black = lv_color_make(0, 0, 0);
           lv_obj_set_style_bg_color(id(cover_art_backdrop), black, 0);
           lv_obj_set_style_bg_color(id(cover_art_accent_overlay), black, 0);
+      - script.execute: cover_art_clear_image_source
+      - script.wait: cover_art_clear_image_source
       - lvgl.widget.hide: cover_art_image_widget
       - script.execute: cover_art_sync_track_text
       - lambda: |-
@@ -774,6 +787,8 @@ script:
           id(cover_art_last_progress_percent) = -1;
           lv_bar_set_value(id(cover_art_progress_bar), 0, LV_ANIM_OFF);
           lv_label_set_text(id(cover_art_time_label), "0:00  /  0:00");
+      - script.execute: cover_art_clear_image_source
+      - script.wait: cover_art_clear_image_source
       - artwork_image.release: cover_art_downloaded_image
       - script.execute: hide_cover_art_view
 
@@ -806,6 +821,8 @@ script:
                            !${cover_art_live_image_updates};
                 then:
                   - script.execute: cover_art_show_black_screen
+                  - script.execute: cover_art_clear_image_source
+                  - script.wait: cover_art_clear_image_source
                   - artwork_image.release: cover_art_downloaded_image
                   - lambda: |-
                       ESP_LOGI("cover_art", "Released current artwork before replacement download");
@@ -1230,6 +1247,8 @@ script:
           condition:
             lambda: 'return std::string("${device_slug}") == "guition-esp32-s3-4848s040";'
           then:
+            - script.execute: cover_art_clear_image_source
+            - script.wait: cover_art_clear_image_source
             - artwork_image.release: cover_art_downloaded_image
             - lambda: |-
                 id(cover_art_image_available) = false;

--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -15,6 +15,9 @@ globals:
   - id: cover_art_download_url
     type: std::string
     initial_value: '""'
+  - id: cover_art_active_download_source_url
+    type: std::string
+    initial_value: '""'
   - id: cover_art_pending_remote_url
     type: std::string
     initial_value: '""'
@@ -522,15 +525,24 @@ script:
                 id: cover_art_image_available
                 value: 'true'
             - lambda: |-
-                id(cover_art_loaded_url) = id(cover_art_url);
+                std::string applied_url = id(cover_art_active_download_source_url).empty()
+                    ? id(cover_art_url)
+                    : id(cover_art_active_download_source_url);
+                bool applied_current_url = applied_url == id(cover_art_url);
+                id(cover_art_loaded_url) = applied_url;
                 id(cover_art_download_url).clear();
-                id(cover_art_refresh_needed) = false;
-                id(cover_art_retry_url) = id(cover_art_url);
+                id(cover_art_active_download_source_url).clear();
+                id(cover_art_refresh_needed) = !applied_current_url;
+                id(cover_art_retry_url) = applied_current_url ? id(cover_art_url) : std::string();
                 id(cover_art_retry_count) = 0;
                 auto *img = id(cover_art_downloaded_image);
                 ESP_LOGI("cover_art", "Applying artwork image=%dx%d content=%dx%d offset=%d,%d",
                          img->get_width(), img->get_height(), img->get_content_width(), img->get_content_height(),
                          img->get_content_offset_x(), img->get_content_offset_y());
+                if (!applied_current_url) {
+                  ESP_LOGI("cover_art", "Current artwork URL changed during download; scheduling follow-up refresh");
+                  id(cover_art_deferred_download).execute();
+                }
             - script.execute: cover_art_apply_responsive_layout
             - script.execute: cover_art_extract_accent_color
             - script.wait: cover_art_extract_accent_color
@@ -678,6 +690,8 @@ script:
             - if:
                 condition:
                   lambda: |-
+                    id(cover_art_download_url).clear();
+                    id(cover_art_active_download_source_url).clear();
                     return !id(cover_art_fallback_url).empty() &&
                            id(cover_art_url) != id(cover_art_fallback_url);
                 then:
@@ -733,6 +747,7 @@ script:
       - lambda: |-
           id(cover_art_url).clear();
           id(cover_art_download_url).clear();
+          id(cover_art_active_download_source_url).clear();
           id(cover_art_pending_remote_url).clear();
           id(cover_art_pending_local_url).clear();
           id(cover_art_cached_remote_url).clear();
@@ -796,6 +811,16 @@ script:
                       ESP_LOGI("cover_art", "Released current artwork before replacement download");
                       id(cover_art_loaded_url).clear();
             - lambda: |-
+                if (!id(cover_art_active_download_source_url).empty() &&
+                    !id(cover_art_download_url).empty()) {
+                  if (id(cover_art_active_download_source_url) == id(cover_art_url)) {
+                    ESP_LOGI("cover_art", "Artwork download already active for current URL; skipping duplicate request");
+                  } else {
+                    ESP_LOGI("cover_art", "Artwork URL changed during active download; deferring follow-up request");
+                    id(cover_art_refresh_needed) = true;
+                  }
+                  return;
+                }
                 if (id(cover_art_url) != id(cover_art_retry_url)) {
                   id(cover_art_retry_url) = id(cover_art_url);
                   id(cover_art_retry_count) = 0;
@@ -811,6 +836,7 @@ script:
                 };
                 const bool needs_artwork_refresh =
                     id(cover_art_refresh_needed) || !id(cover_art_image_available);
+                id(cover_art_active_download_source_url) = id(cover_art_url);
                 id(cover_art_download_url) = needs_artwork_refresh
                     ? refresh_ha_media_proxy_url(id(cover_art_url))
                     : id(cover_art_url);
@@ -822,6 +848,9 @@ script:
                          id(cover_art_refresh_needed) ? "true" : "false");
                 id(cover_art_download_url) =
                     id(cover_art_downloaded_image)->request_update_url(id(cover_art_download_url));
+                if (id(cover_art_download_url).empty()) {
+                  id(cover_art_active_download_source_url).clear();
+                }
 
   - id: cover_art_deferred_download
     mode: restart
@@ -890,6 +919,11 @@ script:
           }
 
           if (chosen.empty()) return;
+          if (!id(cover_art_active_download_source_url).empty() &&
+              !id(cover_art_download_url).empty()) {
+            ESP_LOGI("cover_art", "Cached artwork update received during active download; keeping current request");
+            return;
+          }
 
           std::string fallback;
           std::string capped = esphome::artwork_image::cap_artwork_url(chosen, ${cover_art_decode_size});
@@ -1200,6 +1234,8 @@ script:
             - lambda: |-
                 id(cover_art_image_available) = false;
                 id(cover_art_loaded_url).clear();
+                id(cover_art_download_url).clear();
+                id(cover_art_active_download_source_url).clear();
       - script.execute: clock_bar_apply
 
   - id: cover_art_delay_timer

--- a/components/artwork_image/artwork_image.cpp
+++ b/components/artwork_image/artwork_image.cpp
@@ -941,6 +941,9 @@ void ArtworkImage::retire_active_buffer_() {
 #endif
   this->limit_retired_buffers_();
   this->cleanup_retired_buffers_(false);
+  if (!this->retired_buffers_.empty()) {
+    this->enable_loop();
+  }
 }
 
 void ArtworkImage::cleanup_retired_buffers_(bool force) {

--- a/components/artwork_image/artwork_image.cpp
+++ b/components/artwork_image/artwork_image.cpp
@@ -19,6 +19,7 @@
 static const char *const TAG = "artwork_image";
 static const char *const CONTENT_TYPE_HEADER_NAME = "content-type";
 static constexpr uint32_t RETIRED_BUFFER_GRACE_MS = 3000;
+static constexpr size_t MAX_RETIRED_IMAGE_BUFFERS = 1;
 static constexpr size_t MAX_DOWNLOAD_BUFFER_SIZE = 2 * 1024 * 1024;
 static constexpr int LOCAL_ARTWORK_HTTP_TIMEOUT_MS = 6500;
 
@@ -865,6 +866,16 @@ void ArtworkImage::discard_decode_buffer_() {
   this->decode_offset_y_ = 0;
 }
 
+void ArtworkImage::invalidate_lvgl_cache_() {
+#ifdef USE_LVGL
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2026, 4, 0)
+  lv_image_cache_drop(&this->dsc_);
+#else
+  lv_img_cache_invalidate_src(&this->dsc_);
+#endif
+#endif
+}
+
 bool ArtworkImage::promote_decode_buffer_() {
   if (!this->decode_buffer_) {
     ESP_LOGE(TAG, "Decode finished without a decoded image buffer");
@@ -898,6 +909,7 @@ bool ArtworkImage::promote_decode_buffer_() {
   this->data_start_ = this->buffer_;
   this->width_ = this->buffer_width_;
   this->height_ = this->buffer_height_;
+  this->invalidate_lvgl_cache_();
 #ifdef USE_LVGL
   memset(&this->dsc_, 0, sizeof(this->dsc_));
 #endif
@@ -919,22 +931,44 @@ void ArtworkImage::retire_active_buffer_() {
   this->buffer_offset_y_ = 0;
   this->width_ = 0;
   this->height_ = 0;
+  this->invalidate_lvgl_cache_();
 #ifdef USE_LVGL
   memset(&this->dsc_, 0, sizeof(this->dsc_));
 #endif
+  this->limit_retired_buffers_();
   this->cleanup_retired_buffers_(false);
 }
 
 void ArtworkImage::cleanup_retired_buffers_(bool force) {
   uint32_t now = millis();
   auto it = this->retired_buffers_.begin();
+  size_t freed_bytes = 0;
   while (it != this->retired_buffers_.end()) {
     if (force || now - it->retired_at >= RETIRED_BUFFER_GRACE_MS) {
+      freed_bytes += it->size;
       this->allocator_.deallocate(it->data, it->size);
       it = this->retired_buffers_.erase(it);
     } else {
       ++it;
     }
+  }
+  if (freed_bytes > 0) {
+    size_t remaining_bytes = 0;
+    for (const auto &buffer : this->retired_buffers_) {
+      remaining_bytes += buffer.size;
+    }
+    ESP_LOGI(TAG, "Freed retired artwork buffers: freed=%zu remaining=%zu remaining_bytes=%zu",
+             freed_bytes, this->retired_buffers_.size(), remaining_bytes);
+  }
+}
+
+void ArtworkImage::limit_retired_buffers_() {
+  while (this->retired_buffers_.size() > MAX_RETIRED_IMAGE_BUFFERS) {
+    auto it = this->retired_buffers_.begin();
+    ESP_LOGW(TAG, "Forcing retired artwork buffer cleanup: size=%zu remaining=%zu",
+             it->size, this->retired_buffers_.size() - 1);
+    this->allocator_.deallocate(it->data, it->size);
+    this->retired_buffers_.erase(it);
   }
 }
 
@@ -1053,14 +1087,18 @@ void ArtworkImage::log_state_(const char *stage) {
 #endif
   size_t bytes_read = this->downloader_ ? this->downloader_->get_bytes_read() : 0;
   size_t content_length = this->downloader_ ? this->downloader_->content_length : 0;
+  size_t retired_bytes = 0;
+  for (const auto &buffer : this->retired_buffers_) {
+    retired_bytes += buffer.size;
+  }
   ESP_LOGD(TAG,
-           "State %-24s url_len=%zu http=%zu/%zu dl_buf=%zu/%zu image=%dx%d content=%dx%d@%d,%d decode=%dx%d content=%dx%d@%d,%d retired=%zu heap_free=%zu heap_largest=%zu pending=%s",
+           "State %-24s url_len=%zu http=%zu/%zu dl_buf=%zu/%zu image=%dx%d content=%dx%d@%d,%d decode=%dx%d content=%dx%d@%d,%d retired=%zu retired_bytes=%zu heap_free=%zu heap_largest=%zu pending=%s",
            stage, this->url_.size(), bytes_read, content_length, this->download_buffer_.unread(),
            this->download_buffer_.size(), this->buffer_width_, this->buffer_height_, this->buffer_content_width_,
            this->buffer_content_height_, this->buffer_offset_x_, this->buffer_offset_y_, this->decode_buffer_width_,
            this->decode_buffer_height_, this->decode_content_width_, this->decode_content_height_,
-           this->decode_offset_x_, this->decode_offset_y_, this->retired_buffers_.size(), heap_free, heap_largest,
-           this->update_pending_ ? "yes" : "no");
+           this->decode_offset_x_, this->decode_offset_y_, this->retired_buffers_.size(), retired_bytes, heap_free,
+           heap_largest, this->update_pending_ ? "yes" : "no");
 }
 
 void ArtworkImage::end_connection_() {

--- a/components/artwork_image/artwork_image.cpp
+++ b/components/artwork_image/artwork_image.cpp
@@ -165,10 +165,7 @@ void ArtworkImage::release() {
   this->pending_url_.clear();
   this->end_connection_();
   this->retire_active_buffer_();
-  this->cleanup_retired_buffers_(false);
-  if (!this->retired_buffers_.empty()) {
-    this->enable_loop();
-  }
+  this->cleanup_retired_buffers_(true);
 }
 
 size_t ArtworkImage::resize_(int width_in, int height_in) {

--- a/components/artwork_image/artwork_image.cpp
+++ b/components/artwork_image/artwork_image.cpp
@@ -8,6 +8,10 @@
 #include "esphome/core/log.h"
 #include "esphome/core/version.h"
 
+#if defined(USE_LVGL) && ESPHOME_VERSION_CODE >= VERSION_CODE(2026, 4, 0)
+#include "src/misc/cache/instance/lv_image_cache.h"
+#endif
+
 #ifdef USE_ESP32
 #include "esp_heap_caps.h"
 #endif

--- a/components/artwork_image/artwork_image.h
+++ b/components/artwork_image/artwork_image.h
@@ -175,6 +175,8 @@ class ArtworkImage : public PollingComponent,
   bool promote_decode_buffer_();
   void retire_active_buffer_();
   void cleanup_retired_buffers_(bool force);
+  void limit_retired_buffers_();
+  void invalidate_lvgl_cache_();
   bool ensure_download_buffer_capacity_();
   bool decode_buffered_data_();
   void finish_download_();

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -619,6 +619,7 @@ inline void reset_image_card_pool(const GridConfig &cfg) {
   int count = cfg.image_card_image_count;
   if (count > IMAGE_CARD_MAX_CONTEXTS) count = IMAGE_CARD_MAX_CONTEXTS;
   for (int i = 0; i < count; i++) {
+    image_card_clear_widget_source(contexts[i].widget);
     contexts[i].active = false;
     contexts[i].widget = nullptr;
     contexts[i].btn = nullptr;

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -65,6 +65,7 @@ struct ImageCardCtx {
   bool timer_only = false;
   bool modal_fit = false;
   bool diagnostics_enabled = false;
+  bool access_token_request_pending = false;
   lv_timer_t *modal_cleanup_timer = nullptr;
   uint8_t startup_download_errors = 0;
 };
@@ -653,6 +654,7 @@ inline void reset_image_card_pool(const GridConfig &cfg) {
     contexts[i].timer_only = false;
     contexts[i].modal_fit = false;
     contexts[i].diagnostics_enabled = false;
+    contexts[i].access_token_request_pending = false;
     contexts[i].startup_download_errors = 0;
     contexts[i].image = cfg.image_card_images ? cfg.image_card_images[i] : nullptr;
     contexts[i].modal_image = cfg.image_card_modal_images ? cfg.image_card_modal_images[i] : nullptr;
@@ -1091,6 +1093,10 @@ inline std::string image_card_proxy_path_with_token(const std::string &proxy_pat
   return path;
 }
 
+inline bool image_card_valid_access_token(const std::string &token) {
+  return !token.empty() && token != "unknown" && token != "unavailable";
+}
+
 inline std::string image_card_cache_bust_url(const std::string &url) {
   if (url.empty()) return "";
   std::string next = url;
@@ -1187,29 +1193,41 @@ inline void image_card_request_picture(ImageCardCtx *ctx) {
       image_card_set_loading_state(ctx, "Loading", true);
       return;
     }
+    if (image_card_valid_access_token(ctx->access_token)) {
+      std::string authed_path = image_card_proxy_path_with_token(proxy_path, ctx->access_token);
+      image_card_handle_picture(ctx, esphome::StringRef(authed_path));
+      return;
+    }
+    if (ctx->access_token_request_pending) {
+      image_card_log_diagnostics(ctx, "picture-waiting-token-request");
+      image_card_schedule_picture_retry(ctx, IMAGE_CARD_RETRY_INTERVAL_MS);
+      image_card_set_loading_state(ctx, "Loading", true);
+      return;
+    }
     const uint32_t generation = ha_subscription_generation();
+    ctx->access_token_request_pending = true;
     bool requested = ha_get_attribute(
       entity_id,
       std::string("access_token"),
       std::function<void(esphome::StringRef)>(
         [ctx, entity_id, generation, proxy_path](esphome::StringRef token_ref) {
           if (!image_card_context_current(ctx, entity_id, generation)) return;
+          ctx->access_token_request_pending = false;
           std::string token = string_ref_limited(token_ref, 512);
-          if (token.empty() || token == "unknown" || token == "unavailable") {
+          if (!image_card_valid_access_token(token)) {
             ctx->access_token.clear();
             image_card_log_diagnostics(ctx, "picture-waiting-token");
             image_card_schedule_picture_retry(ctx, IMAGE_CARD_RETRY_INTERVAL_MS);
             image_card_set_loading_state(ctx, "Loading", true);
             return;
           }
-          // Home Assistant image proxy tokens can rotate, so refresh the token
-          // whenever we rebuild the proxy URL instead of reusing a stale one.
           ctx->access_token = token;
           std::string authed_path = image_card_proxy_path_with_token(proxy_path, token);
           image_card_handle_picture(ctx, esphome::StringRef(authed_path));
         })
     );
     if (!requested) {
+      ctx->access_token_request_pending = false;
       image_card_log_diagnostics(ctx, "picture-attribute-request-queued");
       image_card_schedule_picture_retry(
         ctx,
@@ -1236,6 +1254,29 @@ inline void image_card_request_picture(ImageCardCtx *ctx) {
       ctx,
       ha_api_connected() ? IMAGE_CARD_API_RETRY_INTERVAL_MS : IMAGE_CARD_RETRY_INTERVAL_MS);
   }
+}
+
+inline void subscribe_image_card_access_token(ImageCardCtx *ctx,
+                                              const std::string &entity_id) {
+  if (!ctx || image_card_entity_proxy_path(entity_id).empty()) return;
+  const uint32_t generation = ha_subscription_generation();
+  ha_subscribe_attribute(
+    entity_id,
+    std::string("access_token"),
+    std::function<void(esphome::StringRef)>(
+      [ctx, entity_id, generation](esphome::StringRef token_ref) {
+        if (!image_card_context_current(ctx, entity_id, generation)) return;
+        ctx->access_token_request_pending = false;
+        std::string token = string_ref_limited(token_ref, 512);
+        if (!image_card_valid_access_token(token)) {
+          ctx->access_token.clear();
+          return;
+        }
+        if (token == ctx->access_token) return;
+        ctx->access_token = token;
+        image_card_request_picture(ctx);
+      })
+  );
 }
 
 inline void subscribe_image_card_entity_state(ImageCardCtx *ctx,
@@ -1767,6 +1808,7 @@ inline bool bind_image_card(BtnSlot &s, const ParsedCfg &p, const GridConfig &cf
         image_card_handle_picture(ctx, picture);
       })
   );
+  subscribe_image_card_access_token(ctx, image_card_entity_id);
   subscribe_image_card_entity_state(ctx, p.entity);
   image_card_request_picture(ctx);
   return true;


### PR DESCRIPTION
## Purpose
Fix the memory leak seen on P4 screens when camera images or media cover art update repeatedly.

## Practical impact
- Drops stale LVGL image-cache entries before an artwork image descriptor is rebuilt.
- Clears LVGL image widget sources before releasing the backing image memory, both for media cover art and image-card widgets.
- Caps retired artwork buffers to one short-lived buffer, so fast media-cover-art changes cannot accumulate multiple full-screen image buffers.
- Keeps the artwork cleanup loop active while retired buffers are waiting to be freed.
- Forces retired artwork buffers to be freed immediately when the image is explicitly released.
- Prevents duplicate cover-art downloads for the same active URL.
- Adds memory diagnostics for both total free memory and largest free block, so we can tell the difference between a real retained-memory leak and fragmentation/runtime churn.

## Current finding
The stable 4.3-inch P4 decodes cover art at 480x480, which is about 0.44 MiB for RGB565. The larger P4 screens decode at 600x600, 720x720, and 800x800, which are about 0.69 MiB, 0.99 MiB, and 1.22 MiB. So the same cleanup timing issue is much more visible on the larger screens.

The newest on-device diagnostics show the large decoded artwork buffers are now being released. PSRAM may dip while an image is decoded, but the larger displays are no longer showing the old one-way drop by full artwork-buffer-sized chunks.

The remaining movement is small internal heap drift on the larger panels. In the latest live sample, the 10-inch display lost about 7 KB of internal heap over roughly 20-25 minutes, but its largest free heap block stayed stable. That does not look like the original cover-art buffer leak. The 7-inch briefly showed a 721 KB PSRAM dip, which matches one active 600x600 decoded image buffer; that needs a longer Home Assistant history window to confirm it settles after normal image changes.

## Checked
- Reviewed the supplied history.csv memory trend; it showed heap free dropping from 57.46% to 15.23% in about 1h38m.
- Reviewed history-5.csv; it still showed a slower drop from about 51.90% to 46.74% over about 78 minutes after the duplicate-download fix.
- Compared P4 package settings: the 4.3-inch screen is the only P4 using 480x480 cover-art decode; larger P4 screens use 600x600, 720x720, or 800x800.
- Confirmed generated LVGL image cache setting is 0 across checked P4 builds, so this does not appear to be a unique LVGL cache-size setting on the 4.3-inch panel.
- Confirmed the new diagnostics endpoints are available on the flashed 10-inch display.
- npm run check:firmware-parser
- npm run check:firmware-card-runtime
- ESPHome 2026.5.3 full compile: builds/guition-esp32-p4-jc8012p4a1.factory.yaml
- ESPHome 2026.5.3 full compile: devices/guition-esp32-p4-jc8012p4a1/dev.yaml with espcontrol_component_url=file:///Users/jtenniswood/Git/espcontrol-p4-image-memory-leak
- ESPHome 2026.5.3 compile: devices/esp32-p4-86/dev.yaml with espcontrol_component_url=file:///Users/jtenniswood/Git/espcontrol-p4-image-memory-leak

## Device testing
Flashed from this branch on 2026-06-17:
- 7-inch P4
- 10-inch P4
- P4-86 / 4-inch P4
- 4.3-inch P4

Skipped:
- S3 display

Latest live monitoring, 2026-06-17:
- Monitored Heap Free, Heap Largest Block, PSRAM Free, and PSRAM Largest Block on all flashed P4 displays.
- 10-inch and P4-86 PSRAM stayed effectively flat instead of losing one decoded artwork buffer per update.
- 10-inch internal heap drifted by about 7 KB, while its largest free heap block stayed stable.
- 7-inch briefly dipped by about 721 KB of PSRAM, matching one active 600x600 decoded image buffer.
- 4.3-inch remained the stable comparison point with only tiny movement.

Expected result: memory may move briefly while a new image is decoded, but it should settle instead of steadily falling over repeated image updates.

Next useful check: let these flashed builds run normally and export a longer Home Assistant history window for the new memory sensors. That will show whether the remaining small heap movement is harmless runtime churn or a separate slow leak.
