### PR TITLE
Bundle web UI in build firmware

### DIFF
--- a/builds/esp32-p4-86.yaml
+++ b/builds/esp32-p4-86.yaml
@@ -2,6 +2,8 @@
 # BUILD PROFILE - Waveshare ESP32-P4 86 Panel (4" square)
 # =============================================================================
 # CI/local build entry point for the 720x720 square ESP32-P4 panel.
+# Bundles the matching web UI so branch/release builds do not load the shared
+# GitHub Pages copy from main.
 # =============================================================================
 
 substitutions:
@@ -21,3 +23,7 @@ wifi:
     ssid: "${friendly_name}"
 
 captive_portal:
+
+web_server:
+  js_url: ""
+  js_include: "../docs/public/webserver/esp32-p4-86/www.js"

--- a/builds/guition-esp32-p4-jc1060p470.yaml
+++ b/builds/guition-esp32-p4-jc1060p470.yaml
@@ -2,8 +2,8 @@
 # BUILD PROFILE - Guition ESP32-P4 JC1060P470 (7" landscape)
 # =============================================================================
 # CI/local build entry point. Includes the full device package and adds
-# MAC suffix for unique naming. Used by the release workflow; the .factory
-# variant bundles the web UI JS inline for initial flash images.
+# MAC suffix for unique naming. Bundles the matching web UI so branch/release
+# builds do not load the shared GitHub Pages copy from main.
 # =============================================================================
 
 substitutions:
@@ -23,3 +23,7 @@ wifi:
     ssid: "${friendly_name}"
 
 captive_portal:
+
+web_server:
+  js_url: ""
+  js_include: "../docs/public/webserver/guition-esp32-p4-jc1060p470/www.js"

--- a/builds/guition-esp32-p4-jc4880p443.yaml
+++ b/builds/guition-esp32-p4-jc4880p443.yaml
@@ -1,7 +1,9 @@
 # =============================================================================
 # BUILD PROFILE - Guition ESP32-P4 JC4880P443 (4.3" portrait)
 # =============================================================================
-# CI/local build entry point for the 480×800 portrait panel.
+# CI/local build entry point for the 480x800 portrait panel.
+# Bundles the matching web UI so branch/release builds do not load the shared
+# GitHub Pages copy from main.
 # =============================================================================
 
 substitutions:
@@ -21,3 +23,7 @@ wifi:
     ssid: "${friendly_name}"
 
 captive_portal:
+
+web_server:
+  js_url: ""
+  js_include: "../docs/public/webserver/guition-esp32-p4-jc4880p443/www.js"

--- a/builds/guition-esp32-p4-jc8012p4a1.yaml
+++ b/builds/guition-esp32-p4-jc8012p4a1.yaml
@@ -2,8 +2,8 @@
 # BUILD PROFILE - Guition ESP32-P4 JC8012P4A1 (10.1" landscape)
 # =============================================================================
 # CI/local build entry point. Includes the full device package and adds
-# MAC suffix for unique naming. Used by the release workflow; the .factory
-# variant bundles the web UI JS inline for initial flash images.
+# MAC suffix for unique naming. Bundles the matching web UI so branch/release
+# builds do not load the shared GitHub Pages copy from main.
 # =============================================================================
 
 substitutions:
@@ -23,3 +23,7 @@ wifi:
     ssid: "${friendly_name}"
 
 captive_portal:
+
+web_server:
+  js_url: ""
+  js_include: "../docs/public/webserver/guition-esp32-p4-jc8012p4a1/www.js"

--- a/builds/guition-esp32-s3-4848s040.yaml
+++ b/builds/guition-esp32-s3-4848s040.yaml
@@ -1,7 +1,9 @@
 # =============================================================================
 # BUILD PROFILE - Guition ESP32-S3-4848S040 (4" square)
 # =============================================================================
-# CI/local build entry point for the 480×480 square ESP32-S3 panel.
+# CI/local build entry point for the 480x480 square ESP32-S3 panel.
+# Bundles the matching web UI so branch/release builds do not load the shared
+# GitHub Pages copy from main.
 # =============================================================================
 
 substitutions:
@@ -25,3 +27,7 @@ wifi:
     ssid: "${friendly_name}"
 
 captive_portal:
+
+web_server:
+  js_url: ""
+  js_include: "../docs/public/webserver/guition-esp32-s3-4848s040/www.js"

--- a/dev-docs/architecture.md
+++ b/dev-docs/architecture.md
@@ -58,8 +58,9 @@ Use `python3 scripts/build.py --check` to confirm generated files are current.
    theme/config YAML in `common/config/`, and C++ components in
    `components/espcontrol/`.
 3. The device exposes a web server.
-4. The browser setup page loads a per-device `www.js` bundle. In production that
-   bundle is fetched from `docs/public/webserver/<slug>/www.js` on GitHub Pages.
+4. The browser setup page loads a per-device `www.js` bundle. New build
+   entrypoints bundle it into firmware; older installed firmware can still fetch
+   `docs/public/webserver/<slug>/www.js` from GitHub Pages.
 5. The setup page reads and writes ESPHome entities exposed by the device, such
    as `Button N Config` text entities.
 6. Firmware parses the saved compact config string and updates the on-device

