### PR TITLE
Lazy build subpage screens

### DIFF
--- a/components/espcontrol/button_grid_actions.h
+++ b/components/espcontrol/button_grid_actions.h
@@ -786,7 +786,7 @@ inline void handle_button_click(const std::string &cfg, int slot_num,
     ha_action_add_data(req, "slot", slot_buf);
     ha_action_send(req);
   } else if (p.type == "subpage") {
-    lv_obj_t *sub_scr = (lv_obj_t *)lv_obj_get_user_data(btn_obj);
+    lv_obj_t *sub_scr = lazy_subpage_screen_from_user_data(lv_obj_get_user_data(btn_obj));
     if (sub_scr)
       lv_scr_load_anim(sub_scr, LV_SCR_LOAD_ANIM_NONE, 0, 0, false);
   } else if (p.type == "alarm") {

--- a/components/espcontrol/button_grid_config.h
+++ b/components/espcontrol/button_grid_config.h
@@ -122,6 +122,18 @@ struct BtnSlot {
   lv_obj_t *subpage_lbl = nullptr;  // small chevron marker for subpage cards
 };
 
+struct LazySubpageRuntimeCtx {
+  lv_obj_t *screen = nullptr;
+  std::function<lv_obj_t *()> build;
+};
+
+inline lv_obj_t *lazy_subpage_screen_from_user_data(void *ptr) {
+  LazySubpageRuntimeCtx *ctx = static_cast<LazySubpageRuntimeCtx *>(ptr);
+  if (ctx == nullptr) return nullptr;
+  if (ctx->screen == nullptr && ctx->build) ctx->screen = ctx->build();
+  return ctx->screen;
+}
+
 struct ParsedCfg;
 inline void set_card_checked_state(lv_obj_t *btn, bool checked);
 

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -1030,7 +1030,10 @@ inline bool grid_subpage_needs_startup_build(const std::string &sp_cfg) {
   auto sp_btns = parse_subpage_config(sp_cfg);
   for (const auto &sb : sp_btns) {
     ParsedCfg sb_cfg = parsed_cfg_from_subpage_btn(sb);
-    if (sb_cfg.type == "climate") return true;
+    if (!sb_cfg.entity.empty() || !sb_cfg.sensor.empty()) return true;
+    if (sb_cfg.type == "climate" || sb_cfg.type == "media" ||
+        sb_cfg.type == "weather_forecast" || sb_cfg.type == "calendar" ||
+        sb_cfg.type == "timezone" || sb_cfg.type == "todo") return true;
   }
   return false;
 }

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -1026,6 +1026,15 @@ inline void grid_clear_subpage_parent_targets(BtnSlot *slots, int slot_count) {
   }
 }
 
