### PR TITLE
Show source label for line input media

### DIFF
--- a/common/config/strings.cs.txt
+++ b/common/config/strings.cs.txt
@@ -108,6 +108,7 @@ none=Žádné
 no_options=Žádné možnosti
 no_presets=Žádné předvolby
 no_sources=Žádné zdroje
+source=Zdroj
 not_available=Není dostupné
 off=Vypnuto
 on=Zapnuto

--- a/common/config/strings.da.txt
+++ b/common/config/strings.da.txt
@@ -108,6 +108,7 @@ none=Ingen
 no_options=Ingen muligheder
 no_presets=Ingen forvalg
 no_sources=Ingen kilder
+source=Kilde
 not_available=Ikke tilgængelig
 off=Slukket
 on=Tændt

--- a/common/config/strings.de.txt
+++ b/common/config/strings.de.txt
@@ -108,6 +108,7 @@ none=Keine
 no_options=Keine Optionen
 no_presets=Keine Voreinstellungen
 no_sources=Keine Quellen
+source=Quelle
 not_available=Nicht verfügbar
 off=Aus
 on=Ein

--- a/common/config/strings.en.txt
+++ b/common/config/strings.en.txt
@@ -108,6 +108,7 @@ none=None
 no_options=No options
 no_presets=No presets
 no_sources=No sources
+source=Source
 not_available=Not available
 off=Off
 on=On

--- a/common/config/strings.es.txt
+++ b/common/config/strings.es.txt
@@ -108,6 +108,7 @@ none=Ninguno
 no_options=Sin opciones
 no_presets=Sin preajustes
 no_sources=Sin fuentes
+source=Fuente
 not_available=No disponible
 off=Apagado
 on=Encendido

--- a/common/config/strings.fi.txt
+++ b/common/config/strings.fi.txt
@@ -108,6 +108,7 @@ none=Ei mitään
 no_options=Ei vaihtoehtoja
 no_presets=Ei esiasetuksia
 no_sources=Ei lähteitä
+source=Lähde
 not_available=Ei saatavilla
 off=Pois
 on=Päällä

--- a/common/config/strings.fr.txt
+++ b/common/config/strings.fr.txt
@@ -108,6 +108,7 @@ none=Aucun
 no_options=Aucune option
 no_presets=Aucun préréglage
 no_sources=Aucune source
+source=Source
 not_available=Non disponible
 off=Éteint
 on=Allumé

--- a/common/config/strings.hu.txt
+++ b/common/config/strings.hu.txt
@@ -108,6 +108,7 @@ none=Nincs
 no_options=Nincsenek opciók
 no_presets=Nincsenek előbeállítások
 no_sources=Nincsenek források
+source=Forrás
 not_available=Nem érhető el
 off=Ki
 on=Be

--- a/common/config/strings.it.txt
+++ b/common/config/strings.it.txt
@@ -108,6 +108,7 @@ none=Nessuno
 no_options=Nessuna opzione
 no_presets=Nessun preset
 no_sources=Nessuna sorgente
+source=Fonte
 not_available=Non disponibile
 off=Spento
 on=Acceso

--- a/common/config/strings.nb.txt
+++ b/common/config/strings.nb.txt
@@ -108,6 +108,7 @@ none=Ingen
 no_options=Ingen alternativer
 no_presets=Ingen forhåndsvalg
 no_sources=Ingen kilder
+source=Kilde
 not_available=Ikke tilgjengelig
 off=Av
 on=På

--- a/common/config/strings.nl.txt
+++ b/common/config/strings.nl.txt
@@ -108,6 +108,7 @@ none=Geen
 no_options=Geen opties
 no_presets=Geen voorinstellingen
 no_sources=Geen bronnen
+source=Bron
 not_available=Niet beschikbaar
 off=Uit
 on=Aan

--- a/common/config/strings.pl.txt
+++ b/common/config/strings.pl.txt
@@ -108,6 +108,7 @@ none=Brak
 no_options=Brak opcji
 no_presets=Brak presetów
 no_sources=Brak źródeł
+source=Źródło
 not_available=Niedostępne
 off=Wyłączone
 on=Włączone

--- a/common/config/strings.pt-br.txt
+++ b/common/config/strings.pt-br.txt
@@ -108,6 +108,7 @@ none=Nenhum
 no_options=Sem opções
 no_presets=Sem predefinições
 no_sources=Sem fontes
+source=Fonte
 not_available=Não disponível
 off=Desligado
 on=Ligado

--- a/common/config/strings.pt.txt
+++ b/common/config/strings.pt.txt
@@ -108,6 +108,7 @@ none=Nenhum
 no_options=Sem opções
 no_presets=Sem predefinições
 no_sources=Sem fontes
+source=Fonte
 not_available=Não disponível
 off=Desligado
 on=Ligado

--- a/common/config/strings.ro.txt
+++ b/common/config/strings.ro.txt
@@ -108,6 +108,7 @@ none=Niciunul
 no_options=Fără opțiuni
 no_presets=Fără presetări
 no_sources=Fără surse
+source=Sursă
 not_available=Indisponibil
 off=Oprit
 on=Pornit

--- a/common/config/strings.sk.txt
+++ b/common/config/strings.sk.txt
@@ -108,6 +108,7 @@ none=Žiadne
 no_options=Žiadne možnosti
 no_presets=Žiadne predvoľby
 no_sources=Žiadne zdroje
+source=Zdroj
 not_available=Nie je dostupné
 off=Vypnuté
 on=Zapnuté

--- a/common/config/strings.sl.txt
+++ b/common/config/strings.sl.txt
@@ -108,6 +108,7 @@ none=Brez
 no_options=Ni možnosti
 no_presets=Ni prednastavitev
 no_sources=Ni virov
+source=Vir
 not_available=Ni na voljo
 off=Izklop
 on=Vklop

