### PR TITLE
Remove cover art dismissal cooldown

### DIFF
--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -599,11 +599,6 @@ script:
           condition:
             lambda: 'return id(cover_art_screensaver_active);'
           then:
-            - lambda: |-
-                float timeout = id(screensaver_timeout).state;
-                if (std::isnan(timeout) || timeout <= 0.0f) timeout = 300.0f;
-                id(cover_art_dismissed_until_ms) = millis() + (uint32_t)(timeout * 1000.0f);
-                ESP_LOGD("cover_art", "Cover art dismissed by touch for %.0fs", timeout);
             - globals.set:
                 id: screensaver_wake_touch_guard_skip_once
                 value: 'true'

--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -42,9 +42,6 @@ globals:
   - id: cover_art_last_good_url
     type: std::string
     initial_value: '""'
-  - id: cover_art_dismissed_until_ms
-    type: uint32_t
-    initial_value: '0'
   - id: cover_art_refresh_needed
     type: bool
     initial_value: 'false'
@@ -1328,33 +1325,6 @@ script:
       - if:
           condition:
             lambda: |-
-              uint32_t now = millis();
-              uint32_t until = id(cover_art_dismissed_until_ms);
-              if (until == 0 || (int32_t)(until - now) <= 0) {
-                id(cover_art_dismissed_until_ms) = 0;
-                return false;
-              }
-              ESP_LOGD("cover_art", "Cover art manually dismissed; waiting before showing again");
-              return true;
-          then:
-            - delay: 5s
-            - if:
-                condition:
-                  lambda: |-
-                    return id(media_player_sleep_prevention_enabled).state ||
-                           id(display_asleep) ||
-                           id(screen_schedule_asleep) ||
-                           id(screensaver_display_off_active) ||
-                           id(screensaver_dimmed_active) ||
-                           id(is_clock_showing);
-                then:
-                  - script.execute: cover_art_delay_timer
-                else:
-                  - script.execute: screensaver_idle_check
-            - script.stop: cover_art_delay_timer
-      - if:
-          condition:
-            lambda: |-
               bool voice_active = ${voice_interaction_active_condition};
               return id(cover_art_screensaver_enabled).state &&
                      id(cover_art_media_playing) &&
@@ -2048,9 +2018,6 @@ script:
       - globals.set:
           id: cover_art_media_playing
           value: 'false'
-      - globals.set:
-          id: cover_art_dismissed_until_ms
-          value: '0'
       - lambda: |-
           id(cover_art_media_position) = 0.0f;
           id(cover_art_position_anchor) = 0.0f;


### PR DESCRIPTION
## Purpose
Fixes #635 by removing the cover-art dismissal cooldown that reused the general screensaver timeout.

## Practical impact
When cover art is woken or touched, the firmware no longer hides cover art for 30 minutes. The normal cover art delay still applies, and the wake touch guard remains so the same wake tap does not accidentally press a dashboard button.

## Testing
- Ran `python3 scripts/check_firmware_ha_bindings.py`
- Ran `python3 scripts/check_firmware_parser.py`
- Ran `python3 scripts/check_firmware_display_tokens.py`
- Confirmed the old dismissal state/log strings are no longer present with `rg`

## Device testing notes
Flash this branch to a display with cover art enabled and media playing. Confirm cover art can return after the normal cover art delay and the log no longer repeats `Cover art manually dismissed; waiting before showing again` every 5 seconds.