### PR TITLE
Recovery after Home Assistant restart

### DIFF
--- a/common/device/core_infra.yaml
+++ b/common/device/core_infra.yaml
@@ -40,26 +40,30 @@ api:
             ESP_LOGW("api", "Home Assistant API client address is empty; image proxy base URL not updated");
           }
           refresh_image_cards();
+          ha_start_subscription_resync_window();
           if (ha_api_state_connected()) {
             apply_registered_ha_control_availability(true);
             refresh_weather_forecast_cards();
             ha_flush_deferred_state_requests();
+            ha_run_subscription_resync_window();
           }
         }
         register_local_action_endpoint();
-    - delay: 2s
+    - delay: 5s
     - lambda: |-
         if (ha_api_connected()) refresh_image_cards();
         if (ha_api_state_connected()) {
           ha_flush_deferred_state_requests();
+          ha_run_subscription_resync_window();
         }
         todo_reload_active_modal();
-    - delay: 8s
+    - delay: 10s
     - lambda: |-
         if (ha_api_connected()) refresh_image_cards();
         if (ha_api_state_connected()) {
           refresh_weather_forecast_cards();
           ha_flush_deferred_state_requests();
+          ha_run_subscription_resync_window();
         }
         todo_reload_active_modal();
     - delay: 20s
@@ -68,6 +72,15 @@ api:
         if (ha_api_state_connected()) {
           refresh_weather_forecast_cards();
           ha_flush_deferred_state_requests();
+          ha_run_subscription_resync_window();
+        }
+        todo_reload_active_modal();
+    - delay: 25s
+    - lambda: |-
+        if (ha_api_state_connected()) {
+          refresh_weather_forecast_cards();
+          ha_flush_deferred_state_requests();
+          ha_run_subscription_resync_window();
         }
         todo_reload_active_modal();
     - delay: 25s
@@ -87,6 +100,7 @@ api:
         weather_forecast_cancel_pending_requests();
         cover_stop_cancel_pending_request();
         todo_cancel_pending_request("api disconnected");
+        ha_stop_subscription_resync_window();
         apply_registered_ha_control_availability(false);
 
 interval:
@@ -96,6 +110,7 @@ interval:
           weather_forecast_cancel_stale_requests();
           weather_forecast_send_next_queued();
           ha_flush_deferred_state_requests();
+          ha_run_subscription_resync_window();
           todo_retry_waiting_modal();
 
   - interval: 1h

