### PR TITLE
Fix 10-inch touch scaling

### DIFF
--- a/components/gsl3680/gsl3680.cpp
+++ b/components/gsl3680/gsl3680.cpp
@@ -11,12 +11,12 @@ namespace gsl3680 {
 void GSL3680::setup() {
 
     ESP_LOGD(TAG, "Setup start");
-    constexpr int16_t TOUCH_RAW_WIDTH = 1280;
-    constexpr int16_t TOUCH_RAW_HEIGHT = 800;
-    // The bundled GSL3680 config reports a 1280x800 touch range even though
-    // the MIPI display is configured as a portrait-native 800x1280 panel.
-    this->x_raw_max_ = this->swap_x_y_ ? TOUCH_RAW_HEIGHT : TOUCH_RAW_WIDTH;
-    this->y_raw_max_ = this->swap_x_y_ ? TOUCH_RAW_WIDTH : TOUCH_RAW_HEIGHT;
+    // LVGL applies the final screen rotation after the touchscreen reports a
+    // display-space point, so calibrate against the native display dimensions.
+    this->x_raw_max_ =
+        this->swap_x_y_ ? this->get_display()->get_native_height() : this->get_display()->get_native_width();
+    this->y_raw_max_ =
+        this->swap_x_y_ ? this->get_display()->get_native_width() : this->get_display()->get_native_height();
 
     this->reset_pin_->pin_mode(esphome::gpio::FLAG_OUTPUT);
     this->reset_pin_->setup();

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -100,6 +100,8 @@ esphome:
       - "-DESPCONTROL_KEEP_LVGL_ACTIVE_ON_DISPLAY_OFF=1"
       # Rebuild marker for noisy/multi-contact wake taps on the GSL3680 panel.
       - "-DESPCONTROL_JC8012P4A1_GSL3680_WAKE_TAP_20260625=1"
+      # Rebuild marker for restoring native display-space GSL3680 touch scaling.
+      - "-DESPCONTROL_JC8012P4A1_GSL3680_TOUCH_SCALE_20260626=1"
     build_src_flags:
       - "-Wno-literal-suffix"
   on_boot:


### PR DESCRIPTION
## Purpose
Fix the 10-inch GSL3680 touch scaling regression where touch targets were offset after a recent change hardcoded the panel touch range to 1280x800.

## Practical impact
The 10-inch display now reports touch points in the display's native coordinate space again, letting LVGL apply the configured screen rotation normally. This should line touch targets back up with the visible UI.

## How it was checked
- Built the 10-inch firmware successfully.
- Flashed the patched firmware over OTA to the 10-inch display at 192.168.6.103.
- Confirmed the display came back online after reboot with a successful ping.

## Device testing
Affected display: 10-inch Guition ESP32-P4 JC8012P4A1.

Please test touch accuracy on the physical 10-inch screen before merging.