### PR TITLE
Add 10-inch wall mount docs link

### DIFF
--- a/docs/reference/3d-printable-stands.md
+++ b/docs/reference/3d-printable-stands.md
@@ -1,20 +1,21 @@
 ---
-title: Printable Stands
+title: Printable Stands and Mounts
 description:
-  3D printable desk stands and case stands for EspControl supported ESP32 touchscreens, with links to the matching MakerWorld print files.
+  3D printable stands and mounts for EspControl supported ESP32 touchscreens, with links to the matching MakerWorld print files.
 ---
 
-# Printable Stands
+# Printable Stands and Mounts
 
-These stands are optional desk mounts for supported EspControl panels. They are useful when you want a display on a desk, shelf, bedside table, or test bench instead of wall mounting it.
+These printable files are optional stands and mounts for supported EspControl panels. They are useful when you want a display on a desk, shelf, bedside table, test bench, or wall.
 
-Choose the stand that matches your exact screen model. The cases are shaped around the panel body, ports, and cable position, so a stand for one display usually will not fit another display cleanly.
+Choose the print file that matches your exact screen model. The cases are shaped around the panel body, ports, and cable position, so a stand or mount for one display usually will not fit another display cleanly.
 
 ## Available Print Files
 
-| Screen | Stand type | Print file |
+| Screen | Mount type | Print file |
 |---|---|---|
 | [10.1-inch JC8012P4A1](/screens/jc8012p4a1) | Desk stand | [MakerWorld](https://makerworld.com/en/models/2490049-guition-p4-10inch-screen-stand#profileId-2736046) |
+| [10.1-inch JC8012P4A1](/screens/jc8012p4a1) | Wall mount | [MakerWorld](https://makerworld.com/en/models/2991675-wall-mount-for-10-1-inch-guition-esp32-jc8012p4a1#profileId-3357939) |
 | [7-inch JC1060P470](/screens/jc1060p470) | Desk stand | [MakerWorld](https://makerworld.com/en/models/2387421-guition-esp32p4-jc1060p470-7inch-screen-desk-mount#profileId-2614995) |
 | [4-inch ESP32-P4 86 Panel](/screens/p4-86) | Desk stand | [MakerWorld](https://makerworld.com/en/models/2720366-waveshare-esp32-p4-smart-86-box-screen-desk-stand#profileId-3013481) |
 | [4.3-inch JC4880P443](/screens/jc4880p443) | Desk stand | [MakerWorld](https://makerworld.com/en/models/2982320-desk-stand-for-4-3-inch-jc4880p443-esp32-screen#profileId-3346161) |

--- a/docs/screens/jc8012p4a1.md
+++ b/docs/screens/jc8012p4a1.md
@@ -64,3 +64,4 @@ packages:
 
 - **AliExpress:** [~£40](https://s.click.aliexpress.com/e/_c4W6TYvp)
 - **Desk stand** (3D printable): [MakerWorld](https://makerworld.com/en/models/2490049-guition-p4-10inch-screen-stand#profileId-2736046)
+- **Wall mount** (3D printable): [MakerWorld](https://makerworld.com/en/models/2991675-wall-mount-for-10-1-inch-guition-esp32-jc8012p4a1#profileId-3357939)


### PR DESCRIPTION
## Purpose

Add the MakerWorld wall mount link for the 10.1-inch Guition JC8012P4A1 screen.

## Practical impact

People viewing the 10.1-inch screen docs can now find both the existing printable desk stand and the new printable wall mount. The shared printable stands page now refers to stands and mounts so the wording matches the available options.

## How it was checked

- Ran `npm run docs:build` successfully.

<!-- espcontrol-pr-testing-guidance -->
## Automated testing guidance

No physical device test is expected from the changed files.

Suggested checks:
- Confirm the documentation or workflow text says what a user should do.
- Confirm automated checks pass.

Suggested PR status: Ready to merge after review and user confirmation.

Changed files considered:
- `docs/reference/3d-printable-stands.md`
- `docs/screens/jc8012p4a1.md`

## Physical device testing

Not required. This is a documentation-only change and does not affect firmware or display behaviour.
