### PR TITLE
fix: switch non-firmware CI jobs from self-hosted to ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
   sync-icons:
     name: Sync Generated Icons
     if: github.event_name != 'pull_request'
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     outputs:
@@ -122,9 +122,9 @@ jobs:
     if: >-
       always() &&
       (github.event_name == 'pull_request' || needs.sync-icons.outputs.changed != 'true')
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
-      - name: Prepare self-hosted workspace
+      - name: Prepare workspace
         run: |
           rm -rf "${GITHUB_WORKSPACE:?}/"* "${GITHUB_WORKSPACE:?}/".[!.]* "${GITHUB_WORKSPACE:?}/"..?* 2>/dev/null ||
             sudo rm -rf "${GITHUB_WORKSPACE:?}/"* "${GITHUB_WORKSPACE:?}/".[!.]* "${GITHUB_WORKSPACE:?}/"..?*
@@ -155,9 +155,9 @@ jobs:
       always() &&
       needs.validate.result == 'success' &&
       (github.event_name == 'pull_request' || needs.sync-icons.outputs.changed != 'true')
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
-      - name: Prepare self-hosted workspace
+      - name: Prepare workspace
         run: |
           rm -rf "${GITHUB_WORKSPACE:?}/"* "${GITHUB_WORKSPACE:?}/".[!.]* "${GITHUB_WORKSPACE:?}/"..?* 2>/dev/null ||
             sudo rm -rf "${GITHUB_WORKSPACE:?}/"* "${GITHUB_WORKSPACE:?}/".[!.]* "${GITHUB_WORKSPACE:?}/"..?*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,9 @@ jobs:
 
   preflight:
     name: Product Preflight
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
-      - name: Prepare self-hosted workspace
+      - name: Prepare workspace
         run: |
           rm -rf "${GITHUB_WORKSPACE:?}/"* "${GITHUB_WORKSPACE:?}/".[!.]* "${GITHUB_WORKSPACE:?}/"..?* 2>/dev/null ||
             sudo rm -rf "${GITHUB_WORKSPACE:?}/"* "${GITHUB_WORKSPACE:?}/".[!.]* "${GITHUB_WORKSPACE:?}/"..?*
@@ -68,11 +68,11 @@ jobs:
   device-matrix:
     name: Prepare Device Matrix
     needs: preflight
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
-      - name: Prepare self-hosted workspace
+      - name: Prepare workspace
         run: |
           rm -rf "${GITHUB_WORKSPACE:?}/"* "${GITHUB_WORKSPACE:?}/".[!.]* "${GITHUB_WORKSPACE:?}/"..?* 2>/dev/null ||
             sudo rm -rf "${GITHUB_WORKSPACE:?}/"* "${GITHUB_WORKSPACE:?}/".[!.]* "${GITHUB_WORKSPACE:?}/"..?*
@@ -260,7 +260,7 @@ jobs:
     name: Publish to Release
     if: github.event_name == 'release' || inputs.release_tag != ''
     needs: build-firmware
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Download all firmware artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Problem

The self-hosted GitHub Actions runner has been going offline intermittently, blocking several workflows:

- **CI validate/docs/sync-icons jobs** — These run on `self-hosted` but only need Node.js, Python, and npm, which are all available on standard GitHub-hosted runners.
- **Nightly firmware test build** — 5 compile jobs cancelled today with *"The job was not acquired by Runner of type self-hosted even after multiple attempts"*
- **Release preflight/device-matrix/publish** — These don't need special hardware but are blocked when the runner is down.

Example failing runs: Nightly \#43, CI \#3076

## Changes

| Workflow | Job(s) Changed | Old Runner | New Runner |
|---|---|---|---|
| CI (`ci.yml`) | sync-icons, validate, docs | self-hosted | ubuntu-latest |
| Build Release (`release.yml`) | preflight, device-matrix, publish | self-hosted | ubuntu-latest |

**Intentionally kept on `self-hosted`:** All firmware compile jobs (`nightly-firmware.yml`, `firmware-compile.yml`, `release.yml` build-firmware) and runner disk cleanup — these need Docker + ESPHome + PlatformIO which require the self-hosted runner's hardware.

## Testing notes

- After merge, the next CI run on any PR or push will use `ubuntu-latest` for validate, docs, and sync-icons
- Firmware compilation still requires the self-hosted runner to be online
- A quick way to verify: push a trivial commit to a PR branch and check that the validate/docs jobs run on ubuntu-latest