### PR TITLE
Reduce S3 WiFi IRAM usage

### DIFF
--- a/devices/guition-esp32-s3-4848s040/device/device.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/device.yaml
@@ -34,6 +34,10 @@ esp32:
       # and LVGL buffers are initialized.
       CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM: "8"
       CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP: "y"
+      # Prefer IRAM headroom over maximum WiFi throughput on this display.
+      CONFIG_ESP_WIFI_IRAM_OPT: "n"
+      CONFIG_ESP_WIFI_RX_IRAM_OPT: "n"
+      CONFIG_ESP_PHY_IRAM_OPT: "n"
 
 # ---------------------------------------------------------------------------
 # External component

--- a/devices/guition-esp32-s3-4848s040/device/device.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/device.yaml
@@ -38,6 +38,12 @@ esp32:
       CONFIG_ESP_WIFI_IRAM_OPT: "n"
       CONFIG_ESP_WIFI_RX_IRAM_OPT: "n"
       CONFIG_ESP_PHY_IRAM_OPT: "n"
+      # This firmware targets standard WPA2 networks; leave WPA3 code out of
+      # the S3 build to reduce internal executable-memory pressure.
+      CONFIG_ESP_WIFI_ENABLE_WPA3_SAE: "n"
+      CONFIG_ESP_WIFI_ENABLE_SAE_PK: "n"
+      CONFIG_ESP_WIFI_ENABLE_SAE_H2E: "n"
+      CONFIG_ESP_WIFI_ENABLE_WPA3_OWE_STA: "n"
 
 # ---------------------------------------------------------------------------
 # External component


### PR DESCRIPTION
## Purpose
Reduce internal executable-memory pressure on the Guition ESP32-S3 4848S040 firmware by disabling WiFi/PHY IRAM optimizations and WPA3 support for this S3 device only.

## Practical impact
This trades maximum WiFi throughput and WPA3 compatibility for more internal RAM headroom on the S3 display build. P4 devices are unchanged. The S3 build should still work on standard WPA2 networks.

## Checked
- Compiled `devices/guition-esp32-s3-4848s040/dev.yaml` with ESPHome 2026.6.2.
- Verified generated SDK config has `CONFIG_ESP_WIFI_IRAM_OPT`, `CONFIG_ESP_WIFI_RX_IRAM_OPT`, `CONFIG_ESP_PHY_IRAM_OPT`, `CONFIG_ESP_WIFI_ENABLE_WPA3_SAE`, `CONFIG_ESP_WIFI_ENABLE_SAE_PK`, `CONFIG_ESP_WIFI_ENABLE_SAE_H2E`, and `CONFIG_ESP_WIFI_ENABLE_WPA3_OWE_STA` disabled.
- Compile memory summary after both changes: DIRAM 181,291 bytes used, `.text` 45,883 bytes; IRAM remains 16,384 bytes used.

## Device testing
Flash/test on the Guition ESP32-S3 4848S040 using a WPA2 WiFi network. Please confirm WiFi connects normally, Home Assistant API/web UI remain reachable, OTA still works, and normal screen interactions feel unchanged.