### PR TITLE
Fix clock bar after cover art stops

### DIFF
--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -1482,7 +1482,7 @@ script:
                 if (id(cover_art_screensaver_active)) id(cover_art_refresh_progress).execute();
                 id(cover_art_delay_timer).stop();
                 id(cover_art_show_track_overlay).stop();
-                id(hide_cover_art_view).execute();
+                id(cover_art_return_home_after_playback).execute();
                 return;
               }
 
@@ -1903,4 +1903,34 @@ script:
           id(cover_art_last_progress_percent) = -1;
           lv_bar_set_value(id(cover_art_progress_bar), 0, LV_ANIM_OFF);
           lv_label_set_text(id(cover_art_time_label), "0:00  /  0:00");
+      - script.execute: cover_art_return_home_after_playback
+
+  - id: cover_art_return_home_after_playback
+    mode: restart
+    then:
+      - if:
+          condition:
+            lambda: |-
+              return id(cover_art_screensaver_active) &&
+                     !id(screen_schedule_asleep) &&
+                     !id(screensaver_display_off_active) &&
+                     !id(screensaver_dimmed_active) &&
+                     !id(is_clock_showing);
+          then:
+            - globals.set:
+                id: display_asleep
+                value: 'false'
       - script.execute: hide_cover_art_view
+      - script.wait: hide_cover_art_view
+      - if:
+          condition:
+            lambda: |-
+              return !id(display_asleep) &&
+                     !id(screen_schedule_asleep) &&
+                     !id(screensaver_display_off_active) &&
+                     !id(screensaver_dimmed_active) &&
+                     !id(is_clock_showing);
+          then:
+            - script.execute: backlight_apply_brightness
+            - script.execute: screensaver_idle_check
+            - script.execute: home_screen_idle_check


### PR DESCRIPTION
## Purpose
Fixes #547. When the cover-art screensaver closes because the selected media player pauses or stops, the display should return to the normal home screen with the clock bar visible.

## Practical impact
The shared cover-art firmware now marks the display awake again before hiding the cover-art screen after playback ends. That lets the existing clock-bar logic recalculate correctly instead of leaving the bar hidden until the next tap.

## Checked
- `npm run check:fast`

## Device testing
Flash this branch to any display using the cover-art screensaver. Start playback so cover art appears, then stop playback from another device. The cover-art screen should disappear and the clock bar should reappear without needing to tap the screen.