### PR TITLE
Subscribe to the entity current_position / percentage / brightness before subscribing to the entity state

### DIFF
--- a/components/espcontrol/button_grid_sliders.h
+++ b/components/espcontrol/button_grid_sliders.h
@@ -2402,28 +2402,6 @@ inline void subscribe_slider_state(lv_obj_t *btn_ptr, lv_obj_t *icon_lbl,
   bool is_cover = is_cover_entity(entity_id);
   bool is_fan = is_fan_entity(entity_id);
   bool is_light = slider_entity_is_light(entity_id);
-  ESP_LOGI("slider", "Subscribing slider state for %s", entity_id.c_str());
-  ha_subscribe_state(
-    entity_id,
-    std::function<void(esphome::StringRef)>(
-      [slider, btn_ptr, fill, horiz, inv, rad, icon_lbl, has_icon_on, icon_off, icon_on, sctx](esphome::StringRef state) {
-        if (sctx && !sctx->logged_state) {
-          sctx->logged_state = true;
-          ESP_LOGI("slider", "First slider state for %s: %s",
-            sctx->entity_id.c_str(), string_ref_limited(state, HA_SHORT_STATE_MAX_LEN).c_str());
-        }
-        bool unavailable = ha_state_unavailable_ref(state);
-        if (sctx) sctx->available = !unavailable;
-        apply_control_availability(btn_ptr, slider, !unavailable);
-        bool on = is_entity_on_ref(state);
-        if (!on) {
-          slider_set_value_safe(slider, 0);
-          slider_update_fill(fill, btn_ptr, inv ? 100 : 0, horiz, inv, rad);
-        }
-        if (has_icon_on)
-          slider_set_icon_safe(icon_lbl, on ? icon_on : icon_off);
-      })
-  );
   if (is_cover) {
     ha_subscribe_attribute(
       entity_id, std::string(cover_tilt ? "current_tilt_position" : "current_position"),
@@ -2474,6 +2452,28 @@ inline void subscribe_slider_state(lv_obj_t *btn_ptr, lv_obj_t *icon_lbl,
     ESP_LOGW("slider", "No brightness attribute subscription for non-light slider entity %s",
       entity_id.c_str());
   }
+  ESP_LOGI("slider", "Subscribing slider state for %s", entity_id.c_str());
+  ha_subscribe_state(
+    entity_id,
+    std::function<void(esphome::StringRef)>(
+      [slider, btn_ptr, fill, horiz, inv, rad, icon_lbl, has_icon_on, icon_off, icon_on, sctx](esphome::StringRef state) {
+        if (sctx && !sctx->logged_state) {
+          sctx->logged_state = true;
+          ESP_LOGI("slider", "First slider state for %s: %s",
+            sctx->entity_id.c_str(), string_ref_limited(state, HA_SHORT_STATE_MAX_LEN).c_str());
+        }
+        bool unavailable = ha_state_unavailable_ref(state);
+        if (sctx) sctx->available = !unavailable;
+        apply_control_availability(btn_ptr, slider, !unavailable);
+        bool on = is_entity_on_ref(state);
+        if (!on) {
+          slider_set_value_safe(slider, 0);
+          slider_update_fill(fill, btn_ptr, inv ? 100 : 0, horiz, inv, rad);
+        }
+        if (has_icon_on)
+          slider_set_icon_safe(icon_lbl, on ? icon_on : icon_off);
+      })
+  );
 }
 
 // ── Light temperature card helpers ───────────────────────────────────


### PR DESCRIPTION
## Summary

- This PR fixes the problem where the slider value is rendered on booting, even if the entity is off.
- In my setup, I have a slider representing a fan entity. When espcontrol boots up, the slider is rendered with the fan speed even if the fan is currently turned off.

## Testing

- [x] I checked the change locally where practical.
- [x] User testing is still needed before merge.
- [ ] Affected display/device, if applicable: I have only tested this on an ESP32-P4 86 panel, though the issue should be present across all devices.

## Notes for testing

- Create a slider and bind it to a fan entity
- Turn off the fan
- Reboot the ESP32 panel - the slider should render with a value of 0 because the fan is turned off

## Issue handling

- [ ] Do not close related issues until the user confirms the fix works.