--- a/common/config/strings.sv.txt
+++ b/common/config/strings.sv.txt
@@ -108,6 +108,7 @@ none=Ingen
 no_options=Inga alternativ
 no_presets=Inga förval
 no_sources=Inga källor
+source=Källa
 not_available=Inte tillgänglig
 off=Av
 on=På

--- a/common/config/strings.tr.txt
+++ b/common/config/strings.tr.txt
@@ -108,6 +108,7 @@ none=Yok
 no_options=Seçenek yok
 no_presets=Ön ayar yok
 no_sources=Kaynak yok
+source=Kaynak
 not_available=Mevcut değil
 off=Kapalı
 on=Açık

--- a/common/config/strings.uk.txt
+++ b/common/config/strings.uk.txt
@@ -108,6 +108,7 @@ none=Немає
 no_options=Немає параметрів
 no_presets=Немає пресетів
 no_sources=Немає джерел
+source=Джерело
 not_available=Недоступно
 off=Вимкнено
 on=Увімкнено

--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -1812,9 +1812,13 @@ script:
                   cover_entity != id(cover_art_media_player_entity).state) return;
               std::string next = string_ref_limited(source, HA_STATE_TEXT_MAX_LEN);
               if (next == "unknown" || next == "unavailable") next.clear();
-              bool external = next == "TV" || next == "tv" ||
-                              next == "Line-in" || next == "line-in" ||
-                              next == "Line in" || next == "line in";
+              std::string normalized_source = next;
+              for (char &ch : normalized_source) {
+                ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+              }
+              bool external = normalized_source == "tv" ||
+                              normalized_source == "line-in" ||
+                              normalized_source == "line in";
               if (next == id(cover_art_media_source) &&
                   external == id(cover_art_external_input_active)) return;
               id(cover_art_media_source) = next;

--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -1169,11 +1169,15 @@ script:
             return id(cover_art_title);
       - if:
           condition:
-            lambda: 'return !id(cover_art_artist).empty();'
+            lambda: 'return id(cover_art_external_input_active) || !id(cover_art_artist).empty();'
           then:
             - lvgl.label.update:
                 id: cover_art_artist_label
-                text: !lambda 'return id(cover_art_artist);'
+                text: !lambda |-
+                  if (id(cover_art_external_input_active)) {
+                    return espcontrol_i18n(std::string("Source"));
+                  }
+                  return id(cover_art_artist);
             - lvgl.widget.show: cover_art_artist_label
           else:
             - lvgl.widget.hide: cover_art_artist_label
@@ -1819,10 +1823,12 @@ script:
               ESP_LOGI("cover_art", "Media source for %s: '%s' (external=%s)",
                        cover_entity.c_str(), next.c_str(), external ? "true" : "false");
               id(cover_art_apply_external_input_policy).execute();
+              id(cover_art_sync_track_text).execute();
               if (id(cover_art_screensaver_active) &&
                   id(cover_art_attribute_conditions_match) &&
                   !(id(cover_art_hide_external_input_enabled).state &&
                     id(cover_art_external_input_active))) {
+                id(cover_art_show_track_overlay).execute();
                 id(cover_art_request_artwork).execute();
               }
             };

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -117,24 +117,45 @@ inline constexpr bool media_control_progress_supported() {
   return !media_control_low_heap_mode();
 }
 