--- a/components/espcontrol/button_grid_ha.h
+++ b/components/espcontrol/button_grid_ha.h
@@ -90,7 +90,12 @@ inline uint8_t &ha_state_callback_depth() {
 
 struct HaSubscriptionCallbackRef {
   std::shared_ptr<HomeAssistantStateCallback> callback;
+  std::string entity_id;
+  std::string attribute;
+  uint32_t generation = 0;
   uint32_t scope = HA_SUBSCRIPTION_SCOPE_DEFAULT;
+  bool has_attribute = false;
+  bool persistent = false;
 };
 
 inline std::vector<HaSubscriptionCallbackRef> &ha_subscription_callback_refs() {
@@ -147,11 +152,21 @@ inline void ha_reset_subscription_callbacks(uint32_t scope = HA_SUBSCRIPTION_SCO
 
 inline void ha_track_subscription_callback(
     const std::shared_ptr<HomeAssistantStateCallback> &callback,
-    uint32_t scope = HA_SUBSCRIPTION_SCOPE_DEFAULT) {
+    const std::string &entity_id,
+    const std::string &attribute,
+    uint32_t generation,
+    uint32_t scope = HA_SUBSCRIPTION_SCOPE_DEFAULT,
+    bool has_attribute = false,
+    bool persistent = false) {
   if (!callback || !*callback) return;
   ha_subscription_callback_refs().push_back({
     callback,
+    entity_id,
+    attribute,
+    generation,
     scope,
+    has_attribute,
+    persistent,
   });
 }
 
@@ -253,6 +268,125 @@ inline void ha_flush_deferred_state_requests(size_t max_requests = 8) {
   ha_release_deferred_state_request_storage();
 }
 
+constexpr uint32_t HA_SUBSCRIPTION_RESYNC_WINDOW_MS = 5 * 60 * 1000UL;
+constexpr size_t HA_SUBSCRIPTION_RESYNC_REQUESTS_PER_PASS = 128;
+
+inline size_t &ha_subscription_resync_cursor() {
+  static size_t cursor = 0;
+  return cursor;
+}
+
+inline bool &ha_subscription_resync_window_active() {
+  static bool active = false;
+  return active;
+}
+
+inline uint32_t &ha_subscription_resync_window_generation() {
+  static uint32_t generation = 0;
+  return generation;
+}
+
+inline uint32_t &ha_subscription_resync_window_started_ms() {
+  static uint32_t started_ms = 0;
+  return started_ms;
+}
+
+inline uint32_t &ha_subscription_resync_window_duration_ms() {
+  static uint32_t duration_ms = HA_SUBSCRIPTION_RESYNC_WINDOW_MS;
+  return duration_ms;
+}
+
+inline void ha_start_subscription_resync_window(uint32_t duration_ms = HA_SUBSCRIPTION_RESYNC_WINDOW_MS) {
+  ha_subscription_resync_cursor() = 0;
+  ha_subscription_resync_window_generation() = ha_subscription_generation();
+  ha_subscription_resync_window_started_ms() = esphome::millis();
+  ha_subscription_resync_window_duration_ms() = duration_ms;
+  ha_subscription_resync_window_active() = true;
+}
+
+inline void ha_stop_subscription_resync_window() {
+  ha_subscription_resync_window_active() = false;
+  ha_subscription_resync_window_started_ms() = 0;
+}
+
+inline bool ha_subscription_resync_window_expired() {
+  if (!ha_subscription_resync_window_active()) return true;
+  if (ha_subscription_resync_window_generation() != ha_subscription_generation()) return true;
+  return (int32_t) (esphome::millis() - ha_subscription_resync_window_started_ms() -
+                    ha_subscription_resync_window_duration_ms()) >= 0;
+}
+
+inline bool ha_resync_persistent_subscriptions(size_t max_requests = HA_SUBSCRIPTION_RESYNC_REQUESTS_PER_PASS,
+                                               uint32_t scope = HA_SUBSCRIPTION_SCOPE_ALL) {
+  if (ha_state_callback_depth() != 0 || !ha_api_state_connected() || max_requests == 0) return false;
+  if (!ha_internal_heap_available("Home Assistant subscription resync",
+                                  HA_READ_INTERNAL_FREE_MIN_BYTES,
+                                  HA_READ_INTERNAL_LARGEST_MIN_BYTES)) return false;
+
+  std::vector<HaSubscriptionCallbackRef> &refs = ha_subscription_callback_refs();
+  if (refs.empty()) return true;
+
+  const uint32_t active_generation = ha_subscription_generation();
+  size_t &cursor = ha_subscription_resync_cursor();
+  if (cursor >= refs.size()) cursor = 0;
+  const size_t start_cursor = cursor;
+
+  size_t processed = 0;
+  size_t scanned = 0;
+  bool completed_cycle = false;
+  while (scanned < refs.size() && processed < max_requests) {
+    size_t index = cursor;
+    cursor = (cursor + 1) % refs.size();
+    scanned++;
+    if (cursor == start_cursor) completed_cycle = true;
+
+    HaSubscriptionCallbackRef &ref = refs[index];
+    if (!ref.persistent || !ref.callback || !*ref.callback) continue;
+    const bool retained_cover_art = (ref.scope & HA_SUBSCRIPTION_SCOPE_COVER_ART) != 0;
+    if (!retained_cover_art && ref.generation != active_generation) continue;
+    if (scope != HA_SUBSCRIPTION_SCOPE_ALL && (ref.scope & scope) == 0) continue;
+
+    const std::string entity_id = ref.entity_id;
+    const std::string attribute = ref.attribute;
+    const bool has_attribute = ref.has_attribute;
+    const uint32_t generation = ref.generation;
+    const bool check_generation = !retained_cover_art;
+    auto callback = ref.callback;
+
+    if (has_attribute) {
+      esphome::api::global_api_server->get_home_assistant_state(
+        entity_id,
+        attribute,
+        [callback, generation, check_generation](esphome::StringRef state) {
+          if (check_generation && generation != ha_subscription_generation()) return;
+          ha_invoke_state_callback(callback, state);
+        });
+    } else {
+      esphome::api::global_api_server->get_home_assistant_state(
+        entity_id,
+        {},
+        [callback, generation, check_generation](esphome::StringRef state) {
+          if (check_generation && generation != ha_subscription_generation()) return;
+          ha_invoke_state_callback(callback, state);
+        });
+    }
+    processed++;
+  }
+  return completed_cycle || scanned >= refs.size();
+}
+
+inline void ha_run_subscription_resync_window(size_t max_requests = HA_SUBSCRIPTION_RESYNC_REQUESTS_PER_PASS) {
+  if (!ha_subscription_resync_window_active()) return;
+  if (ha_subscription_resync_window_expired()) {
+    ha_stop_subscription_resync_window();
+    return;
+  }
+  if (!ha_api_state_connected()) return;
+  if (ha_resync_persistent_subscriptions(max_requests)) {
+    ha_stop_subscription_resync_window();
+  }
+}
+
 inline bool ha_action_begin(esphome::api::HomeassistantActionRequest &req,
                             const char *service,
                             bool is_event,
@@ -344,7 +478,9 @@ inline bool ha_subscribe_state(const std::string &entity_id,
                                uint32_t scope = HA_SUBSCRIPTION_SCOPE_DEFAULT) {
   if (!ha_api_available() || entity_id.empty() || !callback) return false;
   auto callback_ref = std::make_shared<HomeAssistantStateCallback>(std::move(callback));
-  ha_track_subscription_callback(callback_ref, scope);
+  const uint32_t generation = ha_subscription_generation();
+  ha_track_subscription_callback(callback_ref, entity_id, std::string(),
+                                 generation, scope, false, true);
   esphome::api::global_api_server->subscribe_home_assistant_state(
     entity_id, {},
     [callback_ref](esphome::StringRef state) {
@@ -377,7 +513,9 @@ inline bool ha_subscribe_attribute(const std::string &entity_id,
                                    uint32_t scope = HA_SUBSCRIPTION_SCOPE_DEFAULT) {
   if (!ha_api_available() || entity_id.empty() || !callback) return false;
   auto callback_ref = std::make_shared<HomeAssistantStateCallback>(std::move(callback));
-  ha_track_subscription_callback(callback_ref, scope);
+  const uint32_t generation = ha_subscription_generation();
+  ha_track_subscription_callback(callback_ref, entity_id, attribute,
+                                 generation, scope, true, true);
   esphome::api::global_api_server->subscribe_home_assistant_state(
     entity_id, attribute,
     [callback_ref](esphome::StringRef state) {

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -125,6 +125,37 @@ def firmware_ha_boundary_errors(firmware_dir: Path, root: Path) -> list[str]:
     )
     if any(symbol in text for symbol in retry_symbols):
         errors.append(f"{rel}: do not reintroduce unavailable HA state retry polling")
+    if "ha_resync_persistent_subscriptions" not in text:
+        errors.append(f"{rel}: expose bounded Home Assistant startup subscription resync")
+    if "ha_start_subscription_resync_window" not in text or "ha_run_subscription_resync_window" not in text:
+        errors.append(f"{rel}: run Home Assistant startup resync until the bounded window completes")
+    if "HA_SUBSCRIPTION_RESYNC_WINDOW_MS" not in text or "5 * 60 * 1000" not in text:
+        errors.append(f"{rel}: keep Home Assistant startup resync bounded to five minutes")
+    if "ha_subscription_resync_cursor" not in text:
+        errors.append(f"{rel}: rotate bounded Home Assistant startup resync requests")
+    if "ref.generation != active_generation" not in text:
+        errors.append(f"{rel}: keep Home Assistant startup resync on the active subscription generation")
+    if "ref.persistent" not in text:
+        errors.append(f"{rel}: resync persistent Home Assistant subscriptions only")
+    if not re.search(
+        r"ha_resync_persistent_subscriptions\s*\([^)]*uint32_t\s+scope\s*=\s*HA_SUBSCRIPTION_SCOPE_ALL",
+        text,
+        re.DOTALL,
+    ):
+        errors.append(f"{rel}: include all persistent Home Assistant subscription scopes in reconnect resync")
+    if "completed_cycle || scanned >= refs.size()" not in text:
+        errors.append(f"{rel}: stop Home Assistant startup resync after the cursor covers every tracked subscription")
+    if "if (!ha_api_state_connected()) return;" not in text:
+        errors.append(f"{rel}: wait for Home Assistant state subscription before issuing resync reads")
+    start_match = re.search(
+        r"inline\s+void\s+ha_start_subscription_resync_window\s*\([^)]*\)\s*\{(?P<body>.*?)\n\}",
+        text,
+        re.DOTALL,
+    )
+    if start_match and "ha_api_state_connected()" in start_match.group("body"):
+        errors.append(f"{rel}: start the reconnect resync window before Home Assistant state subscription is ready")
+    if "retained_cover_art" not in text or "check_generation && generation != ha_subscription_generation()" not in text:
+        errors.append(f"{rel}: resync retained cover-art subscriptions across grid generation changes")
 
     attribute_helper = ATTRIBUTE_HELPER_PATTERN.search(text)
     if not attribute_helper:
@@ -190,6 +221,14 @@ def firmware_unavailable_retry_errors(
         core_text = core_infra_path.read_text(encoding="utf-8")
         if "ha_retry_unavailable_states" in core_text:
             errors.append(f"{core_rel}: do not retry unavailable HA states after reconnects or during maintenance")
+        if "ha_start_subscription_resync_window();" not in core_text:
+            errors.append(f"{core_rel}: resync Home Assistant subscriptions after startup reconnects")
+        if core_text.find("ha_start_subscription_resync_window();") > core_text.find("if (ha_api_state_connected())"):
+            errors.append(f"{core_rel}: open the startup resync window before Home Assistant state subscription is ready")
+        if "ha_run_subscription_resync_window();" not in core_text:
+            errors.append(f"{core_rel}: continue bounded Home Assistant subscription resync during maintenance")
+        if "interval: 5s" not in core_text or "ha_run_subscription_resync_window();" not in core_text:
+            errors.append(f"{core_rel}: keep Home Assistant startup resync active for up to five minutes")
     return errors
 
 
@@ -2254,6 +2293,22 @@ def run_self_test() -> int:
             "do not reset removed unavailable HA state retries",
             "do not keep removed unavailable HA state retry helpers",
             "do not retry unavailable HA states",
+        ),
+    )
+    expect_unavailable_retry_errors(
+        "missing bounded startup resync",
+        "inline void bump_ha_subscription_generation() {\n"
+        "  ha_reset_deferred_state_requests();\n"
+        "  ha_reset_subscription_callbacks(HA_SUBSCRIPTION_SCOPE_DEFAULT);\n"
+        "}\n",
+        "interval:\n"
+        "  - interval: 5s\n"
+        "    then:\n"
+        "      - lambda: |-\n"
+        "          ha_flush_deferred_state_requests();\n",
+        (
+            "resync Home Assistant subscriptions after startup reconnects",
+            "keep Home Assistant startup resync active for up to five minutes",
         ),
     )
     with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Purpose
Re-open the Home Assistant availability resync code that was removed by PR #826, so it can be reviewed and tested separately from the revert.

## Practical impact
- Restores the reconnect subscription resync window.
- Restores persistent tracking of Home Assistant subscription metadata.
- Restores replay of tracked state and attribute subscriptions after Home Assistant reconnects.
- Keeps the late guarded weather-card reconnect refresh that was preserved after the revert.

## Important testing note
This is the same class of code that was removed because the 4-inch S3 showed internal-memory pressure, crash loops, and web server failures. Treat this PR as a review/test branch, not as confirmed safe for merging.

## Testing
- Ran firmware Home Assistant binding checks locally: passed.
- Compiled the exact PR branch firmware for the 4-inch S3 dev configuration: passed.

## Physical device testing
Please flash/test the 4-inch S3 before considering merge. Specifically check boot stability, available heap, local web server response, Home Assistant reconnect behavior, and weather-card loading after reconnect.