### PR TITLE
Fix button widget translated label compile

### DIFF
--- a/common/device/button_widget.yaml
+++ b/common/device/button_widget.yaml
@@ -50,7 +50,7 @@ button:
     - label:
         align: bottom_left
         id: button_${num}_text_label
-        text: !lambda 'return espcontrol_i18n("Configure");'
+        text: !lambda 'return std::string(espcontrol_i18n("Configure"));'
         long_mode: wrap
         width: 100%
     # Subpage marker (shown only for subpage cards by the shared grid code)


### PR DESCRIPTION
## Purpose
Fixes a compile failure in the shared button widget translation label. ESPHome generated code expects the label text to behave like a string, so the translated Configure label is now wrapped as a string before ESPHome uses it.

## Practical impact
The display firmware can compile again when the shared button widget is included.

## Checked
- Flashed 7-inch P4 at 192.168.6.102 using dev.yaml over OTA, then confirmed it responded to ping.
- Flashed 10-inch P4 at 192.168.6.103 using dev.yaml over OTA, then confirmed it responded to ping.
- Flashed 4-inch P4 / P4-86 at 192.168.10.52 using dev.yaml over OTA, then confirmed it responded to ping.
- Flashed 4.3-inch P4 at 192.168.6.101 using dev.yaml over OTA, then confirmed it responded to ping.
- Flashed 4-inch S3 at 192.168.10.226 using dev.yaml over OTA, then confirmed it responded to ping.

## Device testing notes
Please check the Configure button or related button widgets on the flashed displays, especially after changing language if available.