### PR TITLE
Fix display-off screensaver wake on 10 inch panel

### DIFF
--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -370,23 +370,34 @@ script:
     then:
       - if:
           condition:
-            lambda: 'return !id(display_takeover_suspended);'
+            lambda: 'return id(display_takeover_suspended);'
           then:
-            - script.execute: backlight_force_display_off
-            - delay: 100ms
+            - lambda: 'ESP_LOGD("backlight", "Skipping LVGL pause while image modal is active");'
+          else:
             - if:
                 condition:
                   lambda: |-
-                    return id(screen_rotation_select).current_option() == "90" ||
-                           id(screen_rotation_select).current_option() == "270";
+                    #ifdef ESPCONTROL_KEEP_LVGL_ACTIVE_ON_DISPLAY_OFF
+                    return false;
+                    #else
+                    return true;
+                    #endif
                 then:
-                  - lvgl.pause:
+                  - script.execute: backlight_force_display_off
+                  - delay: 100ms
+                  - if:
+                      condition:
+                        lambda: |-
+                          return id(screen_rotation_select).current_option() == "90" ||
+                                 id(screen_rotation_select).current_option() == "270";
+                      then:
+                        - lvgl.pause:
+                      else:
+                        - lvgl.pause:
+                            show_snow: true
+                  - script.execute: backlight_force_display_off
                 else:
-                  - lvgl.pause:
-                      show_snow: true
-            - script.execute: backlight_force_display_off
-          else:
-            - lambda: 'ESP_LOGD("backlight", "Skipping LVGL pause while image modal is active");'
+                  - lambda: 'ESP_LOGD("backlight", "Keeping LVGL active during display-off so touch can wake the screen");'
 
   - id: backlight_fade_current_ui_to_black
     mode: restart

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -95,6 +95,9 @@ esphome:
       - "-DESPCONTROL_JC8012P4A1_IMAGE_CARD_BOOTFIX_20260611=1"
       # Rebuild marker for bad restore crash recovery.
       - "-DESPCONTROL_JC8012P4A1_RESTORE_CRASH_RECOVERY_20260611=1"
+      # Keep LVGL active while the backlight is off so the GSL3680 touch
+      # controller can still deliver the wake tap from display-off screensaver.
+      - "-DESPCONTROL_KEEP_LVGL_ACTIVE_ON_DISPLAY_OFF=1"
     build_src_flags:
       - "-Wno-literal-suffix"
   on_boot:


### PR DESCRIPTION
## Purpose

Addresses issue #681, where the 10.1-inch JC8012P4A1 panel can enter the screensaver "Display Off" state but does not wake from a touch.

## Practical impact

The 10.1-inch panel still turns the backlight fully off for the display-off screensaver, but it keeps LVGL active on that specific GSL3680 touch panel so the first touch can reach the existing wake script. Other panels keep the existing LVGL pause behavior.

## Checks

- `python3 scripts/check_firmware_ha_bindings.py`
- `python3 scripts/check_firmware_parser.py`
- `npm run check:firmware-display-tokens`
- `npm run check:firmware-modals`
- `npm run check:fast`
- `esphome -s firmware_version dev -s espcontrol_component_url file:///Users/jtenniswood/Git/espcontrol-fix-display-off-wake compile devices/guition-esp32-p4-jc8012p4a1/dev.yaml`

## Device testing notes

Flash/test this branch on the 10.1-inch JC8012P4A1. Set the screensaver action to "Display Off", let the screensaver turn the screen off, then tap the display. Expected result: the screen wakes without needing to turn the backlight back on from Home Assistant.