### PR TITLE
Fix display-off screensaver wake tap

### DIFF
--- a/components/gsl3680/gsl3680.cpp
+++ b/components/gsl3680/gsl3680.cpp
@@ -11,10 +11,12 @@ namespace gsl3680 {
 void GSL3680::setup() {
 
     ESP_LOGD(TAG, "Setup start");
-    // The panel can be mounted with swapped axes. Use the display's native
-    // dimensions so raw touch coordinates match the active orientation.
-    this->x_raw_max_ = this->swap_x_y_? this->get_display()->get_native_height(): this->get_display()->get_native_width() ;
-    this->y_raw_max_ = this->swap_x_y_? this->get_display()->get_native_width() : this->get_display()->get_native_height();
+    constexpr int16_t TOUCH_RAW_WIDTH = 1280;
+    constexpr int16_t TOUCH_RAW_HEIGHT = 800;
+    // The bundled GSL3680 config reports a 1280x800 touch range even though
+    // the MIPI display is configured as a portrait-native 800x1280 panel.
+    this->x_raw_max_ = this->swap_x_y_ ? TOUCH_RAW_HEIGHT : TOUCH_RAW_WIDTH;
+    this->y_raw_max_ = this->swap_x_y_ ? TOUCH_RAW_WIDTH : TOUCH_RAW_HEIGHT;
 
     this->reset_pin_->pin_mode(esphome::gpio::FLAG_OUTPUT);
     this->reset_pin_->setup();

--- a/components/gsl3680/gsl3680.cpp
+++ b/components/gsl3680/gsl3680.cpp
@@ -224,10 +224,15 @@ void GSL3680::update_touches() {
 
     ESP_LOGV(TAG, "update_touches: touch [%d] %dx%d (%d)", cinfo.finger_num, cinfo.x[0], cinfo.y[0], mask);
 
-    if (cinfo.finger_num >= 1) {
+    const bool first_touch_in_bounds =
+        cinfo.x[0] >= this->x_raw_min_ && cinfo.x[0] <= this->x_raw_max_ &&
+        cinfo.y[0] >= this->y_raw_min_ && cinfo.y[0] <= this->y_raw_max_;
+    if (cinfo.finger_num >= 1 && first_touch_in_bounds) {
         // Report the first contact even when the controller sees a noisy or
         // multi-touch wake tap; the screensaver wake path only needs one touch.
         this->add_raw_touch_position_(0, cinfo.x[0], cinfo.y[0]);
+    } else if (cinfo.finger_num >= 1) {
+        ESP_LOGW(TAG, "Ignoring out-of-bounds GSL3680 touch %dx%d", cinfo.x[0], cinfo.y[0]);
     }
 }
 

--- a/components/gsl3680/gsl3680.cpp
+++ b/components/gsl3680/gsl3680.cpp
@@ -224,15 +224,23 @@ void GSL3680::update_touches() {
 
     ESP_LOGV(TAG, "update_touches: touch [%d] %dx%d (%d)", cinfo.finger_num, cinfo.x[0], cinfo.y[0], mask);
 
-    const bool first_touch_in_bounds =
-        cinfo.x[0] >= this->x_raw_min_ && cinfo.x[0] <= this->x_raw_max_ &&
-        cinfo.y[0] >= this->y_raw_min_ && cinfo.y[0] <= this->y_raw_max_;
-    if (cinfo.finger_num >= 1 && first_touch_in_bounds) {
-        // Report the first contact even when the controller sees a noisy or
-        // multi-touch wake tap; the screensaver wake path only needs one touch.
-        this->add_raw_touch_position_(0, cinfo.x[0], cinfo.y[0]);
+    int selected_touch = -1;
+    for (int i = 0; i < cinfo.finger_num && i < 2; i++) {
+        const bool touch_in_bounds =
+            cinfo.x[i] >= this->x_raw_min_ && cinfo.x[i] <= this->x_raw_max_ &&
+            cinfo.y[i] >= this->y_raw_min_ && cinfo.y[i] <= this->y_raw_max_;
+        if (touch_in_bounds) {
+            selected_touch = i;
+            break;
+        }
+    }
+    if (selected_touch >= 0) {
+        // Report the first valid contact even when the controller sees a noisy
+        // or multi-touch wake tap; the screensaver wake path only needs one touch.
+        this->add_raw_touch_position_(0, cinfo.x[selected_touch], cinfo.y[selected_touch]);
     } else if (cinfo.finger_num >= 1) {
-        ESP_LOGW(TAG, "Ignoring out-of-bounds GSL3680 touch %dx%d", cinfo.x[0], cinfo.y[0]);
+        ESP_LOGW(TAG, "Ignoring out-of-bounds GSL3680 touches %dx%d and %dx%d",
+                 cinfo.x[0], cinfo.y[0], cinfo.x[1], cinfo.y[1]);
     }
 }
 


### PR DESCRIPTION
## Purpose

Address issue #681, where the 10.1-inch JC8012P4A1 can go dark when the screensaver action is set to Display Off and then fail to wake from the screen itself.

## Practical impact

The GSL3680 touch driver now forwards the first valid contact whenever the controller reports one or more touches, so noisy or multi-contact wake taps can still wake the display.

This review pass also adds a raw-coordinate bounds check before forwarding the touch. That keeps impossible noisy coordinates from being treated as a real button press.

A 10.1-inch rebuild marker is included so ESPHome rebuilds the affected touch-driver object instead of reusing stale cached output.

## Checked

- python3 scripts/check_firmware_ha_bindings.py
- python3 scripts/check_firmware_parser.py
- git diff --check
- esphome -s espcontrol_component_url file:///Users/jtenniswood/Git/espcontrol/.worktrees/review-pr-718 compile builds/guition-esp32-p4-jc8012p4a1.yaml

## Device testing

Affected display: 10.1-inch JC8012P4A1.

To test, install this PR firmware on the 10.1-inch display, set Screensaver to Display Off, wait for it to turn the screen off, then tap the screen. The display should wake without needing Home Assistant to turn the backlight back on.

Note: PR #718 appears to be pinned to an old hidden PR ref after its branch disappeared, so this PR uses the restored branch with the review fix included.