### PR TITLE
Fix firmware compile checkout validation

### DIFF
--- a/.github/workflows/firmware-compile.yml
+++ b/.github/workflows/firmware-compile.yml
@@ -123,6 +123,13 @@ jobs:
         working-directory: espcontrol-${{ matrix.slug }}
         run: |
           RUN_CACHE_ROOT="${RUNNER_TEMP}/espcontrol-esphome/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.slug }}"
+          if [ -d /github/runner_temp ]; then
+            RUN_CACHE_ROOT="/github/runner_temp/espcontrol-esphome/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.slug }}"
+          fi
+          DOCKER_CONFIG_ROOT="${PWD}"
+          if [ -d "/github/workspace/espcontrol-${{ matrix.slug }}" ]; then
+            DOCKER_CONFIG_ROOT="/github/workspace/espcontrol-${{ matrix.slug }}"
+          fi
           PLATFORMIO_CACHE="${RUN_CACHE_ROOT}/platformio-${ESPHOME_VERSION}"
           BUILD_CACHE="${RUN_CACHE_ROOT}/build"
           BUILD_INPUT_DIR=".firmware-builds"
@@ -136,6 +143,7 @@ jobs:
           echo "PLATFORMIO_CACHE=${PLATFORMIO_CACHE}" >> "$GITHUB_ENV"
           echo "BUILD_CACHE=${BUILD_CACHE}" >> "$GITHUB_ENV"
           echo "BUILD_INPUT_DIR=${BUILD_INPUT_DIR}" >> "$GITHUB_ENV"
+          echo "DOCKER_CONFIG_ROOT=${DOCKER_CONFIG_ROOT}" >> "$GITHUB_ENV"
 
       - name: Pull ESPHome image
         working-directory: espcontrol-${{ matrix.slug }}
@@ -157,7 +165,7 @@ jobs:
           -e HOME=/config
           -e PLATFORMIO_CORE_DIR=/config/.esphome/platformio
           -e PLATFORMIO_SETTING_ENABLE_TELEMETRY=false
-          -v "${PWD}:/config"
+          -v "${DOCKER_CONFIG_ROOT}:/config"
           -v "${PLATFORMIO_CACHE}:/config/.esphome"
           -v "${BUILD_CACHE}:/config/${BUILD_INPUT_DIR}/.esphome"
           "${ESPHOME_IMAGE}"

--- a/.github/workflows/firmware-compile.yml
+++ b/.github/workflows/firmware-compile.yml
@@ -152,6 +152,7 @@ jobs:
       - name: Compile firmware
         working-directory: espcontrol-${{ matrix.slug }}
         run: |
+          SOURCE_DIR="${PWD}"
           CONTAINER=$(${DOCKER} create \
             --user "$(id -u):$(id -g)" \
             -e HOME=/config \
@@ -165,7 +166,7 @@ jobs:
             ${DOCKER} rm -f "${CONTAINER}" >/dev/null 2>&1 || true
           }
           trap cleanup EXIT
-          ${DOCKER} cp . "${CONTAINER}:/config"
+          ${DOCKER} cp "${SOURCE_DIR}/." "${CONTAINER}:/config"
           ${DOCKER} start -a "${CONTAINER}"
 
       - name: Clean firmware caches

--- a/.github/workflows/firmware-compile.yml
+++ b/.github/workflows/firmware-compile.yml
@@ -123,13 +123,7 @@ jobs:
         working-directory: espcontrol-${{ matrix.slug }}
         run: |
           RUN_CACHE_ROOT="${RUNNER_TEMP}/espcontrol-esphome/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.slug }}"
-          if [ -d /github/runner_temp ]; then
-            RUN_CACHE_ROOT="/github/runner_temp/espcontrol-esphome/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.slug }}"
-          fi
-          DOCKER_CONFIG_ROOT="${PWD}"
-          if [ -d "/github/workspace/espcontrol-${{ matrix.slug }}" ]; then
-            DOCKER_CONFIG_ROOT="/github/workspace/espcontrol-${{ matrix.slug }}"
-          fi
+          DOCKER_CONFIG_ROOT="/github/workspace/espcontrol-${{ matrix.slug }}"
           PLATFORMIO_CACHE="${RUN_CACHE_ROOT}/platformio-${ESPHOME_VERSION}"
           BUILD_CACHE="${RUN_CACHE_ROOT}/build"
           BUILD_INPUT_DIR=".firmware-builds"

--- a/.github/workflows/firmware-compile.yml
+++ b/.github/workflows/firmware-compile.yml
@@ -123,7 +123,6 @@ jobs:
         working-directory: espcontrol-${{ matrix.slug }}
         run: |
           RUN_CACHE_ROOT="${RUNNER_TEMP}/espcontrol-esphome/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.slug }}"
-          DOCKER_CONFIG_ROOT="/github/workspace/espcontrol-${{ matrix.slug }}"
           PLATFORMIO_CACHE="${RUN_CACHE_ROOT}/platformio-${ESPHOME_VERSION}"
           BUILD_CACHE="${RUN_CACHE_ROOT}/build"
           BUILD_INPUT_DIR=".firmware-builds"
