### PR TITLE
Fix cover art start delay

### DIFF
--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -224,7 +224,7 @@ script:
                                    id(cover_art_external_input_active)) &&
                                  !id(cover_art_media_player_entity).state.empty();
                       then:
-                        - script.execute: cover_art_delay_timer
+                        - script.execute: show_cover_art_view
                       else:
                         - if:
                             condition:

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -838,6 +838,16 @@ def firmware_media_sleep_prevention_errors(
                 idle_body,
             ):
                 errors.append(f"{rel}: do not let cover art alone keep the idle timer awake")
+        sleep_body = yaml_script_body(text, "screensaver_sleep_timer")
+        if sleep_body is not None:
+            cover_art_sleep_match = re.search(
+                r"id\(cover_art_screensaver_enabled\)\.state[\s\S]{0,360}"
+                r"id\(cover_art_media_playing\)[\s\S]{0,360}"
+                r"then:\s*\n\s*-\s*script\.execute:\s*([a-zA-Z0-9_]+)",
+                sleep_body,
+            )
+            if cover_art_sleep_match and cover_art_sleep_match.group(1) != "show_cover_art_view":
+                errors.append(f"{rel}: start cover art directly after the normal screensaver timeout")
 
     if display_path.exists():
         rel = display_path.relative_to(root)
@@ -3297,6 +3307,82 @@ def run_self_test() -> int:
         "          else:\n"
         "            - script.execute: screensaver_idle_check\n",
         (),
+    )
+    expect_media_sleep_prevention_errors(
+        "normal screensaver timeout starts cover art directly",
+        "script:\n"
+        "  - id: screensaver_idle_check\n"
+        "    then:\n"
+        "      - if:\n"
+        "          condition:\n"
+        "            lambda: |-\n"
+        "              return id(cover_art_screensaver_active) ||\n"
+        "                     (id(media_player_sleep_prevention_enabled).state &&\n"
+        "                      id(media_player_playing));\n"
+        "  - id: screensaver_sleep_timer\n"
+        "    then:\n"
+        "      - if:\n"
+        "          condition:\n"
+        "            lambda: |-\n"
+        "              return id(cover_art_screensaver_enabled).state &&\n"
+        "                     id(cover_art_media_playing) &&\n"
+        "                     !id(cover_art_media_player_entity).state.empty();\n"
+        "          then:\n"
+        "            - script.execute: show_cover_art_view\n",
+        "switch:\n"
+        "  - platform: template\n"
+        "    id: cover_art_screensaver_enabled\n",
+        "script:\n"
+        "  - id: cover_art_playback_started\n"
+        "    then:\n"
+        "      - if:\n"
+        "          condition:\n"
+        "            lambda: |-\n"
+        "              return id(media_player_sleep_prevention_enabled).state ||\n"
+        "                     id(display_asleep);\n"
+        "          then:\n"
+        "            - script.execute: cover_art_delay_timer\n"
+        "          else:\n"
+        "            - script.execute: screensaver_idle_check\n",
+        (),
+    )
+    expect_media_sleep_prevention_errors(
+        "normal screensaver timeout does not add cover art delay",
+        "script:\n"
+        "  - id: screensaver_idle_check\n"
+        "    then:\n"
+        "      - if:\n"
+        "          condition:\n"
+        "            lambda: |-\n"
+        "              return id(cover_art_screensaver_active) ||\n"
+        "                     (id(media_player_sleep_prevention_enabled).state &&\n"
+        "                      id(media_player_playing));\n"
+        "  - id: screensaver_sleep_timer\n"
+        "    then:\n"
+        "      - if:\n"
+        "          condition:\n"
+        "            lambda: |-\n"
+        "              return id(cover_art_screensaver_enabled).state &&\n"
+        "                     id(cover_art_media_playing) &&\n"
+        "                     !id(cover_art_media_player_entity).state.empty();\n"
+        "          then:\n"
+        "            - script.execute: cover_art_delay_timer\n",
+        "switch:\n"
+        "  - platform: template\n"
+        "    id: cover_art_screensaver_enabled\n",
+        "script:\n"
+        "  - id: cover_art_playback_started\n"
+        "    then:\n"
+        "      - if:\n"
+        "          condition:\n"
+        "            lambda: |-\n"
+        "              return id(media_player_sleep_prevention_enabled).state ||\n"
+        "                     id(display_asleep);\n"
+        "          then:\n"
+        "            - script.execute: cover_art_delay_timer\n"
+        "          else:\n"
+        "            - script.execute: screensaver_idle_check\n",
+        ("start cover art directly after the normal screensaver timeout",),
     )
     expect_image_card_entity_errors(
         "legacy camera-only image card guard",


### PR DESCRIPTION
## Summary
- Starts cover art directly once the normal screensaver timeout has already completed.
- Keeps the cover art Show After delay for playback-start and wake/dismiss paths.
- Adds a firmware scanner check so the normal screensaver timeout path does not accidentally add a second cover-art delay again.

## Root cause
A recent shared backlight change made the normal screensaver timeout run the cover art delay timer instead of showing cover art immediately. That stacked the cover art Show After delay on top of the normal screensaver idle timeout, making cover art appear not to start on devices.

## Checks
- python3 scripts/check_firmware_ha_bindings.py --self-test
- python3 scripts/check_firmware_ha_bindings.py
- git diff --check
- npm run check:product

## Device testing
Not physically tested yet. Please flash an affected display and confirm that cover art starts after the normal screensaver timeout when Show Cover Art is enabled and media is playing.