### PR TITLE
Fix Pages firmware asset fallback

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -133,6 +133,7 @@ jobs:
           for SLUG in $DEVICE_SLUGS; do
             mkdir -p "firmware/${SLUG}"
             INDEX_ENTRIES=$(mktemp)
+            HAVE_CURRENT=false
             : > "${INDEX_ENTRIES}"
 
             for IDX in $(seq 0 $((RELEASE_COUNT - 1))); do
@@ -151,11 +152,9 @@ jobs:
               fi
               VERSION_PATH=$(printf '%s' "${VERSION}" | sed 's/[^A-Za-z0-9._-]/_/g')
 
-              if [ "${IDX}" -eq 0 ]; then
-                cp "${MANIFEST_TMP}" "firmware/${SLUG}/manifest.json"
+              if [ "${HAVE_CURRENT}" = false ]; then
                 OTA_OUTPUT="firmware/${SLUG}/${SLUG}.ota.bin"
                 OTA_INDEX_PATH="${SLUG}.ota.bin"
-                download_asset "${RELEASE_JSON}" "${SLUG}.factory.bin" "firmware/${SLUG}/${SLUG}.factory.bin" || true
               else
                 OTA_OUTPUT="firmware/${SLUG}/versions/${VERSION_PATH}/${SLUG}.ota.bin"
                 OTA_INDEX_PATH="versions/${VERSION_PATH}/${SLUG}.ota.bin"
@@ -163,6 +162,12 @@ jobs:
 
               if ! download_asset "${RELEASE_JSON}" "${SLUG}.ota.bin" "${OTA_OUTPUT}"; then
                 continue
+              fi
+
+              if [ "${HAVE_CURRENT}" = false ]; then
+                cp "${MANIFEST_TMP}" "firmware/${SLUG}/manifest.json"
+                download_asset "${RELEASE_JSON}" "${SLUG}.factory.bin" "firmware/${SLUG}/${SLUG}.factory.bin" || true
+                HAVE_CURRENT=true
               fi
 
               OTA_MD5=$(ota_md5 "${MANIFEST_TMP}" "${SLUG}.ota.bin")


### PR DESCRIPTION
## Purpose
Fix the GitHub Pages deploy so website updates still publish when the newest stable release does not have firmware assets attached yet.

## Practical impact
The current live site is stuck on the last successful deploy, so the new JC8012P4A1 V2 web setup bundle is present in the repository but missing from GitHub Pages. This change lets the Pages workflow use the newest stable release that actually has firmware assets for each device instead of requiring the latest release to have them.

## Root cause
The workflow only copied `manifest.json` and current OTA files when processing release index `0`. If the latest stable release had no assets, older valid release assets were only considered as historical versions and no current firmware folder was produced, causing the deploy to fail before publishing docs.

## Checks
- Parsed `.github/workflows/pages.yml` as YAML.
- Ran `python3 scripts/check_public_firmware.py --self-test`.
- Ran `git diff --check`.

## Device testing
No firmware behavior changed. Once this PR lands and the Pages workflow completes, confirm this URL returns `200` instead of `404`: `https://jtenniswood.github.io/espcontrol/webserver/guition-esp32-p4-jc8012p4a1-v2/www.js`.

Related to #952.