### PR TITLE
Use dev for local firmware version

### DIFF
--- a/dev-docs/devices-and-builds.md
+++ b/dev-docs/devices-and-builds.md
@@ -63,12 +63,10 @@ Build and upload local firmware from the repo root with the local ESPHome helper
 python3 scripts/local_esphome.py devices/<slug>/dev.yaml run
 ```
 
-The helper injects a dynamic `firmware_version` such as
-`fix-issue-581-esp32-p4-86-a1b566c`. That version appears in ESPHome logs,
-Home Assistant diagnostics, and the firmware version sensor, which makes local
-test builds easier to identify in bug reports. Running `esphome run dev.yaml`
-directly still works, but it uses the static fallback version from
-`devices/<slug>/packages.yaml`.
+The helper injects `dev` as the `firmware_version`. That version appears in
+ESPHome logs, Home Assistant diagnostics, and the firmware version sensor.
+Running `esphome run dev.yaml` directly still works, and it uses the same static
+fallback version from `devices/<slug>/packages.yaml`.
 
 If both USB and over-the-air upload targets are available, ESPHome prompts for a
 choice. In scripts or background runs, that prompt can stop the upload, so pass

--- a/devices/esp32-p4-86/packages.yaml
+++ b/devices/esp32-p4-86/packages.yaml
@@ -9,7 +9,7 @@
 substitutions:
   device_slug: "esp32-p4-86"
   firmware_manifest_slug: "esp32-p4-86"
-  firmware_version: "dev-esp32-p4-86-20260611-livecheck"
+  firmware_version: "dev"
   screen_width: "720"
   screen_height: "720"
   content_width: "570"

--- a/devices/guition-esp32-p4-jc1060p470/packages.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/packages.yaml
@@ -9,7 +9,7 @@
 substitutions:
   device_slug: "guition-esp32-p4-jc1060p470"
   firmware_manifest_slug: "guition-esp32-p4-jc1060p470"
-  firmware_version: "dev-jc1060p470-20260611-livecheck"
+  firmware_version: "dev"
   screen_width: "1024"
   screen_height: "600"
   content_width: "550"

--- a/devices/guition-esp32-p4-jc4880p443/packages.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/packages.yaml
@@ -9,7 +9,7 @@
 substitutions:
   device_slug: "guition-esp32-p4-jc4880p443"
   firmware_manifest_slug: "guition-esp32-p4-jc4880p443"
-  firmware_version: "dev-jc4880p443-20260611-livecheck"
+  firmware_version: "dev"
   screen_width: "480"
   screen_height: "800"
   content_width: "440"

--- a/devices/guition-esp32-p4-jc8012p4a1/packages.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/packages.yaml
@@ -9,7 +9,7 @@
 substitutions:
   device_slug: "guition-esp32-p4-jc8012p4a1"
   firmware_manifest_slug: "guition-esp32-p4-jc8012p4a1"
-  firmware_version: "dev-jc8012p4a1-20260611-livecheck"
+  firmware_version: "dev"
   screen_width: "1280"
   screen_height: "800"
   content_width: "760"

--- a/devices/guition-esp32-s3-4848s040/packages.yaml
+++ b/devices/guition-esp32-s3-4848s040/packages.yaml
@@ -9,7 +9,7 @@
 substitutions:
   device_slug: "guition-esp32-s3-4848s040"
   firmware_manifest_slug: "guition-esp32-s3-4848s040"
-  firmware_version: "dev-4848s040-20260611-livecheck"
+  firmware_version: "dev"
   screen_width: "480"
   screen_height: "480"
   content_width: "380"

--- a/devices/manifest.json
+++ b/devices/manifest.json
@@ -102,7 +102,7 @@
           "volumeWidthCompensationPercent": 95
         },
         "package": {
-          "firmwareVersion": "dev-jc1060p470-20260611-livecheck",
+          "firmwareVersion": "dev",
           "substitutions": {
             "screen_width": "\"1024\"",
             "screen_height": "\"600\"",
@@ -247,7 +247,7 @@
           "subpageChevronTextWidthPercent": 96
         },
         "package": {
-          "firmwareVersion": "dev-jc4880p443-20260611-livecheck",
+          "firmwareVersion": "dev",
           "substitutions": {
             "screen_width": "\"480\"",
             "screen_height": "\"800\"",
@@ -386,7 +386,7 @@
           "subpageChevronY": -2
         },
         "package": {
-          "firmwareVersion": "dev-jc8012p4a1-20260611-livecheck",
+          "firmwareVersion": "dev",
           "substitutions": {
             "screen_width": "\"1280\"",
             "screen_height": "\"800\"",
@@ -528,7 +528,7 @@
           "wrapTallLabels": false
         },
         "package": {
-          "firmwareVersion": "dev-esp32-p4-86-20260611-livecheck",
+          "firmwareVersion": "dev",
           "substitutions": {
             "screen_width": "\"720\"",
             "screen_height": "\"720\"",
@@ -687,7 +687,7 @@
           "subpageChevronTextWidthPercent": 96
         },
         "package": {
-          "firmwareVersion": "dev-4848s040-20260611-livecheck",
+          "firmwareVersion": "dev",
           "subpageConfigChunks": 4,
           "substitutions": {
             "screen_width": "\"480\"",

--- a/scripts/local_esphome.py
+++ b/scripts/local_esphome.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-"""Run local ESPHome commands with a dynamic EspControl firmware version."""
+"""Run local ESPHome commands with the EspControl dev firmware version."""
 
 from __future__ import annotations
 
 import os
-import re
 import shlex
 import subprocess
 import sys
@@ -20,39 +19,6 @@ class LocalEsphomeError(RuntimeError):
     pass
 
 
-def sanitize_version_part(value: str, fallback: str = "local") -> str:
-    sanitized = re.sub(r"[^A-Za-z0-9]+", "-", value.strip().lower())
-    sanitized = re.sub(r"-+", "-", sanitized).strip("-")
-    return sanitized or fallback
-
-
-def run_git(args: list[str]) -> str:
-    result = subprocess.run(
-        ["git", *args],
-        cwd=ROOT,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    return result.stdout.strip()
-
-
-def current_branch() -> str:
-    try:
-        branch = run_git(["symbolic-ref", "--quiet", "--short", "HEAD"])
-    except subprocess.CalledProcessError:
-        return "detached"
-    return branch
-
-
-def current_short_commit() -> str:
-    return run_git(["rev-parse", "--short", "HEAD"])
-
-
-def working_tree_dirty() -> bool:
-    return bool(run_git(["status", "--porcelain"]))
-
-
 def resolve_yaml_path(yaml_arg: str, cwd: Path | None = None) -> Path:
     base = cwd or Path.cwd()
     path = Path(yaml_arg)
@@ -64,42 +30,8 @@ def resolve_yaml_path(yaml_arg: str, cwd: Path | None = None) -> Path:
     return resolved
 
 
-def device_slug_from_yaml(yaml_path: Path) -> str:
-    parts = yaml_path.resolve().parts
-    try:
-        devices_index = parts.index("devices")
-    except ValueError as exc:
-        raise LocalEsphomeError(
-            f"Could not determine device slug from {yaml_path}; expected a path under devices/<slug>/"
-        ) from exc
-
-    if len(parts) <= devices_index + 1:
-        raise LocalEsphomeError(
-            f"Could not determine device slug from {yaml_path}; expected a path under devices/<slug>/"
-        )
-    return parts[devices_index + 1]
-
-
-def build_local_version(branch: str, device_slug: str, commit: str, dirty: bool) -> str:
-    version = "-".join(
-        [
-            sanitize_version_part(branch, fallback="detached"),
-            sanitize_version_part(device_slug, fallback="device"),
-            sanitize_version_part(commit, fallback="commit"),
-        ]
-    )
-    if dirty:
-        version += "-dirty"
-    return version
-
-
-def local_version_for(yaml_path: Path) -> str:
-    return build_local_version(
-        current_branch(),
-        device_slug_from_yaml(yaml_path),
-        current_short_commit(),
-        working_tree_dirty(),
-    )
+def local_version_for(_yaml_path: Path) -> str:
+    return "dev"
 
 
 def build_esphome_command(
@@ -169,23 +101,16 @@ def run(argv: list[str]) -> int:
 
 
 class LocalEsphomeTests(unittest.TestCase):
-    def test_sanitizes_branch_names(self) -> None:
-        self.assertEqual(sanitize_version_part("Feature/Issue 581_local!"), "feature-issue-581-local")
-
-    def test_extracts_device_slug_from_dev_yaml(self) -> None:
+    def test_uses_dev_firmware_version(self) -> None:
         path = ROOT / "devices" / "esp32-p4-86" / "dev.yaml"
-        self.assertEqual(device_slug_from_yaml(path), "esp32-p4-86")
-
-    def test_adds_dirty_suffix(self) -> None:
-        version = build_local_version("fix/issue-581", "esp32-p4-86", "a1b566c", dirty=True)
-        self.assertEqual(version, "fix-issue-581-esp32-p4-86-a1b566c-dirty")
+        self.assertEqual(local_version_for(path), "dev")
 
     def test_builds_esphome_command_with_firmware_version_substitution(self) -> None:
         command = build_esphome_command(
             Path("/tmp/dev.yaml"),
             "run",
             ["--device", "192.168.1.10"],
-            "fix-issue-581-esp32-p4-86-a1b566c",
+            "dev",
             "esphome",
         )
         self.assertEqual(
@@ -194,7 +119,7 @@ class LocalEsphomeTests(unittest.TestCase):
                 "esphome",
                 "-s",
                 "firmware_version",
-                "fix-issue-581-esp32-p4-86-a1b566c",
+                "dev",
                 "run",
                 "/tmp/dev.yaml",
                 "--device",


### PR DESCRIPTION
## Purpose
Set local ESPHome firmware builds back to the simple `dev` version string instead of long device/date-specific dev versions.

## Practical impact
When building or installing with ESPHome, including the JC1060P470 path, the firmware version passed into ESPHome is now `dev`. The generated device package defaults also use `dev`, so direct `esphome run dev.yaml` behaves the same way.

## Checked
- `python3 scripts/local_esphome.py --self-test`
- `python3 scripts/build.py devices --check`
- `python3 scripts/generate_device_slots.py --check`
- `python3 scripts/local_esphome.py devices/guition-esp32-p4-jc1060p470/dev.yaml run --dry-run` confirmed `-s firmware_version dev`

## Device testing
Please test by installing the `guition-esp32-p4-jc1060p470` dev firmware from this branch and confirming Home Assistant / the device version endpoint reports `dev`.

Note: a full `python3 scripts/build.py` was attempted first, but this fresh worktree does not have `node_modules` installed, so it stopped at missing `esbuild`. The focused device-generation checks above passed.