### PR TITLE
Fix media progress slider tab flash

### DIFF
--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -1885,6 +1885,7 @@ inline void media_control_create_progress_tab_content(MediaControlCtx *ctx) {
 
   ui.progress_slider = lv_slider_create(ui.content_box);
   if (!ui.progress_slider) return;
+  lv_obj_add_flag(ui.progress_slider, LV_OBJ_FLAG_HIDDEN);
   media_control_style_progress_slider(
     ui.progress_slider, DARK_BACKGROUND_SECONDARY, ctx->accent_color);
   ui.progress_fill = media_control_create_progress_fill(
@@ -1892,6 +1893,7 @@ inline void media_control_create_progress_tab_content(MediaControlCtx *ctx) {
   ui.progress_handle = media_control_create_progress_handle(ui.progress_slider);
   ui.progress_time_lbl = lv_label_create(ui.content_box);
   if (ui.progress_time_lbl) {
+    lv_obj_add_flag(ui.progress_time_lbl, LV_OBJ_FLAG_HIDDEN);
     lv_label_set_text(ui.progress_time_lbl, "0:00");
     lv_obj_set_style_text_color(ui.progress_time_lbl, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
     lv_obj_set_style_text_align(ui.progress_time_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
@@ -2191,6 +2193,7 @@ inline void media_control_layout_modal(MediaControlCtx *ctx) {
       lv_color_hex(ctx->accent_color));
     media_control_update_progress_handle(
       ui.progress_slider, ui.progress_handle, lv_slider_get_value(ui.progress_slider));
+    lv_obj_clear_flag(ui.progress_slider, LV_OBJ_FLAG_HIDDEN);
   }
   if (ui.progress_time_lbl) {
     lv_coord_t time_h = title_font && title_font->line_height > 0
@@ -2204,6 +2207,7 @@ inline void media_control_layout_modal(MediaControlCtx *ctx) {
     if (time_y < 0) time_y = 0;
     lv_obj_set_size(ui.progress_time_lbl, text_w, time_h);
     lv_obj_align(ui.progress_time_lbl, LV_ALIGN_TOP_MID, 0, time_y);
+    lv_obj_clear_flag(ui.progress_time_lbl, LV_OBJ_FLAG_HIDDEN);
   }
   lv_obj_t *buttons[3] = {ui.previous_btn, ui.play_btn, ui.next_btn};
   for (int i = 0; i < 3; i++) {


### PR DESCRIPTION
## Purpose
Fixes a brief visual glitch in the media control modal where the track position slider appears as a very thin bar when switching to the progress tab, before resizing to its intended height.

## Practical impact
The progress slider is now hidden while LVGL creates it at its temporary default size, then shown after the modal layout has applied the correct dimensions. This should make the tab switch look stable instead of flashing a narrow bar.

## Automated checks run
- python3 scripts/check_firmware_ha_bindings.py
- python3 scripts/check_firmware_modals.py
- git diff --check

<!-- espcontrol-pr-testing-guidance -->
## Device testing guidance

Device testing is expected before merge because this change affects the on-device media modal.

Suggested devices to test:
- ESP32-P4 86 Panel (4 inches, Square)
- Guition JC1060P470 (7 inches, Landscape)
- Guition JC4880P443 (4.3 inches, Portrait)
- Guition JC8012P4A1 (10.1 inches, Landscape)
- Guition 4848S040 (4 inches, Square)

Suggested checks:
- Open a media control modal with progress available.
- Switch to the track position/progress tab.
- Confirm the slider appears at the intended height without first flashing as a narrow bar.
- Confirm dragging/seeking still works.
- Confirm the device boots normally and touch/navigation still works.

Physical device testing: not run yet.