### PR TITLE
docs: update user-facing documentation for recent features

### DIFF
--- a/docs/card-types/alarms.md
+++ b/docs/card-types/alarms.md
@@ -63,6 +63,12 @@ Use the PIN settings to match how you want the wall panel to behave:
 - Leave **PIN required for disarming** on for panels in shared spaces.
 - Turn off the arming PIN only when quick arming is safe for that panel location.
 
+## Entry and Exit Delays
+
+If Home Assistant reports an alarm arming delay or pending entry delay, the panel shows the delay state in the alarm screen with a countdown timer. A progress bar under the timer gives a quick visual indication of how much delay time is left before the alarm changes state.
+
+The delay display follows the alarm entity updates from Home Assistant, so it works whether Home Assistant sends the total delay once or keeps sending updated remaining-time values during the countdown.
+
 ## How It Works on the Panel
 
 - The card subscribes to the alarm entity state in Home Assistant.

--- a/docs/features/firmware-updates.md
+++ b/docs/features/firmware-updates.md
@@ -50,3 +50,18 @@ You can also manage updates from Home Assistant. The **Auto Update** toggle, **U
 The standard Home Assistant **Update** entity may also appear, depending on your Home Assistant version.
 
 Displays built with `disable_updates: "true"` do not expose EspControl's built-in GitHub update controls. They can still be updated manually through ESPHome.
+
+## ESP32-C6 WiFi Co-processor Updates
+
+Some ESP32-P4 displays use a separate ESP32-C6 chip for WiFi. EspControl exposes separate Home Assistant entities for that co-processor firmware on the supported P4 WiFi builds:
+
+- **7-inch JC1060P470**
+- **10.1-inch JC8012P4A1**
+- **4.3-inch JC4880P443**
+- **4-inch ESP32-P4-86**
+
+These entities are separate from the main EspControl display firmware controls. The normal **Firmware: Check for Update** and **Firmware: Install Update** controls update the panel firmware. The ESP32-C6 controls check and install compatible WiFi co-processor firmware from ESPHome's hosted firmware manifest.
+
+In Home Assistant, look for ESP32-C6 diagnostic entities showing the current version, latest version, and whether an update is available. When an update is available, use the ESP32-C6 check/install buttons for the co-processor, and continue using the regular EspControl firmware controls for normal panel updates.
+
+Advanced Ethernet-only builds keep the ESP32-C6 WiFi co-processor off, so they do not expose these ESP32-C6 update controls.


### PR DESCRIPTION
## Summary
- Added user-facing firmware update documentation for ESP32-C6 WiFi co-processor update entities on supported ESP32-P4 displays.
- Added alarm card documentation for entry/exit delay countdown and progress display behavior.

## Merged PRs reviewed
- #591 https://github.com/jtenniswood/espcontrol/pull/591 — local ESPHome helper cwd fix; skipped as developer tooling behavior only.
- #590 https://github.com/jtenniswood/espcontrol/pull/590 — actions/checkout v7 update; skipped as CI/tooling maintenance.
- #589 https://github.com/jtenniswood/espcontrol/pull/589 — ESPHome 2026.6.0 workflow/component compatibility update; skipped as build/internal compatibility with no new user-facing documentation needed.
- #588 https://github.com/jtenniswood/espcontrol/pull/588 — dynamic local ESPHome firmware versions; skipped as developer/local test workflow docs were updated in that PR.
- #587 https://github.com/jtenniswood/espcontrol/pull/587 — alarm delay display now shows readable delay state text, countdown, and progress bar; documented in this PR.
- #579 https://github.com/jtenniswood/espcontrol/pull/579 — docs-only catch-up PR; skipped as already-documentation.
- #577 https://github.com/jtenniswood/espcontrol/pull/577 — firmware compile workflow manual-only; skipped as CI/build behavior.
- #576 https://github.com/jtenniswood/espcontrol/pull/576 — firmware matrix concurrency fix; skipped as CI/build behavior.
- #564 https://github.com/jtenniswood/espcontrol/pull/564 — ESP32-C6 WiFi co-processor firmware update entities for P4 displays; documented in this PR.

## PRs resulting in documentation updates
- #564 — Adds user-visible Home Assistant diagnostic entities and check/install buttons for ESP32-C6 WiFi co-processor firmware on supported ESP32-P4 WiFi panels. Updated `docs/features/firmware-updates.md` to explain how these controls differ from normal EspControl panel firmware updates, which displays are covered, and why Ethernet-only builds do not expose them.
- #587 — Changes the visible alarm delay experience on the panel. Updated `docs/card-types/alarms.md` to describe the entry/exit delay countdown and progress bar.

## Skipped backend/internal/docs-already-covered PRs
- Skipped 7 reviewed PRs because they were CI/build/tooling maintenance, developer-only workflow changes, docs-only updates, or build/internal compatibility changes without new user-facing documentation needs.

## Verification
- `git status --short` before commit showed only `docs/card-types/alarms.md` and `docs/features/firmware-updates.md` changed.
- `git diff --stat` before commit: 2 files changed, 21 insertions(+).
- `npm ci` completed successfully; npm reported 3 existing dependency audit findings (2 moderate, 1 high).
- `npm run docs:build` passed (`build complete in 3.99s`).
- `npm run check:dev-docs` passed (`dev-docs check passed`).

## Assumptions / clarification needed
- None.
