### PR TITLE
Fix cover art refresh on artwork URL changes

### DIFF
--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -1010,6 +1010,7 @@ script:
           ESP_LOGI("cover_art", "Using cached artwork URL (%u chars)", (unsigned) chosen.size());
           id(cover_art_url) = chosen;
           id(cover_art_last_good_url) = chosen;
+          id(cover_art_refresh_needed) = true;
           id(cover_art_retry_url).clear();
           id(cover_art_retry_count) = 0;
           if (id(cover_art_loaded_url).empty()) {
@@ -1814,6 +1815,11 @@ script:
               cached = url;
               if (!local) {
                 id(cover_art_cached_local_url).clear();
+              }
+              if (!url.empty() && url != id(cover_art_url)) {
+                id(cover_art_refresh_needed) = true;
+                id(cover_art_retry_url).clear();
+                id(cover_art_retry_count) = 0;
               }
               ESP_LOGI("cover_art", "Cached artwork %s (%u chars, url %u chars, active=%s)",
                        local ? "entity_picture_local" : "entity_picture",

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -665,6 +665,13 @@ def firmware_cover_art_refresh_errors(path: Path, root: Path) -> list[str]:
         ):
             errors.append(f"{rel}: do not exit early from {script_id} when stale artwork needs refresh")
 
+    cached_body = yaml_script_body(text, "cover_art_use_cached_artwork")
+    if cached_body and cached_body.count("id(cover_art_refresh_needed) = true;") < 2:
+        errors.append(f"{rel}: mark changed cached artwork URLs as stale before downloading")
+    resubscribe_body = yaml_script_body(text, "cover_art_resubscribe")
+    if resubscribe_body and "if (!url.empty() && url != id(cover_art_url))" not in resubscribe_body:
+        errors.append(f"{rel}: mark changed Home Assistant artwork attributes as stale")
+
     apply_body = yaml_script_body(text, "cover_art_apply_downloaded_image")
     if not apply_body:
         errors.append(f"{rel}: missing cover_art_apply_downloaded_image script")
@@ -2636,9 +2643,14 @@ def run_self_test() -> int:
         "  - id: cover_art_use_cached_artwork\n"
         "    then:\n"
         "      - lambda: |-\n"
+        "          if (chosen != id(cover_art_url)) {\n"
+        "            id(cover_art_refresh_needed) = true;\n"
+        "          }\n"
         "          if (chosen == id(cover_art_url)) {\n"
         "            if (!id(cover_art_image_available) || id(cover_art_refresh_needed)) {}\n"
         "          }\n"
+        "          id(cover_art_url) = chosen;\n"
+        "          id(cover_art_refresh_needed) = true;\n"
         "  - id: cover_art_request_artwork\n"
         "    then:\n"
         "      - lambda: |-\n"
@@ -2668,6 +2680,9 @@ def run_self_test() -> int:
         "          mark_artwork_refresh_needed();\n"
         "          mark_artwork_refresh_needed();\n"
         "          mark_artwork_refresh_needed();\n"
+        "          if (!url.empty() && url != id(cover_art_url)) {\n"
+        "            id(cover_art_refresh_needed) = true;\n"
+        "          }\n"
         "          ha_subscribe_attribute(cover_entity, std::string(\"media_album_name\"), handle_media_album);\n"
         "          ha_get_attribute(cover_entity, std::string(\"media_album_name\"), handle_media_album);\n",
         (),


### PR DESCRIPTION
## Purpose

Fixes a follow-up path for issue #582 where Home Assistant reports a new `entity_picture`, but the display can keep treating the currently shown cover art as reusable.

## What changed

- Mark changed Home Assistant artwork attributes as stale as soon as the URL changes.
- Mark newly selected cached artwork URLs as needing a replacement download before they are displayed.
- Extend the firmware Home Assistant binding guard so future changes keep this refresh behavior intact.

## Practical impact

When the media player moves to a new track and Home Assistant provides a different cover-art URL, the display should request and apply the replacement artwork instead of leaving the first loaded cover art on screen.

## Checks

- `python3 scripts/check_firmware_ha_bindings.py`
- `python3 scripts/check_firmware_ha_bindings.py --self-test`
- `npm run check:fast`

## Device testing

Please test on a display with the cover art screensaver enabled by playing several tracks from the same media player. The track text and cover art should both change as the track changes.

Note: local ESPHome config validation was attempted, but this fresh worktree does not include the device `secrets.yaml`, and Docker is installed but the daemon is not running. The PR firmware compile workflow should provide the full device build validation.

Refs #582
