### PR TITLE
Fix cooling climate drag direction

### DIFF
--- a/components/espcontrol/button_grid_climate.h
+++ b/components/espcontrol/button_grid_climate.h
@@ -679,6 +679,13 @@ inline int climate_modal_arc_value(ClimateControlCtx *ctx, bool temp_enabled, in
   return value;
 }
 
+inline int climate_target_from_modal_arc_value(ClimateControlCtx *ctx, int value) {
+  if (!ctx) return CLIMATE_DEFAULT_TARGET_TENTHS;
+  value = climate_clamp_tenths(ctx, value);
+  if (climate_uses_cooling_arc(ctx)) return ctx->min_tenths + ctx->max_tenths - value;
+  return value;
+}
+
 inline uint32_t climate_active_color(ClimateControlCtx *ctx) {
   if (!ctx) return DEFAULT_SLIDER_COLOR;
   if (ctx->hvac_action == "heating") return CLIMATE_HEATING_COLOR;
@@ -1692,13 +1699,16 @@ inline void climate_control_open_modal(ClimateControlCtx *ctx) {
     if (ui.updating_arc || !ui.active) return;
     ui.dragging_arc = true;
     lv_obj_t *arc = static_cast<lv_obj_t *>(lv_event_get_target(e));
-    climate_preview_selected_target(ui.active, lv_arc_get_value(arc));
+    climate_preview_selected_target(ui.active,
+      climate_target_from_modal_arc_value(ui.active, lv_arc_get_value(arc)));
   }, LV_EVENT_VALUE_CHANGED, nullptr);
   lv_obj_add_event_cb(ui.arc, [](lv_event_t *e) {
     ClimateControlModalUi &ui = climate_control_modal_ui();
     if (ui.updating_arc || !ui.active) return;
     lv_obj_t *arc = static_cast<lv_obj_t *>(lv_event_get_target(e));
-    int value = ui.has_drag_preview ? ui.drag_preview_tenths : lv_arc_get_value(arc);
+    int value = ui.has_drag_preview
+      ? ui.drag_preview_tenths
+      : climate_target_from_modal_arc_value(ui.active, lv_arc_get_value(arc));
     ui.dragging_arc = false;
     ui.has_drag_preview = false;
     climate_apply_selected_target(ui.active, value, true, false);

--- a/scripts/check_firmware_modals.py
+++ b/scripts/check_firmware_modals.py
@@ -444,7 +444,8 @@ def firmware_climate_step_errors(root: Path) -> list[str]:
         "int step = climate_effective_step_tenths(ctx);",
         "int base = ctx->precision <= 0 ? 0 : ctx->min_tenths;",
         "climate_round_to_step(ctx, climate_constrain_selected_target(ctx, value))",
-        "climate_preview_selected_target(ui.active, lv_arc_get_value(arc));",
+        "climate_preview_selected_target(ui.active,",
+        "climate_target_from_modal_arc_value(ui.active, lv_arc_get_value(arc))",
         "climate_apply_selected_target(ui.active, value, true, false);",
         "climate_selected_target(ui.active) - climate_effective_step_tenths(ui.active)",
         "climate_selected_target(ui.active) + climate_effective_step_tenths(ui.active)",
@@ -462,6 +463,16 @@ def firmware_climate_step_errors(root: Path) -> list[str]:
     for needle in forbidden:
         if needle in text:
             errors.append(f"{rel}: do not allow 0.1C climate modal temperature steps")
+            break
+
+    cooling_drag_required = (
+        "inline int climate_target_from_modal_arc_value(ClimateControlCtx *ctx, int value)",
+        "if (climate_uses_cooling_arc(ctx)) return ctx->min_tenths + ctx->max_tenths - value;",
+        "climate_target_from_modal_arc_value(ui.active, lv_arc_get_value(arc))",
+    )
+    for needle in cooling_drag_required:
+        if needle not in text:
+            errors.append(f"{rel}: keep cooling-mode climate arc drags aligned with the touch direction")
             break
 
     return errors
@@ -796,8 +807,13 @@ def run_self_test() -> int:
             "      ? CLIMATE_DEFAULT_STEP_TENTHS\n"
             "      : CLIMATE_WHOLE_NUMBER_STEP_TENTHS;\n"
             "}\n"
+            "inline int climate_target_from_modal_arc_value(ClimateControlCtx *ctx, int value) {\n"
+            "  if (climate_uses_cooling_arc(ctx)) return ctx->min_tenths + ctx->max_tenths - value;\n"
+            "  return value;\n"
+            "}\n"
             "inline void climate_control_open_modal(ClimateControlCtx *ctx) {\n"
-            "  climate_preview_selected_target(ui.active, lv_arc_get_value(arc));\n"
+            "  climate_preview_selected_target(ui.active,\n"
+            "    climate_target_from_modal_arc_value(ui.active, lv_arc_get_value(arc)));\n"
             "  climate_apply_selected_target(ui.active, value, true, false);\n"
             "  climate_selected_target(ui.active) - climate_effective_step_tenths(ui.active);\n"
             "  climate_selected_target(ui.active) + climate_effective_step_tenths(ui.active);\n"


### PR DESCRIPTION
## Purpose
Fix the climate control dial when the HVAC mode is set to cooling. Previously the visible cooling arc was reversed, but drag events still used the raw arc value, so the handle preview moved opposite to the user's drag direction.

## Practical impact
When a user drags the climate dial in cooling mode, the target indicator should now follow their finger in the expected direction. Heating and other modes continue to use the normal arc value.

## Checks
- python3 scripts/check_firmware_modals.py
- python3 scripts/check_firmware_modals.py --self-test
- python3 scripts/check_firmware_ha_bindings.py
- git diff --check

## Device testing
Flash a display with this branch, open a climate card, set the HVAC mode to Cool, and drag the temperature dial in both directions. The handle/temperature preview should move with the drag rather than against it.