### PR TITLE
Fix camera subpage reboot loop

### DIFF
--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -1149,9 +1149,10 @@ inline void grid_phase2(
   grid_release_main_runtime_allocations(slots, NS);
   grid_clear_subpage_parent_targets(slots, NS);
   navigation_clear_home_targets();
+  // Image-card contexts may still point at widgets inside subpage screens.
+  reset_image_card_pool(cfg);
   navigation_clear_subpages();
   clear_subpage_vacuum_card_text_refs();
-  reset_image_card_pool(cfg);
 
   bool has_on;
   uint32_t on_val = parse_hex_color(on_hex, has_on);

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -618,7 +618,8 @@ inline void reset_image_card_pool(const GridConfig &cfg) {
   ImageCardCtx *contexts = image_card_contexts();
   int count = cfg.image_card_image_count;
   if (count > IMAGE_CARD_MAX_CONTEXTS) count = IMAGE_CARD_MAX_CONTEXTS;
-  for (int i = 0; i < count; i++) {
+  if (count < 0) count = 0;
+  for (int i = 0; i < IMAGE_CARD_MAX_CONTEXTS; i++) {
     image_card_clear_widget_source(contexts[i].widget);
     contexts[i].active = false;
     contexts[i].widget = nullptr;
@@ -657,8 +658,8 @@ inline void reset_image_card_pool(const GridConfig &cfg) {
     contexts[i].diagnostics_enabled = false;
     contexts[i].access_token_request_pending = false;
     contexts[i].startup_download_errors = 0;
-    contexts[i].image = cfg.image_card_images ? cfg.image_card_images[i] : nullptr;
-    contexts[i].modal_image = cfg.image_card_modal_images ? cfg.image_card_modal_images[i] : nullptr;
+    contexts[i].image = (i < count && cfg.image_card_images) ? cfg.image_card_images[i] : nullptr;
+    contexts[i].modal_image = (i < count && cfg.image_card_modal_images) ? cfg.image_card_modal_images[i] : nullptr;
     contexts[i].modal_url.clear();
     if (contexts[i].image) contexts[i].image->release();
     if (image_card_has_separate_modal_image(&contexts[i])) contexts[i].modal_image->release();

--- a/scripts/check_firmware_card_runtime.py
+++ b/scripts/check_firmware_card_runtime.py
@@ -37,6 +37,7 @@ SERVICE_MAPPING_PATTERN = re.compile(
 
 LAWN_MOWER_HEADER = "button_grid_lawn_mower.h"
 GRID_HEADER = "button_grid_grid.h"
+IMAGE_HEADER = "button_grid_image.h"
 
 
 def service_mapping_line_allowed(line: str) -> bool:
@@ -103,6 +104,19 @@ def check_root(root: Path) -> list[str]:
         ):
             failures.append(
                 f"components/espcontrol/{GRID_HEADER}: include full light controls in generic subpage parent indicators"
+            )
+        image_reset_pos = text.find("reset_image_card_pool(cfg);")
+        subpage_clear_pos = text.find("navigation_clear_subpages();")
+        if image_reset_pos < 0 or subpage_clear_pos < 0 or image_reset_pos > subpage_clear_pos:
+            failures.append(
+                f"components/espcontrol/{GRID_HEADER}: reset image-card contexts before deleting subpage screens"
+            )
+    image_header = root / "components" / "espcontrol" / IMAGE_HEADER
+    if image_header.exists():
+        text = image_header.read_text(encoding="utf-8")
+        if "for (int i = 0; i < IMAGE_CARD_MAX_CONTEXTS; i++)" not in text:
+            failures.append(
+                f"components/espcontrol/{IMAGE_HEADER}: reset every image-card context, including disabled slots"
             )
     return failures
 
@@ -175,6 +189,24 @@ def run_self_test() -> None:
                 )
             },
             ("include full light controls in generic subpage parent indicators",),
+        ),
+        (
+            {
+                "button_grid_grid.h": (
+                    'if (parent_subpage_kind == "lawn_mower") { lawn_mower_state_active_ref(state); }\n'
+                    'if (sb_cfg.type == "light_control") {\n'
+                    '  subscribe_light_control_state(ctx);\n'
+                    '  add_parent_indicator(sb_cfg.entity);\n'
+                    '}\n'
+                    'navigation_clear_subpages();\n'
+                    'reset_image_card_pool(cfg);\n'
+                )
+            },
+            ("reset image-card contexts before deleting subpage screens",),
+        ),
+        (
+            {"button_grid_image.h": "for (int i = 0; i < count; i++) {}\n"},
+            ("reset every image-card context, including disabled slots",),
         ),
     )
     for files, expected in cases:


### PR DESCRIPTION
## Summary

- Fix a reboot loop risk when Camera cards are placed inside a Subpage.
- Reset image-card runtime state before old subpage screens are deleted during grid rebuilds.
- Add firmware runtime checks to prevent the reset ordering from regressing.

## Practical impact

Users should be able to create a Subpage labelled `Cameras`, add Camera cards inside it, apply the configuration, and have the panel restart normally instead of getting stuck rebooting.

Root cause: camera-card contexts could still point at widgets inside an old subpage screen. The old rebuild order deleted that screen first, then tried to clear the image widget through the stale context.

Related: #893

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- The public Camera and Subpage pages already say Camera cards can be used inside subpages; this fix restores that documented behavior.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.
- [ ] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- ESP32-P4 86 Panel (4 inches, Square)
- Guition JC1060P470 (7 inches, Landscape)
- Guition JC4880P443 (4.3 inches, Portrait)
- Guition JC8012P4A1 (10.1 inches, Landscape)
- Guition 4848S040 (4 inches, Square)

## Notes for testing

Local checks run:

- `python3 scripts/check_firmware_card_runtime.py --self-test`
- `python3 scripts/check_firmware_card_runtime.py`
- `npm run check:config`
- `npm run check:fast`

Physical device testing still needed:

- Confirm the device boots normally and does not restart repeatedly.
- Create a Subpage card labelled `Cameras`, add one or more Camera cards inside it, apply the configuration, and confirm the panel comes back normally.
- Open the Cameras subpage and confirm the camera tiles show Loading, Unavailable, Too many, or an image instead of causing a restart.
- Confirm touch/navigation still works, including the subpage Back card and tapping a camera tile to open the expanded image.
- Confirm there is no obvious text overlap, clipping, blank screen, or missing icon.

## PR status

- [ ] Checks running or waiting.
- [ ] Needs automated fix.
- [x] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.

<!-- espcontrol-pr-testing-guidance -->
## Automated testing guidance

Device testing is expected before merge because this change may affect firmware or the on-device experience.

Suggested devices to test:
- ESP32-P4 86 Panel (4 inches, Square)
- Guition JC1060P470 (7 inches, Landscape)
- Guition JC4880P443 (4.3 inches, Portrait)
- Guition JC8012P4A1 (10.1 inches, Landscape)
- Guition 4848S040 (4 inches, Square)

Suggested checks:
- Confirm the device boots normally and does not restart repeatedly.
- Create a Subpage card labelled `Cameras`, add one or more Camera cards inside it, apply the configuration, and confirm the panel comes back normally.
- Open the Cameras subpage and confirm the camera tiles show Loading, Unavailable, Too many, or an image instead of causing a restart.
- Confirm touch/navigation still works, including the subpage Back card and tapping a camera tile to open the expanded image.
- Confirm there is no obvious text overlap, clipping, blank screen, or missing icon.

Suggested PR status: Ready for device test once automated checks pass.

Changed files considered:
- `components/espcontrol/button_grid_grid.h`
- `components/espcontrol/button_grid_image.h`
- `scripts/check_firmware_card_runtime.py`

