### PR TITLE
Increase option select choice limit

### DIFF
--- a/components/espcontrol/button_grid_option_select.h
+++ b/components/espcontrol/button_grid_option_select.h
@@ -4,9 +4,10 @@
 
 // ── Option select card helpers ───────────────────────────────────────
 
-constexpr int OPTION_SELECT_MAX_OPTIONS = 32;
+constexpr int OPTION_SELECT_MAX_OPTIONS = 64;
 constexpr size_t OPTION_SELECT_OPTION_MAX_LEN = 96;
-constexpr size_t OPTION_SELECT_OPTIONS_TEXT_MAX_LEN = 1024;
+constexpr size_t OPTION_SELECT_OPTIONS_TEXT_MAX_LEN =
+  OPTION_SELECT_MAX_OPTIONS * (OPTION_SELECT_OPTION_MAX_LEN + 4);
 
 struct OptionSelectCtx {
   std::string entity_id;


### PR DESCRIPTION
## Purpose
Fixes #627 by allowing Option Select action cards to show more than 32 Home Assistant options.

## Practical impact
- Raises the option-select modal limit from 32 choices to 64 choices.
- Raises the Home Assistant options attribute read limit from 1024 to 6400 characters, matching 64 options at the existing per-option text limit plus delimiters, so longer option lists are less likely to be truncated before parsing.
- Keeps the existing per-option text limit unchanged.

## Testing
- npm run check:firmware-modals
- npm run check:firmware-ha-bindings
- npm run check:firmware-parser

## Device testing notes
Flash this branch to a panel with an Option Select action card pointed at a select or input_select entity with more than 32 options, such as a Wiz effects select. Confirm options beyond the 32nd entry appear and can be selected.
