### PR TITLE
Fix media controls modal opener

### DIFF
--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -1488,6 +1488,11 @@ inline void grid_phase2(
             display_icon_font(display),
             display_volume_width_percent(display)));
           subscribe_media_control_state(ctx);
+          lv_obj_add_event_cb(s.btn, [](lv_event_t *e) {
+            lv_obj_t *target = static_cast<lv_obj_t *>(lv_event_get_target(e));
+            MediaControlCtx *ctx = (MediaControlCtx *)lv_obj_get_user_data(target);
+            if (ctx) media_control_open_modal(ctx);
+          }, LV_EVENT_CLICKED, nullptr);
         } else if (mode == "volume") {
           MediaVolumeCtx *ctx = create_media_volume_context(
             s.btn, s.text_lbl, p, has_on ? on_val : DEFAULT_SLIDER_COLOR,

--- a/scripts/check_firmware_modals.py
+++ b/scripts/check_firmware_modals.py
@@ -276,6 +276,25 @@ def firmware_subpage_modal_wiring_errors(root: Path) -> list[str]:
         return errors
 
     text = grid_path.read_text(encoding="utf-8")
+    media_home_block = re.search(
+        r"MediaControlCtx \*ctx = grid_track_media_control_runtime"
+        r"(?P<body>.*?)"
+        r"\n\s*\}\s*else if\s*\(mode == \"volume\"\)",
+        text,
+        re.S,
+    )
+    if media_home_block is None:
+        errors.append("components/espcontrol/button_grid_grid.h: keep media control cards wired on the home grid")
+    else:
+        body = media_home_block.group("body")
+        if (
+            "create_media_control_context" not in body
+            or "subscribe_media_control_state(ctx);" not in body
+            or "media_control_open_modal(ctx);" not in body
+            or "LV_EVENT_CLICKED" not in body
+        ):
+            errors.append("components/espcontrol/button_grid_grid.h: open media control modals from home grid cards")
+
     light_block = re.search(
         r'if\s*\(\s*sb_cfg\.type\s*==\s*"light_control"\s*\)\s*\{(?P<body>.*?)\n      \}',
         text,
@@ -697,6 +716,17 @@ def expect_subpage_modal_wiring_errors(name: str, grid_text: str, expected: tupl
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(
             grid_text +
+            '        } else if (mode == "control_modal") {\n'
+            "          MediaControlCtx *ctx = grid_track_media_control_runtime(s.btn, create_media_control_context(\n"
+            "            s, p, DEFAULT_SLIDER_COLOR, DEFAULT_OFF_COLOR, DEFAULT_TERTIARY_COLOR,\n"
+            "            nullptr, nullptr, nullptr, nullptr, 100));\n"
+            "          subscribe_media_control_state(ctx);\n"
+            "          lv_obj_add_event_cb(s.btn, [](lv_event_t *e) {\n"
+            "            lv_obj_t *target = static_cast<lv_obj_t *>(lv_event_get_target(e));\n"
+            "            MediaControlCtx *ctx = (MediaControlCtx *)lv_obj_get_user_data(target);\n"
+            "            if (ctx) media_control_open_modal(ctx);\n"
+            "          }, LV_EVENT_CLICKED, nullptr);\n"
+            '        } else if (mode == "volume") {\n'
             '      if (sb_cfg.type == "fan_control") {\n'
             "        if (!sb_cfg.entity.empty()) {\n"
             "          FanCardCtx *ctx = create_fan_card_context(\n"


### PR DESCRIPTION
## Purpose
Fix the Media card's All Controls modal on the home grid. The card was creating and subscribing its media-control state, but the home-grid card was not attaching the tap handler that opens the modal.

## Practical impact
Tapping a Media card configured as All Controls should open the playback/progress/volume modal again. Subpage media controls already had this wiring and are unchanged.

## What changed
- Added the missing home-grid tap handler for Media All Controls cards.
- Added a firmware modal guard so this wiring is checked automatically.

## Automated checks
- `npm test` passed.
- `python3 scripts/check_firmware_modals.py` passed.
- `python3 scripts/check_firmware_modals.py --self-test` passed.
- `python3 scripts/check_firmware_ha_bindings.py` passed.

## Device testing
Device testing is still needed before merge because this affects the on-device firmware UI.

Suggested devices to test:
- ESP32-P4 86 Panel (4 inches, Square)
- Guition JC1060P470 (7 inches, Landscape)
- Guition JC4880P443 (4.3 inches, Portrait)
- Guition JC8012P4A1 (10.1 inches, Landscape)
- Guition 4848S040 (4 inches, Square)

Suggested checks:
- Add or use a Media card set to All Controls on the home grid.
- Tap the card and confirm the media controls modal opens.
- Check playback, progress, and volume tabs still display and respond normally.
- Confirm touch/navigation still works and there is no obvious text overlap, clipping, blank screen, or missing icon.
