### PR TITLE
Fix generated icon sync workflow path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,43 @@ jobs:
       - name: Generate icon outputs
         run: python3 scripts/build.py icons
 
+      - name: Check for generated icon changes
+        id: icon_changes
+        run: |
+          if git diff --quiet -- \
+            common/assets/icon_glyphs.yaml \
+            components/espcontrol/icons.h \
+            src/webserver/entry.js; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-node@v6
+        if: steps.icon_changes.outputs.changed == 'true'
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        if: steps.icon_changes.outputs.changed == 'true'
+        run: |
+          NPM_CACHE="${HOME}/.cache/espcontrol-actions/npm"
+          mkdir -p "${NPM_CACHE}"
+          npm ci --prefer-offline --cache "${NPM_CACHE}"
+          bash scripts/prune_actions_cache.sh "${NPM_CACHE}" "${ESPCONTROL_NPM_CACHE_MAX_MB}" --strategy reset
+
+      - name: Build generated web bundles
+        if: steps.icon_changes.outputs.changed == 'true'
+        run: python3 scripts/build.py www
+
       - name: Commit generated icon outputs
         id: commit
         run: |
           if git diff --quiet -- \
             common/assets/icon_glyphs.yaml \
             components/espcontrol/icons.h \
-            src/webserver/entry.js; then
+            src/webserver/entry.js \
+            docs/public/webserver/*/www.js; then
             echo "Generated icon files are already up to date."
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -68,7 +98,8 @@ jobs:
           git add \
             common/assets/icon_glyphs.yaml \
             components/espcontrol/icons.h \
-            src/webserver/entry.js
+            src/webserver/entry.js \
+            docs/public/webserver/*/www.js
           git commit -m "Build generated icon files"
           git push
           echo "changed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           if git diff --quiet -- \
             common/assets/icon_glyphs.yaml \
             components/espcontrol/icons.h \
-            src/webserver/www.js; then
+            src/webserver/entry.js; then
             echo "Generated icon files are already up to date."
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -68,7 +68,7 @@ jobs:
           git add \
             common/assets/icon_glyphs.yaml \
             components/espcontrol/icons.h \
-            src/webserver/www.js
+            src/webserver/entry.js
           git commit -m "Build generated icon files"
           git push
           echo "changed=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Updates the CI icon sync job to check and stage src/webserver/entry.js, which is where the icon generator now writes web icon data.
- Keeps the workflow aligned with the source-of-truth docs and scripts/build.py.

## Testing
- [x] npm run check:fast
- [x] Confirmed no src/webserver/www.js references remain in the CI workflow
- [ ] User testing is still needed before merge.
- [ ] Affected display/device, if applicable: none

## Notes for testing
- This is CI-only. No device flashing is needed.
- The next generated icon sync should commit entry.js instead of failing on the old missing www.js path.

## Issue handling
- [x] Do not close related issues until the user confirms the fix works.