### PR TITLE
Round cover modal control buttons

### DIFF
--- a/components/espcontrol/button_grid_sliders.h
+++ b/components/espcontrol/button_grid_sliders.h
@@ -1971,10 +1971,11 @@ inline void cover_control_layout_modal(CoverControlCtx *ctx) {
     lv_coord_t start_x = (box_w - total_w) / 2;
     if (start_x < 0) start_x = 0;
     lv_obj_t *buttons[3] = {ui.up_btn, ui.stop_btn, ui.down_btn};
+    lv_coord_t button_radius = control_modal_card_radius(ctx->btn);
     for (int i = 0; i < 3; i++) {
       if (!buttons[i]) continue;
       lv_obj_set_size(buttons[i], btn_size, btn_size);
-      lv_obj_set_style_radius(buttons[i], 0, LV_PART_MAIN);
+      lv_obj_set_style_radius(buttons[i], button_radius, LV_PART_MAIN);
       lv_obj_align(buttons[i], LV_ALIGN_LEFT_MID, start_x + i * (btn_size + gap), 0);
       lv_obj_t *label = lv_obj_get_child(buttons[i], 0);
       if (label) lv_obj_center(label);


### PR DESCRIPTION
## Purpose
Make the cover modal's position/control buttons visually match the rounded corners used by the home page buttons.

## Practical impact
The open, stop, and close controls in the cover modal now use the same corner radius as the card button that opened the modal, instead of being forced to square corners.

## Checked
- python3 scripts/check_firmware_modals.py
- git diff --check

## Device testing
Flash a device with a Cover card using modal controls, open the cover modal, and check that the control buttons have the same rounded corners as the home page buttons.