### PR TITLE
Fix cover art replacement flicker

### DIFF
--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -720,34 +720,6 @@ script:
             - lvgl.widget.hide: cover_art_progress_bar
       - script.execute: cover_art_refresh_progress
 
-  - id: cover_art_show_artwork_transition
-    mode: restart
-    then:
-      - script.execute: cover_art_apply_responsive_layout
-      - globals.set:
-          id: cover_art_image_available
-          value: 'false'
-      - lambda: |-
-          lv_color_t black = lv_color_make(0, 0, 0);
-          lv_obj_set_style_bg_color(id(cover_art_backdrop), black, 0);
-          lv_obj_set_style_bg_color(id(cover_art_accent_overlay), black, 0);
-      - script.execute: cover_art_sync_track_text
-      - lambda: |-
-          lv_obj_set_style_text_line_space(id(cover_art_title_label), ${cover_art_title_line_space}, 0);
-      - lvgl.widget.hide: cover_art_image_widget
-      - if:
-          condition:
-            lambda: 'return id(cover_art_screensaver_active) && id(cover_art_media_playing);'
-          then:
-            - lvgl.widget.show: cover_art_accent_overlay
-            - lvgl.widget.show: cover_art_track_panel
-            - lvgl.widget.show: cover_art_progress_bar
-          else:
-            - lvgl.widget.hide: cover_art_accent_overlay
-            - lvgl.widget.hide: cover_art_track_panel
-            - lvgl.widget.hide: cover_art_progress_bar
-      - script.execute: cover_art_refresh_progress
-
   - id: cover_art_download_failed
     mode: restart
     then:
@@ -890,12 +862,9 @@ script:
                            id(cover_art_refresh_needed) &&
                            !${cover_art_live_image_updates};
                 then:
-                  - script.execute: cover_art_show_artwork_transition
-                  - script.execute: cover_art_clear_image_source
-                  - script.wait: cover_art_clear_image_source
-                  - artwork_image.release: cover_art_downloaded_image
+                  - script.execute: cover_art_show_track_overlay
                   - lambda: |-
-                      ESP_LOGI("cover_art", "Hid current artwork before replacement download");
+                      ESP_LOGI("cover_art", "Keeping current artwork visible during replacement download");
             - lambda: |-
                 if (!id(cover_art_active_download_source_url).empty() &&
                     !id(cover_art_download_url).empty()) {

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -679,10 +679,14 @@ def firmware_cover_art_refresh_errors(path: Path, root: Path) -> list[str]:
             errors.append(f"{rel}: keep a dedicated replacement artwork transition path")
         else:
             replacement_body = replacement_match.group("body")
-            if "script.execute: cover_art_show_artwork_transition" not in replacement_body:
-                errors.append(f"{rel}: hide stale artwork without blanking the track overlay during replacement downloads")
+            if "script.execute: cover_art_show_track_overlay" not in replacement_body:
+                errors.append(f"{rel}: keep the current artwork visible with updated track text during replacement downloads")
             if "script.execute: cover_art_show_black_screen" in replacement_body:
                 errors.append(f"{rel}: do not use the full black fallback for replacement artwork downloads")
+            if "script.execute: cover_art_clear_image_source" in replacement_body:
+                errors.append(f"{rel}: do not detach visible artwork before replacement artwork is ready")
+            if "artwork_image.release: cover_art_downloaded_image" in replacement_body:
+                errors.append(f"{rel}: do not release visible artwork before replacement artwork is ready")
             if "id(cover_art_loaded_url).clear()" in replacement_body:
                 errors.append(f"{rel}: keep the previous loaded artwork marker until replacement artwork applies")
 
@@ -2873,7 +2877,7 @@ def run_self_test() -> int:
         "                     id(cover_art_refresh_needed) &&\n"
         "                     !${cover_art_live_image_updates};\n"
         "          then:\n"
-        "            - script.execute: cover_art_show_artwork_transition\n"
+        "            - script.execute: cover_art_show_track_overlay\n"
         "      - lambda: |-\n"
         "          if (url.find(\"/api/media_player_proxy/\") != std::string::npos) {\n"
         "            url += url.find('?') == std::string::npos ? \"?time=\" : \"&time=\";\n"


### PR DESCRIPTION
## Purpose
Fix media cover art updates so changing tracks does not deliberately blank the artwork area while the next image is downloading.

## What changed
- Keeps the currently displayed cover art visible during replacement downloads.
- Updates the track overlay text while the replacement artwork loads.
- Removes the unused black-transition script that caused the visible flash/blank period.
- Strengthens the firmware binding check so replacement artwork downloads do not detach or release visible artwork before the new image is ready.

## Root cause
For displays with live image updates disabled, the firmware hid the current image and released its artwork buffer before starting the replacement download. If the Home Assistant artwork download took a few seconds, the screen went black until the new image decoded and applied.

## Checks
- `python3 scripts/check_firmware_ha_bindings.py`
- `git diff --check`
- `npm run check:firmware-ha-bindings`
- `npm run check:product`

## Device testing notes
Flash this branch to a display with cover art enabled, then change tracks several times. The previous cover should remain visible while the next image loads, and the artwork should swap once the new image is ready instead of flashing to black.