### PR TITLE
Run firmware compile on relevant PRs

### DIFF
--- a/.github/workflows/firmware-compile.yml
+++ b/.github/workflows/firmware-compile.yml
@@ -2,22 +2,6 @@ name: Firmware Compile
 
 on:
   pull_request:
-    paths:
-      - '.github/workflows/firmware-compile.yml'
-      - '.github/workflows/nightly-firmware.yml'
-      - '.github/workflows/release.yml'
-      - 'common/**'
-      - 'components/**'
-      - 'devices/**'
-      - 'builds/**'
-      - 'src/webserver/**'
-      - 'docs/public/webserver/**'
-      - 'scripts/build.py'
-      - 'scripts/device_matrix.py'
-      - 'scripts/device_profiles.py'
-      - 'scripts/generate_device_slots.py'
-      - 'package.json'
-      - 'package-lock.json'
   workflow_dispatch:
 
 env:
@@ -27,6 +11,7 @@ env:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: firmware-compile-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/firmware-compile.yml
+++ b/.github/workflows/firmware-compile.yml
@@ -1,6 +1,23 @@
 name: Firmware Compile
 
 on:
+  pull_request:
+    paths:
+      - '.github/workflows/firmware-compile.yml'
+      - '.github/workflows/nightly-firmware.yml'
+      - '.github/workflows/release.yml'
+      - 'common/**'
+      - 'components/**'
+      - 'devices/**'
+      - 'builds/**'
+      - 'src/webserver/**'
+      - 'docs/public/webserver/**'
+      - 'scripts/build.py'
+      - 'scripts/device_matrix.py'
+      - 'scripts/device_profiles.py'
+      - 'scripts/generate_device_slots.py'
+      - 'package.json'
+      - 'package-lock.json'
   workflow_dispatch:
 
 env:

--- a/dev-docs/checks-and-releases.md
+++ b/dev-docs/checks-and-releases.md
@@ -103,11 +103,11 @@ npm run docs:build
 For firmware changes, also compile the affected device with ESPHome before
 publishing.
 
-The `Firmware Compile` GitHub workflow runs automatically on pull requests that
-touch firmware-visible paths such as `common/`, `components/`, `devices/`,
+The `Firmware Compile` GitHub workflow starts on every pull request, then checks
+the changed files itself. It only runs the expensive firmware compile when a PR
+touches firmware-visible paths such as `common/`, `components/`, `devices/`,
 `builds/`, generated web bundles, or the device build scripts. It can still be
-started manually with `workflow_dispatch` when a full firmware compile is needed
-for a branch that did not match those paths.
+started manually with `workflow_dispatch` when a full firmware compile is needed.
 
 If generated inputs changed, make sure the regenerated outputs are committed too.
 `python3 scripts/build.py --check` is the command that catches stale or missing

--- a/dev-docs/checks-and-releases.md
+++ b/dev-docs/checks-and-releases.md
@@ -103,6 +103,12 @@ npm run docs:build
 For firmware changes, also compile the affected device with ESPHome before
 publishing.
 
+The `Firmware Compile` GitHub workflow runs automatically on pull requests that
+touch firmware-visible paths such as `common/`, `components/`, `devices/`,
+`builds/`, generated web bundles, or the device build scripts. It can still be
+started manually with `workflow_dispatch` when a full firmware compile is needed
+for a branch that did not match those paths.
+
 If generated inputs changed, make sure the regenerated outputs are committed too.
 `python3 scripts/build.py --check` is the command that catches stale or missing
 generated files before CI does.


### PR DESCRIPTION
## Summary
- Enables the Firmware Compile workflow for pull requests that touch firmware-visible paths.
- Keeps the existing manual workflow dispatch path for full branch compiles.
- Documents when automatic firmware compile should run.

## Testing
- [x] npm run check:dev-docs
- [x] Checked the firmware workflow contains the expected pull_request path filters
- [ ] User testing is still needed before merge.
- [ ] Affected display/device, if applicable: all firmware-visible PRs

## Notes for testing
- This is a GitHub Actions workflow change. No device flashing is needed for this PR itself.
- A PR that changes devices, components, common firmware config, builds, generated web bundles, or device build scripts should now get the Firmware Compile workflow automatically.

## Issue handling
- [x] Do not close related issues until the user confirms the fix works.