### PR TITLE
Fix firmware version label in network status

### DIFF
--- a/components/espcontrol/network_status.h
+++ b/components/espcontrol/network_status.h
@@ -84,11 +84,42 @@ inline std::string network_status_trim_copy(const std::string &value) {
   return value.substr(first, last - first + 1);
 }
 
+inline bool network_status_is_specific_firmware_version(const std::string &version) {
+  std::string trimmed = network_status_trim_copy(version);
+  const size_t len = trimmed.size();
+  if (len < 6 || (trimmed[0] != 'v' && trimmed[0] != 'V')) return false;
+
+  size_t pos = 1;
+  auto read_number = [&]() -> bool {
+    if (pos >= len || !std::isdigit(static_cast<unsigned char>(trimmed[pos]))) return false;
+    while (pos < len && std::isdigit(static_cast<unsigned char>(trimmed[pos]))) ++pos;
+    return true;
+  };
+
+  if (!read_number()) return false;
+  for (int part = 0; part < 2; ++part) {
+    if (pos >= len || trimmed[pos] != '.') return false;
+    ++pos;
+    if (!read_number()) return false;
+  }
+  if (pos == len) return true;
+  if (trimmed[pos] != '-' && trimmed[pos] != '+') return false;
+  ++pos;
+  if (pos == len) return false;
+  while (pos < len) {
+    unsigned char c = static_cast<unsigned char>(trimmed[pos]);
+    if (!std::isalnum(c) && trimmed[pos] != '.' && trimmed[pos] != '-') return false;
+    ++pos;
+  }
+  return true;
+}
+
 inline std::string network_status_firmware_label(const std::string &version) {
   std::string trimmed = network_status_trim_copy(version);
   if (trimmed.empty()) return espcontrol_i18n(std::string("Version unknown"));
-  if (trimmed == "dev" || trimmed == "Dev" || trimmed == "0.0.0") return espcontrol_i18n(std::string("Dev build"));
-  return trimmed;
+  if (trimmed == "Version unknown") return espcontrol_i18n(std::string("Version unknown"));
+  if (network_status_is_specific_firmware_version(trimmed)) return trimmed;
+  return espcontrol_i18n(std::string("Dev build"));
 }
 
 inline void network_status_clean_obj(lv_obj_t *obj) {

--- a/scripts/check_firmware_modals.py
+++ b/scripts/check_firmware_modals.py
@@ -257,10 +257,42 @@ def firmware_subpage_modal_wiring_errors(root: Path) -> list[str]:
     return errors
 
 
+def firmware_network_status_version_errors(root: Path) -> list[str]:
+    path = root / "components" / "espcontrol" / "network_status.h"
+    errors: list[str] = []
+    if not path.exists():
+        errors.append("components/espcontrol/network_status.h: keep network status version labeling")
+        return errors
+
+    text = path.read_text(encoding="utf-8")
+    if "network_status_is_specific_firmware_version" not in text:
+        errors.append("components/espcontrol/network_status.h: classify release versions before labeling firmware")
+
+    label_match = re.search(
+        r"inline\s+std::string\s+network_status_firmware_label\s*\([^)]*\)\s*\{(?P<body>.*?)\n\}",
+        text,
+        re.S,
+    )
+    if label_match is None:
+        errors.append("components/espcontrol/network_status.h: keep network_status_firmware_label helper")
+        return errors
+
+    body = label_match.group("body")
+    if "network_status_is_specific_firmware_version(trimmed)" not in body:
+        errors.append("components/espcontrol/network_status.h: show only release versions as installed versions")
+    if 'espcontrol_i18n(std::string("Dev build"))' not in body:
+        errors.append("components/espcontrol/network_status.h: label local ESPHome builds as Dev build")
+    if 'espcontrol_i18n(std::string("Version unknown"))' not in body:
+        errors.append("components/espcontrol/network_status.h: keep empty firmware versions readable")
+
+    return errors
+
+
 def run_scan() -> int:
     errors = firmware_modal_errors(FIRMWARE_DIR, ROOT)
     errors.extend(firmware_modal_sleep_takeover_errors(ROOT))
     errors.extend(firmware_subpage_modal_wiring_errors(ROOT))
+    errors.extend(firmware_network_status_version_errors(ROOT))
 
     if errors:
         print("Firmware modal allocation check failed:")
@@ -310,6 +342,20 @@ def expect_subpage_modal_wiring_errors(name: str, grid_text: str, expected: tupl
         path.write_text(grid_text, encoding="utf-8")
 
         errors = firmware_subpage_modal_wiring_errors(root)
+        for item in expected:
+            assert any(item in error for error in errors), f"{name}: missing {item!r} in {errors!r}"
+        if not expected:
+            assert not errors, f"{name}: expected no errors, got {errors!r}"
+
+
+def expect_network_status_version_errors(name: str, header_text: str, expected: tuple[str, ...]) -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        path = root / "components" / "espcontrol" / "network_status.h"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(header_text, encoding="utf-8")
+
+        errors = firmware_network_status_version_errors(root)
         for item in expected:
             assert any(item in error for error in errors), f"{name}: missing {item!r} in {errors!r}"
         if not expected:
@@ -465,6 +511,34 @@ def run_self_test() -> int:
             "        }\n"
             "        continue;\n"
             "      }\n"
+        ),
+        (),
+    )
+    expect_network_status_version_errors(
+        "raw local firmware version leaks",
+        (
+            "inline std::string network_status_firmware_label(const std::string &version) {\n"
+            "  std::string trimmed = version;\n"
+            "  if (trimmed.empty()) return espcontrol_i18n(std::string(\"Version unknown\"));\n"
+            "  if (trimmed == \"dev\" || trimmed == \"0.0.0\") return espcontrol_i18n(std::string(\"Dev build\"));\n"
+            "  return trimmed;\n"
+            "}\n"
+        ),
+        (
+            "classify release versions before labeling firmware",
+            "show only release versions as installed versions",
+        ),
+    )
+    expect_network_status_version_errors(
+        "release-only firmware version label",
+        (
+            "inline bool network_status_is_specific_firmware_version(const std::string &version) { return true; }\n"
+            "inline std::string network_status_firmware_label(const std::string &version) {\n"
+            "  std::string trimmed = version;\n"
+            "  if (trimmed.empty()) return espcontrol_i18n(std::string(\"Version unknown\"));\n"
+            "  if (network_status_is_specific_firmware_version(trimmed)) return trimmed;\n"
+            "  return espcontrol_i18n(std::string(\"Dev build\"));\n"
+            "}\n"
         ),
         (),
     )

