### PR TITLE
ci: make firmware compile manual only

### DIFF
--- a/.github/workflows/firmware-compile.yml
+++ b/.github/workflows/firmware-compile.yml
@@ -1,7 +1,6 @@
 name: Firmware Compile
 
 on:
-  pull_request:
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary
- Removes the `pull_request` trigger from the `Firmware Compile` workflow.
- Leaves `workflow_dispatch` so the firmware compile can still be run manually when needed.

## Why
James asked to stop doing a firmware compile on every PR. This keeps normal PR CI lighter and avoids tying every PR to the self-hosted firmware compile runner.

## Verification
- Confirmed the workflow trigger block no longer contains `pull_request`.
- Confirmed `workflow_dispatch` remains.
- `git diff --check` passed.

## Notes
This intentionally changes CI behavior: PRs will no longer automatically run the `Firmware Compile` workflow. Use the manual workflow dispatch when a full firmware compile is needed.
