### PR TITLE
Share modal tab layout helpers

### DIFF
--- a/components/espcontrol/button_grid_climate.h
+++ b/components/espcontrol/button_grid_climate.h
@@ -166,20 +166,6 @@ struct ClimateControlVisibleTabs {
 
 inline ClimateControlVisibleTabs climate_control_visible_tabs(ClimateControlCtx *ctx);
 
-struct ClimateControlTabLayout {
-  int tab_count = 1;
-  bool show_tab_bar = false;
-  lv_coord_t tab_size = 48;
-  lv_coord_t selected_tab_size = 54;
-  lv_coord_t tab_frame_pad = 9;
-  lv_coord_t tab_gap = 12;
-  lv_coord_t tabs_total_w = 48;
-  lv_coord_t tab_frame_w = 66;
-  lv_coord_t tab_frame_h = 66;
-  lv_coord_t tab_safe_left = 0;
-  lv_coord_t centered_left = 0;
-};
-
 struct ClimateControlModalUi {
   lv_obj_t *overlay = nullptr;
   lv_obj_t *panel = nullptr;
@@ -610,42 +596,12 @@ inline ClimateControlTab climate_control_first_visible_tab(ClimateControlCtx *ct
   return tabs.count == 0 ? ClimateControlTab::TEMPERATURE : tabs.tabs[0];
 }
 
-inline ClimateControlTabLayout climate_control_calc_tab_layout(
+inline ControlModalTabLayout climate_control_calc_tab_layout(
     ClimateControlCtx *ctx, const ControlModalLayout &layout) {
-  ClimateControlTabLayout tabs_layout;
   ClimateControlVisibleTabs visible_tabs = climate_control_visible_tabs(ctx);
-  tabs_layout.tab_count = static_cast<int>(visible_tabs.count);
-  if (tabs_layout.tab_count < 1) tabs_layout.tab_count = 1;
-  tabs_layout.show_tab_bar = ctx && ctx->all_controls && tabs_layout.tab_count > 1;
-  tabs_layout.tab_size = control_modal_uses_p4_86_tuning(layout)
-    ? control_modal_scaled_px(CLIMATE_MODAL_P4_86_TAB_REF_PX, layout.short_side)
-    : control_modal_prominent_card_tab_size(layout);
-  tabs_layout.selected_tab_size = tabs_layout.tab_size + tabs_layout.tab_size / 8;
-  tabs_layout.tab_frame_pad = tabs_layout.tab_size / 5;
-  tabs_layout.tab_gap = control_modal_control_tab_gap(layout, tabs_layout.tab_size);
-  tabs_layout.tabs_total_w =
-    tabs_layout.tab_size * tabs_layout.tab_count + tabs_layout.tab_gap * (tabs_layout.tab_count - 1);
-  tabs_layout.tab_frame_w = tabs_layout.tabs_total_w + tabs_layout.tab_frame_pad * 2;
-  tabs_layout.tab_frame_h = tabs_layout.tab_size + tabs_layout.tab_frame_pad * 2;
-  tabs_layout.tab_safe_left = layout.back_inset_x + layout.back_size + layout.inset / 2;
-  tabs_layout.centered_left = (layout.panel_w - tabs_layout.tab_frame_w) / 2;
-  lv_coord_t min_tab_size = control_modal_control_tab_min_size(layout);
-  while (tabs_layout.show_tab_bar &&
-         !control_modal_uses_compact_portrait_tuning(layout) &&
-         !control_modal_uses_p4_86_tuning(layout) &&
-         tabs_layout.centered_left < tabs_layout.tab_safe_left &&
-         tabs_layout.tab_size > min_tab_size) {
-    tabs_layout.tab_size--;
-    tabs_layout.selected_tab_size = tabs_layout.tab_size + tabs_layout.tab_size / 8;
-    tabs_layout.tab_frame_pad = tabs_layout.tab_size / 5;
-    tabs_layout.tab_gap = control_modal_control_tab_gap(layout, tabs_layout.tab_size);
-    tabs_layout.tabs_total_w =
-      tabs_layout.tab_size * tabs_layout.tab_count + tabs_layout.tab_gap * (tabs_layout.tab_count - 1);
-    tabs_layout.tab_frame_w = tabs_layout.tabs_total_w + tabs_layout.tab_frame_pad * 2;
-    tabs_layout.tab_frame_h = tabs_layout.tab_size + tabs_layout.tab_frame_pad * 2;
-    tabs_layout.centered_left = (layout.panel_w - tabs_layout.tab_frame_w) / 2;
-  }
-  return tabs_layout;
+  int tab_count = static_cast<int>(visible_tabs.count);
+  bool show_tab_bar = ctx && ctx->all_controls && tab_count > 1;
+  return control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);
 }
 
 inline void climate_control_ensure_visible_tab(ClimateControlCtx *ctx) {
@@ -787,11 +743,7 @@ inline lv_coord_t climate_control_labels_down_ref(const ControlModalLayout &layo
 }
 
 inline lv_coord_t climate_control_tab_content_gap(const ControlModalLayout &layout) {
-  if (climate_control_uses_p4_86_modal_tuning(layout))
-    return control_modal_scaled_px(CLIMATE_MODAL_P4_86_TAB_CONTENT_GAP_REF_PX, layout.short_side);
-  if (climate_control_uses_compact_portrait_modal_tuning(layout))
-    return control_modal_scaled_px(CLIMATE_MODAL_JC4880P443_TAB_CONTENT_GAP_REF_PX, layout.short_side);
-  return control_modal_prominent_card_tab_content_gap(layout);
+  return control_modal_shared_tab_content_gap(layout);
 }
 
 inline lv_coord_t climate_control_unit_y_ref(const ControlModalLayout &layout) {
@@ -916,7 +868,7 @@ inline ControlModalLayout climate_control_calc_layout(ClimateControlCtx *ctx) {
   layout.controls_center_y = layout.arc_center_y + layout.arc_size / 2 -
     layout.btn_size / 2 - layout.inset +
     control_modal_controls_down_px(layout);
-  ClimateControlTabLayout tabs_layout = climate_control_calc_tab_layout(ctx, layout);
+  ControlModalTabLayout tabs_layout = climate_control_calc_tab_layout(ctx, layout);
   if (tabs_layout.show_tab_bar) {
     lv_coord_t tab_bottom = layout.inset + 2 + tabs_layout.tab_frame_h;
     lv_coord_t desired_control_top = tab_bottom + climate_control_tab_content_gap(layout);
@@ -1487,11 +1439,7 @@ inline void climate_control_layout_modal(ClimateControlCtx *ctx);
 inline void climate_control_apply_tab_visibility();
 
 inline void climate_center_tab_icon(lv_obj_t *label) {
-  if (!label) return;
-  lv_obj_update_layout(label);
-  lv_obj_set_style_transform_pivot_x(label, lv_obj_get_width(label) / 2, LV_PART_MAIN);
-  lv_obj_set_style_transform_pivot_y(label, lv_obj_get_height(label) / 2, LV_PART_MAIN);
-  lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
+  control_modal_center_tab_icon(label);
 }
 
 inline lv_obj_t *climate_control_create_tab_button(lv_obj_t *parent, const char *icon,
@@ -1903,46 +1851,16 @@ inline void climate_control_layout_modal(ClimateControlCtx *ctx) {
     control_modal_card_radius(ctx->btn));
   control_modal_apply_back_button_layout(ui.back_btn, layout);
   ClimateControlVisibleTabs visible_tabs = climate_control_visible_tabs(ctx);
-  ClimateControlTabLayout tabs_layout = climate_control_calc_tab_layout(ctx, layout);
+  ControlModalTabLayout tabs_layout = climate_control_calc_tab_layout(ctx, layout);
   int tab_count = tabs_layout.tab_count;
   bool show_tab_bar = tabs_layout.show_tab_bar;
-  lv_coord_t tab_size = tabs_layout.tab_size;
-  lv_coord_t selected_tab_size = tabs_layout.selected_tab_size;
-  lv_coord_t tab_gap = tabs_layout.tab_gap;
-  lv_coord_t tabs_total_w = tabs_layout.tabs_total_w;
-  lv_coord_t tab_frame_w = tabs_layout.tab_frame_w;
   lv_coord_t tab_frame_h = tabs_layout.tab_frame_h;
-  lv_coord_t tab_safe_left = tabs_layout.tab_safe_left;
-  lv_coord_t centered_left = tabs_layout.centered_left;
-  if (ui.tab_row) {
-    if (show_tab_bar) {
-      lv_obj_clear_flag(ui.tab_row, LV_OBJ_FLAG_HIDDEN);
-      lv_obj_set_size(ui.tab_row, tab_frame_w, tab_frame_h);
-      lv_obj_set_style_radius(ui.tab_row, tab_frame_h / 2, LV_PART_MAIN);
-      if (centered_left < tab_safe_left) centered_left = tab_safe_left;
-      lv_obj_align(ui.tab_row, LV_ALIGN_TOP_LEFT, centered_left, layout.inset + 2);
-    } else {
-      lv_obj_add_flag(ui.tab_row, LV_OBJ_FLAG_HIDDEN);
-    }
-  }
-  lv_coord_t first_tab_x = (tab_frame_w - tabs_total_w) / 2;
+  control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);
   for (int i = 0; show_tab_bar && i < tab_count; i++) {
     lv_obj_t *tab_btn = climate_control_tab_button(ui, visible_tabs.tabs[i]);
     if (!tab_btn) continue;
     bool active = visible_tabs.tabs[i] == ui.tab;
-    lv_coord_t tab_btn_size = active ? selected_tab_size : tab_size;
-    lv_obj_set_size(tab_btn, tab_btn_size, tab_btn_size);
-    lv_obj_set_style_radius(tab_btn, tab_btn_size / 2, LV_PART_MAIN);
-    lv_coord_t tab_x = first_tab_x + i * (tab_size + tab_gap);
-    lv_obj_align(tab_btn, LV_ALIGN_LEFT_MID, tab_x - (tab_btn_size - tab_size) / 2, 0);
-    lv_obj_t *label = lv_obj_get_child(tab_btn, 0);
-    if (label) {
-      lv_obj_set_style_transform_zoom(label,
-        (control_modal_uses_compact_portrait_tuning(layout) ||
-         climate_control_uses_p4_86_modal_tuning(layout)) ? 220 : 180,
-        LV_PART_MAIN);
-    }
-    climate_center_tab_icon(label);
+    control_modal_layout_tab_button(tab_btn, layout, tabs_layout, i, active);
   }
   if (ui.mode_btn) {
     lv_obj_set_size(ui.mode_btn, layout.back_size, layout.back_size);

--- a/components/espcontrol/button_grid_fan.h
+++ b/components/espcontrol/button_grid_fan.h
@@ -767,55 +767,19 @@ inline void fan_control_layout_modal(FanCardCtx *ctx) {
   FanControlVisibleTabs visible_tabs = fan_control_visible_tabs(ctx);
   ControlModalLayout layout = control_modal_calc_layout(ctx->width_compensation_percent);
   int tab_count = static_cast<int>(visible_tabs.count);
-  if (tab_count < 1) tab_count = 1;
   bool show_tab_bar = visible_tabs.count > 1;
-  lv_coord_t tab_size = layout.back_size * 7 / 10;
-  if (tab_size < 44) tab_size = 44;
-  if (tab_size > 64) tab_size = 64;
-  lv_coord_t selected_tab_size = tab_size + tab_size / 8;
-  lv_coord_t tab_frame_pad = tab_size / 5;
-  lv_coord_t tab_gap = tab_size / 4;
-  lv_coord_t tabs_total_w = tab_size * tab_count + tab_gap * (tab_count - 1);
-  lv_coord_t tab_frame_w = tabs_total_w + tab_frame_pad * 2;
-  lv_coord_t tab_frame_h = tab_size + tab_frame_pad * 2;
-  lv_coord_t tab_safe_left = layout.back_inset_x + layout.back_size + layout.inset / 2;
-  lv_coord_t centered_left = (layout.panel_w - tab_frame_w) / 2;
-  while (show_tab_bar && centered_left < tab_safe_left && tab_size > 40) {
-    tab_size--;
-    selected_tab_size = tab_size + tab_size / 8;
-    tab_frame_pad = tab_size / 5;
-    tab_gap = tab_size / 4;
-    tabs_total_w = tab_size * tab_count + tab_gap * (tab_count - 1);
-    tab_frame_w = tabs_total_w + tab_frame_pad * 2;
-    tab_frame_h = tab_size + tab_frame_pad * 2;
-    centered_left = (layout.panel_w - tab_frame_w) / 2;
-  }
-  if (!show_tab_bar) tab_frame_h = 0;
-  if (ui.tab_row) {
-    if (show_tab_bar) {
-      lv_obj_clear_flag(ui.tab_row, LV_OBJ_FLAG_HIDDEN);
-      lv_obj_set_size(ui.tab_row, tab_frame_w, tab_frame_h);
-      lv_obj_set_style_radius(ui.tab_row, tab_frame_h / 2, LV_PART_MAIN);
-      if (centered_left < tab_safe_left) centered_left = tab_safe_left;
-      lv_obj_align(ui.tab_row, LV_ALIGN_TOP_LEFT, centered_left, layout.inset + 2);
-    } else {
-      lv_obj_add_flag(ui.tab_row, LV_OBJ_FLAG_HIDDEN);
-    }
-  }
-  lv_coord_t first_tab_x = (tab_frame_w - tabs_total_w) / 2;
+  ControlModalTabLayout tabs_layout = control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);
+  control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);
   for (int i = 0; show_tab_bar && i < tab_count; i++) {
     lv_obj_t *tab_btn = fan_control_tab_button(ui, visible_tabs.tabs[i]);
     if (!tab_btn) continue;
     bool active = visible_tabs.tabs[i] == ui.tab;
-    lv_coord_t tab_btn_size = active ? selected_tab_size : tab_size;
-    lv_obj_set_size(tab_btn, tab_btn_size, tab_btn_size);
-    lv_obj_set_style_radius(tab_btn, tab_btn_size / 2, LV_PART_MAIN);
-    lv_coord_t tab_x = first_tab_x + i * (tab_size + tab_gap);
-    lv_obj_align(tab_btn, LV_ALIGN_LEFT_MID, tab_x - (tab_btn_size - tab_size) / 2, 0);
-    light_control_center_icon_label(lv_obj_get_child(tab_btn, 0));
+    control_modal_layout_tab_button(tab_btn, layout, tabs_layout, i, active);
   }
 
-  lv_coord_t content_top = show_tab_bar ? layout.inset + tab_frame_h + 16 : layout.inset * 2;
+  lv_coord_t content_top = show_tab_bar
+    ? layout.inset + tabs_layout.tab_frame_h + tabs_layout.content_gap
+    : layout.inset * 2;
   lv_coord_t chrome_safe_top = layout.back_inset_y + layout.back_size + layout.inset / 2;
   if (!show_tab_bar && content_top < chrome_safe_top) content_top = chrome_safe_top;
   lv_coord_t content_bottom = layout.panel_h - layout.inset;

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -1172,11 +1172,6 @@ inline void media_control_style_progress_slider(lv_obj_t *slider, uint32_t backg
   lv_obj_set_style_height(slider, 0, LV_PART_KNOB);
 }
 
-inline lv_coord_t media_control_tab_size(const ControlModalLayout &layout) {
-  if (control_modal_uses_p4_86_tuning(layout)) return 68;
-  return control_modal_prominent_card_tab_size(layout);
-}
-
 inline void media_control_layout_modal(MediaControlCtx *ctx) {
   MediaControlModalUi &ui = media_control_modal_ui();
   if (!ctx || !ui.overlay || !ui.panel) return;
@@ -1184,22 +1179,10 @@ inline void media_control_layout_modal(MediaControlCtx *ctx) {
   control_modal_apply_panel_layout(ui.overlay, ui.panel, layout, control_modal_card_radius(ctx->btn));
   control_modal_apply_back_button_layout(ui.back_btn, layout);
 
-  lv_coord_t tab_size = media_control_tab_size(layout);
-  lv_coord_t selected_tab_size = tab_size + tab_size / 8;
-  lv_coord_t tab_frame_pad = tab_size / 5;
-  lv_coord_t tab_frame_h = tab_size + tab_frame_pad * 2;
-  lv_coord_t tab_gap = control_modal_control_tab_gap(layout, tab_size);
   constexpr int MEDIA_CONTROL_TAB_COUNT = 3;
-  lv_coord_t tabs_total_w =
-    tab_size * MEDIA_CONTROL_TAB_COUNT + tab_gap * (MEDIA_CONTROL_TAB_COUNT - 1);
-  lv_coord_t tab_frame_w = tabs_total_w + tab_frame_pad * 2;
-  lv_coord_t max_tab_frame_w = layout.panel_w - layout.inset * 3;
-  if (tab_frame_w > max_tab_frame_w) tab_frame_w = max_tab_frame_w;
-  if (ui.tab_row) {
-    lv_obj_set_size(ui.tab_row, tab_frame_w, tab_frame_h);
-    lv_obj_set_style_radius(ui.tab_row, tab_frame_h / 2, LV_PART_MAIN);
-    lv_obj_align(ui.tab_row, LV_ALIGN_TOP_MID, 0, layout.inset + 2);
-  }
+  ControlModalTabLayout tabs_layout =
+    control_modal_calc_tab_layout(layout, MEDIA_CONTROL_TAB_COUNT, true);
+  control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);
 
   struct MediaControlTabLayout {
     lv_obj_t *btn;
@@ -1210,25 +1193,14 @@ inline void media_control_layout_modal(MediaControlCtx *ctx) {
     {ui.progress_tab, MediaControlTab::PROGRESS},
     {ui.volume_tab, MediaControlTab::VOLUME},
   };
-  lv_coord_t first_tab_x = (tab_frame_w - tabs_total_w) / 2;
   for (int i = 0; i < MEDIA_CONTROL_TAB_COUNT; i++) {
     if (!tabs[i].btn) continue;
     bool active = tabs[i].tab == ui.tab;
-    lv_coord_t tab_btn_size = active ? selected_tab_size : tab_size;
-    lv_obj_set_size(tabs[i].btn, tab_btn_size, tab_btn_size);
-    lv_obj_set_style_radius(tabs[i].btn, tab_btn_size / 2, LV_PART_MAIN);
-    lv_coord_t tab_x = first_tab_x + i * (tab_size + tab_gap);
-    lv_obj_align(tabs[i].btn, LV_ALIGN_LEFT_MID, tab_x - (tab_btn_size - tab_size) / 2, 0);
-    lv_obj_t *label = lv_obj_get_child(tabs[i].btn, 0);
-    if (label && control_modal_uses_compact_portrait_tuning(layout))
-      lv_obj_set_style_transform_zoom(label, 210, LV_PART_MAIN);
-    else if (label && control_modal_uses_p4_86_tuning(layout))
-      lv_obj_set_style_transform_zoom(label, 190, LV_PART_MAIN);
-    light_control_center_icon_label(label);
+    control_modal_layout_tab_button(tabs[i].btn, layout, tabs_layout, i, active);
   }
 
   lv_coord_t content_top =
-    layout.inset + tab_frame_h + control_modal_prominent_card_tab_content_gap(layout);
+    layout.inset + tabs_layout.tab_frame_h + tabs_layout.content_gap;
   lv_coord_t content_w = layout.panel_w - layout.inset * 2;
   lv_coord_t content_h = layout.panel_h - content_top - layout.inset;
   if (content_h < 180) content_h = layout.panel_h / 2;

--- a/components/espcontrol/button_grid_modal.h
+++ b/components/espcontrol/button_grid_modal.h
@@ -12,6 +12,9 @@ constexpr lv_coord_t CONTROL_MODAL_INSET_REF_PX = DISPLAY_MODAL_INSET_REF_PX;
 constexpr lv_coord_t CONTROL_MODAL_CONTROLS_GAP_REF_PX = DISPLAY_MODAL_CONTROLS_GAP_REF_PX;
 constexpr lv_coord_t CONTROL_MODAL_CONTROLS_DOWN_REF_PX = DISPLAY_MODAL_CONTROLS_DOWN_REF_PX;
 constexpr lv_coord_t CONTROL_MODAL_TITLE_GAP_REF_PX = DISPLAY_MODAL_TITLE_GAP_REF_PX;
+constexpr lv_coord_t CONTROL_MODAL_P4_86_TAB_REF_PX = 50;
+constexpr lv_coord_t CONTROL_MODAL_P4_86_TAB_CONTENT_GAP_REF_PX = 30;
+constexpr lv_coord_t CONTROL_MODAL_JC4880P443_TAB_CONTENT_GAP_REF_PX = 12;
 
 enum class ControlModalKind {
   NONE,
@@ -158,6 +161,22 @@ struct ControlModalLayout {
   lv_coord_t controls_center_y = 0;
 };
 
+struct ControlModalTabLayout {
+  int tab_count = 1;
+  bool show_tab_bar = false;
+  lv_coord_t tab_size = 48;
+  lv_coord_t selected_tab_size = 54;
+  lv_coord_t tab_frame_pad = 9;
+  lv_coord_t tab_gap = 12;
+  lv_coord_t tabs_total_w = 48;
+  lv_coord_t tab_frame_w = 66;
+  lv_coord_t tab_frame_h = 66;
+  lv_coord_t tab_safe_left = 0;
+  lv_coord_t centered_left = 0;
+  lv_coord_t row_left = 0;
+  lv_coord_t content_gap = 16;
+};
+
 struct ControlModalShell {
   lv_obj_t *overlay = nullptr;
   lv_obj_t *panel = nullptr;
@@ -272,6 +291,172 @@ inline bool control_modal_current_is_4848_size() {
 
 inline lv_coord_t control_modal_controls_down_px(const ControlModalLayout &layout) {
   return control_modal_scaled_px(CONTROL_MODAL_CONTROLS_DOWN_REF_PX, layout.short_side);
+}
+
+inline lv_coord_t control_modal_control_tab_min_size(const ControlModalLayout &layout) {
+  if (control_modal_uses_large_landscape_tuning(layout)) return 64;
+  if (control_modal_uses_compact_portrait_tuning(layout)) return 72;
+  return 48;
+}
+
+inline lv_coord_t control_modal_control_tab_size(const ControlModalLayout &layout) {
+  if (control_modal_uses_compact_portrait_tuning(layout)) {
+    lv_coord_t size = control_modal_scaled_px(72, layout.short_side);
+    lv_coord_t min_size = control_modal_control_tab_min_size(layout);
+    lv_coord_t max_size = 76;
+    if (size < min_size) size = min_size;
+    if (size > max_size) size = max_size;
+    return size;
+  }
+  lv_coord_t size = layout.back_size * (control_modal_uses_large_landscape_tuning(layout) ? 4 : 7) /
+                    (control_modal_uses_large_landscape_tuning(layout) ? 5 : 10);
+  lv_coord_t min_size = control_modal_control_tab_min_size(layout);
+  lv_coord_t max_size = control_modal_uses_large_landscape_tuning(layout) ? 88 : 68;
+  if (size < min_size) size = min_size;
+  if (size > max_size) size = max_size;
+  return size;
+}
+
+inline lv_coord_t control_modal_card_tab_size(const ControlModalLayout &layout) {
+  if (control_modal_uses_jc1060p470_tuning(layout))
+    return control_modal_scaled_px(54, layout.short_side);
+  return control_modal_control_tab_size(layout);
+}
+
+inline lv_coord_t control_modal_prominent_card_tab_size(const ControlModalLayout &layout) {
+  if (control_modal_uses_compact_portrait_tuning(layout))
+    return control_modal_scaled_px(58, layout.short_side);
+  return control_modal_card_tab_size(layout);
+}
+
+inline lv_coord_t control_modal_shared_tab_size(const ControlModalLayout &layout) {
+  if (control_modal_uses_p4_86_tuning(layout))
+    return control_modal_scaled_px(CONTROL_MODAL_P4_86_TAB_REF_PX, layout.short_side);
+  return control_modal_prominent_card_tab_size(layout);
+}
+
+inline lv_coord_t control_modal_control_tab_gap(const ControlModalLayout &layout,
+                                                lv_coord_t tab_size) {
+  lv_coord_t gap = control_modal_uses_large_landscape_tuning(layout)
+    ? tab_size * 2 / 5
+    : tab_size / 4;
+  lv_coord_t min_gap = control_modal_uses_large_landscape_tuning(layout) ? 24 : 12;
+  if (gap < min_gap) gap = min_gap;
+  return gap;
+}
+
+inline lv_coord_t control_modal_control_tab_content_gap(const ControlModalLayout &layout) {
+  if (!control_modal_uses_large_landscape_tuning(layout)) return 16;
+  lv_coord_t gap = control_modal_scaled_px(22, layout.short_side);
+  if (gap < 28) gap = 28;
+  return gap;
+}
+
+inline lv_coord_t control_modal_card_tab_content_gap(const ControlModalLayout &layout) {
+  if (control_modal_uses_jc1060p470_tuning(layout))
+    return control_modal_scaled_px(28, layout.short_side);
+  return control_modal_control_tab_content_gap(layout);
+}
+
+inline lv_coord_t control_modal_prominent_card_tab_content_gap(const ControlModalLayout &layout) {
+  if (control_modal_uses_compact_portrait_tuning(layout))
+    return control_modal_scaled_px(30, layout.short_side);
+  return control_modal_card_tab_content_gap(layout);
+}
+
+inline lv_coord_t control_modal_shared_tab_content_gap(const ControlModalLayout &layout) {
+  if (control_modal_uses_p4_86_tuning(layout))
+    return control_modal_scaled_px(CONTROL_MODAL_P4_86_TAB_CONTENT_GAP_REF_PX, layout.short_side);
+  if (control_modal_uses_compact_portrait_tuning(layout))
+    return control_modal_scaled_px(CONTROL_MODAL_JC4880P443_TAB_CONTENT_GAP_REF_PX, layout.short_side);
+  return control_modal_prominent_card_tab_content_gap(layout);
+}
+
+inline ControlModalTabLayout control_modal_calc_tab_layout(
+    const ControlModalLayout &layout, int tab_count, bool show_tab_bar,
+    bool avoid_back_button = true) {
+  ControlModalTabLayout tabs_layout;
+  tabs_layout.tab_count = tab_count < 1 ? 1 : tab_count;
+  tabs_layout.show_tab_bar = show_tab_bar && tabs_layout.tab_count > 1;
+  tabs_layout.tab_size = control_modal_shared_tab_size(layout);
+  tabs_layout.selected_tab_size = tabs_layout.tab_size + tabs_layout.tab_size / 8;
+  tabs_layout.tab_frame_pad = tabs_layout.tab_size / 5;
+  tabs_layout.tab_gap = control_modal_control_tab_gap(layout, tabs_layout.tab_size);
+  tabs_layout.tabs_total_w =
+    tabs_layout.tab_size * tabs_layout.tab_count + tabs_layout.tab_gap * (tabs_layout.tab_count - 1);
+  tabs_layout.tab_frame_w = tabs_layout.tabs_total_w + tabs_layout.tab_frame_pad * 2;
+  tabs_layout.tab_frame_h = tabs_layout.tab_size + tabs_layout.tab_frame_pad * 2;
+  tabs_layout.tab_safe_left = layout.back_inset_x + layout.back_size + layout.inset / 2;
+  tabs_layout.centered_left = (layout.panel_w - tabs_layout.tab_frame_w) / 2;
+  tabs_layout.row_left = tabs_layout.centered_left;
+  tabs_layout.content_gap = control_modal_shared_tab_content_gap(layout);
+  lv_coord_t min_tab_size = control_modal_control_tab_min_size(layout);
+  while (tabs_layout.show_tab_bar &&
+         avoid_back_button &&
+         !control_modal_uses_compact_portrait_tuning(layout) &&
+         !control_modal_uses_p4_86_tuning(layout) &&
+         tabs_layout.row_left < tabs_layout.tab_safe_left &&
+         tabs_layout.tab_size > min_tab_size) {
+    tabs_layout.tab_size--;
+    tabs_layout.selected_tab_size = tabs_layout.tab_size + tabs_layout.tab_size / 8;
+    tabs_layout.tab_frame_pad = tabs_layout.tab_size / 5;
+    tabs_layout.tab_gap = control_modal_control_tab_gap(layout, tabs_layout.tab_size);
+    tabs_layout.tabs_total_w =
+      tabs_layout.tab_size * tabs_layout.tab_count + tabs_layout.tab_gap * (tabs_layout.tab_count - 1);
+    tabs_layout.tab_frame_w = tabs_layout.tabs_total_w + tabs_layout.tab_frame_pad * 2;
+    tabs_layout.tab_frame_h = tabs_layout.tab_size + tabs_layout.tab_frame_pad * 2;
+    tabs_layout.centered_left = (layout.panel_w - tabs_layout.tab_frame_w) / 2;
+    tabs_layout.row_left = tabs_layout.centered_left;
+  }
+  if (avoid_back_button && tabs_layout.row_left < tabs_layout.tab_safe_left)
+    tabs_layout.row_left = tabs_layout.tab_safe_left;
+  if (!tabs_layout.show_tab_bar) tabs_layout.tab_frame_h = 0;
+  return tabs_layout;
+}
+
+inline void control_modal_apply_tab_row(lv_obj_t *tab_row,
+                                        const ControlModalLayout &layout,
+                                        const ControlModalTabLayout &tabs_layout) {
+  if (!tab_row) return;
+  if (tabs_layout.show_tab_bar) {
+    lv_obj_clear_flag(tab_row, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_set_size(tab_row, tabs_layout.tab_frame_w, tabs_layout.tab_frame_h);
+    lv_obj_set_style_radius(tab_row, tabs_layout.tab_frame_h / 2, LV_PART_MAIN);
+    lv_obj_align(tab_row, LV_ALIGN_TOP_LEFT, tabs_layout.row_left, layout.inset + 2);
+  } else {
+    lv_obj_add_flag(tab_row, LV_OBJ_FLAG_HIDDEN);
+  }
+}
+
+inline void control_modal_center_tab_icon(lv_obj_t *label) {
+  if (!label) return;
+  lv_obj_update_layout(label);
+  lv_obj_set_style_transform_pivot_x(label, lv_obj_get_width(label) / 2, LV_PART_MAIN);
+  lv_obj_set_style_transform_pivot_y(label, lv_obj_get_height(label) / 2, LV_PART_MAIN);
+  lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
+}
+
+inline uint16_t control_modal_tab_icon_zoom(const ControlModalLayout &layout) {
+  return (control_modal_uses_compact_portrait_tuning(layout) ||
+          control_modal_uses_p4_86_tuning(layout)) ? 220 : 180;
+}
+
+inline void control_modal_layout_tab_button(lv_obj_t *tab_btn,
+                                            const ControlModalLayout &layout,
+                                            const ControlModalTabLayout &tabs_layout,
+                                            int index, bool active,
+                                            int width_compensation_percent = 100) {
+  if (!tab_btn || !tabs_layout.show_tab_bar) return;
+  lv_coord_t tab_btn_size = active ? tabs_layout.selected_tab_size : tabs_layout.tab_size;
+  lv_obj_set_size(tab_btn, tab_btn_size, tab_btn_size);
+  apply_width_compensation(tab_btn, width_compensation_percent);
+  lv_obj_set_style_radius(tab_btn, tab_btn_size / 2, LV_PART_MAIN);
+  lv_coord_t first_tab_x = (tabs_layout.tab_frame_w - tabs_layout.tabs_total_w) / 2;
+  lv_coord_t tab_x = first_tab_x + index * (tabs_layout.tab_size + tabs_layout.tab_gap);
+  lv_obj_align(tab_btn, LV_ALIGN_LEFT_MID, tab_x - (tab_btn_size - tabs_layout.tab_size) / 2, 0);
+  lv_obj_t *label = lv_obj_get_child(tab_btn, 0);
+  if (label) lv_obj_set_style_transform_zoom(label, control_modal_tab_icon_zoom(layout), LV_PART_MAIN);
+  control_modal_center_tab_icon(label);
 }
 
 inline lv_coord_t control_modal_card_radius(lv_obj_t *btn) {

--- a/components/espcontrol/button_grid_sliders.h
+++ b/components/espcontrol/button_grid_sliders.h
@@ -507,77 +507,8 @@ inline void light_control_apply_tab_visibility() {
 
 inline void light_control_layout_modal(LightControlCtx *ctx);
 
-inline lv_coord_t control_modal_control_tab_min_size(const ControlModalLayout &layout) {
-  if (control_modal_uses_large_landscape_tuning(layout)) return 64;
-  if (control_modal_uses_compact_portrait_tuning(layout)) return 72;
-  return 48;
-}
-
-inline lv_coord_t control_modal_control_tab_size(const ControlModalLayout &layout) {
-  if (control_modal_uses_compact_portrait_tuning(layout)) {
-    lv_coord_t size = control_modal_scaled_px(72, layout.short_side);
-    lv_coord_t min_size = control_modal_control_tab_min_size(layout);
-    lv_coord_t max_size = 76;
-    if (size < min_size) size = min_size;
-    if (size > max_size) size = max_size;
-    return size;
-  }
-  lv_coord_t size = layout.back_size * (control_modal_uses_large_landscape_tuning(layout) ? 4 : 7) /
-                    (control_modal_uses_large_landscape_tuning(layout) ? 5 : 10);
-  lv_coord_t min_size = control_modal_control_tab_min_size(layout);
-  lv_coord_t max_size = control_modal_uses_large_landscape_tuning(layout) ? 88 : 68;
-  if (size < min_size) size = min_size;
-  if (size > max_size) size = max_size;
-  return size;
-}
-
-inline lv_coord_t control_modal_card_tab_size(const ControlModalLayout &layout) {
-  if (control_modal_uses_jc1060p470_tuning(layout))
-    return control_modal_scaled_px(54, layout.short_side);
-  return control_modal_control_tab_size(layout);
-}
-
-inline lv_coord_t control_modal_prominent_card_tab_size(const ControlModalLayout &layout) {
-  if (control_modal_uses_compact_portrait_tuning(layout))
-    return control_modal_scaled_px(58, layout.short_side);
-  return control_modal_card_tab_size(layout);
-}
-
-inline lv_coord_t control_modal_control_tab_gap(const ControlModalLayout &layout,
-                                                lv_coord_t tab_size) {
-  lv_coord_t gap = control_modal_uses_large_landscape_tuning(layout)
-    ? tab_size * 2 / 5
-    : tab_size / 4;
-  lv_coord_t min_gap = control_modal_uses_large_landscape_tuning(layout) ? 24 : 12;
-  if (gap < min_gap) gap = min_gap;
-  return gap;
-}
-
-inline lv_coord_t control_modal_control_tab_content_gap(const ControlModalLayout &layout) {
-  if (!control_modal_uses_large_landscape_tuning(layout)) return 16;
-  lv_coord_t gap = control_modal_scaled_px(22, layout.short_side);
-  if (gap < 28) gap = 28;
-  return gap;
-}
-
-inline lv_coord_t control_modal_card_tab_content_gap(const ControlModalLayout &layout) {
-  if (control_modal_uses_jc1060p470_tuning(layout))
-    return control_modal_scaled_px(28, layout.short_side);
-  return control_modal_control_tab_content_gap(layout);
-}
-
-inline lv_coord_t control_modal_prominent_card_tab_content_gap(const ControlModalLayout &layout) {
-  if (control_modal_uses_compact_portrait_tuning(layout))
-    return control_modal_scaled_px(30, layout.short_side);
-  return control_modal_card_tab_content_gap(layout);
-}
-
 inline void light_control_center_icon_label(lv_obj_t *label) {
-  if (!label) return;
-  lv_obj_update_layout(label);
-  lv_obj_set_style_transform_pivot_x(label, lv_obj_get_width(label) / 2, LV_PART_MAIN);
-  lv_obj_set_style_transform_pivot_y(label, lv_obj_get_height(label) / 2, LV_PART_MAIN);
-  lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
+  control_modal_center_tab_icon(label);
 }
 
 inline lv_obj_t *light_control_create_tab_button(lv_obj_t *parent, const char *icon,
@@ -848,60 +779,18 @@ inline void light_control_layout_modal(LightControlCtx *ctx) {
   ControlModalLayout layout = control_modal_calc_layout(ctx->width_compensation_percent);
 
   int tab_count = static_cast<int>(visible_tabs.count);
-  if (tab_count < 1) tab_count = 1;
   bool show_tab_bar = tab_count > 1;
-  lv_coord_t tab_size = control_modal_prominent_card_tab_size(layout);
-  lv_coord_t selected_tab_size = tab_size + tab_size / 8;
-  lv_coord_t tab_frame_pad = tab_size / 5;
-  lv_coord_t tab_gap = control_modal_control_tab_gap(layout, tab_size);
-  lv_coord_t tabs_total_w = tab_size * tab_count + tab_gap * (tab_count - 1);
-  lv_coord_t tab_frame_w = tabs_total_w + tab_frame_pad * 2;
-  lv_coord_t tab_frame_h = tab_size + tab_frame_pad * 2;
-  lv_coord_t tab_safe_left = layout.back_inset_x + layout.back_size + layout.inset / 2;
-  lv_coord_t centered_left = (layout.panel_w - tab_frame_w) / 2;
-  lv_coord_t min_tab_size = control_modal_control_tab_min_size(layout);
-  while (show_tab_bar && !control_modal_uses_compact_portrait_tuning(layout) &&
-         centered_left < tab_safe_left && tab_size > min_tab_size) {
-    tab_size--;
-    selected_tab_size = tab_size + tab_size / 8;
-    tab_frame_pad = tab_size / 5;
-    tab_gap = control_modal_control_tab_gap(layout, tab_size);
-    tabs_total_w = tab_size * tab_count + tab_gap * (tab_count - 1);
-    tab_frame_w = tabs_total_w + tab_frame_pad * 2;
-    tab_frame_h = tab_size + tab_frame_pad * 2;
-    centered_left = (layout.panel_w - tab_frame_w) / 2;
-  }
-  if (!show_tab_bar) tab_frame_h = 0;
-  if (ui.tab_row) {
-    if (show_tab_bar) {
-      lv_obj_clear_flag(ui.tab_row, LV_OBJ_FLAG_HIDDEN);
-      lv_obj_set_size(ui.tab_row, tab_frame_w, tab_frame_h);
-      lv_obj_set_style_radius(ui.tab_row, tab_frame_h / 2, LV_PART_MAIN);
-      if (centered_left < tab_safe_left) centered_left = tab_safe_left;
-      lv_obj_align(ui.tab_row, LV_ALIGN_TOP_LEFT, centered_left, layout.inset + 2);
-    } else {
-      lv_obj_add_flag(ui.tab_row, LV_OBJ_FLAG_HIDDEN);
-    }
-  }
-  lv_coord_t first_tab_x = (tab_frame_w - tabs_total_w) / 2;
+  ControlModalTabLayout tabs_layout = control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);
+  control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);
   for (int i = 0; show_tab_bar && i < tab_count; i++) {
     lv_obj_t *tab_btn = light_control_tab_button(ui, visible_tabs.tabs[i]);
     if (!tab_btn) continue;
     bool active = (visible_tabs.tabs[i] == ui.tab);
-    lv_coord_t tab_btn_size = active ? selected_tab_size : tab_size;
-    lv_obj_set_size(tab_btn, tab_btn_size, tab_btn_size);
-    lv_obj_set_style_radius(tab_btn, tab_btn_size / 2, LV_PART_MAIN);
-    lv_coord_t tab_x = first_tab_x + i * (tab_size + tab_gap);
-    lv_obj_align(tab_btn, LV_ALIGN_LEFT_MID, tab_x - (tab_btn_size - tab_size) / 2, 0);
-    lv_obj_t *label = lv_obj_get_child(tab_btn, 0);
-    if (label && control_modal_uses_compact_portrait_tuning(layout)) {
-      lv_obj_set_style_transform_zoom(label, 220, LV_PART_MAIN);
-    }
-    light_control_center_icon_label(label);
+    control_modal_layout_tab_button(tab_btn, layout, tabs_layout, i, active);
   }
 
   lv_coord_t content_top = show_tab_bar
-    ? layout.inset + tab_frame_h + control_modal_prominent_card_tab_content_gap(layout)
+    ? layout.inset + tabs_layout.tab_frame_h + tabs_layout.content_gap
     : layout.inset * 2;
   lv_coord_t content_bottom = layout.panel_h - layout.inset;
   lv_coord_t slider_h = content_bottom - content_top;
@@ -1991,42 +1880,19 @@ inline void cover_control_layout_modal(CoverControlCtx *ctx) {
   ControlModalLayout layout = control_modal_calc_layout(ctx->width_compensation_percent);
 
   int tab_count = static_cast<int>(visible_tabs.count);
-  if (tab_count < 1) tab_count = 1;
   bool show_tab_bar = tab_count > 1;
-  lv_coord_t tab_size = control_modal_prominent_card_tab_size(layout);
-  lv_coord_t selected_tab_size = tab_size + tab_size / 8;
-  lv_coord_t tab_frame_pad = tab_size / 5;
-  lv_coord_t tab_frame_h = tab_size + tab_frame_pad * 2;
-  lv_coord_t tab_gap = control_modal_control_tab_gap(layout, tab_size);
-  lv_coord_t tabs_total_w = tab_size * tab_count + tab_gap * (tab_count - 1);
-  lv_coord_t tab_frame_w = tabs_total_w + tab_frame_pad * 2;
-  lv_coord_t max_tab_frame_w = layout.panel_w - layout.inset * 3;
-  if (tab_frame_w > max_tab_frame_w) tab_frame_w = max_tab_frame_w;
-  if (ui.tab_row && show_tab_bar) {
-    lv_obj_set_size(ui.tab_row, tab_frame_w, tab_frame_h);
-    lv_obj_set_style_radius(ui.tab_row, tab_frame_h / 2, LV_PART_MAIN);
-    lv_obj_align(ui.tab_row, LV_ALIGN_TOP_MID, 0, layout.inset + 2);
-  }
-  lv_coord_t first_tab_x = (tab_frame_w - tabs_total_w) / 2;
+  ControlModalTabLayout tabs_layout = control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);
+  control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);
   for (int i = 0; show_tab_bar && i < tab_count; i++) {
     lv_obj_t *tab_btn = cover_control_tab_button(ui, visible_tabs.tabs[i]);
     if (!tab_btn) continue;
     bool active = (visible_tabs.tabs[i] == ui.tab);
-    lv_coord_t tab_btn_size = active ? selected_tab_size : tab_size;
-    lv_obj_set_size(tab_btn, tab_btn_size, tab_btn_size);
-    apply_width_compensation(tab_btn, ctx->width_compensation_percent);
-    lv_obj_set_style_radius(tab_btn, tab_btn_size / 2, LV_PART_MAIN);
-    lv_coord_t tab_x = first_tab_x + i * (tab_size + tab_gap);
-    lv_obj_align(tab_btn, LV_ALIGN_LEFT_MID, tab_x - (tab_btn_size - tab_size) / 2, 0);
-    lv_obj_t *label = lv_obj_get_child(tab_btn, 0);
-    if (label && control_modal_uses_compact_portrait_tuning(layout)) {
-      lv_obj_set_style_transform_zoom(label, 240, LV_PART_MAIN);
-    }
-    light_control_center_icon_label(label);
+    control_modal_layout_tab_button(
+      tab_btn, layout, tabs_layout, i, active, ctx->width_compensation_percent);
   }
 
   lv_coord_t content_top = show_tab_bar
-    ? layout.inset + tab_frame_h + control_modal_prominent_card_tab_content_gap(layout)
+    ? layout.inset + tabs_layout.tab_frame_h + tabs_layout.content_gap
     : layout.inset * 2;
   lv_coord_t content_bottom = layout.panel_h - layout.inset;
   lv_coord_t content_h = content_bottom - content_top;

--- a/scripts/check_firmware_modals.py
+++ b/scripts/check_firmware_modals.py
@@ -367,8 +367,8 @@ def firmware_cover_control_tab_errors(root: Path) -> list[str]:
     text = path.read_text(encoding="utf-8")
     if "bool show_tab_bar = visible_tabs.count > 1;" not in text:
         errors.append("components/espcontrol/button_grid_sliders.h: hide cover modal tabs when only one control is visible")
-    if "if (show_tab_bar) lv_obj_clear_flag(ui.tab_row, LV_OBJ_FLAG_HIDDEN);" not in text:
-        errors.append("components/espcontrol/button_grid_sliders.h: keep cover modal tab row hidden for single-control modals")
+    if "control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);" not in text:
+        errors.append("components/espcontrol/button_grid_sliders.h: keep cover modal tab row hidden through the shared tab layout helper")
     if "lv_coord_t content_top = show_tab_bar" not in text:
         errors.append("components/espcontrol/button_grid_sliders.h: position cover modal content from explicit top and bottom bounds")
     if "lv_coord_t content_center_y = content_top + content_h / 2 - layout.panel_h / 2;" not in text:
@@ -390,8 +390,8 @@ def firmware_light_control_tab_errors(root: Path) -> list[str]:
         errors.append("components/espcontrol/button_grid_sliders.h: keep light modal tab visibility helper")
     if text.count("bool show_tab_bar = visible_tabs.count > 1;") < 2:
         errors.append("components/espcontrol/button_grid_sliders.h: hide light and cover modal tabs when only one control is visible")
-    if text.count("if (show_tab_bar) lv_obj_clear_flag(ui.tab_row, LV_OBJ_FLAG_HIDDEN);") < 2:
-        errors.append("components/espcontrol/button_grid_sliders.h: keep single-tab modal rows hidden on the device")
+    if text.count("control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);") < 2:
+        errors.append("components/espcontrol/button_grid_sliders.h: keep single-tab modal rows hidden through the shared tab layout helper")
     if "lv_coord_t content_top = show_tab_bar" not in text:
         errors.append("components/espcontrol/button_grid_sliders.h: let single-control modals use the tab row space")
 
@@ -415,7 +415,7 @@ def firmware_climate_control_tab_errors(root: Path) -> list[str]:
         errors.append("components/espcontrol/button_grid_climate.h: filter climate tabs using Home Assistant capabilities")
     if "ui.tab = climate_control_first_visible_tab(ctx);" not in text:
         errors.append("components/espcontrol/button_grid_climate.h: fall back when the active climate tab disappears")
-    if "tabs_layout.show_tab_bar = ctx && ctx->all_controls && tabs_layout.tab_count > 1;" not in text:
+    if "bool show_tab_bar = ctx && ctx->all_controls && tab_count > 1;" not in text:
         errors.append("components/espcontrol/button_grid_climate.h: hide climate modal tabs unless All Controls has multiple visible controls")
     if 'ctx->all_controls = p.type == "climate_control";' not in text:
         errors.append("components/espcontrol/button_grid_climate.h: keep climate tabs scoped to the All Controls subtype")
@@ -423,6 +423,109 @@ def firmware_climate_control_tab_errors(root: Path) -> list[str]:
         errors.append("components/espcontrol/button_grid_climate.h: keep temperature controls scoped to the temperature tab")
     if "climate_open_inline_option_list(ctx, climate_control_tab_kind(ui.tab))" not in text:
         errors.append("components/espcontrol/button_grid_climate.h: show non-temperature climate controls as tab pages")
+
+    return errors
+
+
+def firmware_modal_tab_layout_errors(root: Path) -> list[str]:
+    firmware_dir = root / "components" / "espcontrol"
+    modal_path = firmware_dir / "button_grid_modal.h"
+    errors: list[str] = []
+
+    if not modal_path.exists():
+        errors.append("components/espcontrol/button_grid_modal.h: provide shared modal tab layout helpers")
+    else:
+        text = modal_path.read_text(encoding="utf-8")
+        required = (
+            "struct ControlModalTabLayout",
+            "inline ControlModalTabLayout control_modal_calc_tab_layout",
+            "inline void control_modal_apply_tab_row",
+            "inline void control_modal_layout_tab_button",
+            "inline lv_coord_t control_modal_shared_tab_content_gap",
+            "CONTROL_MODAL_P4_86_TAB_REF_PX",
+            "CONTROL_MODAL_JC4880P443_TAB_CONTENT_GAP_REF_PX",
+        )
+        for needle in required:
+            if needle not in text:
+                errors.append("components/espcontrol/button_grid_modal.h: keep shared modal tab layout helpers")
+                break
+
+    required_by_file = {
+        "button_grid_climate.h": (
+            "return control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);",
+            "control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);",
+            "control_modal_layout_tab_button(tab_btn, layout, tabs_layout, i, active);",
+            "return control_modal_shared_tab_content_gap(layout);",
+        ),
+        "button_grid_fan.h": (
+            "ControlModalTabLayout tabs_layout = control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);",
+            "control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);",
+            "control_modal_layout_tab_button(tab_btn, layout, tabs_layout, i, active);",
+            "tabs_layout.content_gap",
+        ),
+        "button_grid_media.h": (
+            "control_modal_calc_tab_layout(layout, MEDIA_CONTROL_TAB_COUNT, true)",
+            "control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);",
+            "control_modal_layout_tab_button(tabs[i].btn, layout, tabs_layout, i, active);",
+            "tabs_layout.content_gap",
+        ),
+    }
+    sliders_required = (
+        "ControlModalTabLayout tabs_layout = control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);",
+        "control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);",
+        "control_modal_layout_tab_button(",
+        "tabs_layout.content_gap",
+    )
+    for filename, required in required_by_file.items():
+        path = firmware_dir / filename
+        if not path.exists():
+            errors.append(f"components/espcontrol/{filename}: use shared modal tab layout helpers")
+            continue
+        text = path.read_text(encoding="utf-8")
+        for needle in required:
+            if needle not in text:
+                errors.append(f"components/espcontrol/{filename}: use shared modal tab layout helpers")
+                break
+
+    sliders_path = firmware_dir / "button_grid_sliders.h"
+    if not sliders_path.exists():
+        errors.append("components/espcontrol/button_grid_sliders.h: use shared modal tab layout helpers")
+    else:
+        text = sliders_path.read_text(encoding="utf-8")
+        for needle in sliders_required:
+            if needle not in text:
+                errors.append("components/espcontrol/button_grid_sliders.h: use shared modal tab layout helpers")
+                break
+        if (
+            text.count("ControlModalTabLayout tabs_layout = control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);") < 2
+            or text.count("control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);") < 2
+            or text.count("tabs_layout.content_gap") < 2
+        ):
+            errors.append("components/espcontrol/button_grid_sliders.h: use shared modal tab layout helpers for light and cover tabs")
+
+    forbidden_tab_math = (
+        "lv_coord_t selected_tab_size =",
+        "lv_coord_t tab_frame_pad =",
+        "lv_coord_t tabs_total_w =",
+        "lv_coord_t first_tab_x =",
+        "lv_coord_t centered_left =",
+        "lv_coord_t tab_safe_left =",
+        "lv_coord_t max_tab_frame_w =",
+    )
+    for filename in (
+        "button_grid_climate.h",
+        "button_grid_fan.h",
+        "button_grid_media.h",
+        "button_grid_sliders.h",
+    ):
+        path = firmware_dir / filename
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        for needle in forbidden_tab_math:
+            if needle in text:
+                errors.append(f"components/espcontrol/{filename}: keep modal tab sizing in button_grid_modal.h")
+                break
 
     return errors
 
@@ -536,6 +639,7 @@ def run_scan() -> int:
     errors.extend(firmware_light_control_tab_errors(ROOT))
     errors.extend(firmware_cover_control_tab_errors(ROOT))
     errors.extend(firmware_climate_control_tab_errors(ROOT))
+    errors.extend(firmware_modal_tab_layout_errors(ROOT))
     errors.extend(firmware_network_status_version_errors(ROOT))
 
     if errors:
@@ -650,6 +754,63 @@ def expect_network_status_version_errors(name: str, header_text: str, expected: 
         path.write_text(header_text, encoding="utf-8")
 
         errors = firmware_network_status_version_errors(root)
+        for item in expected:
+            assert any(item in error for error in errors), f"{name}: missing {item!r} in {errors!r}"
+        if not expected:
+            assert not errors, f"{name}: expected no errors, got {errors!r}"
+
+
+def valid_modal_tab_layout_files() -> dict[str, str]:
+    return {
+        "components/espcontrol/button_grid_modal.h": (
+            "constexpr lv_coord_t CONTROL_MODAL_P4_86_TAB_REF_PX = 50;\n"
+            "constexpr lv_coord_t CONTROL_MODAL_JC4880P443_TAB_CONTENT_GAP_REF_PX = 12;\n"
+            "struct ControlModalTabLayout {};\n"
+            "inline lv_coord_t control_modal_shared_tab_content_gap(const ControlModalLayout &layout) { return 0; }\n"
+            "inline ControlModalTabLayout control_modal_calc_tab_layout(const ControlModalLayout &layout, int tab_count, bool show_tab_bar) {}\n"
+            "inline void control_modal_apply_tab_row(lv_obj_t *tab_row, const ControlModalLayout &layout, const ControlModalTabLayout &tabs_layout) {}\n"
+            "inline void control_modal_layout_tab_button(lv_obj_t *tab_btn, const ControlModalLayout &layout, const ControlModalTabLayout &tabs_layout, int index, bool active) {}\n"
+        ),
+        "components/espcontrol/button_grid_climate.h": (
+            "return control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);\n"
+            "return control_modal_shared_tab_content_gap(layout);\n"
+            "control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);\n"
+            "control_modal_layout_tab_button(tab_btn, layout, tabs_layout, i, active);\n"
+        ),
+        "components/espcontrol/button_grid_fan.h": (
+            "ControlModalTabLayout tabs_layout = control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);\n"
+            "control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);\n"
+            "control_modal_layout_tab_button(tab_btn, layout, tabs_layout, i, active);\n"
+            "tabs_layout.content_gap\n"
+        ),
+        "components/espcontrol/button_grid_media.h": (
+            "control_modal_calc_tab_layout(layout, MEDIA_CONTROL_TAB_COUNT, true)\n"
+            "control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);\n"
+            "control_modal_layout_tab_button(tabs[i].btn, layout, tabs_layout, i, active);\n"
+            "tabs_layout.content_gap\n"
+        ),
+        "components/espcontrol/button_grid_sliders.h": (
+            "ControlModalTabLayout tabs_layout = control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);\n"
+            "control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);\n"
+            "control_modal_layout_tab_button(\n"
+            "tabs_layout.content_gap\n"
+            "ControlModalTabLayout tabs_layout = control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);\n"
+            "control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);\n"
+            "control_modal_layout_tab_button(\n"
+            "tabs_layout.content_gap\n"
+        ),
+    }
+
+
+def expect_modal_tab_layout_errors(name: str, files: dict[str, str], expected: tuple[str, ...]) -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        for filename, text in files.items():
+            path = root / filename
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(text, encoding="utf-8")
+
+        errors = firmware_modal_tab_layout_errors(root)
         for item in expected:
             assert any(item in error for error in errors), f"{name}: missing {item!r} in {errors!r}"
         if not expected:
@@ -917,6 +1078,30 @@ def run_self_test() -> int:
             "}\n"
         ),
         (),
+    )
+    expect_modal_tab_layout_errors(
+        "shared modal tab layout",
+        valid_modal_tab_layout_files(),
+        (),
+    )
+    old_tab_layout = valid_modal_tab_layout_files()
+    old_tab_layout["components/espcontrol/button_grid_fan.h"] = (
+        old_tab_layout["components/espcontrol/button_grid_fan.h"]
+        + "lv_coord_t selected_tab_size = tab_size + tab_size / 8;\n"
+    )
+    expect_modal_tab_layout_errors(
+        "modal tab layout drifts back to local sizing",
+        old_tab_layout,
+        ("keep modal tab sizing in button_grid_modal.h",),
+    )
+    missing_shared_tab_helper = valid_modal_tab_layout_files()
+    missing_shared_tab_helper["components/espcontrol/button_grid_media.h"] = (
+        "lv_coord_t selected_tab_size = tab_size + tab_size / 8;\n"
+    )
+    expect_modal_tab_layout_errors(
+        "media modal stops using shared tab helper",
+        missing_shared_tab_helper,
+        ("use shared modal tab layout helpers",),
     )
     home_idle_gated = valid_sleep_takeover_files()
     home_idle_gated["common/addon/backlight.yaml"] = (


### PR DESCRIPTION
## Summary

- Adds shared modal tab layout helpers for control modals, using the climate All Controls layout as the reference.
- Updates climate, light, cover, fan, and media modal tab rows to use the shared layout/positioning helpers.
- Extends the firmware modal checker so tabbed modals must keep using the shared component and self-tests catch old hard-coded tab math returning.

## Practical impact

Tabbed modal controls should now use consistent tab sizing, spacing, and back-button avoidance within each supported display size, while still allowing each device size to keep its own tuned layout.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Internal modal tab layout consistency change only; public configuration and documented behavior are unchanged.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.
- [ ] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- P4-86
- Guition JC1060P470
- Guition JC4880P443
- Guition JC8012P4A1
- Guition ESP32-S3-4848S040

## Notes for testing

Automated checks completed:

- `npm run check:firmware-modals` passed.
- `npm run check:fast` passed.
- Firmware compile completed successfully for:
  - `builds/esp32-p4-86.factory.yaml`
  - `builds/guition-esp32-p4-jc1060p470.factory.yaml`

Physical/device testing still needed:

- Open climate, light, cover, fan, and media tabbed modals on each affected display size.
- Confirm tabs line up consistently per device, avoid the back button, and leave modal content correctly spaced.

Compile testing note:

- The full compile sweep was stopped by request after the 4.3-inch P4 build had started and was progressing without errors.
- Remaining factory compile targets still need a full pass before merge if complete firmware build coverage is required:
  - `builds/guition-esp32-p4-jc4880p443.factory.yaml`
  - `builds/guition-esp32-p4-jc8012p4a1.factory.yaml`
  - `builds/guition-esp32-s3-4848s040.factory.yaml`

## PR status

- [ ] Checks running or waiting.
- [ ] Needs automated fix.
- [x] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.
