### PR TITLE
Add broader media codec support for P4-86 voice playback

### DIFF
--- a/devices/esp32-p4-86/device/voice_assistant.yaml
+++ b/devices/esp32-p4-86/device/voice_assistant.yaml
@@ -106,7 +106,6 @@ media_player:
     id: voice_media_player
     name: Voice Media Player
     icon: mdi:speaker
-    codec_support_enabled: true
     buffer_size: 4000000
     task_stack_in_psram: true
     files:
@@ -126,7 +125,7 @@ media_player:
       sample_rate: 48000
     media_pipeline:
       speaker: voice_media_resampling_speaker
-      format: FLAC
+      format: NONE
       sample_rate: 48000
     on_announcement:
       - mixer_speaker.apply_ducking:


### PR DESCRIPTION
## Purpose
This expands the P4-86 voice media player so it can accept the full set of supported audio codecs for normal media playback, instead of being limited to FLAC.

That gives the device a bit more breathing room as a Home Assistant media endpoint: users should be able to send common formats such as MP3, WAV, and FLAC through the voice media player without needing everything to arrive as FLAC first.

## What changed
- Removed the deprecated `codec_support_enabled` option from the P4-86 speaker media player.
- Set the regular media pipeline to `format: NONE`, which lets ESPHome include all supported codecs for that pipeline.
- Left the announcement pipeline on `FLAC`, since the local voice chimes and TTS path are already using that intentionally.

## Practical impact
The P4-86 has enough flash headroom for the extra codec support, and this makes the voice media player more flexible for real-world media sources.

## Checks
- ESPHome factory config validation passed for `builds/esp32-p4-86.factory.yaml` using the local component override.
- Full ESPHome compile passed for the P4-86 factory build.
- Confirmed the previous `codec_support_enabled` deprecation warning no longer appears during config validation.

## Testing perfomed
On a Waveshare ESP32-P4-86:
1. Flashed this build.
2. Played normal FLAC voice/chime audio and confirmed voice assistant responses still work.
3. Played common media formats such as MP3 and WAV to the device from Home Assistant and confirmed playback works.