--- a/dev-docs/compatibility-contract.md
+++ b/dev-docs/compatibility-contract.md
@@ -13,7 +13,7 @@ explicit migration path, compatibility fixture, release note, and rollback plan.
 | Option values | Existing option keys and values either keep working or have a fallback parser. | `src/webserver/modules/config_codec.js`, `components/espcontrol/button_grid_config.h` |
 | Device slugs | Published device slugs remain valid for firmware bundles, web bundles, docs, manifests, and release assets. | `devices/manifest.json`, `npm run check:device-profiles`, `npm run check:firmware-release` |
 | Public firmware URLs | Installed panels can still find update manifests and OTA assets at the expected public paths. | `npm run check:firmware-release`, `npm run check:public-firmware-script` |
-| Public web bundles | Devices can still load `docs/public/webserver/<slug>/www.js` for their slug. | `python3 scripts/build.py www`, `npm run check:web-smoke` |
+| Public web bundles | Older firmware can still load `docs/public/webserver/<slug>/www.js` for its slug; new build entrypoints bundle the same generated file locally. | `python3 scripts/build.py www`, `npm run check:web-smoke` |
 | Generated device YAML | Generated package and sensor blocks stay reproducible from manifest data. | `python3 scripts/generate_device_slots.py --check` |
 | Home Assistant actions | Existing card controls keep calling the same Home Assistant services unless a migration is deliberate. | `npm run check:firmware-ha-bindings`, `npm run check:firmware-card-runtime` |
 

--- a/dev-docs/devices-and-builds.md
+++ b/dev-docs/devices-and-builds.md
@@ -116,9 +116,11 @@ Each device gets a bundle at:
 docs/public/webserver/<slug>/www.js
 ```
 
-Production firmware points the browser setup page at the GitHub Pages copy of
-that bundle. Local testing can override `web_server.js_url` to load a bundle
-served from a development machine.
+Generated bundles are committed even when firmware bundles them locally. Older
+installed firmware can still point at the GitHub Pages copy of this path, while
+new `builds/*.yaml` entry points use `web_server.js_include` so the setup page
+matches the firmware branch being flashed. Local testing can still override
+`web_server.js_url` to load a bundle served from a development machine.
 
 ## Firmware Build Artifacts
 

--- a/dev-docs/web-configurator.md
+++ b/dev-docs/web-configurator.md
@@ -14,7 +14,7 @@ server. It is written as plain JavaScript modules and bundled into a single
 | `src/webserver/model/*.ts` | Typed model sources. |
 | `src/webserver/modules/model_generated.js` | Generated web model output. |
 | `scripts/web_modules.json` | Explicit order for shared modules. |
-| `docs/public/webserver/<slug>/www.js` | Generated per-device bundles served in production. |
+| `docs/public/webserver/<slug>/www.js` | Generated per-device bundles used for bundled firmware and hosted compatibility. |
 
 Files in `src/webserver/types/` are discovered by the build. Shared files in
 `src/webserver/modules/` must be listed in `scripts/web_modules.json`.
@@ -28,14 +28,18 @@ python3 scripts/build.py www
 That command writes `docs/public/webserver/<slug>/www.js` for each supported
 device. Commit those generated bundles when web behavior changes.
 
-The configurator page itself is served by the device, but in production the
-JavaScript bundle is fetched from GitHub Pages:
+The configurator page itself is served by the device. New build entry points in
+`builds/*.yaml` bundle the matching JavaScript with `web_server.js_include`, so
+a flashed branch uses that branch's setup UI. The generated files are still
+published for older firmware that loads the hosted GitHub Pages copy:
 
 ```text
 https://jtenniswood.github.io/espcontrol/webserver/<slug>/www.js
 ```
 
-The default bundle URL is set as `js_url` in `common/device/core_infra.yaml`.
+The fallback hosted bundle URL is set as `js_url` in
+`common/device/core_infra.yaml`. Keep that path stable for older installed
+firmware and imported configs.
 
 ## Device API Shape
 


### PR DESCRIPTION
## Summary
- bundle the generated web UI into normal build firmware via `web_server.js_include`
- keep the hosted GitHub Pages `www.js` path intact for older firmware and imported configs
- update maintainer docs to explain the bundled-vs-hosted compatibility model

## Testing
- `python3 scripts/build.py www --check`
- `npm run check:device-profiles`
- `npm run check:device-matrix`
- `npm run check:web-smoke`
- `esphome -s espcontrol_component_url file:///Users/jtenniswood/Git/espcontrol-bundle-web-ui compile builds/guition-esp32-s3-4848s040.yaml` - passed, firmware used 2,945,131 bytes of 8,126,464
- `esphome -s espcontrol_component_url file:///Users/jtenniswood/Git/espcontrol-bundle-web-ui compile builds/guition-esp32-p4-jc8012p4a1.yaml` - passed, firmware used 3,708,922 bytes of 8,126,464

## Device testing
Please flash this branch to a test display and confirm the device web setup page reflects branch web UI changes instead of the hosted main copy.