### PR TITLE
Update ESPHome compile image

### DIFF
--- a/.agents/skills/compile/SKILL.md
+++ b/.agents/skills/compile/SKILL.md
@@ -32,7 +32,7 @@ entry point CI uses, so the test matches what a release build would do.
 ```bash
 docker run --rm \
   -v "/Users/jtenniswood/Library/CloudStorage/Dropbox/Git/espcontrol:/config" \
-  ghcr.io/esphome/esphome:2026.5.3 \
+  ghcr.io/esphome/esphome:2026.6.2 \
   compile /config/builds/<slug>.factory.yaml
 ```
 
@@ -41,10 +41,10 @@ Run devices sequentially because each compile is resource-intensive. Use a
 stalled too early. If a compile backgrounds, poll the terminal output until it
 finishes and read the result.
 
-If `ghcr.io/esphome/esphome:2026.5.3` is missing, pull it first:
+If `ghcr.io/esphome/esphome:2026.6.2` is missing, pull it first:
 
 ```bash
-docker pull ghcr.io/esphome/esphome:2026.5.3
+docker pull ghcr.io/esphome/esphome:2026.6.2
 ```
 
 ### 2. Interpret Results


### PR DESCRIPTION
## Summary

- Update the tracked local compile instructions to use the ESPHome Docker image version already used by CI.
- Keep local compile guidance aligned with `ESPHOME_VERSION: 2026.6.2` in the GitHub firmware workflows.

## Practical impact

Local compile instructions now point at `ghcr.io/esphome/esphome:2026.6.2`, so manual compile checks use the same ESPHome version as the automated firmware workflows.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- This only updates internal/local compile instructions, not public setup or device behavior.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [ ] Device testing is required before merge.
- [x] Device testing is not required; explain why in Notes for testing.
- [ ] Device tested by user.

Affected display/device, if applicable:

- None; internal compile instruction update only.

## Notes for testing

- `git diff --check` passed.
- Searched workflow and agent instruction files to confirm no remaining `2026.5.3` ESPHome image references.
- Firmware compile was not run because this change only updates local compile instructions and does not alter firmware source or build configuration.
- No physical device test is required because no firmware or on-device behavior changed.

## PR status

- [x] Checks running or waiting.
- [ ] Needs automated fix.
- [ ] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.
