### PR TITLE
Remove JC4880P443 card grid image

### DIFF
--- a/docs/screens/jc4880p443.md
+++ b/docs/screens/jc4880p443.md
@@ -27,8 +27,6 @@ The **Guition JC4880P443** is a 4.3-inch portrait touchscreen powered by an **ES
 
 ## Card Grid
 
-![JC4880P443 card grid showing 6 configurable tiles](/images/jc4880p443-buttons.png)
-
 <!--@include: ../generated/screens/jc4880p443-grid.md-->
 
 ## Install


### PR DESCRIPTION
## Purpose
Remove the card grid screenshot from the JC4880P443 screen documentation page.

## Practical impact
The published page keeps the card grid details, but no longer shows the extra grid image under the Card Grid section.

## How it was checked
- npm run docs:build

## Testing notes
After the PR preview or GitHub Pages update is available, check `/espcontrol/screens/jc4880p443` and confirm the Card Grid section no longer shows the grid screenshot.