### PR TITLE
Remove user-tested checkbox from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,6 @@ Docs notes:
 - [ ] Automated/local checks passed or were run where practical.
 - [ ] Device testing is required before merge.
 - [ ] Device testing is not required; explain why in Notes for testing.
-- [ ] Device tested by user.
 
 Affected display/device, if applicable:
 

--- a/scripts/check_pr_process.py
+++ b/scripts/check_pr_process.py
@@ -144,7 +144,6 @@ Docs notes:
 - [x] Automated/local checks passed or were run where practical.
 - [x] Device testing is required before merge.
 - [ ] Device testing is not required; explain why in Notes for testing.
-- [ ] Device tested by user.
 
 Affected display/device, if applicable:
 


### PR DESCRIPTION
## Summary

- Remove the "Device tested by user" checkbox from the pull request template.
- Update the PR process self-test example so it matches the template.

## Practical impact

New pull requests no longer ask authors to tick a separate user device-tested line. The remaining PR status section still tracks device testing progress and successful device testing.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Internal PR template change only.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [ ] Device testing is required before merge.
- [x] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- None.

## Notes for testing

- Ran PR process self-test: passed.
- No device testing needed for this repository metadata change.

## PR status

- [x] Checks running or waiting.
- [ ] Needs automated fix.
- [ ] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.
