### PR TITLE
Fix P4-86 compile config issues

### DIFF
--- a/devices/esp32-p4-86/device/physical_volume_button.yaml
+++ b/devices/esp32-p4-86/device/physical_volume_button.yaml
@@ -12,6 +12,7 @@ binary_sensor:
     internal: true
     pin:
       number: GPIO35
+      ignore_strapping_warning: true
       mode:
         input: true
         pullup: true

--- a/devices/esp32-p4-86/packages.yaml
+++ b/devices/esp32-p4-86/packages.yaml
@@ -60,8 +60,8 @@ substitutions:
   screen_saver_clock_default_brightness: "35"
   screen_schedule_clock_min_brightness: "1"
   screen_schedule_clock_default_brightness: "10"
-  voice_wake_chime_file: "../devices/esp32-p4-86/device/voice_wake_chime.flac"
-  voice_timer_alert_file: "../devices/esp32-p4-86/device/voice_timer_alert.flac"
+  voice_wake_chime_file: "https://raw.githubusercontent.com/jtenniswood/espcontrol/main/devices/esp32-p4-86/device/voice_wake_chime.flac"
+  voice_timer_alert_file: "https://raw.githubusercontent.com/jtenniswood/espcontrol/main/devices/esp32-p4-86/device/voice_timer_alert.flac"
   network_transport: "wifi"
   disable_updates: "false"
   network_package_suffix: ${ "_ethernet" if network_transport == "ethernet" else "" }

--- a/devices/manifest.json
+++ b/devices/manifest.json
@@ -561,8 +561,8 @@
             "screen_saver_clock_default_brightness": "\"35\"",
             "screen_schedule_clock_min_brightness": "\"1\"",
             "screen_schedule_clock_default_brightness": "\"10\"",
-            "voice_wake_chime_file": "\"../devices/esp32-p4-86/device/voice_wake_chime.flac\"",
-            "voice_timer_alert_file": "\"../devices/esp32-p4-86/device/voice_timer_alert.flac\""
+            "voice_wake_chime_file": "\"https://raw.githubusercontent.com/jtenniswood/espcontrol/main/devices/esp32-p4-86/device/voice_wake_chime.flac\"",
+            "voice_timer_alert_file": "\"https://raw.githubusercontent.com/jtenniswood/espcontrol/main/devices/esp32-p4-86/device/voice_timer_alert.flac\""
           },
           "deviceFontPackageKey": "fonts_device",
           "touchscreenPackage": true,


### PR DESCRIPTION
## Purpose
Fixes #628.

The P4-86 package was pointing its built-in voice chime FLAC files at a relative path that ESPHome resolves from the user's Home Assistant config folder when the package is imported remotely. That makes ESPHome look under /config/devices/... instead of the package checkout.

## Practical impact
- P4-86 remote package builds now download the wake chime and timer alert FLAC files from the project repository.
- GPIO35 on the P4-86 physical volume button is explicitly marked as an intentional strapping-pin use, removing the warning reported in the issue.

## Checked
- python3 scripts/build.py
- python3 scripts/check_device_manifest.py
- python3 scripts/check_device_profiles.py
- esphome -s espcontrol_component_url file:///Users/jtenniswood/Git/espcontrol-fix-issue-628-compile-config compile builds/esp32-p4-86.factory.yaml

Note: Docker was not running locally, so I used the installed ESPHome 2026.5.3 fallback and passed the local component URL substitution that Docker normally provides via /config. The full P4-86 factory firmware compiled successfully.