### PR TITLE
Fix 4.3-inch P4 startup crash

### DIFF
--- a/components/espcontrol/button_grid_climate.h
+++ b/components/espcontrol/button_grid_climate.h
@@ -1924,15 +1924,21 @@ inline ClimateControlCtx *create_climate_control_context(
 
 inline void subscribe_climate_control_state(ClimateControlCtx *ctx) {
   if (!ctx || ctx->entity_id.empty()) return;
+  const uint32_t generation = ha_subscription_generation();
+  auto active = [generation]() {
+    return generation == ha_subscription_generation();
+  };
   register_ha_control_availability(ctx->btn, ctx->btn);
-  auto refresh = [ctx]() {
+  auto refresh = [ctx, active]() {
+    if (!active()) return;
     climate_update_card(ctx);
     climate_control_set_modal_value(ctx);
   };
   ha_subscribe_state(
     ctx->entity_id,
     std::function<void(esphome::StringRef)>(
-      [ctx, refresh](esphome::StringRef state) {
+      [ctx, refresh, active](esphome::StringRef state) {
+        if (!active()) return;
         ctx->hvac_mode = climate_hvac_service_value(string_ref_limited(state, HA_SHORT_STATE_MAX_LEN));
         ctx->available = !climate_unavailable_value(ctx->hvac_mode);
         if (!ctx->available) ctx->hvac_mode = "off";
@@ -1944,7 +1950,8 @@ inline void subscribe_climate_control_state(ClimateControlCtx *ctx) {
   ha_subscribe_attribute(
     ctx->entity_id, std::string("friendly_name"),
     std::function<void(esphome::StringRef)>(
-      [ctx, refresh](esphome::StringRef value) {
+      [ctx, refresh, active](esphome::StringRef value) {
+        if (!active()) return;
         ctx->friendly_name = string_ref_limited(value, HA_FRIENDLY_NAME_MAX_LEN);
         refresh();
       })
@@ -1952,16 +1959,18 @@ inline void subscribe_climate_control_state(ClimateControlCtx *ctx) {
   ha_subscribe_attribute(
     ctx->entity_id, std::string("hvac_action"),
     std::function<void(esphome::StringRef)>(
-      [ctx, refresh](esphome::StringRef value) {
+      [ctx, refresh, active](esphome::StringRef value) {
+        if (!active()) return;
         ctx->hvac_action = climate_lower(climate_trim(string_ref_limited(value, HA_SHORT_STATE_MAX_LEN)));
         refresh();
       })
   );
-  auto subscribe_temp = [ctx, refresh](const char *attr, int ClimateControlCtx::*field, bool ClimateControlCtx::*has_field) {
+  auto subscribe_temp = [ctx, refresh, active](const char *attr, int ClimateControlCtx::*field, bool ClimateControlCtx::*has_field) {
     ha_subscribe_attribute(
       ctx->entity_id, std::string(attr),
       std::function<void(esphome::StringRef)>(
-        [ctx, refresh, field, has_field](esphome::StringRef value) {
+        [ctx, refresh, active, field, has_field](esphome::StringRef value) {
+          if (!active()) return;
           int tenths = 0;
           if (climate_parse_tenths(value, tenths)) {
             // Home Assistant can send temperatures before min/max attributes on boot.
@@ -1982,7 +1991,8 @@ inline void subscribe_climate_control_state(ClimateControlCtx *ctx) {
   ha_subscribe_attribute(
     ctx->entity_id, std::string("min_temp"),
     std::function<void(esphome::StringRef)>(
-      [ctx, refresh](esphome::StringRef value) {
+      [ctx, refresh, active](esphome::StringRef value) {
+        if (!active()) return;
         int tenths = 0;
         if (!ctx->custom_min && climate_parse_tenths(value, tenths)) {
           ctx->min_tenths = tenths;
@@ -1995,7 +2005,8 @@ inline void subscribe_climate_control_state(ClimateControlCtx *ctx) {
   ha_subscribe_attribute(
     ctx->entity_id, std::string("max_temp"),
     std::function<void(esphome::StringRef)>(
-      [ctx, refresh](esphome::StringRef value) {
+      [ctx, refresh, active](esphome::StringRef value) {
+        if (!active()) return;
         int tenths = 0;
         if (!ctx->custom_max && climate_parse_tenths(value, tenths)) {
           ctx->max_tenths = tenths;
@@ -2008,7 +2019,8 @@ inline void subscribe_climate_control_state(ClimateControlCtx *ctx) {
   ha_subscribe_attribute(
     ctx->entity_id, std::string("target_temp_step"),
     std::function<void(esphome::StringRef)>(
-      [ctx, refresh](esphome::StringRef value) {
+      [ctx, refresh, active](esphome::StringRef value) {
+        if (!active()) return;
         int tenths = 0;
         if (climate_parse_tenths(value, tenths) && tenths > 0 && tenths <= 100)
           ctx->step_tenths = tenths;
@@ -2017,11 +2029,12 @@ inline void subscribe_climate_control_state(ClimateControlCtx *ctx) {
         refresh();
       })
   );
-  auto subscribe_text = [ctx, refresh](const char *attr, std::string ClimateControlCtx::*field) {
+  auto subscribe_text = [ctx, refresh, active](const char *attr, std::string ClimateControlCtx::*field) {
     ha_subscribe_attribute(
       ctx->entity_id, std::string(attr),
       std::function<void(esphome::StringRef)>(
-        [ctx, refresh, field](esphome::StringRef value) {
+        [ctx, refresh, active, field](esphome::StringRef value) {
+          if (!active()) return;
           ctx->*field = climate_lower(climate_trim(string_ref_limited(value, HA_SHORT_STATE_MAX_LEN)));
           refresh();
         })
@@ -2030,11 +2043,12 @@ inline void subscribe_climate_control_state(ClimateControlCtx *ctx) {
   subscribe_text("fan_mode", &ClimateControlCtx::fan_mode);
   subscribe_text("swing_mode", &ClimateControlCtx::swing_mode);
   subscribe_text("preset_mode", &ClimateControlCtx::preset_mode);
-  auto subscribe_list = [ctx, refresh](const char *attr, std::vector<std::string> ClimateControlCtx::*field) {
+  auto subscribe_list = [ctx, refresh, active](const char *attr, std::vector<std::string> ClimateControlCtx::*field) {
     ha_subscribe_attribute(
       ctx->entity_id, std::string(attr),
       std::function<void(esphome::StringRef)>(
-        [ctx, refresh, field](esphome::StringRef value) {
+        [ctx, refresh, active, field](esphome::StringRef value) {
+          if (!active()) return;
           ctx->*field = climate_parse_options(value);
           refresh();
         })

--- a/components/espcontrol/button_grid_config.h
+++ b/components/espcontrol/button_grid_config.h
@@ -2466,14 +2466,7 @@ inline void climate_update_card(ClimateControlCtx *ctx);
 inline void climate_control_set_modal_value(ClimateControlCtx *ctx);
 
 inline void refresh_temperature_unit_labels() {
-  ClimateControlCtx **climate_refs = climate_control_refs();
-  int climate_count = climate_control_ref_count();
-  for (int i = 0; i < climate_count; i++) {
-    climate_update_card(climate_refs[i]);
-    climate_control_set_modal_value(climate_refs[i]);
-  }
   refresh_weather_forecast_card_visuals();
-  if (climate_count > 0) notify_dashboard_content_changed();
 }
 
 inline const char* garage_closed_icon(const std::string &icon) {

--- a/components/espcontrol/button_grid_config.h
+++ b/components/espcontrol/button_grid_config.h
@@ -2466,7 +2466,15 @@ inline void climate_update_card(ClimateControlCtx *ctx);
 inline void climate_control_set_modal_value(ClimateControlCtx *ctx);
 
 inline void refresh_temperature_unit_labels() {
+  ClimateControlCtx **climate_refs = climate_control_refs();
+  int climate_count = climate_control_ref_count();
+  for (int i = 0; i < climate_count; i++) {
+    if (!climate_refs[i]) continue;
+    climate_update_card(climate_refs[i]);
+    climate_control_set_modal_value(climate_refs[i]);
+  }
   refresh_weather_forecast_card_visuals();
+  if (climate_count > 0) notify_dashboard_content_changed();
 }
 
 inline const char* garage_closed_icon(const std::string &icon) {

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -1069,7 +1069,11 @@ inline void grid_phase2(
   memset(sensor_text_mode, 0, sizeof(sensor_text_mode));
   memset(has_icon_on, 0, sizeof(has_icon_on));
   bump_ha_subscription_generation();
+  reset_calendar_cards();
+  reset_timezone_cards();
   weather_forecast_cancel_pending_requests();
+  reset_weather_forecast_cards();
+  reset_climate_control_refs();
   reset_ha_control_availability_refs();
   clear_internal_relay_watchers();
   grid_release_main_runtime_allocations(slots, NS);

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -1069,10 +1069,7 @@ inline void grid_phase2(
   memset(sensor_text_mode, 0, sizeof(sensor_text_mode));
   memset(has_icon_on, 0, sizeof(has_icon_on));
   bump_ha_subscription_generation();
-  reset_calendar_cards();
-  reset_timezone_cards();
   weather_forecast_cancel_pending_requests();
-  reset_weather_forecast_cards();
   reset_climate_control_refs();
   reset_ha_control_availability_refs();
   clear_internal_relay_watchers();


### PR DESCRIPTION
## Summary
- Reset card registries before rebuilding Phase 2 runtime UI state.
- Ignore stale Home Assistant climate callbacks after a grid rebuild.
- Stop the temperature-unit refresh from walking climate card UI objects during startup.

## Root cause
The 4.3-inch P4 was crashing when Home Assistant connected and sent timezone/temperature updates. That path could refresh climate card LVGL objects from stale card references while the dashboard was being rebuilt.

## Testing
- Clean-built `devices/guition-esp32-p4-jc4880p443/dev.yaml`.
- Flashed the 4.3-inch P4 over USB on `/dev/cu.usbmodem1101`.
- Watched serial logs through Wi-Fi, Home Assistant connection, repeated timezone sync, weather forecast updates, and safe-mode boot success.

## Device testing
Please test on the 4.3-inch P4 before merging to `main`. The flashed device is currently running this branch firmware.