### PR TITLE
Revert HA availability resync

### DIFF
--- a/common/device/core_infra.yaml
+++ b/common/device/core_infra.yaml
@@ -70,6 +70,13 @@ api:
           ha_flush_deferred_state_requests();
         }
         todo_reload_active_modal();
+    - delay: 25s
+    - lambda: |-
+        if (ha_api_state_connected()) {
+          refresh_weather_forecast_cards();
+          ha_flush_deferred_state_requests();
+        }
+        todo_reload_active_modal();
   on_client_disconnected:
     - lambda: |-
         ESP_LOGW("api", "API client disconnected: %s", client_info.c_str());

--- a/common/device/core_infra.yaml
+++ b/common/device/core_infra.yaml
@@ -40,30 +40,26 @@ api:
             ESP_LOGW("api", "Home Assistant API client address is empty; image proxy base URL not updated");
           }
           refresh_image_cards();
-          ha_start_subscription_resync_window();
           if (ha_api_state_connected()) {
             apply_registered_ha_control_availability(true);
             refresh_weather_forecast_cards();
             ha_flush_deferred_state_requests();
-            ha_run_subscription_resync_window();
           }
         }
         register_local_action_endpoint();
-    - delay: 5s
+    - delay: 2s
     - lambda: |-
         if (ha_api_connected()) refresh_image_cards();
         if (ha_api_state_connected()) {
           ha_flush_deferred_state_requests();
-          ha_run_subscription_resync_window();
         }
         todo_reload_active_modal();
-    - delay: 10s
+    - delay: 8s
     - lambda: |-
         if (ha_api_connected()) refresh_image_cards();
         if (ha_api_state_connected()) {
           refresh_weather_forecast_cards();
           ha_flush_deferred_state_requests();
-          ha_run_subscription_resync_window();
         }
         todo_reload_active_modal();
     - delay: 20s
@@ -72,15 +68,6 @@ api:
         if (ha_api_state_connected()) {
           refresh_weather_forecast_cards();
           ha_flush_deferred_state_requests();
-          ha_run_subscription_resync_window();
-        }
-        todo_reload_active_modal();
-    - delay: 25s
-    - lambda: |-
-        if (ha_api_state_connected()) {
-          refresh_weather_forecast_cards();
-          ha_flush_deferred_state_requests();
-          ha_run_subscription_resync_window();
         }
         todo_reload_active_modal();
   on_client_disconnected:
@@ -93,7 +80,6 @@ api:
         weather_forecast_cancel_pending_requests();
         cover_stop_cancel_pending_request();
         todo_cancel_pending_request("api disconnected");
-        ha_stop_subscription_resync_window();
         apply_registered_ha_control_availability(false);
 
 interval:
@@ -103,7 +89,6 @@ interval:
           weather_forecast_cancel_stale_requests();
           weather_forecast_send_next_queued();
           ha_flush_deferred_state_requests();
-          ha_run_subscription_resync_window();
           todo_retry_waiting_modal();
 
   - interval: 1h

