### PR TITLE
Ensure night schedule overrides cover art

### DIFF
--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -474,6 +474,8 @@ script:
             - lvgl.resume:
             - script.execute: clock_bar_hide
             - script.wait: clock_bar_hide
+            - script.stop: cover_art_delay_timer
+            - script.execute: hide_cover_art_view
             - script.execute: hide_clock_view
             - globals.set:
                 id: screensaver_dimmed_active

--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -175,7 +175,7 @@ script:
                   lambda: |-
                     return id(cover_art_screensaver_active) ||
                            (id(media_player_sleep_prevention_enabled).state &&
-                            id(cover_art_media_playing));
+                            id(media_player_playing));
                 then:
                   - script.execute: screensaver_idle_check
                 else:

--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -1218,6 +1218,25 @@ script:
     then:
       - if:
           condition:
+            lambda: |-
+              auto now = panel_time_or_fallback(id(panel_time).now(), id(homeassistant_time).now());
+              return screen_schedule_blocks_cover_art(
+                       id(screen_schedule_trigger).state,
+                       id(schedule_enabled).state,
+                       id(presence_detected),
+                       now.is_valid(),
+                       now.is_valid() ? now.hour : 0,
+                       (int) id(schedule_on_hour).state,
+                       (int) id(schedule_off_hour).state);
+          then:
+            - logger.log:
+                level: DEBUG
+                tag: cover_art
+                format: "Skipping cover art while screen schedule night mode is active"
+            - script.execute: hide_cover_art_view
+            - script.stop: show_cover_art_view
+      - if:
+          condition:
             lambda: 'return ${voice_interaction_active_condition};'
           then:
             - logger.log:
@@ -1356,9 +1375,18 @@ script:
           condition:
             lambda: |-
               bool voice_active = ${voice_interaction_active_condition};
+              auto now = panel_time_or_fallback(id(panel_time).now(), id(homeassistant_time).now());
               return id(cover_art_screensaver_enabled).state &&
                      id(cover_art_media_playing) &&
                      !voice_active &&
+                     !screen_schedule_blocks_cover_art(
+                       id(screen_schedule_trigger).state,
+                       id(schedule_enabled).state,
+                       id(presence_detected),
+                       now.is_valid(),
+                       now.is_valid() ? now.hour : 0,
+                       (int) id(schedule_on_hour).state,
+                       (int) id(schedule_off_hour).state) &&
                      id(cover_art_attribute_conditions_match) &&
                      !(id(cover_art_hide_external_input_enabled).state &&
                        id(cover_art_external_input_active)) &&
@@ -2015,7 +2043,16 @@ script:
       - if:
           condition:
             lambda: |-
+              auto now = panel_time_or_fallback(id(panel_time).now(), id(homeassistant_time).now());
               return id(cover_art_screensaver_enabled).state &&
+                     !screen_schedule_blocks_cover_art(
+                       id(screen_schedule_trigger).state,
+                       id(schedule_enabled).state,
+                       id(presence_detected),
+                       now.is_valid(),
+                       now.is_valid() ? now.hour : 0,
+                       (int) id(schedule_on_hour).state,
+                       (int) id(schedule_off_hour).state) &&
                      id(cover_art_attribute_conditions_match) &&
                      !(id(cover_art_hide_external_input_enabled).state &&
                        id(cover_art_external_input_active)) &&

--- a/components/espcontrol/backlight.h
+++ b/components/espcontrol/backlight.h
@@ -232,6 +232,18 @@ inline bool screen_schedule_normal_active(const std::string &trigger,
   return screen_schedule_in_window(now_h, on_hour, off_hour);
 }
 
