### PR TITLE
Update PostCSS audit dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "devDependencies": {
         "esbuild": "^0.28.0",
         "playwright": "^1.60.0",
+        "postcss": "^8.5.15",
         "typescript": "^6.0.3",
         "vitepress": "^1.6.3"
       }
@@ -2051,9 +2052,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -2143,9 +2144,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -2163,7 +2164,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "esbuild": "^0.28.0",
     "playwright": "^1.60.0",
+    "postcss": "^8.5.15",
     "typescript": "^6.0.3",
     "vitepress": "^1.6.3"
   }


### PR DESCRIPTION
## Summary
- Adds PostCSS as an explicit dev dependency at the fixed 8.5.15 range.
- Updates package-lock.json so the docs/tooling stack no longer uses the vulnerable PostCSS 8.5.8 package.
- Leaves VitePress on its supported Vite 5 stack; forcing Vite 6.4.3 made the docs build fail, so the remaining Vite/esbuild audit advisory needs an upstream-compatible VitePress path later.

## Testing
- [x] npm run check:fast
- [x] npm run docs:build
- [x] npm audit --audit-level=moderate (PostCSS advisory fixed; VitePress/Vite advisory remains with no compatible fix)
- [ ] User testing is still needed before merge.
- [ ] Affected display/device, if applicable: none

## Notes for testing
- This is docs/tooling dependency maintenance only. No device flashing is needed.

## Issue handling
- [x] Do not close related issues until the user confirms the fix works.