### PR TITLE
Fix media controls modal after grid refresh

### DIFF
--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -589,6 +589,8 @@ inline LockCardCtx *bind_lock_status_card(BtnSlot &s, const ParsedCfg &p,
   return ctx;
 }
 
+inline MediaControlCtx *grid_media_control_runtime_for_owner(lv_obj_t *owner);
+
 inline void refresh_media_card_layout(BtnSlot &s, const ParsedCfg &p,
                                       const GridConfig &cfg,
                                       int row_span = 1) {
@@ -637,10 +639,10 @@ inline void refresh_media_card_layout(BtnSlot &s, const ParsedCfg &p,
     return;
   }
   if (mode == "control_modal") {
-    if (s.btn) lv_obj_set_user_data(s.btn, nullptr);
+    MediaControlCtx *ctx = grid_media_control_runtime_for_owner(s.btn);
     setup_media_control_button(
       s.btn, s.icon_lbl, s.sensor_container, s.sensor_lbl, s.unit_lbl, s.text_lbl, p);
-    MediaControlCtx *ctx = (MediaControlCtx *)lv_obj_get_user_data(s.btn);
+    if (s.btn) lv_obj_set_user_data(s.btn, ctx);
     if (ctx) media_control_refresh_parent_card(ctx);
     return;
   }
@@ -1023,6 +1025,17 @@ inline MediaControlCtx *grid_track_media_control_runtime(lv_obj_t *owner,
     });
   }
   return ctx;
