### PR TITLE
Fix initial cover art refresh

### DIFF
--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -1578,6 +1578,16 @@ script:
               bool playing = state_text == "playing" || state_text == "buffering";
               if (state_text == id(cover_art_last_playback_state) &&
                   id(cover_art_media_playing) == playing) {
+                if (playing &&
+                    id(cover_art_screensaver_enabled).state &&
+                    (!id(cover_art_image_available) ||
+                     (id(cover_art_screensaver_active) && id(cover_art_url).empty()))) {
+                  ESP_LOGI("cover_art", "Playback unchanged but artwork is not ready; refreshing current track");
+                  id(cover_art_playback_started).execute();
+                  if (id(cover_art_screensaver_active)) {
+                    id(cover_art_request_artwork).execute();
+                  }
+                }
                 return;
               }
               id(cover_art_last_playback_state) = state_text;


### PR DESCRIPTION
## Purpose
Fix cover art mode so the current artwork and track details refresh when the mode first appears while a song is already playing.

## Practical impact
When the player reports the same current playback state but the display has no artwork ready, the firmware now starts the normal cover-art refresh path instead of waiting for the next track change.

## Checked
- Firmware Home Assistant binding checks passed.
- Firmware parser checks passed.

## Device testing
Device testing is still needed before merge. After flashing this branch, start music, enable/show cover art mode while the track is already playing, and confirm the current cover art, title, artist, and progress appear before the next song starts.

Suggested devices to test:
- ESP32-P4 86 Panel (4 inches, Square)
- Guition JC1060P470 (7 inches, Landscape)
- Guition JC4880P443 (4.3 inches, Portrait)
- Guition JC8012P4A1 (10.1 inches, Landscape)
- Guition 4848S040 (4 inches, Square)