+inline bool grid_subpage_needs_startup_build(const std::string &sp_cfg) {
+  auto sp_btns = parse_subpage_config(sp_cfg);
+  for (const auto &sb : sp_btns) {
+    ParsedCfg sb_cfg = parsed_cfg_from_subpage_btn(sb);
+    if (sb_cfg.type == "climate") return true;
+  }
+  return false;
+}
+
 inline void grid_phase2(
     BtnSlot *slots, const GridConfig &cfg,
     esphome::text::Text **sp_configs,
@@ -1635,6 +1644,7 @@ inline void grid_phase2(
       optional_text_state(sp_ext6_configs, si) +
       optional_text_state(sp_ext7_configs, si);
     if (sp_cfg.empty()) continue;
+    bool build_at_startup = grid_subpage_needs_startup_build(sp_cfg);
 
     LazySubpageRuntimeCtx *lazy_ctx =
       grid_track_runtime_allocation(slots[si].btn, new LazySubpageRuntimeCtx());
@@ -2401,6 +2411,10 @@ inline void grid_phase2(
       normalize_subpage_kind(cfg_option_value(p.options, "subpage_kind")),
       nullptr, lazy_ctx);
     lv_obj_set_user_data(slots[si].btn, lazy_ctx);
+    if (build_at_startup) {
+      ESP_LOGI("sensors", "Subpage %d contains heavy controls; building during startup", si + 1);
+      lazy_subpage_screen_from_user_data(lazy_ctx);
+    }
   }
   if (!ha_api_state_connected()) apply_registered_ha_control_availability(false);
   screen_lock_apply();

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -1075,10 +1075,10 @@ inline void grid_phase2(
   reset_climate_control_refs();
   reset_ha_control_availability_refs();
   clear_internal_relay_watchers();
+  navigation_clear_subpages();
   grid_release_main_runtime_allocations(slots, NS);
   grid_clear_subpage_parent_targets(slots, NS);
   navigation_clear_home_targets();
-  navigation_clear_subpages();
   clear_subpage_vacuum_card_text_refs();
   reset_image_card_pool(cfg);
 
@@ -1636,25 +1636,18 @@ inline void grid_phase2(
       optional_text_state(sp_ext7_configs, si);
     if (sp_cfg.empty()) continue;
 
-    auto sp_btns = parse_subpage_config(sp_cfg);
-    std::string sp_order_str = get_subpage_order(sp_cfg);
-    std::string sp_back_label = get_subpage_back_label(sp_order_str);
+    LazySubpageRuntimeCtx *lazy_ctx =
+      grid_track_runtime_allocation(slots[si].btn, new LazySubpageRuntimeCtx());
+    lazy_ctx->build = [=]() -> lv_obj_t * {
+      auto sp_btns = parse_subpage_config(sp_cfg);
+      std::string sp_order_str = get_subpage_order(sp_cfg);
+      std::string sp_back_label = get_subpage_back_label(sp_order_str);
 
-    SubpageOrder sp_ord;
-    parse_subpage_order(sp_order_str, NS, sp_btns.size(), sp_ord);
+      SubpageOrder sp_ord;
+      parse_subpage_order(sp_order_str, NS, sp_btns.size(), sp_ord);
 
-    lv_obj_t *sub_scr = lv_obj_create(NULL);
-    int display_order = NS;
-    for (int pos = 0; pos < NS; pos++) {
-      if (parsed.positions[pos] == si + 1) {
-        display_order = pos;
-        break;
-      }
-    }
-    navigation_register_subpage(
-      si + 1, display_order,
-      normalize_subpage_kind(cfg_option_value(p.options, "subpage_kind")),
-      sub_scr);
+      lv_obj_t *sub_scr = lv_obj_create(NULL);
+      clock_bar_register_button_grid_page(sub_scr);
     lv_obj_set_style_bg_color(sub_scr, lv_obj_get_style_bg_color(main_page_obj, LV_PART_MAIN), LV_PART_MAIN);
     lv_obj_set_style_bg_opa(sub_scr, LV_OPA_COVER, LV_PART_MAIN);
     lv_obj_set_layout(sub_scr, LV_LAYOUT_GRID);
@@ -2392,7 +2385,22 @@ inline void grid_phase2(
       }
     }
 
-    lv_obj_set_user_data(slots[si].btn, (void *)sub_scr);
+    screen_lock_apply();
+    return sub_scr;
+    };
+
+    int display_order = NS;
+    for (int pos = 0; pos < NS; pos++) {
+      if (parsed.positions[pos] == si + 1) {
+        display_order = pos;
+        break;
+      }
+    }
+    navigation_register_subpage(
+      si + 1, display_order,
+      normalize_subpage_kind(cfg_option_value(p.options, "subpage_kind")),
+      nullptr, lazy_ctx);
+    lv_obj_set_user_data(slots[si].btn, lazy_ctx);
   }
   if (!ha_api_state_connected()) apply_registered_ha_control_availability(false);
   screen_lock_apply();

--- a/components/espcontrol/button_grid_ha.h
+++ b/components/espcontrol/button_grid_ha.h
@@ -41,6 +41,8 @@ inline bool ha_api_state_connected() {
 
 constexpr size_t HA_READ_INTERNAL_FREE_MIN_BYTES = 8 * 1024;
 constexpr size_t HA_READ_INTERNAL_LARGEST_MIN_BYTES = 4 * 1024;
+constexpr size_t HA_RESYNC_INTERNAL_FREE_MIN_BYTES = 24 * 1024;
+constexpr size_t HA_RESYNC_INTERNAL_LARGEST_MIN_BYTES = 8 * 1024;
 constexpr size_t HA_ACTION_INTERNAL_FREE_MIN_BYTES = 12 * 1024;
 constexpr size_t HA_ACTION_INTERNAL_LARGEST_MIN_BYTES = 4 * 1024;
 
@@ -320,8 +322,8 @@ inline bool ha_resync_persistent_subscriptions(size_t max_requests = HA_SUBSCRIP
                                                uint32_t scope = HA_SUBSCRIPTION_SCOPE_ALL) {
   if (ha_state_callback_depth() != 0 || !ha_api_state_connected() || max_requests == 0) return false;
   if (!ha_internal_heap_available("Home Assistant subscription resync",
-                                  HA_READ_INTERNAL_FREE_MIN_BYTES,
-                                  HA_READ_INTERNAL_LARGEST_MIN_BYTES)) return false;
+                                  HA_RESYNC_INTERNAL_FREE_MIN_BYTES,
+                                  HA_RESYNC_INTERNAL_LARGEST_MIN_BYTES)) return false;
 
   std::vector<HaSubscriptionCallbackRef> &refs = ha_subscription_callback_refs();
   if (refs.empty()) return true;

--- a/components/espcontrol/button_grid_navigation.h
+++ b/components/espcontrol/button_grid_navigation.h
@@ -19,6 +19,7 @@ struct NavigationSubpageEntry {
   int display_order = 0;
   std::string kind;
   lv_obj_t *screen = nullptr;
+  LazySubpageRuntimeCtx *lazy = nullptr;
 };
 
 inline std::vector<NavigationHomeTargetEntry> &navigation_home_targets() {
@@ -104,8 +105,11 @@ inline void navigation_clear_home_targets() {
 inline void navigation_clear_subpages() {
   lv_obj_t *active = lv_scr_act();
   for (auto &entry : navigation_subpages()) {
-    if (entry.screen != nullptr && entry.screen != active) {
-      lv_obj_del(entry.screen);
+    lv_obj_t *screen = entry.screen;
+    if (screen == nullptr && entry.lazy != nullptr) screen = entry.lazy->screen;
+    if (screen != nullptr && screen != active) {
+      lv_obj_del(screen);
+      if (entry.lazy != nullptr) entry.lazy->screen = nullptr;
     }
   }
   navigation_subpages().clear();
@@ -128,15 +132,17 @@ inline void navigation_register_home_target(int slot, int display_order,
 
 inline void navigation_register_subpage(int slot, int display_order,
                                         const std::string &kind,
-                                        lv_obj_t *screen) {
-  if (slot <= 0 || screen == nullptr) return;
+                                        lv_obj_t *screen,
+                                        LazySubpageRuntimeCtx *lazy = nullptr) {
+  if (slot <= 0 || (screen == nullptr && lazy == nullptr)) return;
   NavigationSubpageEntry entry;
   entry.slot = slot;
   entry.display_order = display_order;
   entry.kind = navigation_lower(navigation_trim(kind));
   entry.screen = screen;
+  entry.lazy = lazy;
   navigation_subpages().push_back(entry);
-  clock_bar_register_button_grid_page(screen);
+  if (screen != nullptr) clock_bar_register_button_grid_page(screen);
 }
 
 inline int navigation_slot_from_target(const std::string &target) {
@@ -205,7 +211,7 @@ inline NavigationSubpageEntry *navigation_find_first_kind(const std::string &kin
   if (wanted.empty()) return nullptr;
   NavigationSubpageEntry *best = nullptr;
   for (auto &entry : navigation_subpages()) {
-    if (entry.screen == nullptr || entry.kind != wanted) continue;
+    if ((entry.screen == nullptr && entry.lazy == nullptr) || entry.kind != wanted) continue;
     if (best == nullptr || entry.display_order < best->display_order) {
       best = &entry;
     }
@@ -221,7 +227,12 @@ inline bool navigation_open_first_kind(const std::string &kind,
     ESP_LOGW("navigation", "No subpage of kind '%s'", navigation_trim(kind).c_str());
     return false;
   }
-  lv_scr_load_anim(target->screen, LV_SCR_LOAD_ANIM_NONE, 0, 0, false);
+  lv_obj_t *screen = target->screen;
+  if (screen == nullptr && target->lazy != nullptr) {
+    screen = lazy_subpage_screen_from_user_data(target->lazy);
+  }
+  if (screen == nullptr) return false;
+  lv_scr_load_anim(screen, LV_SCR_LOAD_ANIM_NONE, 0, 0, false);
   return true;
 }
 


### PR DESCRIPTION
## Purpose

Change existing Subpage cards so their hidden screen is built on first open instead of during firmware startup. This is intended as a test branch to judge the real device experience impact before considering nested subpages.

## Practical impact

- Existing saved subpage configuration stays the same.
- Subpage cards still open the same one-level subpage screens.
- The first tap on a subpage may take slightly longer because the screen is created at that moment.
- Later opens reuse the built screen.
- Home Assistant navigation by subpage type can still open a lazy subpage.

## Testing

Automated checks run locally:
- npm run check:fast
- ESPHome compile for `builds/esp32-p4-86.yaml` with local component substitutions

Device testing still needed:
- Confirm the device boots normally.
- Tap existing Subpage cards and compare first-open delay against the current release.
- Open the same Subpage card a second time and confirm it feels normal after the first build.
- Check Back navigation from subpages.
- Check state updates on cards inside subpages after opening them.

## Automated testing guidance

Device testing is expected before merge because this change affects firmware and the on-device experience. Suggested devices to test: ESP32-P4 86 Panel, 7-inch P4, 4.3-inch P4, 10.1-inch P4, and 4-inch S3.