### PR TITLE
Added ESP32-C6 firmware update to ESP32-P4-86 device

### DIFF
--- a/devices/esp32-p4-86/device/network_coprocessor.yaml
+++ b/devices/esp32-p4-86/device/network_coprocessor.yaml
@@ -6,6 +6,7 @@
 # =============================================================================
 
 esp32_hosted:
+  id: esp32_c6_hosted
   variant: esp32c6
   reset_pin: GPIO54
   cmd_pin: GPIO19
@@ -16,3 +17,82 @@ esp32_hosted:
   d3_pin: GPIO17
   active_high: true
   sdio_frequency: 20MHz
+
+logger:
+  level: DEBUG
+  logs:
+    esp32_hosted: DEBUG
+    esp32_hosted.update: DEBUG
+
+http_request:
+
+update:
+  - platform: esp32_hosted
+    id: esp32_c6_update
+    type: http
+    source: https://esphome.github.io/esp-hosted-firmware/manifest/esp32c6.json
+    update_interval: 24h
+
+text_sensor:
+  - platform: template
+    name: "ESP32-C6: Update Available"
+    entity_category: DIAGNOSTIC
+    id: c6_update_available
+    lambda: |-
+      auto upd = id(esp32_c6_update);
+      if (!upd) return std::string("Unknown");
+      if (upd->state == esphome::update::UpdateState::UPDATE_STATE_AVAILABLE)
+        return std::string("Update available");
+      else
+        return std::string("Up-to-date");
+
+  - platform: template
+    name: "ESP32-C6: Current Firmware"
+    entity_category: DIAGNOSTIC
+    id: c6_update_current_firmware
+    icon: mdi:chip
+    lambda: |-
+      auto upd = id(esp32_c6_update);
+      if (!upd) return std::string("Unknown");
+      auto &cur = upd->update_info.current_version;
+      if (cur.empty()) return std::string("Unknown");
+      return cur;
+    update_interval: 60s
+
+  - platform: template
+    name: "ESP32-C6: Latest Firmware"
+    entity_category: DIAGNOSTIC
+    id: c6_update_latest_firmware
+    icon: mdi:chip
+    lambda: |-
+      auto upd = id(esp32_c6_update);
+      if (!upd) return std::string("Unknown");
+      auto &lat = upd->update_info.latest_version;
+      if (lat.empty()) return std::string("Unknown");
+      return lat;
+    update_interval: 60s
+
+button:
+  - platform: template
+    name: "Firmware ESP32-C6: Install Update"
+    entity_category: CONFIG
+    icon: mdi:download
+    on_press:
+      then:
+        - logger.log:
+            level: WARN
+            format: "Installing ESP32-C6 firmware update..."
+        - update.perform:
+            id: esp32_c6_update
+
+  - platform: template
+    name: "Firmware ESP32-C6: Check for Update"
+    entity_category: CONFIG
+    icon: mdi:update
+    on_press:
+      then:
+        - logger.log:
+            level: WARN
+            format: "Checking if ESP32-C6 firmware update is available..."
+        - update.check:
+            id: esp32_c6_update


### PR DESCRIPTION
## Summary
Due stability issues with the fabric firmware in the ESP32-C6 on Waveshare ESP32-P4-86 device, I decided to add updating firmware of this co-processor.

Added buttons to check and update firmware of the co-processor ESP32-C6 on the ESP32-P4 device.
It expose (every minute) to HA the current, latest firmware versions and if update is available.
The updates manifest will be downloaded every 24h automatically. The check button does this manually.

<img width="327" height="265" alt="Diagnostic" src="https://github.com/user-attachments/assets/9479af55-6b0c-4aae-adbd-727b94658ba3" />

<img width="333" height="341" alt="Configuration" src="https://github.com/user-attachments/assets/c3042837-5aea-40f9-b9c8-525c47e69f78" />


## Testing

- [X] I checked the change locally where practical.
- [ ] User testing is still needed before merge.
- [X] Affected display/device, if applicable:
ESP32-P4-86

## Notes for testing
The fabric Waveshare ESP32-P4-86 display has an old ESP32-C6 firmware. It has WiFi stability issues, like lost connection randomly. It also does not expose current firmware version.
So the first time running with included this PR, the current firmware version will be `Unknown` shown in the entity. After the display is started and wifi is connected, wait one minute before you press on the ESP32-C6 firmware update button. It does not harm is you do. It must fetch first the manifest to know the [available firmwares](https://esphome.github.io/esp-hosted-firmware/).
After pressed on the ESP32-C6 firmware update button, just wait. The device will restart automatically when ESP32-C6 firmware has been updated.

The ESPhome update process will determine the correct latest **compatible** available firmware. There are newer versions available, but the ESPhome and esp-idf framework used must be compatible with the hosted ESP32-C6 firmware.

Debug logging shows information about the ESP32-C6 update info/processing.
-

## Issue handling
No issue created.

- [ ] Do not close related issues until the user confirms the fix works.
