### PR TITLE
Fix media controls modal tap context

### DIFF
--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -1489,10 +1489,9 @@ inline void grid_phase2(
             display_volume_width_percent(display)));
           subscribe_media_control_state(ctx);
           lv_obj_add_event_cb(s.btn, [](lv_event_t *e) {
-            lv_obj_t *target = static_cast<lv_obj_t *>(lv_event_get_target(e));
-            MediaControlCtx *ctx = (MediaControlCtx *)lv_obj_get_user_data(target);
+            MediaControlCtx *ctx = (MediaControlCtx *)lv_event_get_user_data(e);
             if (ctx) media_control_open_modal(ctx);
-          }, LV_EVENT_CLICKED, nullptr);
+          }, LV_EVENT_CLICKED, ctx);
         } else if (mode == "volume") {
           MediaVolumeCtx *ctx = create_media_volume_context(
             s.btn, s.text_lbl, p, has_on ? on_val : DEFAULT_SLIDER_COLOR,

--- a/scripts/check_firmware_modals.py
+++ b/scripts/check_firmware_modals.py
@@ -291,7 +291,8 @@ def firmware_subpage_modal_wiring_errors(root: Path) -> list[str]:
             "create_media_control_context" not in body
             or "subscribe_media_control_state(ctx);" not in body
             or "media_control_open_modal(ctx);" not in body
-            or "LV_EVENT_CLICKED" not in body
+            or "lv_event_get_user_data(e)" not in body
+            or "LV_EVENT_CLICKED, ctx" not in body
         ):
             errors.append("components/espcontrol/button_grid_grid.h: open media control modals from home grid cards")
 
@@ -722,10 +723,9 @@ def expect_subpage_modal_wiring_errors(name: str, grid_text: str, expected: tupl
             "            nullptr, nullptr, nullptr, nullptr, 100));\n"
             "          subscribe_media_control_state(ctx);\n"
             "          lv_obj_add_event_cb(s.btn, [](lv_event_t *e) {\n"
-            "            lv_obj_t *target = static_cast<lv_obj_t *>(lv_event_get_target(e));\n"
-            "            MediaControlCtx *ctx = (MediaControlCtx *)lv_obj_get_user_data(target);\n"
+            "            MediaControlCtx *ctx = (MediaControlCtx *)lv_event_get_user_data(e);\n"
             "            if (ctx) media_control_open_modal(ctx);\n"
-            "          }, LV_EVENT_CLICKED, nullptr);\n"
+            "          }, LV_EVENT_CLICKED, ctx);\n"
             '        } else if (mode == "volume") {\n'
             '      if (sb_cfg.type == "fan_control") {\n'
             "        if (!sb_cfg.entity.empty()) {\n"


### PR DESCRIPTION
## Purpose
Follow-up to PR #866. The Media All Controls home-grid card still may not open because the tap handler looked the media-control context up from the event target. On-device touches can arrive through a child object, so that lookup can miss the context.

## Practical impact
Tapping a home-grid Media card configured as All Controls should now open the media modal reliably.

## What changed
- Pass the `MediaControlCtx` directly as the click handler user data, matching the already-working subpage media control path.
- Tighten the firmware modal guard so the home-grid media control handler must use the direct context wiring.

## Automated checks
- `npm test` passed.
- `python3 scripts/check_firmware_modals.py && python3 scripts/check_firmware_modals.py --self-test` passed.
- `python3 scripts/check_firmware_ha_bindings.py` passed.

## Device testing
Device testing is still needed before merge because this affects the on-device firmware UI.

Suggested check:
- Flash this branch to the affected device.
- Tap a home-grid Media card set to All Controls.
- Confirm the playback/progress/volume modal opens and the tabs still respond.