--- a/components/espcontrol/button_grid_ha.h
+++ b/components/espcontrol/button_grid_ha.h
@@ -90,12 +90,7 @@ inline uint8_t &ha_state_callback_depth() {
 
 struct HaSubscriptionCallbackRef {
   std::shared_ptr<HomeAssistantStateCallback> callback;
-  std::string entity_id;
-  std::string attribute;
-  uint32_t generation = 0;
   uint32_t scope = HA_SUBSCRIPTION_SCOPE_DEFAULT;
-  bool has_attribute = false;
-  bool persistent = false;
 };
 
 inline std::vector<HaSubscriptionCallbackRef> &ha_subscription_callback_refs() {
@@ -152,21 +147,11 @@ inline void ha_reset_subscription_callbacks(uint32_t scope = HA_SUBSCRIPTION_SCO
 
 inline void ha_track_subscription_callback(
     const std::shared_ptr<HomeAssistantStateCallback> &callback,
-    const std::string &entity_id,
-    const std::string &attribute,
-    uint32_t generation,
-    uint32_t scope = HA_SUBSCRIPTION_SCOPE_DEFAULT,
-    bool has_attribute = false,
-    bool persistent = false) {
+    uint32_t scope = HA_SUBSCRIPTION_SCOPE_DEFAULT) {
   if (!callback || !*callback) return;
   ha_subscription_callback_refs().push_back({
     callback,
-    entity_id,
-    attribute,
-    generation,
     scope,
-    has_attribute,
-    persistent,
   });
 }
 
@@ -268,125 +253,6 @@ inline void ha_flush_deferred_state_requests(size_t max_requests = 8) {
   ha_release_deferred_state_request_storage();
 }
 
-constexpr uint32_t HA_SUBSCRIPTION_RESYNC_WINDOW_MS = 5 * 60 * 1000UL;
-constexpr size_t HA_SUBSCRIPTION_RESYNC_REQUESTS_PER_PASS = 128;
-
-inline size_t &ha_subscription_resync_cursor() {
-  static size_t cursor = 0;
-  return cursor;
-}
-
-inline bool &ha_subscription_resync_window_active() {
-  static bool active = false;
-  return active;
-}
-
-inline uint32_t &ha_subscription_resync_window_generation() {
-  static uint32_t generation = 0;
-  return generation;
-}
-
-inline uint32_t &ha_subscription_resync_window_started_ms() {
-  static uint32_t started_ms = 0;
-  return started_ms;
-}
-
-inline uint32_t &ha_subscription_resync_window_duration_ms() {
-  static uint32_t duration_ms = HA_SUBSCRIPTION_RESYNC_WINDOW_MS;
-  return duration_ms;
-}
-
-inline void ha_start_subscription_resync_window(uint32_t duration_ms = HA_SUBSCRIPTION_RESYNC_WINDOW_MS) {
-  ha_subscription_resync_cursor() = 0;
-  ha_subscription_resync_window_generation() = ha_subscription_generation();
-  ha_subscription_resync_window_started_ms() = esphome::millis();
-  ha_subscription_resync_window_duration_ms() = duration_ms;
-  ha_subscription_resync_window_active() = true;
-}
-
-inline void ha_stop_subscription_resync_window() {
-  ha_subscription_resync_window_active() = false;
-  ha_subscription_resync_window_started_ms() = 0;
-}
-
-inline bool ha_subscription_resync_window_expired() {
-  if (!ha_subscription_resync_window_active()) return true;
-  if (ha_subscription_resync_window_generation() != ha_subscription_generation()) return true;
-  return (int32_t) (esphome::millis() - ha_subscription_resync_window_started_ms() -
-                    ha_subscription_resync_window_duration_ms()) >= 0;
-}
-
-inline bool ha_resync_persistent_subscriptions(size_t max_requests = HA_SUBSCRIPTION_RESYNC_REQUESTS_PER_PASS,
-                                               uint32_t scope = HA_SUBSCRIPTION_SCOPE_ALL) {
-  if (ha_state_callback_depth() != 0 || !ha_api_state_connected() || max_requests == 0) return false;
-  if (!ha_internal_heap_available("Home Assistant subscription resync",
-                                  HA_READ_INTERNAL_FREE_MIN_BYTES,
-                                  HA_READ_INTERNAL_LARGEST_MIN_BYTES)) return false;
-
-  std::vector<HaSubscriptionCallbackRef> &refs = ha_subscription_callback_refs();
-  if (refs.empty()) return true;
-
-  const uint32_t active_generation = ha_subscription_generation();
-  size_t &cursor = ha_subscription_resync_cursor();
-  if (cursor >= refs.size()) cursor = 0;
-  const size_t start_cursor = cursor;
-
-  size_t processed = 0;
-  size_t scanned = 0;
-  bool completed_cycle = false;
-  while (scanned < refs.size() && processed < max_requests) {
-    size_t index = cursor;
-    cursor = (cursor + 1) % refs.size();
-    scanned++;
-    if (cursor == start_cursor) completed_cycle = true;
-
-    HaSubscriptionCallbackRef &ref = refs[index];
-    if (!ref.persistent || !ref.callback || !*ref.callback) continue;
-    const bool retained_cover_art = (ref.scope & HA_SUBSCRIPTION_SCOPE_COVER_ART) != 0;
-    if (!retained_cover_art && ref.generation != active_generation) continue;
-    if (scope != HA_SUBSCRIPTION_SCOPE_ALL && (ref.scope & scope) == 0) continue;
-
-    const std::string entity_id = ref.entity_id;
-    const std::string attribute = ref.attribute;
-    const bool has_attribute = ref.has_attribute;
-    const uint32_t generation = ref.generation;
-    const bool check_generation = !retained_cover_art;
-    auto callback = ref.callback;
-
-    if (has_attribute) {
-      esphome::api::global_api_server->get_home_assistant_state(
-        entity_id,
-        attribute,
-        [callback, generation, check_generation](esphome::StringRef state) {
-          if (check_generation && generation != ha_subscription_generation()) return;
-          ha_invoke_state_callback(callback, state);
-        });
-    } else {
-      esphome::api::global_api_server->get_home_assistant_state(
-        entity_id,
-        {},
-        [callback, generation, check_generation](esphome::StringRef state) {
-          if (check_generation && generation != ha_subscription_generation()) return;
-          ha_invoke_state_callback(callback, state);
-        });
-    }
-    processed++;
-  }
-  return completed_cycle || scanned >= refs.size();
-}
-
-inline void ha_run_subscription_resync_window(size_t max_requests = HA_SUBSCRIPTION_RESYNC_REQUESTS_PER_PASS) {
-  if (!ha_subscription_resync_window_active()) return;
-  if (ha_subscription_resync_window_expired()) {
-    ha_stop_subscription_resync_window();
-    return;
-  }
-  if (!ha_api_state_connected()) return;
-  if (ha_resync_persistent_subscriptions(max_requests)) {
-    ha_stop_subscription_resync_window();
-  }
-}
-
 inline bool ha_action_begin(esphome::api::HomeassistantActionRequest &req,
                             const char *service,
                             bool is_event,
@@ -478,9 +344,7 @@ inline bool ha_subscribe_state(const std::string &entity_id,
                                uint32_t scope = HA_SUBSCRIPTION_SCOPE_DEFAULT) {
   if (!ha_api_available() || entity_id.empty() || !callback) return false;
   auto callback_ref = std::make_shared<HomeAssistantStateCallback>(std::move(callback));
-  const uint32_t generation = ha_subscription_generation();
-  ha_track_subscription_callback(callback_ref, entity_id, std::string(),
-                                 generation, scope, false, true);
+  ha_track_subscription_callback(callback_ref, scope);
   esphome::api::global_api_server->subscribe_home_assistant_state(
     entity_id, {},
     [callback_ref](esphome::StringRef state) {
@@ -513,9 +377,7 @@ inline bool ha_subscribe_attribute(const std::string &entity_id,
                                    uint32_t scope = HA_SUBSCRIPTION_SCOPE_DEFAULT) {
   if (!ha_api_available() || entity_id.empty() || !callback) return false;
   auto callback_ref = std::make_shared<HomeAssistantStateCallback>(std::move(callback));
-  const uint32_t generation = ha_subscription_generation();
-  ha_track_subscription_callback(callback_ref, entity_id, attribute,
-                                 generation, scope, true, true);
+  ha_track_subscription_callback(callback_ref, scope);
   esphome::api::global_api_server->subscribe_home_assistant_state(
     entity_id, attribute,
     [callback_ref](esphome::StringRef state) {

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -125,37 +125,6 @@ def firmware_ha_boundary_errors(firmware_dir: Path, root: Path) -> list[str]:
     )
     if any(symbol in text for symbol in retry_symbols):
         errors.append(f"{rel}: do not reintroduce unavailable HA state retry polling")
-    if "ha_resync_persistent_subscriptions" not in text:
-        errors.append(f"{rel}: expose bounded Home Assistant startup subscription resync")
-    if "ha_start_subscription_resync_window" not in text or "ha_run_subscription_resync_window" not in text:
-        errors.append(f"{rel}: run Home Assistant startup resync until the bounded window completes")
-    if "HA_SUBSCRIPTION_RESYNC_WINDOW_MS" not in text or "5 * 60 * 1000" not in text:
-        errors.append(f"{rel}: keep Home Assistant startup resync bounded to five minutes")
-    if "ha_subscription_resync_cursor" not in text:
-        errors.append(f"{rel}: rotate bounded Home Assistant startup resync requests")
-    if "ref.generation != active_generation" not in text:
-        errors.append(f"{rel}: keep Home Assistant startup resync on the active subscription generation")
-    if "ref.persistent" not in text:
-        errors.append(f"{rel}: resync persistent Home Assistant subscriptions only")
-    if not re.search(
-        r"ha_resync_persistent_subscriptions\s*\([^)]*uint32_t\s+scope\s*=\s*HA_SUBSCRIPTION_SCOPE_ALL",
-        text,
-        re.DOTALL,
-    ):
-        errors.append(f"{rel}: include all persistent Home Assistant subscription scopes in reconnect resync")
-    if "completed_cycle || scanned >= refs.size()" not in text:
-        errors.append(f"{rel}: stop Home Assistant startup resync after the cursor covers every tracked subscription")
-    if "if (!ha_api_state_connected()) return;" not in text:
-        errors.append(f"{rel}: wait for Home Assistant state subscription before issuing resync reads")
-    start_match = re.search(
-        r"inline\s+void\s+ha_start_subscription_resync_window\s*\([^)]*\)\s*\{(?P<body>.*?)\n\}",
-        text,
-        re.DOTALL,
-    )
-    if start_match and "ha_api_state_connected()" in start_match.group("body"):
-        errors.append(f"{rel}: start the reconnect resync window before Home Assistant state subscription is ready")
-    if "retained_cover_art" not in text or "check_generation && generation != ha_subscription_generation()" not in text:
-        errors.append(f"{rel}: resync retained cover-art subscriptions across grid generation changes")
 
     attribute_helper = ATTRIBUTE_HELPER_PATTERN.search(text)
     if not attribute_helper:
@@ -221,14 +190,6 @@ def firmware_unavailable_retry_errors(
         core_text = core_infra_path.read_text(encoding="utf-8")
         if "ha_retry_unavailable_states" in core_text:
             errors.append(f"{core_rel}: do not retry unavailable HA states after reconnects or during maintenance")
-        if "ha_start_subscription_resync_window();" not in core_text:
-            errors.append(f"{core_rel}: resync Home Assistant subscriptions after startup reconnects")
-        if core_text.find("ha_start_subscription_resync_window();") > core_text.find("if (ha_api_state_connected())"):
-            errors.append(f"{core_rel}: open the startup resync window before Home Assistant state subscription is ready")
-        if "ha_run_subscription_resync_window();" not in core_text:
-            errors.append(f"{core_rel}: continue bounded Home Assistant subscription resync during maintenance")
-        if "interval: 5s" not in core_text or "ha_run_subscription_resync_window();" not in core_text:
-            errors.append(f"{core_rel}: keep Home Assistant startup resync active for up to five minutes")
     return errors
 
 
@@ -2293,22 +2254,6 @@ def run_self_test() -> int:
             "do not reset removed unavailable HA state retries",
             "do not keep removed unavailable HA state retry helpers",
             "do not retry unavailable HA states",
-        ),
-    )
-    expect_unavailable_retry_errors(
-        "missing bounded startup resync",
-        "inline void bump_ha_subscription_generation() {\n"
-        "  ha_reset_deferred_state_requests();\n"
-        "  ha_reset_subscription_callbacks(HA_SUBSCRIPTION_SCOPE_DEFAULT);\n"
-        "}\n",
-        "interval:\n"
-        "  - interval: 5s\n"
-        "    then:\n"
-        "      - lambda: |-\n"
-        "          ha_flush_deferred_state_requests();\n",
-        (
-            "resync Home Assistant subscriptions after startup reconnects",
-            "keep Home Assistant startup resync active for up to five minutes",
         ),
     )
     with TemporaryDirectory() as tmp:

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -581,7 +581,7 @@ def firmware_weather_reconnect_errors(core_infra_path: Path, root: Path) -> list
         if "ha_api_state_connected()" not in guard_window:
             errors.append(f"{core_rel}: wait for Home Assistant state readiness before forecast reconnect refreshes")
             break
-    if "refresh_weather_forecast_cards();" in body and "delay: 20s" not in body:
+    if "refresh_weather_forecast_cards();" in body and ("delay: 20s" not in body or "delay: 25s" not in body):
         errors.append(f"{core_rel}: retry weather forecast refresh after slow S3 reconnects")
     return errors
 
@@ -2940,12 +2940,26 @@ def run_self_test() -> int:
         ("retry weather forecast refresh",),
     )
     expect_weather_reconnect_errors(
-        "guarded weather reconnect refresh with delayed retry",
+        "guarded weather reconnect refresh missing late retry",
         "api:\n"
         "  on_client_connected:\n"
         "    - lambda: |-\n"
         "        if (ha_api_state_connected()) refresh_weather_forecast_cards();\n"
         "    - delay: 20s\n"
+        "    - lambda: |-\n"
+        "        if (ha_api_state_connected()) refresh_weather_forecast_cards();\n",
+        ("retry weather forecast refresh",),
+    )
+    expect_weather_reconnect_errors(
+        "guarded weather reconnect refresh with delayed retries",
+        "api:\n"
+        "  on_client_connected:\n"
+        "    - lambda: |-\n"
+        "        if (ha_api_state_connected()) refresh_weather_forecast_cards();\n"
+        "    - delay: 20s\n"
+        "    - lambda: |-\n"
+        "        if (ha_api_state_connected()) refresh_weather_forecast_cards();\n"
+        "    - delay: 25s\n"
         "    - lambda: |-\n"
         "        if (ha_api_state_connected()) refresh_weather_forecast_cards();\n",
         (),


### PR DESCRIPTION
## Purpose
Remove the Home Assistant availability/resync change from PR #811 while keeping the harmless late weather-card reconnect retry.

That merge added a reconnect subscription resync path that stores extra subscription metadata and replays Home Assistant state requests after reconnect. On the 4-inch S3 this caused severe internal-memory pressure, crash loops, and the local web server failing to respond.

## Practical impact
- Removes the reconnect subscription resync window.
- Removes the extra persistent entity/attribute tracking added for that resync.
- Restores the previous simpler Home Assistant subscription callback tracking.
- Keeps normal live Home Assistant subscriptions and deferred state requests intact.
- Keeps a late guarded weather-card refresh so slow Home Assistant reconnects still get another chance to load forecasts.

## Testing
- Ran firmware Home Assistant binding checks locally: passed.
- Compiled the exact PR branch firmware for the 4-inch S3 dev configuration over the branch worktree: passed.
- Earlier device testing on this branch showed removing the resync memory pressure restored S3 web server responses and heap headroom.

## Physical device testing
Please flash/test the 4-inch S3 before merging. The final branch has been compile-checked, but has not yet been reflashed after replacing the earlier workaround commits with the direct revert plus late weather refresh.