### PR TITLE
Avoid redundant backlight refreshes

### DIFF
--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -58,6 +58,9 @@ globals:
   - id: screensaver_fade_start_level
     type: float
     initial_value: '1.0'
+  - id: backlight_force_next_write
+    type: bool
+    initial_value: 'false'
   - id: screensaver_clock_target_level
     type: float
     initial_value: '0.35'
@@ -648,6 +651,9 @@ script:
             - globals.set:
                 id: screen_schedule_asleep
                 value: 'false'
+            - globals.set:
+                id: backlight_force_next_write
+                value: 'true'
             - lvgl.resume:
             - lvgl.widget.hide: dim_screensaver_touch_guard
             - script.execute: hide_cover_art_view

--- a/common/addon/backlight_schedule.yaml
+++ b/common/addon/backlight_schedule.yaml
@@ -822,8 +822,17 @@ script:
               &is_day, id(brightness_day).state, id(brightness_night).state);
             id(last_is_daytime) = is_day;
           }
+          float target = pct / 100.0f;
+          if (target < 0.01f) target = 0.01f;
+          if (target > 1.0f) target = 1.0f;
+          float current = 0.0f;
+          id(display_backlight).current_values_as_brightness(&current);
+          if (id(display_backlight).current_values.is_on() &&
+              std::fabs(current - target) < 0.005f) {
+            return;
+          }
           auto call = id(display_backlight).turn_on();
-          call.set_brightness(pct / 100.0f);
+          call.set_brightness(target);
           call.set_transition_length(400);
           call.perform();
 

--- a/common/addon/backlight_schedule.yaml
+++ b/common/addon/backlight_schedule.yaml
@@ -530,6 +530,9 @@ script:
       - globals.set:
           id: manual_wake_ms
           value: '0'
+      - globals.set:
+          id: backlight_force_next_write
+          value: 'true'
       - lambda: 'global_preferences->sync();'
       - lvgl.resume:
       - script.execute: hide_clock_view
@@ -575,6 +578,9 @@ script:
       - globals.set:
           id: manual_wake_ms
           value: '0'
+      - globals.set:
+          id: backlight_force_next_write
+          value: 'true'
       - lvgl.resume:
       - script.execute: hide_clock_view
       - script.execute: hide_cover_art_view
@@ -827,7 +833,8 @@ script:
           if (target > 1.0f) target = 1.0f;
           float current = 0.0f;
           id(display_backlight).current_values_as_brightness(&current);
-          if (id(display_backlight).current_values.is_on() &&
+          if (!id(backlight_force_next_write) &&
+              id(display_backlight).current_values.is_on() &&
               std::fabs(current - target) < 0.005f) {
             return;
           }
@@ -835,6 +842,7 @@ script:
           call.set_brightness(target);
           call.set_transition_length(400);
           call.perform();
+          id(backlight_force_next_write) = false;
 
   # ---------------------------------------------------------------------------
   # Recalculate sunrise/sunset from timezone coordinates and current date


### PR DESCRIPTION
## Purpose

Fixes a likely cause of the brief random screen flashes reported on the Waveshare ESP32-P4-86-Panel-ETH-2RO in issue #648.

## What changed

The automatic backlight scheduler now checks the current physical backlight brightness before sending another light update. If the panel is already at the target brightness, it skips the update instead of re-applying the same 400 ms transition.

## Practical impact

Home Assistant time sync and timezone/backlight refreshes can still run as before, but they should no longer nudge the backlight hardware when the brightness value has not changed. This should reduce or remove the sub-second flash seen near the repeated timezone/backlight log lines.

## Testing

- `npm run check:config`
- `npm run check:firmware-parser`
- `git diff --check`
- `esphome -s firmware_version dev -s espcontrol_component_url file:///Users/jtenniswood/Git/espcontrol-fix-backlight-refresh-flash -s espcontrol_component_ref HEAD compile builds/esp32-p4-86.yaml`

## Device testing notes

Flash this branch to a Waveshare ESP32-P4-86-Panel-ETH-2RO and leave it running for at least 10-15 minutes. Watch for the previously reported short flashes around the repeated timezone/backlight log entries.

Related issue: #648
