### PR TITLE
Update docs for recent feature changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ See the [screen guides](https://jtenniswood.github.io/espcontrol/getting-started
 - **Display scheduling** - use idle timers, night schedules, brightness controls, and optional presence sensors so the screen behaves well in real rooms.
 - **Appearance controls** - choose icons, labels, status text, colours, clock display, rotation, and temperature units from the setup page.
 - **Screensaver and brightness controls** - dim or sleep the display when it is not in use.
-- **Automatic updates** - keep firmware current over WiFi after the first install.
+- **Automatic updates** - keep standard firmware current after the first install.
 - **Backup and restore** - save your layout and copy it to another panel.
 - **Language support** - choose the panel language, with translation files available for contributors.
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -140,7 +140,7 @@ const faqItems = [
   {
     question: 'How Do I Update the Firmware?',
     answer:
-      'Leave Auto Update enabled for automatic updates, or use Check for Update in the Firmware section of the setup page.',
+      'Leave Auto Update enabled for automatic updates, or use Check for Update in the Firmware section of the setup page. Advanced Ethernet-only builds may need to be updated through ESPHome.',
   },
   {
     question: "What If the Icon I Need Isn't Listed?",
@@ -150,7 +150,7 @@ const faqItems = [
   {
     question: 'What Card Types Are Available?',
     answer:
-      'The setup page includes Switch, Lights, Action, Option Select, Webhook, Trigger, Sensor, Doors & Windows, Presence, Slider, Fans, Cover, Garage Door, Lock, Alarm, Date & Time, World Clock, Weather, Camera, Media, Climate, Internal Switches, Screen Lock, and Subpage cards.',
+      'The setup page includes Switch, Lights, Action, Option Select, Webhook, Trigger, Sensor, Doors & Windows, Presence, Slider, Fans, Vacuum, Cover, Garage Door, Lock, Alarm, Date & Time, World Clock, Weather, Camera, Media, Climate, Internal Switches, Screen Lock, and Subpage cards.',
   },
   {
     question: 'How Many Cards Can I Have?',

--- a/docs/card-types/covers.md
+++ b/docs/card-types/covers.md
@@ -14,7 +14,7 @@ A cover card lets you control a Home Assistant cover entity — blinds, shutters
 
 1. Select a card and change its type to **Cover**.
 2. Choose the interaction:
-   - **Modal** opens a full-screen control with tabs for simple controls, position, and tilt. This option is currently available only with Developer/Experimental Features enabled.
+   - **Modal** opens a full-screen control with tabs for simple controls, position, and tilt.
    - **Slider: Position** lets you drag to a precise cover position.
    - **Slider: Tilt** lets you drag to a precise cover tilt position.
    - **Toggle** opens or closes the cover with a tap.

--- a/docs/card-types/index.md
+++ b/docs/card-types/index.md
@@ -15,7 +15,7 @@ Use this page when you know what you want the panel to do but are not sure which
 | Goal | Use this card | Entity or target |
 |---|---|---|
 | Toggle a light, switch, fan, helper, or button-style entity | [Switch](/card-types/switches) | `light`, `switch`, `input_boolean`, `fan`, or `button` |
-| Control a light as on/off, brightness, or colour temperature | [Lights](/card-types/lights) | `light` |
+| Control a light as on/off, brightness, colour temperature, or colour presets | [Lights](/card-types/lights) | `light` |
 | Run a scene, script, automation, helper action, or button press | [Action](/card-types/actions) | Depends on the selected action |
 | Show or control a robot vacuum | [Vacuum](/card-types/vacuum) | `vacuum` |
 | Pick from a Home Assistant select list | [Option Select](/card-types/option-select) | `select` or `input_select` |
@@ -26,7 +26,7 @@ Use this page when you know what you want the panel to do but are not sure which
 | Show presence, motion, person, or tracker state | [Presence](/card-types/presence) | `binary_sensor`, `sensor`, `text_sensor`, `person`, or tracker helpers |
 | Drag to set light brightness or fan speed | [Slider](/card-types/sliders) | `light` or `fan` |
 | Use grouped fan controls | [Fans](/card-types/fans) | `fan` |
-| Control blinds, shutters, shades, gates, or tilt | [Cover](/card-types/covers) | `cover` |
+| Control blinds, shutters, shades, gates, position, or tilt | [Cover](/card-types/covers) | `cover` |
 | Open or close a garage door | [Garage Door](/card-types/garage-doors) | `cover` |
 | Lock or unlock a door lock | [Lock](/card-types/locks) | `lock` |
 | Arm, disarm, or show an alarm panel | [Alarm](/card-types/alarms) | `alarm_control_panel` |
@@ -57,14 +57,14 @@ Some names in the setup page group several related modes:
 
 | Setup page name | Modes |
 |---|---|
-| **Lights** | Switch, Brightness, Colour Temperature |
+| **Lights** | All Controls, Switch, Brightness, Colour Temperature |
 | **Fans** | Switch, Speed, Oscillation, Direction, Preset |
 | **Action** | Scene, Script, Automation, Button, Helper, Option Select |
 | **Vacuum** | Status, Start / Stop, Dock, Pause / Resume, Spot Clean, Locate, Clean Area |
-| **Alarm** | Combined Control, Arm Away, Arm Home, Disarm |
+| **Alarm** | Combined Control, Arm Away, Arm Home, Arm Night, Arm Vacation, Disarm |
 | **Date & Time** | Clock, Date, Time & Date, World Clock |
 | **Media** | Play/Pause, Previous, Next, Volume, Track Position, Now Playing |
-| **Cover** | Position, Tilt, Toggle, Open, Close, Stop, Set Position |
+| **Cover** | Modal, Position, Tilt, Toggle, Open, Close, Stop, Set Position |
 | **Subpage** | Generic, Lights, Climate, Presence, Media |
 
 ## Permissions

--- a/docs/card-types/lights.md
+++ b/docs/card-types/lights.md
@@ -1,12 +1,12 @@
 ---
 title: Light Cards
 description:
-  How to use light cards on your EspControl panel for light switching, brightness, and colour temperature.
+  How to use light cards on your EspControl panel for light switching, brightness, colour temperature, and colour presets.
 ---
 
 # Lights
 
-The Lights card is a guided card type for Home Assistant `light` entities. It keeps the common light controls together, so you can choose whether a light should behave like a switch, a brightness slider, or a colour temperature slider.
+The Lights card is a guided card type for Home Assistant `light` entities. It keeps the common light controls together, so you can choose whether a light should behave like a switch, a brightness slider, a colour temperature slider, or a full light control popup.
 
 ![Light brightness card showing a lightbulb icon and dimmer fill bar](/images/card-light-brightness.png)
 
@@ -14,12 +14,25 @@ The Lights card is a guided card type for Home Assistant `light` entities. It ke
 
 1. Select a card and change its type to **Lights**.
 2. Choose the light **Type**:
+   - **All Controls** opens a full-screen light control with brightness, colour temperature, and colour preset tabs.
    - **Switch** turns the light on or off with a tap.
    - **Brightness** lets you drag a vertical slider from 0 to 100 percent.
    - **Colour Temperature** lets you drag a vertical slider between warm and cool white.
 3. Enter the Home Assistant light entity, for example `light.living_room`.
 4. Set a **Label** if you want custom text. If left blank, the friendly name from Home Assistant is used.
 5. Choose the icon fields shown for the selected type.
+
+## All Controls
+
+All Controls gives one card a full-screen popup for the main light controls.
+
+- Tapping the card opens tabs for brightness, colour temperature, and colour presets.
+- The brightness tab lets you drag from 0 to 100 percent.
+- The colour temperature tab lets you move between warm and cool white.
+- The colour tab provides preset colour swatches for RGB-capable lights.
+- The card uses separate **Off Icon** and **On Icon** settings and lights up while Home Assistant reports the light as on.
+
+Use this when one light should be adjustable without needing separate brightness, colour temperature, and colour buttons on the home screen.
 
 ## Switch
 
@@ -51,7 +64,7 @@ Colour Temperature mode controls the white temperature of a light.
 - The bottom of the slider is warmer; the top is cooler.
 - Releasing the slider sends `light.turn_on` with `color_temp_kelvin`.
 
-This mode needs a Home Assistant light that supports colour temperature. If a light only supports on/off or brightness, use **Switch** or **Brightness** instead.
+This mode needs a Home Assistant light that supports colour temperature. If a light only supports on/off or brightness, use **Switch**, **Brightness**, or **All Controls** without relying on the colour temperature tab.
 
 ## Lights vs Slider
 

--- a/docs/features/firmware-updates.md
+++ b/docs/features/firmware-updates.md
@@ -18,6 +18,8 @@ These are configured from the **Settings** tab in the [Setup](/features/setup) u
 - **Install Version** — choose the latest stable firmware or one of up to four previous stable versions when more than one version is available.
 - **Check for Update** — press this button to check for a new version right now, regardless of the automatic schedule.
 
+Manual Ethernet builds can be different. If you used the advanced Ethernet setup with `disable_updates: "true"`, these built-in GitHub update controls are removed from the panel firmware. Use ESPHome OTA or USB from your ESPHome setup to update that display instead.
+
 ## What Happens During an Update
 
 1. The panel checks the update server for a newer version.
@@ -46,3 +48,5 @@ Some features, especially new card types, need both the web setup page and the p
 You can also manage updates from Home Assistant. The **Auto Update** toggle, **Update Frequency** selector, and **Check for Update** button all appear as entities that you can control from the Home Assistant dashboard or use in automations.
 
 The standard Home Assistant **Update** entity may also appear, depending on your Home Assistant version.
+
+Displays built with `disable_updates: "true"` do not expose EspControl's built-in GitHub update controls. They can still be updated manually through ESPHome.

--- a/docs/features/setup.md
+++ b/docs/features/setup.md
@@ -31,7 +31,7 @@ The setup page uses these card names and grouped modes on the device. For a quic
 | Type | What it does | Needs an entity? |
 |---|---|---|
 | **[Switch](/card-types/switches)** | Controls a Home Assistant entity and shows its on/off state. This is the default card type. | Yes |
-| **[Lights](/card-types/lights)** | Controls a light as a switch, brightness slider, or colour temperature slider. | Yes, as a light entity |
+| **[Lights](/card-types/lights)** | Controls a light as a full control popup, switch, brightness slider, or colour temperature slider. | Yes, as a light entity |
 | **[Action](/card-types/actions)** | Runs a one-tap Home Assistant scene, script, button, helper action, or Option Select picker. | Yes |
 | **[Option Select](/card-types/option-select)** | Opens a live `select` or `input_select` option list through the Action card. | Yes, as a select entity |
 | **[Webhook](/card-types/webhooks)** | Calls an HTTP URL directly from the panel for other automation platforms and webhook services. | URL |
@@ -42,7 +42,7 @@ The setup page uses these card names and grouped modes on the device. For a quic
 | **[Slider](/card-types/sliders)** | Controls light brightness or fan speed with a draggable fill bar. | Yes |
 | **[Fans](/card-types/fans)** | Controls supported fan switch, speed, oscillation, direction, and preset features. | Yes, as a fan entity |
 | **[Vacuum](/card-types/vacuum)** | Shows vacuum status or controls start/stop, dock, pause/resume, spot clean, locate, and clean area. | Yes, as a vacuum entity |
-| **[Cover](/card-types/covers)** | Controls blinds, shutters, and similar cover entities with a slider or tap action. | Yes |
+| **[Cover](/card-types/covers)** | Controls blinds, shutters, and similar cover entities with a full control popup, slider, or tap action. | Yes |
 | **[Garage Door](/card-types/garage-doors)** | Controls a garage door cover entity with an open/close tap action. | Yes |
 | **[Lock](/card-types/locks)** | Locks, unlocks, or toggles a Home Assistant lock entity. | Yes |
 | **[Alarm](/card-types/alarms)** | Arms, disarms, or shows a Home Assistant alarm control panel. | Yes, as an alarm control panel entity |
@@ -56,7 +56,7 @@ The setup page uses these card names and grouped modes on the device. For a quic
 
 For cards that use Home Assistant, enter the entity name from Home Assistant in the **Entity** field, such as `light.living_room`, `switch.garden_lights`, `scene.movie_mode`, or `weather.forecast_home`. Some card types use a more specific label, such as **Sensor Entity**, **Weather Entity**, or **Climate Entity**. You can find entity names under **Settings > Devices & Services** in Home Assistant.
 
-Some card names group several related controls together. **Lights** contains Switch, Brightness, and Colour Temperature options. **Fans** contains Switch, Speed, Oscillation, Direction, and Preset options. **Action** contains scene, script, helper, and Option Select actions. **Vacuum** contains Status, Start / Stop, Dock, Pause / Resume, Spot Clean, Locate, and Clean Area options. **Alarm** contains Combined Control, Arm Away, Arm Home, and Disarm options. **Date & Time** contains Clock, Date, Time & Date, and World Clock options.
+Some card names group several related controls together. **Lights** contains All Controls, Switch, Brightness, and Colour Temperature options. **Fans** contains Switch, Speed, Oscillation, Direction, and Preset options. **Action** contains scene, script, helper, and Option Select actions. **Vacuum** contains Status, Start / Stop, Dock, Pause / Resume, Spot Clean, Locate, and Clean Area options. **Cover** contains Modal, Position, Tilt, Toggle, Open, Close, Stop, and Set Position options. **Alarm** contains Combined Control, Arm Away, Arm Home, Arm Night, Arm Vacation, and Disarm options. **Date & Time** contains Clock, Date, Time & Date, and World Clock options.
 
 For the generated list of current card domains, subpage support, grouping, and options, see the [Card Capability Reference](/generated/cards/capabilities).
 

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -28,6 +28,7 @@ The panel's built-in web page loads some visual resources from the internet. If 
 - Double-check your **WiFi password** — it's easy to mistype on a small screen.
 - Move the panel **closer to your router** during initial setup. You can move it to its final location afterwards.
 - If the panel previously connected but can't anymore (e.g. you changed your WiFi password), it will first try to reconnect. If that does not work, it will create a hotspot so you can enter the new details. Look for a network called **ESP_xxxxxx**; it can take up to **90 seconds** to appear.
+- If you installed an advanced Ethernet-only build, WiFi setup is intentionally disabled. Check the Ethernet cable, switch port, and DHCP/router lease list instead.
 
 ## How Do I Reset the Device?
 
@@ -56,6 +57,8 @@ To update manually:
 2. Go to the **Settings** tab in the [Setup](/features/setup).
 3. Under **Firmware**, press **Check for Update**.
 4. If a new version is available, the panel will download and install it.
+
+Advanced Ethernet-only builds may have these built-in update controls disabled. Update those displays through ESPHome OTA or USB instead.
 
 See [Firmware Updates](/features/firmware-updates) for more details.
 
@@ -93,7 +96,7 @@ EspControl currently supports these touchscreen panels:
 - **ESP32-P4 86 Panel** — 4-inch, 720x720, square (ESP32-P4)
 - **4848S040** — 4-inch, 480x480, square (ESP32-S3)
 
-All use the same firmware features, card configuration, and web UI. The grid layout automatically matches each panel's screen size and orientation.
+All use the same card configuration and web UI. The grid layout automatically matches each panel's screen size and orientation. Some ESP32-P4 models also have an advanced Ethernet-only manual install option, which changes how networking and firmware updates work.
 
 ## Does the Panel Work with Other Smart Home Platforms?
 
@@ -108,4 +111,4 @@ EspControl is built specifically for Home Assistant. It does not support other p
 
 ## How Is My Data Handled?
 
-Everything stays on your local network. The panel communicates directly with your Home Assistant instance over your home WiFi. No data is sent to external servers, cloud services, or third parties. The only internet connection the panel makes is to check for firmware updates and to load the web page styling.
+Everything stays on your local network. The panel communicates directly with your Home Assistant instance over your home network, using WiFi or an advanced Ethernet build depending on how you installed it. No data is sent to external servers, cloud services, or third parties. The only internet connection the standard firmware makes is to check for firmware updates and to load the web page styling.


### PR DESCRIPTION
## Purpose
Update the public documentation after the recent feature and setup changes so the overview pages match the current firmware behaviour.

## What changed
- Documented the light All Controls mode and full cover modal as normal user-facing options.
- Updated grouped card summaries for Lights, Cover, and Alarm, including Night and Vacation alarm modes.
- Clarified firmware update and FAQ wording for advanced Ethernet-only manual builds.
- Brought the FAQ metadata card list back in line with the public docs.

## Checks
- `npm run docs:build`
- `npm run check:types`
- `npm run check:dev-docs`

## Testing notes
This is documentation-only. Please review the affected docs pages for wording and check that the site preview renders correctly before merging.