### PR TITLE
Improve local worktree and browser smoke reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .cache/
+.worktrees/
 node_modules/
 docs/.vitepress/cache/
 docs/.vitepress/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ secrets.yml
 *.secrets.yml
 wifi_secrets*.yaml
 wifi-secrets*.yaml
+
+# Temporary local ESPHome entry points used when flashing PR builds.
+devices/*/dev-pr*.yaml

--- a/scripts/check_web_browser_smoke.js
+++ b/scripts/check_web_browser_smoke.js
@@ -885,16 +885,18 @@ async function assertBackupImportSmoke(page, posts, testCase) {
   );
 }
 
-async function entitySuggestionValues(page, inputSelector, query = "light") {
+async function entitySuggestionValues(page, inputSelector, query = "light", expectedValues = []) {
   await page.locator(inputSelector).fill(query);
-  await page.waitForFunction(({ selector, query }) => {
+  await page.waitForFunction(({ selector, query, expectedValues }) => {
     const input = document.querySelector(selector);
     const normalizedQuery = String(query || "").toLowerCase();
     if (!input || String(input.value || "").toLowerCase() !== normalizedQuery) return false;
     const options = Array.from(input.parentElement.querySelectorAll(".sp-entity-dropdown.sp-open .sp-entity-option"));
     if (!options.length) return false;
-    return options.every((option) => String(option.textContent || "").toLowerCase().includes(normalizedQuery));
-  }, { selector: inputSelector, query });
+    const values = options.map((option) => String(option.textContent || ""));
+    return options.every((option) => String(option.textContent || "").toLowerCase().includes(normalizedQuery)) &&
+      expectedValues.every((value) => values.indexOf(value) !== -1);
+  }, { selector: inputSelector, query, expectedValues });
   return page.locator(inputSelector).evaluate((input) => {
     return Array.from(input.parentElement.querySelectorAll(".sp-entity-dropdown.sp-open .sp-entity-option"))
       .map((option) => option.textContent || "");
@@ -908,7 +910,7 @@ async function assertEditAndApplySmoke(page, posts, errors) {
 
   await page.locator('.sp-main [data-slot="1"]').click();
   await page.getByRole("button", { name: "Edit", exact: true }).click();
-  const switchSuggestions = await entitySuggestionValues(page, "#sp-inp-entity");
+  const switchSuggestions = await entitySuggestionValues(page, "#sp-inp-entity", "light", ["light.kitchen"]);
   assert(switchSuggestions.includes("light.kitchen"), "switch card suggestions include a recently used light");
   assert(!switchSuggestions.includes("sensor.energy"), "switch card suggestions exclude recently used sensors");
   assert(!switchSuggestions.includes("media_player.living"), "switch card suggestions exclude recently used media players");


### PR DESCRIPTION
## Summary
- Adds .worktrees/ to .gitignore so local in-repo Git worktrees do not appear as untracked files.
- Ignores temporary devices/*/dev-pr*.yaml files used for local PR firmware flashing.
- Makes the browser smoke test wait for the expected imported entity suggestion before asserting the dropdown contents.
- Keeps the test focused on the existing behavior: switch suggestions should include a recently used light and exclude unrelated domains.

## Testing
- [x] npm run check:local-artifacts
- [x] git check-ignore matches the local devices/*/dev-pr555.yaml files
- [x] node scripts/check_web_browser_smoke.js
- [ ] User testing is still needed before merge.
- [ ] Affected display/device, if applicable: none

## Notes for testing
- This is developer-workflow and test reliability cleanup only. No device flashing is needed.

## Issue handling
- [x] Do not close related issues until the user confirms the fix works.