### PR TITLE
Reduce 4.3-inch label font

### DIFF
--- a/devices/guition-esp32-p4-jc4880p443/device/fonts.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/device/fonts.yaml
@@ -30,7 +30,7 @@ font:
   # Main labels and setup body text
   - file: "gfonts://Roboto"
     id: font_text_body
-    size: 31
+    size: 29
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:


### PR DESCRIPTION
## Purpose
Reduce the main label/body font a little on the 4.3-inch Guition ESP32-P4 JC4880P443 screen.

## Practical impact
Labels on the 4.3-inch screen render slightly smaller, which should give them a bit more breathing room without changing icons, headings, sensor values, or cover-art text.

## Checks
- python3 scripts/check_device_profiles.py
- python3 scripts/check_device_matrix.py
- python3 scripts/check_firmware_parser.py

## Device testing
Affected display: Guition ESP32-P4 JC4880P443 4.3-inch screen. Flash this PR branch to that display and confirm button/setup labels look a little smaller and still readable.