### PR TITLE
fix: prevent firmware matrix jobs being cancelled

### DIFF
--- a/.github/workflows/firmware-compile.yml
+++ b/.github/workflows/firmware-compile.yml
@@ -74,11 +74,12 @@ jobs:
     needs: [detect-changes, device-matrix]
     if: needs.detect-changes.outputs.compile_required == 'true'
     runs-on: self-hosted
-    concurrency:
-      group: firmware-compile-self-hosted
-      cancel-in-progress: false
     strategy:
       fail-fast: false
+      # Keep self-hosted firmware compiles serialized without using a job-level
+      # concurrency group. GitHub Actions only allows one running and one
+      # pending job per concurrency group, so sharing one group across matrix
+      # children cancels queued device builds before they run.
       max-parallel: 1
       matrix: ${{ fromJSON(needs.device-matrix.outputs.matrix) }}
     steps:


### PR DESCRIPTION
## Summary
- Removes the shared job-level concurrency group from the firmware compile matrix job.
- Keeps firmware compiles serialized with `strategy.max-parallel: 1`.
- Adds a comment explaining why a shared matrix-job concurrency group cancels queued device builds before they run.

## Root cause
The matrix children all used the same `firmware-compile-self-hosted` concurrency group. GitHub Actions concurrency allows only one running and one pending job per group. Because every device compile matrix child shared that same group, newly queued matrix children cancelled earlier pending children before any steps ran. The aggregate `Firmware Compile Gate` then saw the compile job result as cancelled/failure even though the code did not fail to compile.

## Verification
- Confirmed the shared `firmware-compile-self-hosted` job concurrency block was removed and `max-parallel: 1` remains.
- `git diff --check` passed.
- The Firmware Compile workflow completed successfully on this PR after the change.

## Follow-up
Per James's follow-up request, PR #577 removes the automatic PR trigger so Firmware Compile becomes manual-only.