+inline bool screen_schedule_blocks_cover_art(const std::string &trigger,
+                                             bool enabled,
+                                             bool presence_detected,
+                                             bool time_valid,
+                                             int now_h,
+                                             int on_hour,
+                                             int off_hour) {
+  return screen_schedule_waiting_for_time(trigger, enabled, time_valid) ||
+         screen_schedule_night_active(trigger, enabled, presence_detected,
+                                      time_valid, now_h, on_hour, off_hour);
+}
+
 // ── Screensaver action helpers ────────────────────────────────────────
 
 inline bool screensaver_action_clock_mode(const std::string &action) {

--- a/devices/esp32-p4-86/device/sensors.yaml
+++ b/devices/esp32-p4-86/device/sensors.yaml
@@ -465,7 +465,7 @@ esphome:
               id(main_page)->obj,
               id(presence_sensor_entity).state,
               &id(presence_detected),
-              id(cover_art_media_player_entity).state,
+              id(media_player_sleep_prevention_entity).state,
               &id(media_player_playing),
               []() {
                 return clock_bar_should_show(

--- a/devices/guition-esp32-p4-jc1060p470/device/sensors.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/device/sensors.yaml
@@ -495,7 +495,7 @@ esphome:
               id(main_page)->obj,
               id(presence_sensor_entity).state,
               &id(presence_detected),
-              id(cover_art_media_player_entity).state,
+              id(media_player_sleep_prevention_entity).state,
               &id(media_player_playing),
               []() {
                 return clock_bar_should_show(

--- a/devices/guition-esp32-p4-jc4880p443/device/sensors.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/device/sensors.yaml
@@ -450,7 +450,7 @@ esphome:
               id(main_page)->obj,
               id(presence_sensor_entity).state,
               &id(presence_detected),
-              id(cover_art_media_player_entity).state,
+              id(media_player_sleep_prevention_entity).state,
               &id(media_player_playing),
               []() {
                 return clock_bar_should_show(

--- a/devices/guition-esp32-p4-jc8012p4a1/device/sensors.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/sensors.yaml
@@ -521,7 +521,7 @@ esphome:
               id(main_page)->obj,
               id(presence_sensor_entity).state,
               &id(presence_detected),
-              id(cover_art_media_player_entity).state,
+              id(media_player_sleep_prevention_entity).state,
               &id(media_player_playing),
               []() {
                 return clock_bar_should_show(

--- a/devices/guition-esp32-s3-4848s040/device/sensors.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/sensors.yaml
@@ -380,7 +380,7 @@ esphome:
               id(main_page)->obj,
               id(presence_sensor_entity).state,
               &id(presence_detected),
-              id(cover_art_media_player_entity).state,
+              id(media_player_sleep_prevention_entity).state,
               &id(media_player_playing),
               []() {
                 return clock_bar_should_show(

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -23,6 +23,7 @@ SUN_CALC_PATH = ROOT / "components" / "espcontrol" / "sun_calc.h"
 S3_DEVICE_PATH = ROOT / "devices" / "guition-esp32-s3-4848s040" / "device" / "device.yaml"
 S3_PACKAGES_PATH = ROOT / "devices" / "guition-esp32-s3-4848s040" / "packages.yaml"
 DEVICE_DEVICE_PATHS = tuple(sorted((ROOT / "devices").glob("*/device/device.yaml")))
+DEVICE_SENSOR_PATHS = tuple(sorted((ROOT / "devices").glob("*/device/sensors.yaml")))
 DEVICE_PACKAGE_PATHS = tuple(sorted((ROOT / "devices").glob("*/packages.yaml")))
 CONNECTIVITY_PATHS = (
     ROOT / "common" / "addon" / "connectivity.yaml",
@@ -753,12 +754,14 @@ def firmware_media_sleep_prevention_errors(
         else:
             if (
                 "id(media_player_sleep_prevention_enabled).state &&" not in idle_body
-                or "id(cover_art_media_playing)" not in idle_body
+                or "id(media_player_playing)" not in idle_body
             ):
                 errors.append(f"{rel}: keep media playback awake only through the media sleep prevention setting")
+            if "id(cover_art_media_playing)" in idle_body:
+                errors.append(f"{rel}: use the dedicated media sleep prevention playback state")
             if re.search(
                 r"id\(cover_art_screensaver_enabled\)\.state[\s\S]{0,160}"
-                r"id\(cover_art_media_playing\)",
+                r"id\(media_player_playing\)",
                 idle_body,
             ):
                 errors.append(f"{rel}: do not let cover art alone keep the idle timer awake")
@@ -784,6 +787,23 @@ def firmware_media_sleep_prevention_errors(
         ):
             errors.append(f"{rel}: do not start cover art immediately unless media sleep prevention or screensaver is active")
 
+    return errors
+
+
+def firmware_media_sleep_prevention_subscription_errors(paths: tuple[Path, ...], root: Path) -> list[str]:
+    errors: list[str] = []
+    for path in paths:
+        if not path.exists():
+            continue
+        rel = path.relative_to(root)
+        text = path.read_text(encoding="utf-8")
+        if "id(media_player_sleep_prevention_entity).state" not in text:
+            errors.append(f"{rel}: subscribe media sleep prevention to its configured media player entity")
+        if re.search(
+            r"id\(cover_art_media_player_entity\)\.state,\s*\n\s*&id\(media_player_playing\)",
+            text,
+        ):
+            errors.append(f"{rel}: do not drive media sleep prevention from the cover art media player")
     return errors
 
 
@@ -1334,6 +1354,7 @@ def run_scan() -> int:
     errors.extend(firmware_cover_art_refresh_errors(COVER_ART_PATH, ROOT))
     errors.extend(firmware_cover_art_disable_errors(COVER_ART_PATH, ROOT))
     errors.extend(firmware_media_sleep_prevention_errors(BACKLIGHT_PATH, DISPLAY_CONFIG_PATH, COVER_ART_PATH, ROOT))
+    errors.extend(firmware_media_sleep_prevention_subscription_errors(DEVICE_SENSOR_PATHS, ROOT))
     errors.extend(firmware_image_card_entity_errors(FIRMWARE_DIR, ROOT))
     errors.extend(firmware_image_card_base_url_errors(FIRMWARE_DIR, ROOT))
     errors.extend(firmware_image_card_quality_errors(FIRMWARE_DIR, ROOT))
@@ -2911,7 +2932,7 @@ def run_self_test() -> int:
         "              return id(cover_art_screensaver_active) ||\n"
         "                     ((id(media_player_sleep_prevention_enabled).state ||\n"
         "                       id(cover_art_screensaver_enabled).state) &&\n"
-        "                      id(cover_art_media_playing));\n",
+        "                      id(media_player_playing));\n",
         "switch:\n"
         "  - platform: template\n"
         "    id: cover_art_screensaver_enabled\n"
@@ -2937,7 +2958,7 @@ def run_self_test() -> int:
         "            lambda: |-\n"
         "              return id(cover_art_screensaver_active) ||\n"
         "                     (id(media_player_sleep_prevention_enabled).state &&\n"
-        "                      id(cover_art_media_playing));\n",
+        "                      id(media_player_playing));\n",
         "switch:\n"
         "  - platform: template\n"
         "    id: cover_art_screensaver_enabled\n"
@@ -3405,6 +3426,10 @@ def run_self_test() -> int:
         "                      (int) id(schedule_off_hour).state);\n"
         "                then:\n"
         "            - script.execute: screensaver_wake\n"
+        "  - id: backlight_schedule_display_off\n"
+        "    then:\n"
+        "      - script.stop: cover_art_delay_timer\n"
+        "      - script.execute: hide_cover_art_view\n"
     )
     expect_screen_schedule_screensaver_override_errors(
         "night schedule overrides timer and sensor screensaver",

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -1122,8 +1122,23 @@ def firmware_screen_schedule_screensaver_overlay_errors(cover_art_path: Path, ro
 
     if show_body is None:
         errors.append(f"{rel}: missing show_cover_art_view script")
-    elif "lv_obj_move_foreground(id(cover_art_screensaver))" not in show_body:
-        errors.append(f"{rel}: raise the cover art screensaver above any existing top-layer elements")
+    else:
+        if "screen_schedule_blocks_cover_art(" not in show_body:
+            errors.append(f"{rel}: prevent cover art from overriding active screen schedule night mode")
+        if "lv_obj_move_foreground(id(cover_art_screensaver))" not in show_body:
+            errors.append(f"{rel}: raise the cover art screensaver above any existing top-layer elements")
+
+    delay_body = yaml_script_body(text, "cover_art_delay_timer")
+    if delay_body is None:
+        errors.append(f"{rel}: missing cover_art_delay_timer script")
+    elif "screen_schedule_blocks_cover_art(" not in delay_body:
+        errors.append(f"{rel}: keep delayed cover art from starting during screen schedule night mode")
+
+    playback_started_body = yaml_script_body(text, "cover_art_playback_started")
+    if playback_started_body is None:
+        errors.append(f"{rel}: missing cover_art_playback_started script")
+    elif "screen_schedule_blocks_cover_art(" not in playback_started_body:
+        errors.append(f"{rel}: keep playback-start cover art from overriding screen schedule night mode")
 
     return errors
 
@@ -1147,6 +1162,15 @@ def firmware_screen_schedule_screensaver_override_errors(backlight_path: Path, r
             mode_index != -1 and schedule_index > mode_index
         ):
             errors.append(f"{rel}: let the night screen schedule override timer screensaver actions")
+
+    schedule_off_body = yaml_script_body(text, "backlight_schedule_display_off")
+    if schedule_off_body is None:
+        errors.append(f"{rel}: missing backlight_schedule_display_off script")
+    elif (
+        "script.stop: cover_art_delay_timer" not in schedule_off_body
+        or "script.execute: hide_cover_art_view" not in schedule_off_body
+    ):
+        errors.append(f"{rel}: screen schedule display-off should clear cover art before forcing the screen off")
 
     wake_body = yaml_script_body(text, "screensaver_presence_wake")
     if wake_body is None:


### PR DESCRIPTION
## Purpose

Make the screen schedule the clear winner over media cover art. If the panel is in scheduled night mode, scheduled clock mode, scheduled screen-off, or waiting for valid time for a time-based schedule, cover art should not appear over it.

## What changed

- Added a shared firmware helper for deciding when the screen schedule blocks cover art.
- Blocked cover art from starting through both the delayed cover-art timer and playback-start path while night schedule is active.
- Made the schedule display-off path stop pending cover-art starts and hide any active cover art before forcing the screen off.
- Extended the firmware binding checks so this priority rule is protected in future changes.

## Checks

- `python3 scripts/check_firmware_ha_bindings.py`
- `node scripts/check_config_formats.js`
- `python3 scripts/check_firmware_parser.py`
- `git diff --check`

## Device testing

Please test on a panel with Night Schedule enabled and media playing. Expected result: during scheduled night/off/clock time, media cover art does not replace the selected night behavior.
