### PR TITLE
Use primary colour for climate cooling

### DIFF
--- a/components/espcontrol/button_grid_climate.h
+++ b/components/espcontrol/button_grid_climate.h
@@ -5,7 +5,6 @@
 // ── Climate control card helpers ─────────────────────────────────────
 
 constexpr uint32_t CLIMATE_HEATING_COLOR = 0xA44A1C;
-constexpr uint32_t CLIMATE_COOLING_COLOR = 0x1565C0;
 constexpr int CLIMATE_DEFAULT_TARGET_TENTHS = 200;
 constexpr int CLIMATE_DEFAULT_LOW_TENTHS = 180;
 constexpr int CLIMATE_DEFAULT_HIGH_TENTHS = 220;
@@ -668,7 +667,6 @@ inline bool climate_has_active_arc_mode(ClimateControlCtx *ctx) {
 
 inline uint32_t climate_modal_arc_color(ClimateControlCtx *ctx) {
   if (!climate_has_active_arc_mode(ctx)) return DARK_BACKGROUND_SECONDARY;
-  if (climate_uses_cooling_arc(ctx)) return CLIMATE_COOLING_COLOR;
   return ctx ? ctx->accent_color : DEFAULT_SLIDER_COLOR;
 }
 
@@ -689,7 +687,6 @@ inline int climate_target_from_modal_arc_value(ClimateControlCtx *ctx, int value
 inline uint32_t climate_active_color(ClimateControlCtx *ctx) {
   if (!ctx) return DEFAULT_SLIDER_COLOR;
   if (ctx->hvac_action == "heating") return CLIMATE_HEATING_COLOR;
-  if (ctx->hvac_action == "cooling") return CLIMATE_COOLING_COLOR;
   return ctx->accent_color;
 }
 


### PR DESCRIPTION
## Purpose
Use the user-selected primary colour for climate cooling mode instead of the fixed blue cooling colour.

## Practical impact
When a climate card or climate control popup is in cooling mode, it now follows the panel's configured primary colour. Heating keeps its existing warm highlight colour.

## Checked
- python3 scripts/check_firmware_ha_bindings.py
- python3 scripts/check_firmware_parser.py

## Testing notes
Flash a device with this branch and set a climate entity to cooling. Confirm the climate card active colour and the climate popup dial use your configured primary colour.