### PR TITLE
Fix confirm button theme

### DIFF
--- a/common/config/colors.yaml
+++ b/common/config/colors.yaml
@@ -26,6 +26,8 @@ text:
     update_interval: never
     web_server:
       sorting_group_id: sg_display
+    on_value:
+      - script.execute: refresh_button_grid
 
   - platform: template
     name: "${entity_button_off_color}"
@@ -42,6 +44,8 @@ text:
     update_interval: never
     web_server:
       sorting_group_id: sg_display
+    on_value:
+      - script.execute: refresh_button_grid
 
   - platform: template
     name: "${entity_sensor_card_color}"
@@ -58,3 +62,5 @@ text:
     update_interval: never
     web_server:
       sorting_group_id: sg_display
+    on_value:
+      - script.execute: refresh_button_grid

--- a/components/espcontrol/button_grid_alarm.h
+++ b/components/espcontrol/button_grid_alarm.h
@@ -1050,10 +1050,14 @@ inline void alarm_pin_open_modal(AlarmActionCtx *action) {
       ui.panel, key_size, key_size, text, key_font,
       action->card->width_compensation_percent, key_zoom);
     if (strcmp(key_data[i], "submit") == 0) {
-      lv_obj_set_style_bg_color(key_btn, lv_color_hex(DEFAULT_SLIDER_COLOR), LV_PART_MAIN);
-      lv_obj_set_style_border_color(key_btn, lv_color_hex(DEFAULT_SLIDER_COLOR), LV_PART_MAIN);
+      uint32_t submit_color = action->card->on_color;
+      lv_obj_set_style_bg_color(key_btn, lv_color_hex(submit_color), LV_PART_MAIN);
+      lv_obj_set_style_border_color(key_btn, lv_color_hex(submit_color), LV_PART_MAIN);
       lv_obj_t *key_lbl = lv_obj_get_child(key_btn, 0);
-      if (key_lbl) lv_obj_set_style_text_color(key_lbl, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
+      if (key_lbl) {
+        lv_obj_set_style_text_color(
+          key_lbl, lv_color_hex(readable_text_color_for_bg(submit_color)), LV_PART_MAIN);
+      }
     }
     int row = i / 3;
     int col = i % 3;

--- a/components/espcontrol/button_grid_climate.h
+++ b/components/espcontrol/button_grid_climate.h
@@ -4,8 +4,6 @@
 
 // ── Climate control card helpers ─────────────────────────────────────
 
-constexpr uint32_t CLIMATE_HEATING_COLOR = 0xA44A1C;
-constexpr uint32_t CLIMATE_COOLING_COLOR = 0x1565C0;
 constexpr int CLIMATE_DEFAULT_TARGET_TENTHS = 200;
 constexpr int CLIMATE_DEFAULT_LOW_TENTHS = 180;
 constexpr int CLIMATE_DEFAULT_HIGH_TENTHS = 220;
@@ -626,8 +624,6 @@ inline void climate_raise_arc_markers() {
 
 inline uint32_t climate_active_color(ClimateControlCtx *ctx) {
   if (!ctx) return DEFAULT_SLIDER_COLOR;
-  if (ctx->hvac_action == "heating") return CLIMATE_HEATING_COLOR;
-  if (ctx->hvac_action == "cooling") return CLIMATE_COOLING_COLOR;
   return ctx->accent_color;
 }
 

--- a/components/espcontrol/button_grid_config.h
+++ b/components/espcontrol/button_grid_config.h
@@ -73,6 +73,15 @@ constexpr uint32_t DARK_BORDER = correct_display_color(0x3A3A3A);
 constexpr uint32_t DARK_CONTROL_NEUTRAL = correct_display_color(0x424242);
 constexpr uint32_t DARK_OVERLAY = 0x000000;
 constexpr uint32_t DARK_TRACK_BACKGROUND = correct_display_color(0x2F2F2F);
+
+inline uint32_t readable_text_color_for_bg(uint32_t color) {
+  uint32_t r = (color >> 16) & 0xFF;
+  uint32_t g = (color >> 8) & 0xFF;
+  uint32_t b = color & 0xFF;
+  uint32_t luminance = (r * 299 + g * 587 + b * 114) / 1000;
+  return luminance > 160 ? DARK_OVERLAY : DARK_TEXT_PRIMARY;
+}
+
 #ifndef ESPCONTROL_MAX_GRID_SLOTS
 #define ESPCONTROL_MAX_GRID_SLOTS 25
 #endif

--- a/components/espcontrol/button_grid_confirm.h
+++ b/components/espcontrol/button_grid_confirm.h
@@ -46,6 +46,18 @@ inline void set_switch_confirmation_accent_color(uint32_t color) {
   switch_confirmation_accent_color_ref() = color;
 }
 
+inline uint32_t switch_confirmation_button_accent_color(lv_obj_t *btn_obj) {
+  if (!btn_obj) return switch_confirmation_accent_color_ref();
+  bool was_checked = lv_obj_has_state(btn_obj, LV_STATE_CHECKED);
+  if (!was_checked) lv_obj_add_state(btn_obj, LV_STATE_CHECKED);
+  lv_color32_t color = lv_color_to_32(
+    lv_obj_get_style_bg_color(btn_obj, LV_PART_MAIN), LV_OPA_COVER);
+  if (!was_checked) lv_obj_clear_state(btn_obj, LV_STATE_CHECKED);
+  return (static_cast<uint32_t>(color.red) << 16) |
+         (static_cast<uint32_t>(color.green) << 8) |
+         static_cast<uint32_t>(color.blue);
+}
+
 inline const lv_font_t *switch_confirmation_message_font(const lv_font_t *fallback) {
   const lv_font_t *font = switch_confirmation_message_font_ref();
   return font ? font : fallback;
@@ -122,7 +134,7 @@ inline void switch_confirmation_open_modal(const ParsedCfg &p, lv_obj_t *btn_obj
   ui.no_btn = control_modal_create_text_button(
     ui.panel, switch_confirmation_no_text(p), button_max_w, button_min_w, button_h,
     button_h / 2, DARK_BORDER, DARK_TEXT_PRIMARY, button_font);
-  uint32_t confirm_color = switch_confirmation_accent_color_ref();
+  uint32_t confirm_color = switch_confirmation_button_accent_color(btn_obj);
   ui.confirm_btn = control_modal_create_text_button(
     ui.panel, switch_confirmation_yes_text(p), button_max_w, button_min_w, button_h,
     button_h / 2, confirm_color, readable_text_color_for_bg(confirm_color), button_font);

--- a/components/espcontrol/button_grid_confirm.h
+++ b/components/espcontrol/button_grid_confirm.h
@@ -29,12 +29,21 @@ inline const lv_font_t *&switch_confirmation_icon_font_ref() {
   return font;
 }
 
+inline uint32_t &switch_confirmation_accent_color_ref() {
+  static uint32_t color = DEFAULT_SLIDER_COLOR;
+  return color;
+}
+
 inline void set_switch_confirmation_message_font(const lv_font_t *font) {
   switch_confirmation_message_font_ref() = font;
 }
 
 inline void set_switch_confirmation_icon_font(const lv_font_t *font) {
   switch_confirmation_icon_font_ref() = font;
+}
+
+inline void set_switch_confirmation_accent_color(uint32_t color) {
+  switch_confirmation_accent_color_ref() = color;
 }
 
 inline const lv_font_t *switch_confirmation_message_font(const lv_font_t *fallback) {
@@ -115,7 +124,7 @@ inline void switch_confirmation_open_modal(const ParsedCfg &p, lv_obj_t *btn_obj
     button_h / 2, DARK_BORDER, button_font);
   ui.confirm_btn = control_modal_create_text_button(
     ui.panel, switch_confirmation_yes_text(p), button_max_w, button_min_w, button_h,
-    button_h / 2, DEFAULT_SLIDER_COLOR, button_font);
+    button_h / 2, switch_confirmation_accent_color_ref(), button_font);
 
   lv_obj_update_layout(ui.message_lbl);
   lv_obj_update_layout(ui.no_btn);

--- a/components/espcontrol/button_grid_confirm.h
+++ b/components/espcontrol/button_grid_confirm.h
@@ -121,10 +121,11 @@ inline void switch_confirmation_open_modal(const ParsedCfg &p, lv_obj_t *btn_obj
 
   ui.no_btn = control_modal_create_text_button(
     ui.panel, switch_confirmation_no_text(p), button_max_w, button_min_w, button_h,
-    button_h / 2, DARK_BORDER, button_font);
+    button_h / 2, DARK_BORDER, DARK_TEXT_PRIMARY, button_font);
+  uint32_t confirm_color = switch_confirmation_accent_color_ref();
   ui.confirm_btn = control_modal_create_text_button(
     ui.panel, switch_confirmation_yes_text(p), button_max_w, button_min_w, button_h,
-    button_h / 2, switch_confirmation_accent_color_ref(), button_font);
+    button_h / 2, confirm_color, readable_text_color_for_bg(confirm_color), button_font);
 
   lv_obj_update_layout(ui.message_lbl);
   lv_obj_update_layout(ui.no_btn);

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -774,6 +774,7 @@ inline void grid_phase1(
   palette.on_val = has_on ? on_val : DEFAULT_SLIDER_COLOR;
   palette.off_val = has_off ? off_val : DEFAULT_OFF_COLOR;
   palette.sensor_val = has_sensor_color ? sensor_val : DEFAULT_TERTIARY_COLOR;
+  set_switch_confirmation_accent_color(palette.on_val);
 
   bump_ha_subscription_generation();
   reset_calendar_cards();
@@ -882,6 +883,7 @@ inline void grid_phase2(
   palette.on_val = has_on ? on_val : DEFAULT_SLIDER_COLOR;
   palette.off_val = has_off ? off_val : DEFAULT_OFF_COLOR;
   palette.sensor_val = has_sensor_color ? sensor_val : DEFAULT_TERTIARY_COLOR;
+  set_switch_confirmation_accent_color(palette.on_val);
 
   OrderResult parsed, order;
   parse_order_string(order_str, NS, parsed);

--- a/components/espcontrol/button_grid_layout.h
+++ b/components/espcontrol/button_grid_layout.h
@@ -255,6 +255,8 @@ inline void set_grid_card_cell(lv_obj_t *btn,
 
 // ── Button visuals ────────────────────────────────────────────────────
 
+inline void apply_card_descendant_text_color(lv_obj_t *obj, lv_color_t color);
+
 // Apply on/off background colors to a button's checked/pressed/default states
 inline void apply_button_colors(lv_obj_t *btn, bool has_on, uint32_t on_val,
                                 bool has_off, uint32_t off_val) {
@@ -263,11 +265,19 @@ inline void apply_button_colors(lv_obj_t *btn, bool has_on, uint32_t on_val,
       static_cast<lv_style_selector_t>(LV_PART_MAIN) | static_cast<lv_style_selector_t>(LV_STATE_CHECKED));
     lv_obj_set_style_bg_color(btn, lv_color_hex(on_val),
       static_cast<lv_style_selector_t>(LV_PART_MAIN) | static_cast<lv_style_selector_t>(LV_STATE_PRESSED));
+    lv_color_t text_color = lv_color_hex(readable_text_color_for_bg(on_val));
+    lv_obj_set_style_text_color(btn, text_color,
+      static_cast<lv_style_selector_t>(LV_PART_MAIN) | static_cast<lv_style_selector_t>(LV_STATE_CHECKED));
+    lv_obj_set_style_text_color(btn, text_color,
+      static_cast<lv_style_selector_t>(LV_PART_MAIN) | static_cast<lv_style_selector_t>(LV_STATE_PRESSED));
   }
   if (has_off) {
     lv_obj_set_style_bg_color(btn, lv_color_hex(off_val),
       static_cast<lv_style_selector_t>(LV_PART_MAIN) | static_cast<lv_style_selector_t>(LV_STATE_DEFAULT));
+    lv_obj_set_style_text_color(btn, lv_color_hex(readable_text_color_for_bg(off_val)),
+      static_cast<lv_style_selector_t>(LV_PART_MAIN) | static_cast<lv_style_selector_t>(LV_STATE_DEFAULT));
   }
+  apply_card_descendant_text_color(btn, lv_obj_get_style_text_color(btn, LV_PART_MAIN));
 }
 
 inline uint32_t card_pattern_highlight_color(uint32_t color) {

--- a/components/espcontrol/button_grid_modal.h
+++ b/components/espcontrol/button_grid_modal.h
@@ -661,7 +661,8 @@ inline lv_obj_t *control_modal_create_list_row(lv_obj_t *parent,
   lv_label_set_text(value, label.c_str());
   lv_label_set_long_mode(value, LV_LABEL_LONG_DOT);
   lv_obj_set_width(value, lv_pct(100));
-  lv_obj_set_style_text_color(value, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
+  lv_obj_set_style_text_color(
+    value, lv_color_hex(readable_text_color_for_bg(active ? active_color : inactive_color)), LV_PART_MAIN);
   lv_obj_set_style_text_align(value, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (font) lv_obj_set_style_text_font(value, font, LV_PART_MAIN);
   apply_width_compensation(value, width_compensation_percent);
@@ -677,6 +678,7 @@ inline lv_obj_t *control_modal_create_text_button(
     lv_coord_t min_height,
     lv_coord_t radius,
     uint32_t bg_color,
+    uint32_t text_color,
     const lv_font_t *font) {
   lv_obj_t *btn = lv_btn_create(parent);
   lv_obj_set_size(btn, min_width, min_height);
@@ -691,7 +693,7 @@ inline lv_obj_t *control_modal_create_text_button(
   lv_obj_t *label = lv_label_create(btn);
   lv_label_set_text(label, text.c_str());
   lv_label_set_long_mode(label, LV_LABEL_LONG_CLIP);
-  lv_obj_set_style_text_color(label, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
+  lv_obj_set_style_text_color(label, lv_color_hex(text_color), LV_PART_MAIN);
   lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (font) lv_obj_set_style_text_font(label, font, LV_PART_MAIN);
 


### PR DESCRIPTION
## Summary

- This started with the confirmation modal not matching the active button theme: custom button colours worked on the grid, but the final confirm button still used the default slider colour.
- This now carries the selected button’s active colour into the confirmation modal, so the confirm action visually matches the button that opened it.
- Added a readable text colour helper so labels stay legible against both light and dark custom theme colours.
- Applied the contrast handling to themed grid button states, modal selector labels, and confirmation modal buttons.
- Added refresh hooks so configurable theme colour changes redraw the button grid instead of waiting for another refresh.

## Testing

- [x] I checked the change locally where practical.
- [ ] User testing is still needed before merge.
- [x] Affected display/device, if applicable: all devices (I tested against my Guition ESP32-P4 JC8012P4A1)

## Notes for testing

- Test a button with a custom `on` colour and confirm that the confirmation modal’s confirm button uses the same accent colour.
- Test both light and dark custom colours and confirm the button text remains readable.
- Change the configured theme colours and confirm the grid redraws with the updated colours.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.

This PR is also loosely related to #522 in the sense that this also adds some live refresh hooks for card colour settings.