+}
+
+inline MediaControlCtx *grid_media_control_runtime_for_owner(lv_obj_t *owner) {
+  if (owner == nullptr) return nullptr;
+  for (const GridRuntimeAllocation &allocation : grid_runtime_allocations()) {
+    if (allocation.owner == owner &&
+        allocation.deleter == grid_delete_media_control_runtime_ptr) {
+      return static_cast<MediaControlCtx *>(allocation.ptr);
+    }
+  }
+  return nullptr;
 }
 
 inline MediaControlCtx *grid_delete_media_control_with_owner(lv_obj_t *owner,

--- a/scripts/check_firmware_modals.py
+++ b/scripts/check_firmware_modals.py
@@ -295,6 +295,23 @@ def firmware_subpage_modal_wiring_errors(root: Path) -> list[str]:
         if "media_control_open_modal(ctx);" in body or "LV_EVENT_CLICKED, ctx" in body:
             errors.append("components/espcontrol/button_grid_grid.h: open home media control cards through the shared button dispatcher")
 
+    media_refresh_block = re.search(
+        r'if\s*\(\s*mode\s*==\s*"control_modal"\s*\)\s*\{(?P<body>.*?)\n  \}\n  if\s*\(\s*mode\s*==\s*"volume"\s*\)',
+        text,
+        re.S,
+    )
+    if media_refresh_block is None:
+        errors.append("components/espcontrol/button_grid_grid.h: keep media control cards refreshed on grid layout updates")
+    else:
+        body = media_refresh_block.group("body")
+        if (
+            "grid_media_control_runtime_for_owner(s.btn)" not in body
+            or "lv_obj_set_user_data(s.btn, ctx)" not in body
+            or "media_control_refresh_parent_card(ctx)" not in body
+            or "lv_obj_set_user_data(s.btn, nullptr)" in body
+        ):
+            errors.append("components/espcontrol/button_grid_grid.h: preserve media control context during grid layout refresh")
+
     light_block = re.search(
         r'if\s*\(\s*sb_cfg\.type\s*==\s*"light_control"\s*\)\s*\{(?P<body>.*?)\n      \}',
         text,
@@ -716,6 +733,15 @@ def expect_subpage_modal_wiring_errors(name: str, grid_text: str, expected: tupl
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(
             grid_text +
+            '  if (mode == "control_modal") {\n'
+            "    MediaControlCtx *ctx = grid_media_control_runtime_for_owner(s.btn);\n"
+            "    setup_media_control_button(\n"
+            "      s.btn, s.icon_lbl, s.sensor_container, s.sensor_lbl, s.unit_lbl, s.text_lbl, p);\n"
+            "    if (s.btn) lv_obj_set_user_data(s.btn, ctx);\n"
+            "    if (ctx) media_control_refresh_parent_card(ctx);\n"
+            "    return;\n"
+            "  }\n"
+            "  if (mode == \"volume\") return;\n"
             '        } else if (mode == "control_modal") {\n'
             "          MediaControlCtx *ctx = grid_track_media_control_runtime(s.btn, create_media_control_context(\n"
             "            s, p, DEFAULT_SLIDER_COLOR, DEFAULT_OFF_COLOR, DEFAULT_TERTIARY_COLOR,\n"
@@ -977,6 +1003,21 @@ def run_self_test() -> int:
         "display takeover close",
         valid_sleep_takeover_files(),
         (),
+    )
+    expect_subpage_modal_wiring_errors(
+        "media refresh preserves modal context",
+        (
+            '  if (mode == "control_modal") {\n'
+            "    if (s.btn) lv_obj_set_user_data(s.btn, nullptr);\n"
+            "    setup_media_control_button(\n"
+            "      s.btn, s.icon_lbl, s.sensor_container, s.sensor_lbl, s.unit_lbl, s.text_lbl, p);\n"
+            "    MediaControlCtx *ctx = (MediaControlCtx *)lv_obj_get_user_data(s.btn);\n"
+            "    if (ctx) media_control_refresh_parent_card(ctx);\n"
+            "    return;\n"
+            "  }\n"
+            "  if (mode == \"volume\") return;\n"
+        ),
+        ("preserve media control context during grid layout refresh",),
     )
     expect_subpage_modal_wiring_errors(
         "subpage light modal missing click handler",


### PR DESCRIPTION
## Summary

Fixes the Media All Controls card so a grid/layout refresh does not remove the modal context that the home-screen tap handler needs. The card can still redraw its label/icon/volume display, but it restores the tracked media-control runtime context before the shared button dispatcher reads it.

Adds a regression check so the modal wiring test fails if this refresh path starts clearing the media context again.

## Practical impact

Media All Controls cards should keep opening the playback/volume popup after a screen refresh, settings refresh, rotation/layout update, or similar grid redraw.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- The public media card docs already say All Controls opens the popup; this restores that documented behavior.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.
- [ ] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- ESP32-P4 86 Panel
- Guition JC1060P470
- Guition JC4880P443
- Guition JC8012P4A1
- Guition 4848S040

## Notes for testing

Local checks run:

- python3 scripts/check_firmware_modals.py && python3 scripts/check_firmware_modals.py --self-test
- python3 scripts/check_firmware_parser.py
- python3 scripts/check_firmware_card_runtime.py && python3 scripts/check_firmware_card_runtime.py --self-test
- python3 scripts/check_firmware_ha_bindings.py && python3 scripts/check_firmware_ha_bindings.py --self-test
- npm run check:fast

Physical device testing has not been run locally. For device testing, add or use a Media card set to All Controls for a media_player entity, then confirm the playback/volume popup opens before and after a grid refresh such as changing rotation/layout-related settings or saving display settings that refresh the grid.

<!-- espcontrol-pr-testing-guidance -->
## Automated testing guidance

Device testing is expected before merge because this change may affect firmware or the on-device experience.

Suggested devices to test:
- ESP32-P4 86 Panel (4 inches, Square)
- Guition JC1060P470 (7 inches, Landscape)
- Guition JC4880P443 (4.3 inches, Portrait)
- Guition JC8012P4A1 (10.1 inches, Landscape)
- Guition 4848S040 (4 inches, Square)

Suggested checks:
- Confirm the device boots normally and does not restart repeatedly.
- Add or use a Media card set to All Controls for a media_player entity.
- Tap the Media All Controls card before and after a grid refresh, such as changing rotation/layout-related settings or saving display settings that refresh the grid.
- Confirm the playback/volume popup opens each time.
- Confirm touch/navigation still works where the changed area is interactive.
- Confirm there is no obvious text overlap, clipping, blank screen, or missing icon.

Suggested PR status: Ready for device test once automated checks pass.

Changed files considered:
- components/espcontrol/button_grid_grid.h
- scripts/check_firmware_modals.py

## PR status

- [ ] Checks running or waiting.
- [ ] Needs automated fix.
- [x] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [ ] Do not close related issues until the user confirms the fix works.