--- a/scripts/check_web_smoke.js
+++ b/scripts/check_web_smoke.js
@@ -1221,6 +1221,7 @@ assert.strictEqual(hooks.displayFirmwareVersion("v1.11.1"), "v1.11.1");
 assert.strictEqual(hooks.displayFirmwareVersion("dev"), "Dev build");
 assert.strictEqual(hooks.displayFirmwareVersion("0.0.0"), "Dev build");
 assert.strictEqual(hooks.displayFirmwareVersion("main"), "Dev build");
+assert.strictEqual(hooks.displayFirmwareVersion("dev-jc8012p4a1-20260611-livecheck"), "Dev build");
 assert.strictEqual(hooks.displayFirmwareVersion(""), "Version unknown");
 assert.strictEqual(hooks.firmwareVersionFromMetadata({ firmware_version: "v1.12.0" }), "v1.12.0");
 assert.strictEqual(hooks.firmwareVersionFromMetadata({ project_version: "v1.12.1" }), "v1.12.1");


### PR DESCRIPTION
## Purpose

Make the on-device network/status popup show firmware versions the same way as the web setup page.

## Practical impact

- Local ESPHome installs with development-style versions such as `dev-jc8012p4a1-...`, branch names, `dev`, or `0.0.0` now show `Dev build` in the popup.
- GitHub web-installed releases with `v1.2.3`-style versions still show the actual release version.
- The web smoke test now covers a `dev-...` local build version, and the firmware modal guard checks this behavior stays wired into the popup.

## Checks

- `npm run check:firmware-modals`
- `npm run check:web-smoke`
- `npm run check:fast`

## Device testing

Flash this branch to a locally installed ESPHome display and open the popup from the Wi-Fi/network icon. A local build should show `Dev build`; a GitHub release install should continue to show the release version.