### PR TITLE
Refresh cover art after Home Assistant proxy 404

### DIFF
--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -767,6 +767,19 @@ script:
                   - if:
                       condition:
                         lambda: |-
+                          return id(cover_art_downloaded_image)->last_error_was_ha_media_proxy_not_found() &&
+                                 id(cover_art_retry_count) < 5 &&
+                                 !id(cover_art_media_player_entity).state.empty();
+                      then:
+                        - lambda: |-
+                            ESP_LOGW("cover_art", "Home Assistant artwork proxy returned 404; requesting fresh artwork attributes");
+                            id(cover_art_cached_remote_url).clear();
+                            id(cover_art_cached_local_url).clear();
+                            id(cover_art_refresh_needed) = true;
+                        - script.execute: cover_art_resubscribe
+                  - if:
+                      condition:
+                        lambda: |-
                           return !id(cover_art_image_available) &&
                                  id(cover_art_loaded_url).empty();
                       then:

--- a/components/artwork_image/artwork_image.cpp
+++ b/components/artwork_image/artwork_image.cpp
@@ -281,6 +281,8 @@ void ArtworkImage::update() {
     this->queue_pending_update_(this->url_);
     return;
   }
+  this->last_http_status_ = 0;
+  this->last_error_was_ha_media_proxy_ = false;
   ESP_LOGI(TAG, "Updating image %s", sanitize_artwork_url_for_log(this->url_).c_str());
   ESP_LOGD(TAG, "Artwork URL source: %s", classify_artwork_url_for_log(this->url_));
   this->log_state_("request-start");
@@ -322,6 +324,7 @@ void ArtworkImage::update() {
   }
 
   if (this->downloader_ == nullptr) {
+    this->last_error_was_ha_media_proxy_ = is_ha_media_proxy_url(this->url_);
     ESP_LOGE(TAG, "Download failed before response; source=%s url=%s",
              classify_artwork_url_for_log(this->url_), sanitize_artwork_url_for_log(this->url_).c_str());
     this->fail_download_();
@@ -343,6 +346,8 @@ void ArtworkImage::update() {
     return;
   }
   if (http_code != HTTP_CODE_OK) {
+    this->last_http_status_ = http_code;
+    this->last_error_was_ha_media_proxy_ = is_ha_media_proxy_url(this->url_);
     ESP_LOGE(TAG, "Artwork HTTP result: status=%d content_length=%zu content_type=%s source=%s url=%s",
              http_code, this->downloader_->content_length,
              response_header_for_log(this->downloader_.get(), CONTENT_TYPE_HEADER_NAME).c_str(),

--- a/components/artwork_image/artwork_image.h
+++ b/components/artwork_image/artwork_image.h
@@ -76,6 +76,10 @@ class ArtworkImage : public PollingComponent,
   /** Stop any in-flight download/decode while keeping the last completed image buffer available. */
   void cancel_update();
   const std::string &get_url() const { return this->url_; }
+  int get_last_http_status() const { return this->last_http_status_; }
+  bool last_error_was_ha_media_proxy_not_found() const {
+    return this->last_http_status_ == HTTP_CODE_NOT_FOUND && this->last_error_was_ha_media_proxy_;
+  }
 
   void set_target_size(int width, int height) {
     if (width <= 0 || height <= 0) return;
@@ -219,6 +223,8 @@ class ArtworkImage : public PollingComponent,
   image::Image *placeholder_{nullptr};
 
   std::string url_{""};
+  int last_http_status_{0};
+  bool last_error_was_ha_media_proxy_{false};
 
   std::vector<std::pair<std::string, TemplatableValue<std::string> > > request_headers_;
 


### PR DESCRIPTION
## Purpose
Fix intermittent media cover art failures when Home Assistant returns `404` for a stale `/api/media_player_proxy/` artwork URL.

## Practical impact
When the display sees a Home Assistant media proxy 404, it now clears the cached artwork URLs and asks Home Assistant for fresh `entity_picture` / `entity_picture_local` attributes before continuing the retry loop. This should avoid repeatedly retrying the same expired artwork URL.

## Testing
- Compiled the 10-inch P4 dev firmware, matching the panel where the live logs showed the 404 retries:
  `esphome -s firmware_version dev -s espcontrol_component_url file:///Users/jtenniswood/Git/espcontrol-fix-cover-art-proxy-404 compile /Users/jtenniswood/Git/espcontrol-fix-cover-art-proxy-404/devices/guition-esp32-p4-jc8012p4a1/dev.yaml`

## Device testing notes
Flash/test this branch on the display using media cover art, especially `espcontrol-10inch-p4`, and watch for the new log line: `Home Assistant artwork proxy returned 404; requesting fresh artwork attributes` if Home Assistant serves an expired proxy URL.