-inline void media_set_metadata_text(lv_obj_t *label, esphome::StringRef value,
-                                    const char *fallback) {
-  if (!label) return;
+inline std::string media_metadata_text(esphome::StringRef value, const char *fallback) {
   std::string text = string_ref_limited(value, HA_STATE_TEXT_MAX_LEN);
   if (text.empty() || text == "unknown" || text == "unavailable")
     text = fallback ? fallback : "--";
+  return text;
+}
+
+inline void media_set_metadata_text(lv_obj_t *label, esphome::StringRef value,
+                                    const char *fallback) {
+  if (!label) return;
+  std::string text = media_metadata_text(value, fallback);
   lv_label_set_text(label, text.c_str());
 }
 
-inline void media_refresh_artist_text(lv_obj_t *artist_lbl,
+inline bool media_external_source_input(const std::string &source) {
+  return source == "TV" || source == "tv" ||
+         source == "Line-in" || source == "line-in" ||
+         source == "Line in" || source == "line in";
+}
+
+inline void media_apply_now_playing_artist_text(MediaNowPlayingCtx *ctx) {
+  if (!ctx || !ctx->artist_lbl) return;
+  std::string text = ctx->external_source
+    ? espcontrol_i18n(std::string("Source"))
+    : ctx->artist;
+  lv_label_set_text(ctx->artist_lbl, text.c_str());
+}
+
+inline void media_refresh_artist_text(MediaNowPlayingCtx *ctx,
                                       const std::string &entity_id) {
-  if (!artist_lbl || entity_id.empty()) return;
-  lv_label_set_text(artist_lbl, "");
+  if (!ctx || entity_id.empty()) return;
+  ctx->artist.clear();
+  media_apply_now_playing_artist_text(ctx);
   ha_get_attribute(
     entity_id, std::string("media_artist"),
     std::function<void(esphome::StringRef)>(
-      [artist_lbl](esphome::StringRef artist) {
-        media_set_metadata_text(artist_lbl, artist, "");
+      [ctx](esphome::StringRef artist) {
+        ctx->artist = media_metadata_text(artist, "");
+        media_apply_now_playing_artist_text(ctx);
       })
   );
 }
@@ -1927,26 +1948,36 @@ inline void subscribe_media_slider_state(lv_obj_t *btn_ptr,
 
 inline void subscribe_media_now_playing_state(MediaNowPlayingCtx *ctx,
                                               const std::string &entity_id) {
-  if (entity_id.empty()) return;
-  lv_obj_t *title_lbl = ctx ? ctx->title_lbl : nullptr;
-  lv_obj_t *artist_lbl = ctx ? ctx->artist_lbl : nullptr;
+  if (!ctx || entity_id.empty()) return;
   ha_subscribe_attribute(
     entity_id, std::string("media_title"),
     std::function<void(esphome::StringRef)>(
-      [title_lbl, artist_lbl, entity_id](esphome::StringRef title) {
-        media_set_metadata_text(title_lbl, title, "--");
+      [ctx, entity_id](esphome::StringRef title) {
+        media_set_metadata_text(ctx->title_lbl, title, "--");
         if (!media_control_low_heap_mode()) {
-          media_refresh_artist_text(artist_lbl, entity_id);
+          media_refresh_artist_text(ctx, entity_id);
         }
       })
   );
   ha_subscribe_attribute(
     entity_id, std::string("media_artist"),
     std::function<void(esphome::StringRef)>(
-      [artist_lbl](esphome::StringRef artist) {
-        media_set_metadata_text(artist_lbl, artist, "");
+      [ctx](esphome::StringRef artist) {
+        ctx->artist = media_metadata_text(artist, "");
+        media_apply_now_playing_artist_text(ctx);
       })
   );
+  auto handle_media_source = [ctx](esphome::StringRef source) {
+    bool external = media_external_source_input(media_metadata_text(source, ""));
+    if (external == ctx->external_source) return;
+    ctx->external_source = external;
+    media_apply_now_playing_artist_text(ctx);
+  };
+  ha_subscribe_attribute(
+    entity_id, std::string("source"),
+    std::function<void(esphome::StringRef)>(handle_media_source)
+  );
+  ha_get_attribute(entity_id, std::string("source"), handle_media_source);
   if (ctx && ctx->progress_slider) {
     subscribe_media_slider_state(lv_obj_get_parent(ctx->progress_slider), ctx->progress_slider, entity_id);
   }

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -131,10 +131,11 @@ inline void media_set_metadata_text(lv_obj_t *label, esphome::StringRef value,
   lv_label_set_text(label, text.c_str());
 }
 
-inline bool media_external_source_input(const std::string &source) {
-  return source == "TV" || source == "tv" ||
-         source == "Line-in" || source == "line-in" ||
-         source == "Line in" || source == "line in";
+inline bool media_external_source_input(std::string source) {
+  for (char &ch : source) {
+    ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+  }
+  return source == "tv" || source == "line-in" || source == "line in";
 }
 
 inline void media_apply_now_playing_artist_text(MediaNowPlayingCtx *ctx) {

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -139,22 +139,30 @@ inline bool media_external_source_input(const std::string &source) {
 
 inline void media_apply_now_playing_artist_text(MediaNowPlayingCtx *ctx) {
   if (!ctx || !ctx->artist_lbl) return;
-  std::string text = ctx->external_source
-    ? espcontrol_i18n(std::string("Source"))
+  const char *text = ctx->external_source
+    ? espcontrol_i18n("Source")
     : ctx->artist;
-  lv_label_set_text(ctx->artist_lbl, text.c_str());
+  lv_label_set_text(ctx->artist_lbl, text);
+}
+
+inline void media_set_now_playing_artist(MediaNowPlayingCtx *ctx,
+                                         esphome::StringRef artist) {
+  if (!ctx) return;
+  std::string text = media_metadata_text(artist, "");
+  std::strncpy(ctx->artist, text.c_str(), sizeof(ctx->artist) - 1);
+  ctx->artist[sizeof(ctx->artist) - 1] = '\0';
 }
 
 inline void media_refresh_artist_text(MediaNowPlayingCtx *ctx,
                                       const std::string &entity_id) {
   if (!ctx || entity_id.empty()) return;
-  ctx->artist.clear();
+  ctx->artist[0] = '\0';
   media_apply_now_playing_artist_text(ctx);
   ha_get_attribute(
     entity_id, std::string("media_artist"),
     std::function<void(esphome::StringRef)>(
       [ctx](esphome::StringRef artist) {
-        ctx->artist = media_metadata_text(artist, "");
+        media_set_now_playing_artist(ctx, artist);
         media_apply_now_playing_artist_text(ctx);
       })
   );
@@ -1963,7 +1971,7 @@ inline void subscribe_media_now_playing_state(MediaNowPlayingCtx *ctx,
     entity_id, std::string("media_artist"),
     std::function<void(esphome::StringRef)>(
       [ctx](esphome::StringRef artist) {
-        ctx->artist = media_metadata_text(artist, "");
+        media_set_now_playing_artist(ctx, artist);
         media_apply_now_playing_artist_text(ctx);
       })
   );

--- a/components/espcontrol/button_grid_sliders.h
+++ b/components/espcontrol/button_grid_sliders.h
@@ -51,6 +51,8 @@ struct MediaNowPlayingCtx {
   lv_obj_t *artist_lbl = nullptr;
   lv_obj_t *progress_slider = nullptr;
   lv_obj_t *btn = nullptr;
+  std::string artist;
+  bool external_source = false;
   bool play_pause_background = false;
 };
 

--- a/components/espcontrol/button_grid_sliders.h
+++ b/components/espcontrol/button_grid_sliders.h
@@ -51,7 +51,7 @@ struct MediaNowPlayingCtx {
   lv_obj_t *artist_lbl = nullptr;
   lv_obj_t *progress_slider = nullptr;
   lv_obj_t *btn = nullptr;
-  std::string artist;
+  char artist[HA_STATE_TEXT_MAX_LEN + 1] = {};
   bool external_source = false;
   bool play_pause_background = false;
 };

--- a/components/espcontrol/i18n_generated.h
+++ b/components/espcontrol/i18n_generated.h
@@ -113,6 +113,7 @@ inline const char *espcontrol_i18n_cs(const char *text) {
   if (std::strcmp(text, "No options") == 0) return "Žádné možnosti";
   if (std::strcmp(text, "No presets") == 0) return "Žádné předvolby";
   if (std::strcmp(text, "No sources") == 0) return "Žádné zdroje";
+  if (std::strcmp(text, "Source") == 0) return "Zdroj";
   if (std::strcmp(text, "Not available") == 0) return "Není dostupné";
   if (std::strcmp(text, "Off") == 0) return "Vypnuto";
   if (std::strcmp(text, "On") == 0) return "Zapnuto";
@@ -322,6 +323,7 @@ inline const char *espcontrol_i18n_da(const char *text) {
   if (std::strcmp(text, "No options") == 0) return "Ingen muligheder";
   if (std::strcmp(text, "No presets") == 0) return "Ingen forvalg";
   if (std::strcmp(text, "No sources") == 0) return "Ingen kilder";
+  if (std::strcmp(text, "Source") == 0) return "Kilde";
   if (std::strcmp(text, "Not available") == 0) return "Ikke tilgængelig";
   if (std::strcmp(text, "Off") == 0) return "Slukket";
   if (std::strcmp(text, "On") == 0) return "Tændt";
@@ -524,6 +526,7 @@ inline const char *espcontrol_i18n_de(const char *text) {
   if (std::strcmp(text, "No options") == 0) return "Keine Optionen";
   if (std::strcmp(text, "No presets") == 0) return "Keine Voreinstellungen";
   if (std::strcmp(text, "No sources") == 0) return "Keine Quellen";
+  if (std::strcmp(text, "Source") == 0) return "Quelle";
   if (std::strcmp(text, "Not available") == 0) return "Nicht verfügbar";
   if (std::strcmp(text, "Off") == 0) return "Aus";
   if (std::strcmp(text, "On") == 0) return "Ein";
@@ -727,6 +730,7 @@ inline const char *espcontrol_i18n_es(const char *text) {
   if (std::strcmp(text, "No options") == 0) return "Sin opciones";
   if (std::strcmp(text, "No presets") == 0) return "Sin preajustes";
   if (std::strcmp(text, "No sources") == 0) return "Sin fuentes";
+  if (std::strcmp(text, "Source") == 0) return "Fuente";
   if (std::strcmp(text, "Not available") == 0) return "No disponible";
   if (std::strcmp(text, "Off") == 0) return "Apagado";
   if (std::strcmp(text, "On") == 0) return "Encendido";
@@ -941,6 +945,7 @@ inline const char *espcontrol_i18n_fi(const char *text) {
   if (std::strcmp(text, "No options") == 0) return "Ei vaihtoehtoja";
   if (std::strcmp(text, "No presets") == 0) return "Ei esiasetuksia";
   if (std::strcmp(text, "No sources") == 0) return "Ei lähteitä";
+  if (std::strcmp(text, "Source") == 0) return "Lähde";
   if (std::strcmp(text, "Not available") == 0) return "Ei saatavilla";
   if (std::strcmp(text, "Off") == 0) return "Pois";
   if (std::strcmp(text, "On") == 0) return "Päällä";
@@ -1360,6 +1365,7 @@ inline const char *espcontrol_i18n_hu(const char *text) {
   if (std::strcmp(text, "No options") == 0) return "Nincsenek opciók";
   if (std::strcmp(text, "No presets") == 0) return "Nincsenek előbeállítások";
   if (std::strcmp(text, "No sources") == 0) return "Nincsenek források";
+  if (std::strcmp(text, "Source") == 0) return "Forrás";
   if (std::strcmp(text, "Not available") == 0) return "Nem érhető el";
   if (std::strcmp(text, "Off") == 0) return "Ki";
   if (std::strcmp(text, "On") == 0) return "Be";
@@ -1574,6 +1580,7 @@ inline const char *espcontrol_i18n_it(const char *text) {
   if (std::strcmp(text, "No options") == 0) return "Nessuna opzione";
   if (std::strcmp(text, "No presets") == 0) return "Nessun preset";
   if (std::strcmp(text, "No sources") == 0) return "Nessuna sorgente";
+  if (std::strcmp(text, "Source") == 0) return "Fonte";
   if (std::strcmp(text, "Not available") == 0) return "Non disponibile";
   if (std::strcmp(text, "Off") == 0) return "Spento";
   if (std::strcmp(text, "On") == 0) return "Acceso";
@@ -1783,6 +1790,7 @@ inline const char *espcontrol_i18n_nb(const char *text) {
   if (std::strcmp(text, "No options") == 0) return "Ingen alternativer";
   if (std::strcmp(text, "No presets") == 0) return "Ingen forhåndsvalg";
   if (std::strcmp(text, "No sources") == 0) return "Ingen kilder";
+  if (std::strcmp(text, "Source") == 0) return "Kilde";
   if (std::strcmp(text, "Not available") == 0) return "Ikke tilgjengelig";
   if (std::strcmp(text, "Off") == 0) return "Av";
   if (std::strcmp(text, "On") == 0) return "På";
@@ -1991,6 +1999,7 @@ inline const char *espcontrol_i18n_nl(const char *text) {
   if (std::strcmp(text, "No options") == 0) return "Geen opties";
   if (std::strcmp(text, "No presets") == 0) return "Geen voorinstellingen";
   if (std::strcmp(text, "No sources") == 0) return "Geen bronnen";
+  if (std::strcmp(text, "Source") == 0) return "Bron";
   if (std::strcmp(text, "Not available") == 0) return "Niet beschikbaar";
   if (std::strcmp(text, "Off") == 0) return "Uit";
   if (std::strcmp(text, "On") == 0) return "Aan";
@@ -2196,6 +2205,7 @@ inline const char *espcontrol_i18n_pl(const char *text) {
   if (std::strcmp(text, "No options") == 0) return "Brak opcji";
   if (std::strcmp(text, "No presets") == 0) return "Brak presetów";
   if (std::strcmp(text, "No sources") == 0) return "Brak źródeł";
+  if (std::strcmp(text, "Source") == 0) return "Źródło";
   if (std::strcmp(text, "Not available") == 0) return "Niedostępne";
   if (std::strcmp(text, "Off") == 0) return "Wyłączone";
   if (std::strcmp(text, "On") == 0) return "Włączone";
@@ -2403,6 +2413,7 @@ inline const char *espcontrol_i18n_pt_br(const char *text) {
   if (std::strcmp(text, "No options") == 0) return "Sem opções";
   if (std::strcmp(text, "No presets") == 0) return "Sem predefinições";
   if (std::strcmp(text, "No sources") == 0) return "Sem fontes";
+  if (std::strcmp(text, "Source") == 0) return "Fonte";
   if (std::strcmp(text, "Not available") == 0) return "Não disponível";
   if (std::strcmp(text, "Off") == 0) return "Desligado";
   if (std::strcmp(text, "On") == 0) return "Ligado";
@@ -2612,6 +2623,7 @@ inline const char *espcontrol_i18n_pt(const char *text) {
   if (std::strcmp(text, "No options") == 0) return "Sem opções";
   if (std::strcmp(text, "No presets") == 0) return "Sem predefinições";
   if (std::strcmp(text, "No sources") == 0) return "Sem fontes";
+  if (std::strcmp(text, "Source") == 0) return "Fonte";
   if (std::strcmp(text, "Not available") == 0) return "Não disponível";
   if (std::strcmp(text, "Off") == 0) return "Desligado";
   if (std::strcmp(text, "On") == 0) return "Ligado";
@@ -2824,6 +2836,7 @@ inline const char *espcontrol_i18n_ro(const char *text) {
   if (std::strcmp(text, "No options") == 0) return "Fără opțiuni";
   if (std::strcmp(text, "No presets") == 0) return "Fără presetări";
   if (std::strcmp(text, "No sources") == 0) return "Fără surse";
+  if (std::strcmp(text, "Source") == 0) return "Sursă";
   if (std::strcmp(text, "Not available") == 0) return "Indisponibil";
   if (std::strcmp(text, "Off") == 0) return "Oprit";
   if (std::strcmp(text, "On") == 0) return "Pornit";
@@ -3038,6 +3051,7 @@ inline const char *espcontrol_i18n_sk(const char *text) {
   if (std::strcmp(text, "No options") == 0) return "Žiadne možnosti";
   if (std::strcmp(text, "No presets") == 0) return "Žiadne predvoľby";
   if (std::strcmp(text, "No sources") == 0) return "Žiadne zdroje";
+  if (std::strcmp(text, "Source") == 0) return "Zdroj";
   if (std::strcmp(text, "Not available") == 0) return "Nie je dostupné";
   if (std::strcmp(text, "Off") == 0) return "Vypnuté";
   if (std::strcmp(text, "On") == 0) return "Zapnuté";
@@ -3249,6 +3263,7 @@ inline const char *espcontrol_i18n_sl(const char *text) {
   if (std::strcmp(text, "No options") == 0) return "Ni možnosti";
   if (std::strcmp(text, "No presets") == 0) return "Ni prednastavitev";
   if (std::strcmp(text, "No sources") == 0) return "Ni virov";
+  if (std::strcmp(text, "Source") == 0) return "Vir";
   if (std::strcmp(text, "Not available") == 0) return "Ni na voljo";
   if (std::strcmp(text, "Off") == 0) return "Izklop";
   if (std::strcmp(text, "On") == 0) return "Vklop";
@@ -3462,6 +3477,7 @@ inline const char *espcontrol_i18n_sv(const char *text) {
   if (std::strcmp(text, "No options") == 0) return "Inga alternativ";
   if (std::strcmp(text, "No presets") == 0) return "Inga förval";
   if (std::strcmp(text, "No sources") == 0) return "Inga källor";
+  if (std::strcmp(text, "Source") == 0) return "Källa";
   if (std::strcmp(text, "Not available") == 0) return "Inte tillgänglig";
   if (std::strcmp(text, "Off") == 0) return "Av";
   if (std::strcmp(text, "On") == 0) return "På";
@@ -3672,6 +3688,7 @@ inline const char *espcontrol_i18n_tr(const char *text) {
   if (std::strcmp(text, "No options") == 0) return "Seçenek yok";
   if (std::strcmp(text, "No presets") == 0) return "Ön ayar yok";
   if (std::strcmp(text, "No sources") == 0) return "Kaynak yok";
+  if (std::strcmp(text, "Source") == 0) return "Kaynak";
   if (std::strcmp(text, "Not available") == 0) return "Mevcut değil";
   if (std::strcmp(text, "Off") == 0) return "Kapalı";
   if (std::strcmp(text, "On") == 0) return "Açık";
@@ -3892,6 +3909,7 @@ inline const char *espcontrol_i18n_uk(const char *text) {
   if (std::strcmp(text, "No options") == 0) return "Немає параметрів";
   if (std::strcmp(text, "No presets") == 0) return "Немає пресетів";
   if (std::strcmp(text, "No sources") == 0) return "Немає джерел";
+  if (std::strcmp(text, "Source") == 0) return "Джерело";
   if (std::strcmp(text, "Not available") == 0) return "Недоступно";
   if (std::strcmp(text, "Off") == 0) return "Вимкнено";
   if (std::strcmp(text, "On") == 0) return "Увімкнено";
@@ -4116,6 +4134,7 @@ inline const char *espcontrol_i18n_key_en(const char *key) {
   if (std::strcmp(key, "no_options") == 0) return "No options";
   if (std::strcmp(key, "no_presets") == 0) return "No presets";
   if (std::strcmp(key, "no_sources") == 0) return "No sources";
+  if (std::strcmp(key, "source") == 0) return "Source";
   if (std::strcmp(key, "not_available") == 0) return "Not available";
   if (std::strcmp(key, "off") == 0) return "Off";
   if (std::strcmp(key, "on") == 0) return "On";
@@ -4334,6 +4353,7 @@ inline const char *espcontrol_i18n_key_cs(const char *key) {
   if (std::strcmp(key, "no_options") == 0) return "Žádné možnosti";
   if (std::strcmp(key, "no_presets") == 0) return "Žádné předvolby";
   if (std::strcmp(key, "no_sources") == 0) return "Žádné zdroje";
+  if (std::strcmp(key, "source") == 0) return "Zdroj";
   if (std::strcmp(key, "not_available") == 0) return "Není dostupné";
   if (std::strcmp(key, "off") == 0) return "Vypnuto";
   if (std::strcmp(key, "on") == 0) return "Zapnuto";
@@ -4544,6 +4564,7 @@ inline const char *espcontrol_i18n_key_da(const char *key) {
   if (std::strcmp(key, "no_options") == 0) return "Ingen muligheder";
   if (std::strcmp(key, "no_presets") == 0) return "Ingen forvalg";
   if (std::strcmp(key, "no_sources") == 0) return "Ingen kilder";
+  if (std::strcmp(key, "source") == 0) return "Kilde";
   if (std::strcmp(key, "not_available") == 0) return "Ikke tilgængelig";
   if (std::strcmp(key, "off") == 0) return "Slukket";
   if (std::strcmp(key, "on") == 0) return "Tændt";
@@ -4747,6 +4768,7 @@ inline const char *espcontrol_i18n_key_de(const char *key) {
   if (std::strcmp(key, "no_options") == 0) return "Keine Optionen";
   if (std::strcmp(key, "no_presets") == 0) return "Keine Voreinstellungen";
   if (std::strcmp(key, "no_sources") == 0) return "Keine Quellen";
+  if (std::strcmp(key, "source") == 0) return "Quelle";
   if (std::strcmp(key, "not_available") == 0) return "Nicht verfügbar";
   if (std::strcmp(key, "off") == 0) return "Aus";
   if (std::strcmp(key, "on") == 0) return "Ein";
@@ -4951,6 +4973,7 @@ inline const char *espcontrol_i18n_key_es(const char *key) {
   if (std::strcmp(key, "no_options") == 0) return "Sin opciones";
   if (std::strcmp(key, "no_presets") == 0) return "Sin preajustes";
   if (std::strcmp(key, "no_sources") == 0) return "Sin fuentes";
+  if (std::strcmp(key, "source") == 0) return "Fuente";
   if (std::strcmp(key, "not_available") == 0) return "No disponible";
   if (std::strcmp(key, "off") == 0) return "Apagado";
   if (std::strcmp(key, "on") == 0) return "Encendido";
@@ -5166,6 +5189,7 @@ inline const char *espcontrol_i18n_key_fi(const char *key) {
   if (std::strcmp(key, "no_options") == 0) return "Ei vaihtoehtoja";
   if (std::strcmp(key, "no_presets") == 0) return "Ei esiasetuksia";
   if (std::strcmp(key, "no_sources") == 0) return "Ei lähteitä";
+  if (std::strcmp(key, "source") == 0) return "Lähde";
   if (std::strcmp(key, "not_available") == 0) return "Ei saatavilla";
   if (std::strcmp(key, "off") == 0) return "Pois";
   if (std::strcmp(key, "on") == 0) return "Päällä";
@@ -5587,6 +5611,7 @@ inline const char *espcontrol_i18n_key_hu(const char *key) {
   if (std::strcmp(key, "no_options") == 0) return "Nincsenek opciók";
   if (std::strcmp(key, "no_presets") == 0) return "Nincsenek előbeállítások";
   if (std::strcmp(key, "no_sources") == 0) return "Nincsenek források";
+  if (std::strcmp(key, "source") == 0) return "Forrás";
   if (std::strcmp(key, "not_available") == 0) return "Nem érhető el";
   if (std::strcmp(key, "off") == 0) return "Ki";
   if (std::strcmp(key, "on") == 0) return "Be";
@@ -5802,6 +5827,7 @@ inline const char *espcontrol_i18n_key_it(const char *key) {
   if (std::strcmp(key, "no_options") == 0) return "Nessuna opzione";
   if (std::strcmp(key, "no_presets") == 0) return "Nessun preset";
   if (std::strcmp(key, "no_sources") == 0) return "Nessuna sorgente";
+  if (std::strcmp(key, "source") == 0) return "Fonte";
   if (std::strcmp(key, "not_available") == 0) return "Non disponibile";
   if (std::strcmp(key, "off") == 0) return "Spento";
   if (std::strcmp(key, "on") == 0) return "Acceso";
@@ -6012,6 +6038,7 @@ inline const char *espcontrol_i18n_key_nb(const char *key) {
   if (std::strcmp(key, "no_options") == 0) return "Ingen alternativer";
   if (std::strcmp(key, "no_presets") == 0) return "Ingen forhåndsvalg";
   if (std::strcmp(key, "no_sources") == 0) return "Ingen kilder";
+  if (std::strcmp(key, "source") == 0) return "Kilde";
   if (std::strcmp(key, "not_available") == 0) return "Ikke tilgjengelig";
   if (std::strcmp(key, "off") == 0) return "Av";
   if (std::strcmp(key, "on") == 0) return "På";
@@ -6221,6 +6248,7 @@ inline const char *espcontrol_i18n_key_nl(const char *key) {
   if (std::strcmp(key, "no_options") == 0) return "Geen opties";
   if (std::strcmp(key, "no_presets") == 0) return "Geen voorinstellingen";
   if (std::strcmp(key, "no_sources") == 0) return "Geen bronnen";
+  if (std::strcmp(key, "source") == 0) return "Bron";
   if (std::strcmp(key, "not_available") == 0) return "Niet beschikbaar";
   if (std::strcmp(key, "off") == 0) return "Uit";
   if (std::strcmp(key, "on") == 0) return "Aan";
@@ -6426,6 +6454,7 @@ inline const char *espcontrol_i18n_key_pl(const char *key) {
   if (std::strcmp(key, "no_options") == 0) return "Brak opcji";
   if (std::strcmp(key, "no_presets") == 0) return "Brak presetów";
   if (std::strcmp(key, "no_sources") == 0) return "Brak źródeł";
+  if (std::strcmp(key, "source") == 0) return "Źródło";
   if (std::strcmp(key, "not_available") == 0) return "Niedostępne";
   if (std::strcmp(key, "off") == 0) return "Wyłączone";
   if (std::strcmp(key, "on") == 0) return "Włączone";
@@ -6634,6 +6663,7 @@ inline const char *espcontrol_i18n_key_pt_br(const char *key) {
   if (std::strcmp(key, "no_options") == 0) return "Sem opções";
   if (std::strcmp(key, "no_presets") == 0) return "Sem predefinições";
   if (std::strcmp(key, "no_sources") == 0) return "Sem fontes";
+  if (std::strcmp(key, "source") == 0) return "Fonte";
   if (std::strcmp(key, "not_available") == 0) return "Não disponível";
   if (std::strcmp(key, "off") == 0) return "Desligado";
   if (std::strcmp(key, "on") == 0) return "Ligado";
@@ -6844,6 +6874,7 @@ inline const char *espcontrol_i18n_key_pt(const char *key) {
   if (std::strcmp(key, "no_options") == 0) return "Sem opções";
   if (std::strcmp(key, "no_presets") == 0) return "Sem predefinições";
   if (std::strcmp(key, "no_sources") == 0) return "Sem fontes";
+  if (std::strcmp(key, "source") == 0) return "Fonte";
   if (std::strcmp(key, "not_available") == 0) return "Não disponível";
   if (std::strcmp(key, "off") == 0) return "Desligado";
   if (std::strcmp(key, "on") == 0) return "Ligado";
@@ -7057,6 +7088,7 @@ inline const char *espcontrol_i18n_key_ro(const char *key) {
   if (std::strcmp(key, "no_options") == 0) return "Fără opțiuni";
   if (std::strcmp(key, "no_presets") == 0) return "Fără presetări";
   if (std::strcmp(key, "no_sources") == 0) return "Fără surse";
+  if (std::strcmp(key, "source") == 0) return "Sursă";
   if (std::strcmp(key, "not_available") == 0) return "Indisponibil";
   if (std::strcmp(key, "off") == 0) return "Oprit";
   if (std::strcmp(key, "on") == 0) return "Pornit";
@@ -7272,6 +7304,7 @@ inline const char *espcontrol_i18n_key_sk(const char *key) {
   if (std::strcmp(key, "no_options") == 0) return "Žiadne možnosti";
   if (std::strcmp(key, "no_presets") == 0) return "Žiadne predvoľby";
   if (std::strcmp(key, "no_sources") == 0) return "Žiadne zdroje";
+  if (std::strcmp(key, "source") == 0) return "Zdroj";
   if (std::strcmp(key, "not_available") == 0) return "Nie je dostupné";
   if (std::strcmp(key, "off") == 0) return "Vypnuté";
   if (std::strcmp(key, "on") == 0) return "Zapnuté";
@@ -7484,6 +7517,7 @@ inline const char *espcontrol_i18n_key_sl(const char *key) {
   if (std::strcmp(key, "no_options") == 0) return "Ni možnosti";
   if (std::strcmp(key, "no_presets") == 0) return "Ni prednastavitev";
   if (std::strcmp(key, "no_sources") == 0) return "Ni virov";
+  if (std::strcmp(key, "source") == 0) return "Vir";
   if (std::strcmp(key, "not_available") == 0) return "Ni na voljo";
   if (std::strcmp(key, "off") == 0) return "Izklop";
   if (std::strcmp(key, "on") == 0) return "Vklop";
@@ -7698,6 +7732,7 @@ inline const char *espcontrol_i18n_key_sv(const char *key) {
   if (std::strcmp(key, "no_options") == 0) return "Inga alternativ";
   if (std::strcmp(key, "no_presets") == 0) return "Inga förval";
   if (std::strcmp(key, "no_sources") == 0) return "Inga källor";
+  if (std::strcmp(key, "source") == 0) return "Källa";
   if (std::strcmp(key, "not_available") == 0) return "Inte tillgänglig";
   if (std::strcmp(key, "off") == 0) return "Av";
   if (std::strcmp(key, "on") == 0) return "På";
@@ -7909,6 +7944,7 @@ inline const char *espcontrol_i18n_key_tr(const char *key) {
   if (std::strcmp(key, "no_options") == 0) return "Seçenek yok";
   if (std::strcmp(key, "no_presets") == 0) return "Ön ayar yok";
   if (std::strcmp(key, "no_sources") == 0) return "Kaynak yok";
+  if (std::strcmp(key, "source") == 0) return "Kaynak";
   if (std::strcmp(key, "not_available") == 0) return "Mevcut değil";
   if (std::strcmp(key, "off") == 0) return "Kapalı";
   if (std::strcmp(key, "on") == 0) return "Açık";
@@ -8130,6 +8166,7 @@ inline const char *espcontrol_i18n_key_uk(const char *key) {
   if (std::strcmp(key, "no_options") == 0) return "Немає параметрів";
   if (std::strcmp(key, "no_presets") == 0) return "Немає пресетів";
   if (std::strcmp(key, "no_sources") == 0) return "Немає джерел";
+  if (std::strcmp(key, "source") == 0) return "Джерело";
   if (std::strcmp(key, "not_available") == 0) return "Недоступно";
   if (std::strcmp(key, "off") == 0) return "Вимкнено";
   if (std::strcmp(key, "on") == 0) return "Увімкнено";

--- a/docs/card-types/media.md
+++ b/docs/card-types/media.md
@@ -51,7 +51,7 @@ Seeking depends on the media player integration. Some players expose progress bu
 
 ## Now Playing
 
-Now Playing shows the media title and artist from Home Assistant.
+Now Playing shows the media title and artist from Home Assistant. For TV or Line-in sources that do not provide artist data, the artist line shows **Source** instead of reusing the previous track's artist.
 
 You can choose optional controls:
 

--- a/docs/features/media-cover-art.md
+++ b/docs/features/media-cover-art.md
@@ -21,6 +21,8 @@ You will find these controls in **Settings > Sleep & Schedule > Media Cover Art*
 - **Hide for external source inputs** - hides cover art when the selected media player source is `TV` or `Line-in`.
 - **Advanced Filtering** - reveals **Only Show When**, which limits cover art to matching media player attributes, such as `app_id=com.apple.TVMusic` or `app_id=com.apple.TVMusic; media_content_type=music`.
 
+If cover art is shown for `TV` or `Line-in` instead of hidden, the artist line shows **Source** because these inputs normally do not provide artist data.
+
 Cover art is separate from the normal [Screensaver](/features/screensaver) mode. Use Screensaver when you want the panel to dim, show a clock, or turn off after inactivity.
 
 If your Home Assistant instance uses a custom port, open **Settings > System > Home Assistant Settings** and set **Home Assistant Port** to match it. Media cover art downloads use this port when loading artwork from Home Assistant.

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -655,7 +655,10 @@ def firmware_cover_art_external_input_errors(path: Path, root: Path) -> list[str
         errors.append(f"{rel}: release retired cover art Home Assistant subscriptions")
     if 'ha_get_attribute(cover_entity, std::string("source"), handle_media_source)' not in text:
         errors.append(f"{rel}: refresh the media player source attribute")
-    if 'next == "TV"' not in text or 'next == "Line-in"' not in text:
+    if ('normalized_source == "tv"' not in text or
+            'normalized_source == "line-in"' not in text or
+            'normalized_source == "line in"' not in text or
+            "std::tolower" not in text):
         errors.append(f"{rel}: treat TV and Line-in sources as external inputs")
     if "cover_art_apply_external_input_policy" not in text:
         errors.append(f"{rel}: centralize cover art external-input behavior")
@@ -3138,7 +3141,13 @@ def run_self_test() -> int:
         "      - script.stop: cover_art_request_artwork\n"
         "      - lambda: |-\n"
         "          id(cover_art_hide_external_input_enabled).state && id(cover_art_external_input_active);\n"
-        "          bool external = next == \"TV\" || next == \"Line-in\";\n"
+        "          std::string normalized_source = next;\n"
+        "          for (char &ch : normalized_source) {\n"
+        "            ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));\n"
+        "          }\n"
+        "          bool external = normalized_source == \"tv\" ||\n"
+        "                          normalized_source == \"line-in\" ||\n"
+        "                          normalized_source == \"line in\";\n"
         "          ha_reset_subscription_callbacks(HA_SUBSCRIPTION_SCOPE_COVER_ART);\n"
         "          ha_subscribe_attribute(\n"
         "            cover_entity,\n"


### PR DESCRIPTION
## Summary

- Show a translated **Source** label on media artist lines when the selected speaker source is `TV` or `Line-in`.
- Apply the behaviour to both the Media Now Playing card and the Media Cover Art screensaver.
- Add short public docs notes for the visible behaviour.

## Practical impact

TV and Line-in inputs no longer keep showing the previous song artist when Home Assistant does not provide artist data. The display now makes it clear the panel is showing an input source instead.

## Documentation decision

- [x] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [ ] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Updated Media card and Media Cover Art docs to explain the Source label for TV/Line-in inputs.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.
- [ ] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- All supported displays that use Media Now Playing cards or Media Cover Art.
- Suggested devices from the automated guidance: ESP32-P4 86 Panel, Guition JC1060P470, Guition JC4880P443, Guition JC8012P4A1, and Guition 4848S040.

## Notes for testing

Automated/local checks run:

- `python3 scripts/build.py i18n --check`
- `npm run check:product`
- `npm run check:firmware-parser`
- `npm run check:firmware-ha-bindings`
- `npm run docs:build`
- `git diff --check`

Device testing still needed after flashing:

- Use a media player entity that exposes `source` as `TV`, `Line-in`, `line-in`, `Line in`, or `line in`.
- Confirm the Media Now Playing card shows **Source** in the artist line instead of the previous artist.
- Confirm the Media Cover Art overlay shows **Source** in the artist line when external inputs are not hidden.
- Confirm **Hide for external source inputs** still hides cover art for `TV` or `Line-in` when that setting is enabled.
- Confirm normal music playback still shows the real artist when `media_artist` is available.

Note: `npm ci` reported existing npm audit warnings: 2 moderate and 1 high. They were not changed as part of this fix.

## PR status

- [ ] Checks running or waiting.
- [ ] Needs automated fix.
- [x] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.

<!-- espcontrol-pr-testing-guidance -->
## Automated testing guidance

Device testing is expected before merge because this change may affect firmware or the on-device experience.

Suggested checks:

- Confirm the device boots normally and does not restart repeatedly.
- Confirm the affected screen, card, or setting appears correctly.
- Confirm touch/navigation still works where the changed area is interactive.
- Confirm there is no obvious text overlap, clipping, blank screen, or missing icon.

Suggested PR status: Ready for device test once automated checks pass.

