### PR TITLE
Fix climate active action state

### DIFF
--- a/components/espcontrol/button_grid_climate.h
+++ b/components/espcontrol/button_grid_climate.h
@@ -400,22 +400,29 @@ inline std::string climate_hvac_service_value(const std::string &raw) {
   return value;
 }
 
+inline bool climate_action_is_working(const std::string &action) {
+  return action == "heating" || action == "cooling" ||
+         action == "drying" || action == "fan";
+}
+
 inline std::string climate_action_label(ClimateControlCtx *ctx) {
   if (!ctx || !ctx->available) return espcontrol_i18n(std::string("Unavailable"));
-  if (ctx->hvac_mode == "off") return espcontrol_i18n(std::string("Off"));
-  if (ctx->hvac_action.empty() || ctx->hvac_action == "unknown" ||
-      ctx->hvac_action == "unavailable") return climate_option_label(ctx->hvac_mode);
   if (ctx->hvac_action == "heating") return espcontrol_i18n(std::string("Heating"));
   if (ctx->hvac_action == "cooling") return espcontrol_i18n(std::string("Cooling"));
   if (ctx->hvac_action == "drying") return espcontrol_i18n(std::string("Drying"));
   if (ctx->hvac_action == "fan") return espcontrol_i18n(std::string("Fan"));
+  if (ctx->hvac_mode == "off") return espcontrol_i18n(std::string("Off"));
+  if (ctx->hvac_action.empty() || ctx->hvac_action == "unknown" ||
+      ctx->hvac_action == "unavailable") return climate_option_label(ctx->hvac_mode);
   if (ctx->hvac_action == "idle") return espcontrol_i18n(std::string("Idle"));
   if (ctx->hvac_action == "off") return espcontrol_i18n(std::string("Off"));
   return espcontrol_i18n(std::string("Idle"));
 }
 
 inline bool climate_is_active(ClimateControlCtx *ctx) {
-  if (!ctx || !ctx->available || ctx->hvac_mode == "off") return false;
+  if (!ctx || !ctx->available) return false;
+  if (climate_action_is_working(ctx->hvac_action)) return true;
+  if (ctx->hvac_mode == "off") return false;
   if (ctx->hvac_action.empty() || ctx->hvac_action == "unknown" ||
       ctx->hvac_action == "unavailable") {
     return !climate_unavailable_value(ctx->hvac_mode);
@@ -424,7 +431,8 @@ inline bool climate_is_active(ClimateControlCtx *ctx) {
 }
 
 inline bool climate_temperature_controls_enabled(ClimateControlCtx *ctx) {
-  return ctx && ctx->available && ctx->hvac_mode != "off";
+  return ctx && ctx->available &&
+         (ctx->hvac_mode != "off" || climate_action_is_working(ctx->hvac_action));
 }
 
 inline bool climate_modal_temperature_controls_enabled(ClimateControlCtx *ctx) {

--- a/components/espcontrol/button_grid_subpages.h
+++ b/components/espcontrol/button_grid_subpages.h
@@ -442,20 +442,9 @@ struct ClimateSubpageParentIndicatorCtx {
   const char *on_glyph = nullptr;
 };
 
-inline bool climate_subpage_mode_can_work(const std::string &mode) {
-  return mode == "cool" || mode == "heat" || mode == "auto" ||
-         mode == "heat_cool" || mode == "fan_only" || mode == "fan";
-}
-
-inline bool climate_subpage_action_is_working(const std::string &action) {
-  return action == "cooling" || action == "heating" || action == "fan";
-}
-
 inline void apply_climate_subpage_parent_indicator(ClimateSubpageParentIndicatorCtx *ctx) {
   if (!ctx) return;
-  bool working = ctx->available &&
-                 climate_subpage_mode_can_work(ctx->hvac_mode) &&
-                 climate_subpage_action_is_working(ctx->hvac_action);
+  bool working = ctx->available && climate_action_is_working(ctx->hvac_action);
   set_card_checked_state(ctx->parent_btn, working);
   if (ctx->has_alt_icon && ctx->parent_icon)
     lv_label_set_text(ctx->parent_icon, working ? ctx->on_glyph : ctx->off_glyph);


### PR DESCRIPTION
## Purpose
Fixes #604.

The climate card could show `Off` even when Home Assistant reported an active climate action such as `cooling`. This happened because the firmware checked `hvac_mode == "off"` before checking the live `hvac_action` value.

## Practical impact
When Home Assistant reports `hvac_action` as `heating`, `cooling`, `drying`, or `fan`, EspControl now treats the climate card as active before falling back to the `hvac_mode` value. This also applies to the climate card icon state and climate subpage parent indicator.

## Checked
- `npm run check:firmware-parser`
- `npm run check:firmware-ha-bindings`
- `esphome -s firmware_version fix-climate-active-action-local -s espcontrol_component_url file:///Users/jtenniswood/Git/espcontrol-fix-climate-active-action -s espcontrol_component_ref HEAD compile builds/guition-esp32-p4-jc8012p4a1.factory.yaml`

## Device testing notes
Affected display from the report: `guition-esp32-p4-jc8012p4a1` / 10-inch P4.

After flashing a PR build, test with a climate card where Home Assistant shows main state `cool` and `hvac_action: cooling`. The card/status should show the active cooling state rather than `Off`.