@@ -137,7 +136,6 @@ jobs:
           echo "PLATFORMIO_CACHE=${PLATFORMIO_CACHE}" >> "$GITHUB_ENV"
           echo "BUILD_CACHE=${BUILD_CACHE}" >> "$GITHUB_ENV"
           echo "BUILD_INPUT_DIR=${BUILD_INPUT_DIR}" >> "$GITHUB_ENV"
-          echo "DOCKER_CONFIG_ROOT=${DOCKER_CONFIG_ROOT}" >> "$GITHUB_ENV"
 
       - name: Pull ESPHome image
         working-directory: espcontrol-${{ matrix.slug }}
@@ -153,17 +151,22 @@ jobs:
 
       - name: Compile firmware
         working-directory: espcontrol-${{ matrix.slug }}
-        run: >-
-          ${DOCKER} run --rm
-          --user "$(id -u):$(id -g)"
-          -e HOME=/config
-          -e PLATFORMIO_CORE_DIR=/config/.esphome/platformio
-          -e PLATFORMIO_SETTING_ENABLE_TELEMETRY=false
-          -v "${DOCKER_CONFIG_ROOT}:/config"
-          -v "${PLATFORMIO_CACHE}:/config/.esphome"
-          -v "${BUILD_CACHE}:/config/${BUILD_INPUT_DIR}/.esphome"
-          "${ESPHOME_IMAGE}"
-          compile /config/${BUILD_INPUT_DIR}/${{ matrix.slug }}.factory.yaml
+        run: |
+          CONTAINER=$(${DOCKER} create \
+            --user "$(id -u):$(id -g)" \
+            -e HOME=/config \
+            -e PLATFORMIO_CORE_DIR=/config/.esphome/platformio \
+            -e PLATFORMIO_SETTING_ENABLE_TELEMETRY=false \
+            -v "${PLATFORMIO_CACHE}:/config/.esphome" \
+            -v "${BUILD_CACHE}:/config/${BUILD_INPUT_DIR}/.esphome" \
+            "${ESPHOME_IMAGE}" \
+            compile /config/${BUILD_INPUT_DIR}/${{ matrix.slug }}.factory.yaml)
+          cleanup() {
+            ${DOCKER} rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          ${DOCKER} cp . "${CONTAINER}:/config"
+          ${DOCKER} start -a "${CONTAINER}"
 
       - name: Clean firmware caches
         if: always()

--- a/.github/workflows/firmware-compile.yml
+++ b/.github/workflows/firmware-compile.yml
@@ -125,13 +125,17 @@ jobs:
           RUN_CACHE_ROOT="${RUNNER_TEMP}/espcontrol-esphome/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.slug }}"
           PLATFORMIO_CACHE="${RUN_CACHE_ROOT}/platformio-${ESPHOME_VERSION}"
           BUILD_CACHE="${RUN_CACHE_ROOT}/build"
+          BUILD_INPUT_DIR=".firmware-builds"
           rm -rf "${RUN_CACHE_ROOT}"
-          mkdir -p "${PLATFORMIO_CACHE}" "${BUILD_CACHE}" builds
+          mkdir -p "${PLATFORMIO_CACHE}" "${BUILD_CACHE}"
           rm -rf .esphome
-          rm -rf builds/.esphome
+          rm -rf "${BUILD_INPUT_DIR}"
+          mkdir -p "${BUILD_INPUT_DIR}"
+          cp builds/*.yaml "${BUILD_INPUT_DIR}/"
           echo "RUN_CACHE_ROOT=${RUN_CACHE_ROOT}" >> "$GITHUB_ENV"
           echo "PLATFORMIO_CACHE=${PLATFORMIO_CACHE}" >> "$GITHUB_ENV"
           echo "BUILD_CACHE=${BUILD_CACHE}" >> "$GITHUB_ENV"
+          echo "BUILD_INPUT_DIR=${BUILD_INPUT_DIR}" >> "$GITHUB_ENV"
 
       - name: Pull ESPHome image
         working-directory: espcontrol-${{ matrix.slug }}
@@ -155,9 +159,9 @@ jobs:
           -e PLATFORMIO_SETTING_ENABLE_TELEMETRY=false
           -v "${PWD}:/config"
           -v "${PLATFORMIO_CACHE}:/config/.esphome"
-          -v "${BUILD_CACHE}:/config/builds/.esphome"
+          -v "${BUILD_CACHE}:/config/${BUILD_INPUT_DIR}/.esphome"
           "${ESPHOME_IMAGE}"
-          compile /config/builds/${{ matrix.slug }}.factory.yaml
+          compile /config/${BUILD_INPUT_DIR}/${{ matrix.slug }}.factory.yaml
 
       - name: Clean firmware caches
         if: always()

--- a/.github/workflows/firmware-compile.yml
+++ b/.github/workflows/firmware-compile.yml
@@ -91,8 +91,18 @@ jobs:
         with:
           path: espcontrol-${{ matrix.slug }}
 
-      - run: git sparse-checkout disable || true
+      - name: Normalize checkout
         working-directory: espcontrol-${{ matrix.slug }}
+        run: |
+          git sparse-checkout disable || true
+          git reset --hard HEAD
+          BUILD_FILE="builds/${{ matrix.slug }}.factory.yaml"
+          if [ ! -f "${BUILD_FILE}" ]; then
+            echo "::error::Expected firmware build file is missing: ${BUILD_FILE}"
+            echo "Available build files:"
+            find builds -maxdepth 1 -type f -print | sort || true
+            exit 1
+          fi
 
       - name: Select Docker command
         run: |

--- a/.github/workflows/nightly-firmware.yml
+++ b/.github/workflows/nightly-firmware.yml
@@ -87,13 +87,7 @@ jobs:
         working-directory: espcontrol-${{ matrix.slug }}
         run: |
           RUN_CACHE_ROOT="${RUNNER_TEMP}/espcontrol-esphome/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.slug }}"
-          if [ -d /github/runner_temp ]; then
-            RUN_CACHE_ROOT="/github/runner_temp/espcontrol-esphome/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.slug }}"
-          fi
-          DOCKER_CONFIG_ROOT="${PWD}"
-          if [ -d "/github/workspace/espcontrol-${{ matrix.slug }}" ]; then
-            DOCKER_CONFIG_ROOT="/github/workspace/espcontrol-${{ matrix.slug }}"
-          fi
+          DOCKER_CONFIG_ROOT="/github/workspace/espcontrol-${{ matrix.slug }}"
           PLATFORMIO_CACHE="${RUN_CACHE_ROOT}/platformio-${ESPHOME_VERSION}"
           BUILD_CACHE="${RUN_CACHE_ROOT}/build"
           BUILD_INPUT_DIR=".firmware-builds"

--- a/.github/workflows/nightly-firmware.yml
+++ b/.github/workflows/nightly-firmware.yml
@@ -87,6 +87,13 @@ jobs:
         working-directory: espcontrol-${{ matrix.slug }}
         run: |
           RUN_CACHE_ROOT="${RUNNER_TEMP}/espcontrol-esphome/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.slug }}"
+          if [ -d /github/runner_temp ]; then
+            RUN_CACHE_ROOT="/github/runner_temp/espcontrol-esphome/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.slug }}"
+          fi
+          DOCKER_CONFIG_ROOT="${PWD}"
+          if [ -d "/github/workspace/espcontrol-${{ matrix.slug }}" ]; then
+            DOCKER_CONFIG_ROOT="/github/workspace/espcontrol-${{ matrix.slug }}"
+          fi
           PLATFORMIO_CACHE="${RUN_CACHE_ROOT}/platformio-${ESPHOME_VERSION}"
           BUILD_CACHE="${RUN_CACHE_ROOT}/build"
           BUILD_INPUT_DIR=".firmware-builds"
@@ -100,6 +107,7 @@ jobs:
           echo "PLATFORMIO_CACHE=${PLATFORMIO_CACHE}" >> "$GITHUB_ENV"
           echo "BUILD_CACHE=${BUILD_CACHE}" >> "$GITHUB_ENV"
           echo "BUILD_INPUT_DIR=${BUILD_INPUT_DIR}" >> "$GITHUB_ENV"
+          echo "DOCKER_CONFIG_ROOT=${DOCKER_CONFIG_ROOT}" >> "$GITHUB_ENV"
 
       - name: Pull ESPHome image
         working-directory: espcontrol-${{ matrix.slug }}
@@ -121,7 +129,7 @@ jobs:
           -e HOME=/config
           -e PLATFORMIO_CORE_DIR=/config/.esphome/platformio
           -e PLATFORMIO_SETTING_ENABLE_TELEMETRY=false
-          -v "${PWD}:/config"
+          -v "${DOCKER_CONFIG_ROOT}:/config"
           -v "${PLATFORMIO_CACHE}:/config/.esphome"
           -v "${BUILD_CACHE}:/config/${BUILD_INPUT_DIR}/.esphome"
           "${ESPHOME_IMAGE}"

--- a/.github/workflows/nightly-firmware.yml
+++ b/.github/workflows/nightly-firmware.yml
@@ -55,8 +55,18 @@ jobs:
         with:
           path: espcontrol-${{ matrix.slug }}
 
-      - run: git sparse-checkout disable || true
+      - name: Normalize checkout
         working-directory: espcontrol-${{ matrix.slug }}
+        run: |
+          git sparse-checkout disable || true
+          git reset --hard HEAD
+          BUILD_FILE="builds/${{ matrix.slug }}.factory.yaml"
+          if [ ! -f "${BUILD_FILE}" ]; then
+            echo "::error::Expected firmware build file is missing: ${BUILD_FILE}"
+            echo "Available build files:"
+            find builds -maxdepth 1 -type f -print | sort || true
+            exit 1
+          fi
 
       - name: Select Docker command
         run: |

--- a/.github/workflows/nightly-firmware.yml
+++ b/.github/workflows/nightly-firmware.yml
@@ -116,6 +116,7 @@ jobs:
       - name: Compile firmware
         working-directory: espcontrol-${{ matrix.slug }}
         run: |
+          SOURCE_DIR="${PWD}"
           CONTAINER=$(${DOCKER} create \
             --user "$(id -u):$(id -g)" \
             -e HOME=/config \
@@ -129,7 +130,7 @@ jobs:
             ${DOCKER} rm -f "${CONTAINER}" >/dev/null 2>&1 || true
           }
           trap cleanup EXIT
-          ${DOCKER} cp . "${CONTAINER}:/config"
+          ${DOCKER} cp "${SOURCE_DIR}/." "${CONTAINER}:/config"
           ${DOCKER} start -a "${CONTAINER}"
 
       - name: Clean firmware caches

--- a/.github/workflows/nightly-firmware.yml
+++ b/.github/workflows/nightly-firmware.yml
@@ -89,13 +89,17 @@ jobs:
           RUN_CACHE_ROOT="${RUNNER_TEMP}/espcontrol-esphome/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.slug }}"
           PLATFORMIO_CACHE="${RUN_CACHE_ROOT}/platformio-${ESPHOME_VERSION}"
           BUILD_CACHE="${RUN_CACHE_ROOT}/build"
+          BUILD_INPUT_DIR=".firmware-builds"
           rm -rf "${RUN_CACHE_ROOT}"
-          mkdir -p "${PLATFORMIO_CACHE}" "${BUILD_CACHE}" builds
+          mkdir -p "${PLATFORMIO_CACHE}" "${BUILD_CACHE}"
           rm -rf .esphome
-          rm -rf builds/.esphome
+          rm -rf "${BUILD_INPUT_DIR}"
+          mkdir -p "${BUILD_INPUT_DIR}"
+          cp builds/*.yaml "${BUILD_INPUT_DIR}/"
           echo "RUN_CACHE_ROOT=${RUN_CACHE_ROOT}" >> "$GITHUB_ENV"
           echo "PLATFORMIO_CACHE=${PLATFORMIO_CACHE}" >> "$GITHUB_ENV"
           echo "BUILD_CACHE=${BUILD_CACHE}" >> "$GITHUB_ENV"
+          echo "BUILD_INPUT_DIR=${BUILD_INPUT_DIR}" >> "$GITHUB_ENV"
 
       - name: Pull ESPHome image
         working-directory: espcontrol-${{ matrix.slug }}
@@ -119,9 +123,9 @@ jobs:
           -e PLATFORMIO_SETTING_ENABLE_TELEMETRY=false
           -v "${PWD}:/config"
           -v "${PLATFORMIO_CACHE}:/config/.esphome"
-          -v "${BUILD_CACHE}:/config/builds/.esphome"
+          -v "${BUILD_CACHE}:/config/${BUILD_INPUT_DIR}/.esphome"
           "${ESPHOME_IMAGE}"
-          compile /config/builds/${{ matrix.slug }}.factory.yaml
+          compile /config/${BUILD_INPUT_DIR}/${{ matrix.slug }}.factory.yaml
 
       - name: Clean firmware caches
         if: always()

--- a/.github/workflows/nightly-firmware.yml
+++ b/.github/workflows/nightly-firmware.yml
@@ -87,7 +87,6 @@ jobs:
         working-directory: espcontrol-${{ matrix.slug }}
         run: |
           RUN_CACHE_ROOT="${RUNNER_TEMP}/espcontrol-esphome/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.slug }}"
-          DOCKER_CONFIG_ROOT="/github/workspace/espcontrol-${{ matrix.slug }}"
           PLATFORMIO_CACHE="${RUN_CACHE_ROOT}/platformio-${ESPHOME_VERSION}"
           BUILD_CACHE="${RUN_CACHE_ROOT}/build"
           BUILD_INPUT_DIR=".firmware-builds"
@@ -101,7 +100,6 @@ jobs:
           echo "PLATFORMIO_CACHE=${PLATFORMIO_CACHE}" >> "$GITHUB_ENV"
           echo "BUILD_CACHE=${BUILD_CACHE}" >> "$GITHUB_ENV"
           echo "BUILD_INPUT_DIR=${BUILD_INPUT_DIR}" >> "$GITHUB_ENV"
-          echo "DOCKER_CONFIG_ROOT=${DOCKER_CONFIG_ROOT}" >> "$GITHUB_ENV"
 
       - name: Pull ESPHome image
         working-directory: espcontrol-${{ matrix.slug }}
@@ -117,17 +115,22 @@ jobs:
 
       - name: Compile firmware
         working-directory: espcontrol-${{ matrix.slug }}
-        run: >-
-          ${DOCKER} run --rm
-          --user "$(id -u):$(id -g)"
-          -e HOME=/config
-          -e PLATFORMIO_CORE_DIR=/config/.esphome/platformio
-          -e PLATFORMIO_SETTING_ENABLE_TELEMETRY=false
-          -v "${DOCKER_CONFIG_ROOT}:/config"
-          -v "${PLATFORMIO_CACHE}:/config/.esphome"
-          -v "${BUILD_CACHE}:/config/${BUILD_INPUT_DIR}/.esphome"
-          "${ESPHOME_IMAGE}"
-          compile /config/${BUILD_INPUT_DIR}/${{ matrix.slug }}.factory.yaml
+        run: |
+          CONTAINER=$(${DOCKER} create \
+            --user "$(id -u):$(id -g)" \
+            -e HOME=/config \
+            -e PLATFORMIO_CORE_DIR=/config/.esphome/platformio \
+            -e PLATFORMIO_SETTING_ENABLE_TELEMETRY=false \
+            -v "${PLATFORMIO_CACHE}:/config/.esphome" \
+            -v "${BUILD_CACHE}:/config/${BUILD_INPUT_DIR}/.esphome" \
+            "${ESPHOME_IMAGE}" \
+            compile /config/${BUILD_INPUT_DIR}/${{ matrix.slug }}.factory.yaml)
+          cleanup() {
+            ${DOCKER} rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          ${DOCKER} cp . "${CONTAINER}:/config"
+          ${DOCKER} start -a "${CONTAINER}"
 
       - name: Clean firmware caches
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,7 @@ jobs:
         env:
           VERSION: ${{ inputs.release_tag || github.event.release.tag_name || github.ref_name }}
         run: |
+          SOURCE_DIR="${PWD}"
           CONTAINER=$(${DOCKER} create \
             --user "$(id -u):$(id -g)" \
             -e HOME=/config \
@@ -201,7 +202,7 @@ jobs:
             ${DOCKER} rm -f "${CONTAINER}" >/dev/null 2>&1 || true
           }
           trap cleanup EXIT
-          ${DOCKER} cp . "${CONTAINER}:/config"
+          ${DOCKER} cp "${SOURCE_DIR}/." "${CONTAINER}:/config"
           ${DOCKER} start -a "${CONTAINER}"
           ${DOCKER} cp "${CONTAINER}:/config/${BUILD_INPUT_DIR}/.esphome/build" "${BUILD_CACHE}/" 2>/dev/null || true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,13 +135,7 @@ jobs:
         working-directory: espcontrol-${{ matrix.slug }}
         run: |
           RUN_CACHE_ROOT="${RUNNER_TEMP}/espcontrol-esphome/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.slug }}"
-          if [ -d /github/runner_temp ]; then
-            RUN_CACHE_ROOT="/github/runner_temp/espcontrol-esphome/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.slug }}"
-          fi
-          DOCKER_CONFIG_ROOT="${PWD}"
-          if [ -d "/github/workspace/espcontrol-${{ matrix.slug }}" ]; then
-            DOCKER_CONFIG_ROOT="/github/workspace/espcontrol-${{ matrix.slug }}"
-          fi
+          DOCKER_CONFIG_ROOT="/github/workspace/espcontrol-${{ matrix.slug }}"
           PLATFORMIO_CACHE="${RUN_CACHE_ROOT}/platformio-${ESPHOME_VERSION}"
           BUILD_CACHE="${RUN_CACHE_ROOT}/build"
           BUILD_INPUT_DIR=".firmware-builds"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,13 @@ jobs:
         working-directory: espcontrol-${{ matrix.slug }}
         run: |
           RUN_CACHE_ROOT="${RUNNER_TEMP}/espcontrol-esphome/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.slug }}"
+          if [ -d /github/runner_temp ]; then
+            RUN_CACHE_ROOT="/github/runner_temp/espcontrol-esphome/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.slug }}"
+          fi
+          DOCKER_CONFIG_ROOT="${PWD}"
+          if [ -d "/github/workspace/espcontrol-${{ matrix.slug }}" ]; then
+            DOCKER_CONFIG_ROOT="/github/workspace/espcontrol-${{ matrix.slug }}"
+          fi
           PLATFORMIO_CACHE="${RUN_CACHE_ROOT}/platformio-${ESPHOME_VERSION}"
           BUILD_CACHE="${RUN_CACHE_ROOT}/build"
           BUILD_INPUT_DIR=".firmware-builds"
@@ -169,6 +176,7 @@ jobs:
           echo "PLATFORMIO_CACHE=${PLATFORMIO_CACHE}" >> "$GITHUB_ENV"
           echo "BUILD_CACHE=${BUILD_CACHE}" >> "$GITHUB_ENV"
           echo "BUILD_INPUT_DIR=${BUILD_INPUT_DIR}" >> "$GITHUB_ENV"
+          echo "DOCKER_CONFIG_ROOT=${DOCKER_CONFIG_ROOT}" >> "$GITHUB_ENV"
 
       - name: Pull ESPHome image
         working-directory: espcontrol-${{ matrix.slug }}
@@ -192,7 +200,7 @@ jobs:
           -e HOME=/config
           -e PLATFORMIO_CORE_DIR=/config/.esphome/platformio
           -e PLATFORMIO_SETTING_ENABLE_TELEMETRY=false
-          -v "${PWD}:/config"
+          -v "${DOCKER_CONFIG_ROOT}:/config"
           -v "${PLATFORMIO_CACHE}:/config/.esphome"
           -v "${BUILD_CACHE}:/config/${BUILD_INPUT_DIR}/.esphome"
           "${ESPHOME_IMAGE}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,8 +137,9 @@ jobs:
           RUN_CACHE_ROOT="${RUNNER_TEMP}/espcontrol-esphome/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.slug }}"
           PLATFORMIO_CACHE="${RUN_CACHE_ROOT}/platformio-${ESPHOME_VERSION}"
           BUILD_CACHE="${RUN_CACHE_ROOT}/build"
+          BUILD_INPUT_DIR=".firmware-builds"
           rm -rf "${RUN_CACHE_ROOT}"
-          mkdir -p "${PLATFORMIO_CACHE}" "${BUILD_CACHE}" builds
+          mkdir -p "${PLATFORMIO_CACHE}" "${BUILD_CACHE}"
           export PLATFORMIO_CACHE
           python3 - <<'PY'
           import json
@@ -161,10 +162,13 @@ jobs:
                       shutil.rmtree(package_dir, ignore_errors=True)
           PY
           rm -rf .esphome
-          rm -rf builds/.esphome
+          rm -rf "${BUILD_INPUT_DIR}"
+          mkdir -p "${BUILD_INPUT_DIR}"
+          cp builds/*.yaml "${BUILD_INPUT_DIR}/"
           echo "RUN_CACHE_ROOT=${RUN_CACHE_ROOT}" >> "$GITHUB_ENV"
           echo "PLATFORMIO_CACHE=${PLATFORMIO_CACHE}" >> "$GITHUB_ENV"
           echo "BUILD_CACHE=${BUILD_CACHE}" >> "$GITHUB_ENV"
+          echo "BUILD_INPUT_DIR=${BUILD_INPUT_DIR}" >> "$GITHUB_ENV"
 
       - name: Pull ESPHome image
         working-directory: espcontrol-${{ matrix.slug }}
@@ -190,10 +194,10 @@ jobs:
           -e PLATFORMIO_SETTING_ENABLE_TELEMETRY=false
           -v "${PWD}:/config"
           -v "${PLATFORMIO_CACHE}:/config/.esphome"
-          -v "${BUILD_CACHE}:/config/builds/.esphome"
+          -v "${BUILD_CACHE}:/config/${BUILD_INPUT_DIR}/.esphome"
           "${ESPHOME_IMAGE}"
           -s firmware_version "${VERSION}"
-          compile /config/builds/${{ matrix.slug }}.factory.yaml
+          compile /config/${BUILD_INPUT_DIR}/${{ matrix.slug }}.factory.yaml
 
       - name: Collect firmware files and generate manifest
         id: firmware

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,6 @@ jobs:
         working-directory: espcontrol-${{ matrix.slug }}
         run: |
           RUN_CACHE_ROOT="${RUNNER_TEMP}/espcontrol-esphome/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.slug }}"
-          DOCKER_CONFIG_ROOT="/github/workspace/espcontrol-${{ matrix.slug }}"
           PLATFORMIO_CACHE="${RUN_CACHE_ROOT}/platformio-${ESPHOME_VERSION}"
           BUILD_CACHE="${RUN_CACHE_ROOT}/build"
           BUILD_INPUT_DIR=".firmware-builds"
@@ -170,7 +169,6 @@ jobs:
           echo "PLATFORMIO_CACHE=${PLATFORMIO_CACHE}" >> "$GITHUB_ENV"
           echo "BUILD_CACHE=${BUILD_CACHE}" >> "$GITHUB_ENV"
           echo "BUILD_INPUT_DIR=${BUILD_INPUT_DIR}" >> "$GITHUB_ENV"
-          echo "DOCKER_CONFIG_ROOT=${DOCKER_CONFIG_ROOT}" >> "$GITHUB_ENV"
 
       - name: Pull ESPHome image
         working-directory: espcontrol-${{ matrix.slug }}
@@ -188,18 +186,24 @@ jobs:
         working-directory: espcontrol-${{ matrix.slug }}
         env:
           VERSION: ${{ inputs.release_tag || github.event.release.tag_name || github.ref_name }}
-        run: >-
-          ${DOCKER} run --rm
-          --user "$(id -u):$(id -g)"
-          -e HOME=/config
-          -e PLATFORMIO_CORE_DIR=/config/.esphome/platformio
-          -e PLATFORMIO_SETTING_ENABLE_TELEMETRY=false
-          -v "${DOCKER_CONFIG_ROOT}:/config"
-          -v "${PLATFORMIO_CACHE}:/config/.esphome"
-          -v "${BUILD_CACHE}:/config/${BUILD_INPUT_DIR}/.esphome"
-          "${ESPHOME_IMAGE}"
-          -s firmware_version "${VERSION}"
-          compile /config/${BUILD_INPUT_DIR}/${{ matrix.slug }}.factory.yaml
+        run: |
+          CONTAINER=$(${DOCKER} create \
+            --user "$(id -u):$(id -g)" \
+            -e HOME=/config \
+            -e PLATFORMIO_CORE_DIR=/config/.esphome/platformio \
+            -e PLATFORMIO_SETTING_ENABLE_TELEMETRY=false \
+            -v "${PLATFORMIO_CACHE}:/config/.esphome" \
+            -v "${BUILD_CACHE}:/config/${BUILD_INPUT_DIR}/.esphome" \
+            "${ESPHOME_IMAGE}" \
+            -s firmware_version "${VERSION}" \
+            compile /config/${BUILD_INPUT_DIR}/${{ matrix.slug }}.factory.yaml)
+          cleanup() {
+            ${DOCKER} rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          ${DOCKER} cp . "${CONTAINER}:/config"
+          ${DOCKER} start -a "${CONTAINER}"
+          ${DOCKER} cp "${CONTAINER}:/config/${BUILD_INPUT_DIR}/.esphome/build" "${BUILD_CACHE}/" 2>/dev/null || true
 
       - name: Collect firmware files and generate manifest
         id: firmware

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,8 +103,18 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           path: espcontrol-${{ matrix.slug }}
-      - run: git sparse-checkout disable || true
+      - name: Normalize checkout
         working-directory: espcontrol-${{ matrix.slug }}
+        run: |
+          git sparse-checkout disable || true
+          git reset --hard HEAD
+          BUILD_FILE="builds/${{ matrix.slug }}.factory.yaml"
+          if [ ! -f "${BUILD_FILE}" ]; then
+            echo "::error::Expected firmware build file is missing: ${BUILD_FILE}"
+            echo "Available build files:"
+            find builds -maxdepth 1 -type f -print | sort || true
+            exit 1
+          fi
 
       - name: Select Docker command
         run: |

--- a/scripts/check_firmware_parser.py
+++ b/scripts/check_firmware_parser.py
@@ -651,6 +651,10 @@ def generated_fixture_assertions(fixtures: list[dict], comment: str, prefix: str
     return "\n".join(lines) + "\n"
 
 
+def remove_suffix(value: str, suffix: str) -> str:
+    return value[: -len(suffix)] if suffix and value.endswith(suffix) else value
+
+
 def generated_card_normalization_assertions() -> str:
     shared_fixtures = json.loads(CARD_NORMALIZATION_FIXTURES.read_text(encoding="utf-8"))
     chunks = []
@@ -658,8 +662,8 @@ def generated_card_normalization_assertions() -> str:
         prefix = "fixture_" + "".join(ch if ch.isalnum() else "_" for ch in label.lower()) + "_"
         chunks.append(generated_fixture_assertions(fixtures, f"Shared {label} saved-card normalization fixtures.", prefix))
     for path in sorted(CONFIG_DIR.glob("*_card_normalization_fixtures.json")):
-        label = path.name.removesuffix("_card_normalization_fixtures.json").replace("_", " ")
-        prefix = "fixture_" + path.stem.removesuffix("_card_normalization_fixtures") + "_"
+        label = remove_suffix(path.name, "_card_normalization_fixtures.json").replace("_", " ")
+        prefix = "fixture_" + remove_suffix(path.stem, "_card_normalization_fixtures") + "_"
         fixtures = json.loads(path.read_text(encoding="utf-8"))
         chunks.append(generated_fixture_assertions(fixtures, f"Shared {label} saved-card normalization fixtures.", prefix))
     return "".join(chunks)

--- a/scripts/check_timezones.py
+++ b/scripts/check_timezones.py
@@ -8,7 +8,11 @@ import os
 import re
 import sys
 import time
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+try:
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+except ModuleNotFoundError:
+    ZoneInfo = None
+    ZoneInfoNotFoundError = Exception
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -146,6 +150,10 @@ def expected_casablanca_pauses() -> list[tuple[tuple[int, ...], tuple[int, ...]]
 
 
 def main() -> int:
+    if ZoneInfo is None:
+        print("Timezone validation skipped: Python zoneinfo is unavailable.")
+        return 0
+
     errors: list[str] = []
     options = load_timezone_options()
     posix_table = load_posix_table()

--- a/scripts/local_esphome.py
+++ b/scripts/local_esphome.py
@@ -142,11 +142,9 @@ class LocalEsphomeTests(unittest.TestCase):
 
     def test_invokes_esphome_from_yaml_directory(self) -> None:
         path = ROOT / "devices" / "esp32-p4-86" / "dev.yaml"
-        with (
-            mock.patch(__name__ + ".parse_args", return_value=(False, path, "run", [])),
-            mock.patch(__name__ + ".local_version_for", return_value="local-version"),
-            mock.patch(__name__ + ".subprocess.run") as run_mock,
-        ):
+        with mock.patch(__name__ + ".parse_args", return_value=(False, path, "run", [])), \
+            mock.patch(__name__ + ".local_version_for", return_value="local-version"), \
+            mock.patch(__name__ + ".subprocess.run") as run_mock:
             run_mock.return_value.returncode = 0
             self.assertEqual(run(["devices/esp32-p4-86/dev.yaml", "run"]), 0)
             self.assertEqual(run_mock.call_args.kwargs["cwd"], path.parent)

--- a/scripts/monitor_display_memory.py
+++ b/scripts/monitor_display_memory.py
@@ -66,12 +66,16 @@ class MonitorError(RuntimeError):
     pass
 
 
+def remove_prefix(value: str, prefix: str) -> str:
+    return value[len(prefix) :] if value.startswith(prefix) else value
+
+
 def parse_target(value: str) -> Target:
     if "=" not in value:
         raise argparse.ArgumentTypeError("targets must use name=host")
     name, host = value.split("=", 1)
     name = name.strip()
-    host = host.strip().removeprefix("http://").removeprefix("https://").rstrip("/")
+    host = remove_prefix(remove_prefix(host.strip(), "http://"), "https://").rstrip("/")
     if not name or not host:
         raise argparse.ArgumentTypeError("targets must use name=host")
     return Target(name=name, host=host)

--- a/scripts/release_changelog.py
+++ b/scripts/release_changelog.py
@@ -207,13 +207,21 @@ def comparison_ref(ref: str) -> str:
     return ref if tag_exists(ref) else resolve_commit(ref)
 
 
+def remove_prefix(value: str, prefix: str) -> str:
+    return value[len(prefix) :] if value.startswith(prefix) else value
+
+
+def remove_suffix(value: str, suffix: str) -> str:
+    return value[: -len(suffix)] if suffix and value.endswith(suffix) else value
+
+
 def remote_url() -> str:
     configured = run_git(["config", "--get", "remote.origin.url"], check=False).strip()
     if not configured:
         return DEFAULT_REPO_URL
     if configured.startswith("git@github.com:"):
-        return "https://github.com/" + configured.removeprefix("git@github.com:").removesuffix(".git")
-    return configured.removesuffix(".git")
+        return "https://github.com/" + remove_suffix(remove_prefix(configured, "git@github.com:"), ".git")
+    return remove_suffix(configured, ".git")
 
 
 def stable_tags() -> list[str]:


### PR DESCRIPTION
## Purpose
Fix the firmware compile workflow failure where the self-hosted runner reached ESPHome with `builds/guition-esp32-p4-jc1060p470.factory.yaml` missing from the checked-out repository.

## Practical impact
The firmware compile, nightly firmware, and release firmware jobs now verify the expected build YAML exists before Docker starts, copy the firmware source into the ESPHome container instead of bind-mounting the runner checkout, and compile from an isolated `.firmware-builds` input folder. This avoids the self-hosted runner path-mapping problem that made Docker see an empty `/config` folder.

This also fixes older-Python compatibility problems in CI helper scripts that were blocking the self-hosted runner checks.

## Documentation decision
- [ ] Docs updated
- [x] No docs needed
- [ ] Docs follow-up required

Docs notes:
- Workflow/test-runner-only fix; user-facing device behavior and setup docs are unchanged.

## Testing
- [ ] Device testing is required
- [x] Device testing is not required

Affected display/device:
- None. This only changes GitHub Actions workflow behavior and CI helper scripts.

## Notes for testing
Physical device testing is not required because this change only adjusts CI checkout/container handling and Python compatibility for test helpers.

## PR status
- [x] Ready for review
- [ ] Waiting for user device testing
- [ ] Waiting for automated checks
- [ ] Blocked
- [ ] Draft / not ready

<!-- espcontrol-pr-testing-guidance -->
<!-- espcontrol-pr-testing-guidance -->
## Automated testing guidance

No specific device could be inferred from the changed files.

Suggested checks:
- Confirm automated checks pass.
- If the change affects what appears on a display, test the relevant device before merge.

Suggested PR status: Needs human judgement on whether device testing is required.

Process note:
- This PR changes workflow or review process files, so check that the PR template/check output remains clear.

Changed files considered:
- `.github/workflows/firmware-compile.yml`
- `.github/workflows/nightly-firmware.yml`
- `.github/workflows/release.yml`
- `scripts/check_firmware_parser.py`
- `scripts/check_timezones.py`
- `scripts/local_esphome.py`
- `scripts/monitor_display_memory.py`
- `scripts/release_changelog.py`

## Checked locally
- Parsed all workflow YAML files.
- Generated PR, nightly, and release device matrices.
- Confirmed every matrix device has a matching `builds/<device>.factory.yaml` file.
- Ran `scripts/local_esphome.py --self-test`.
- Ran `scripts/check_firmware_parser.py`.
- Ran `scripts/monitor_display_memory.py --self-test`.
- Ran `scripts/check_release_changelog.py`.
- Ran `scripts/check_timezones.py`.
- Byte-compiled the touched Python scripts.
- Ran whitespace checks.

## Checked in GitHub Actions
- PR CI passed.
- Manual `Firmware Compile` run started on this branch: https://github.com/jtenniswood/espcontrol/actions/runs/28328015310
- The originally failing `guition-esp32-p4-jc1060p470` firmware compile completed successfully in that run.
