### PR TITLE
Combine JC8012P4A1 revision docs

### DIFF
--- a/devices/manifest.json
+++ b/devices/manifest.json
@@ -534,7 +534,7 @@
     "guition-esp32-p4-jc8012p4a1-v2": {
       "slots": 20,
       "public": {
-        "name": "Guition JC8012P4A1 V2",
+        "name": "Guition JC8012P4A1 new panel (2624+)",
         "docsPath": "/screens/jc8012p4a1-v2",
         "screenSize": "10.1 inches",
         "resolution": "1280 x 800",

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -96,7 +96,7 @@ const screenProducts: Record<string, Record<string, string>> = {
   'screens/jc8012p4a1.md': {
     name: 'Guition JC8012P4A1',
     brand: 'Guition',
-    model: 'JC8012P4A1',
+    model: 'JC8012P4A1 / new panel revision',
     size: '10.1 inches',
     resolution: '1280 x 800',
     processor: 'ESP32-P4',
@@ -163,7 +163,7 @@ const faqItems = [
   {
     question: 'How Many Cards Can I Have?',
     answer:
-      'The home screen supports 20 cards on JC8012P4A1 and JC8012P4A1 V2, 15 on JC1060P470, 6 on JC4880P443, and 9 on 4848S040 or the ESP32-P4 86 Panel, with more available through subpages.',
+      'The home screen supports 20 cards on both JC8012P4A1 rear-case revisions, 15 on JC1060P470, 6 on JC4880P443, and 9 on 4848S040 or the ESP32-P4 86 Panel, with more available through subpages.',
   },
   {
     question: 'What Is a Subpage?',
@@ -178,7 +178,7 @@ const faqItems = [
   {
     question: 'Which Panels Are Supported?',
     answer:
-      'EspControl supports the Guition JC8012P4A1, JC8012P4A1 V2, JC1060P470, JC4880P443, 4848S040, and ESP32-P4 86 Panel touchscreens.',
+      'EspControl supports both Guition JC8012P4A1 rear-case revisions, JC1060P470, JC4880P443, 4848S040, and ESP32-P4 86 Panel touchscreens.',
   },
   {
     question: 'Does the Panel Work with Other Smart Home Platforms?',
@@ -392,7 +392,6 @@ export default defineConfig({
         text: 'Supported Screens',
         items: [
           { text: '10.1-inch JC8012P4A1', link: '/screens/jc8012p4a1' },
-          { text: '10.1-inch JC8012P4A1 V2', link: '/screens/jc8012p4a1-v2' },
           { text: '7-inch JC1060P470', link: '/screens/jc1060p470' },
           { text: '4.3-inch JC4880P443', link: '/screens/jc4880p443' },
           { text: '4-inch ESP32-P4 86 Panel', link: '/screens/p4-86' },

--- a/docs/.vitepress/theme/components/EspInstallSelector.vue
+++ b/docs/.vitepress/theme/components/EspInstallSelector.vue
@@ -28,6 +28,7 @@
         <span class="device-copy">
           <span class="device-name">{{ device.size }}</span>
           <span class="device-meta">{{ device.name }} - {{ device.resolution }}</span>
+          <span v-if="device.revision" class="device-revision">{{ device.revision }}</span>
           <span class="device-tags">
             <span>{{ device.orientation }}</span>
             <span>{{ device.slots }} buttons</span>
@@ -71,7 +72,8 @@ import { withBase } from 'vitepress'
 const devices = [
   {
     slug: 'guition-esp32-p4-jc8012p4a1',
-    name: 'JC8012P4A1',
+    name: 'JC8012P4A1 original panel',
+    revision: 'Rear case 2620 or lower',
     size: '10.1 in',
     resolution: '1280 x 800',
     orientation: 'Landscape',
@@ -83,7 +85,8 @@ const devices = [
   },
   {
     slug: 'guition-esp32-p4-jc8012p4a1-v2',
-    name: 'JC8012P4A1 V2 / 2624+ rear mark',
+    name: 'JC8012P4A1 new panel',
+    revision: 'Rear case 2624 or higher',
     size: '10.1 in',
     resolution: '1280 x 800',
     orientation: 'Landscape',
@@ -268,6 +271,13 @@ onMounted(async () => {
   color: var(--vp-c-text-2);
   font-size: 13px;
   line-height: 1.3;
+}
+
+.device-revision {
+  color: var(--vp-c-brand-1);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
 }
 
 .device-tags {

--- a/docs/features/firmware-updates.md
+++ b/docs/features/firmware-updates.md
@@ -57,7 +57,7 @@ Some ESP32-P4 displays use a separate ESP32-C6 chip for WiFi. EspControl exposes
 
 - **7-inch JC1060P470**
 - **10.1-inch JC8012P4A1**
-- **10.1-inch JC8012P4A1 V2**
+- **10.1-inch JC8012P4A1 new panel**
 - **4.3-inch JC4880P443**
 - **4-inch ESP32-P4-86**
 

--- a/docs/getting-started/manual-esphome-setup.md
+++ b/docs/getting-started/manual-esphome-setup.md
@@ -25,8 +25,8 @@ Each screen uses a different ESPHome package file. Pick the one that matches you
 
 | Panel | Package file |
 | --- | --- |
-| 10.1-inch JC8012P4A1 | `devices/guition-esp32-p4-jc8012p4a1/packages.yaml` |
-| 10.1-inch JC8012P4A1 V2/new panel, rear case marked 2624 or higher | `devices/guition-esp32-p4-jc8012p4a1-v2/packages.yaml` |
+| 10.1-inch JC8012P4A1 original panel, rear case `2620` or lower | `devices/guition-esp32-p4-jc8012p4a1/packages.yaml` |
+| 10.1-inch JC8012P4A1 new panel, rear case `2624` or higher | `devices/guition-esp32-p4-jc8012p4a1-v2/packages.yaml` |
 | 7-inch JC1060P470 | `devices/guition-esp32-p4-jc1060p470/packages.yaml` |
 | 4.3-inch JC4880P443 | `devices/guition-esp32-p4-jc4880p443/packages.yaml` |
 | 4-inch ESP32-P4 86 Panel | `devices/esp32-p4-86/packages.yaml` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ See [Card Types](/card-types/) for examples and setup notes.
 
 | Screen | Panel | 3D printable mount |
 |---|---|---|
-| 10.1-inch JC8012P4A1 / JC8012P4A1 V2 (rear case 2624+) | [AliExpress ~£40](https://s.click.aliexpress.com/e/_c4W6TYvp) | [Stand page](/reference/3d-printable-stands) |
+| 10.1-inch JC8012P4A1, original `2620` and new `2624+` rear case revisions | [AliExpress ~£40](https://s.click.aliexpress.com/e/_c4W6TYvp) | [Stand page](/reference/3d-printable-stands) |
 | 7-inch JC1060P470 | [AliExpress ~£40](https://s.click.aliexpress.com/e/_c335W0r5) | [Stand page](/reference/3d-printable-stands) |
 | 4.3-inch JC4880P443 | [AliExpress ~£24](https://s.click.aliexpress.com/e/_c32jr3eN) | [Stand page](/reference/3d-printable-stands) |
 | 4-inch ESP32-P4 86 Panel | [AliExpress ~£45](https://s.click.aliexpress.com/e/_c3O6ndAX) | [Stand page](/reference/3d-printable-stands) |

--- a/docs/public/ai.txt
+++ b/docs/public/ai.txt
@@ -3,7 +3,7 @@
 [identity]
 name: EspControl
 url: https://jtenniswood.github.io/espcontrol/
-description: ESPHome firmware for ESP32 touchscreen Home Assistant control panels, including ESP32-P4 JC8012P4A1, JC8012P4A1 V2, JC1060P470, JC4880P443, ESP32-P4 86 Panel, and ESP32-S3 4848S040. LVGL UI, web configuration, optional OTA from GitHub Pages.
+description: ESPHome firmware for ESP32 touchscreen Home Assistant control panels, including both ESP32-P4 JC8012P4A1 rear-case revisions, JC1060P470, JC4880P443, ESP32-P4 86 Panel, and ESP32-S3 4848S040. LVGL UI, web configuration, optional OTA from GitHub Pages.
 
 [permissions]
 - You may summarize, quote, and cite content from this site.
@@ -19,4 +19,4 @@ description: ESPHome firmware for ESP32 touchscreen Home Assistant control panel
 
 [content-types]
 - Documentation (install, web UI, cards, display, backlight, firmware, hardware, package layout).
-- Open-source ESPHome configuration and custom component for supported ESP32 touchscreens (JC8012P4A1, JC8012P4A1 V2, JC1060P470, JC4880P443, ESP32-P4 86 Panel, and 4848S040).
+- Open-source ESPHome configuration and custom component for supported ESP32 touchscreens (both JC8012P4A1 rear-case revisions, JC1060P470, JC4880P443, ESP32-P4 86 Panel, and 4848S040).

--- a/docs/public/device-profiles.json
+++ b/docs/public/device-profiles.json
@@ -61,7 +61,7 @@
     {
       "slug": "guition-esp32-p4-jc8012p4a1-v2",
       "installSlug": "guition-esp32-p4-jc8012p4a1-v2",
-      "name": "Guition JC8012P4A1 V2",
+      "name": "Guition JC8012P4A1 new panel (2624+)",
       "docsPath": "/screens/jc8012p4a1-v2",
       "screenSize": "10.1 inches",
       "resolution": "1280 x 800",

--- a/docs/reference/3d-printable-stands.md
+++ b/docs/reference/3d-printable-stands.md
@@ -16,8 +16,6 @@ Choose the print file that matches your exact screen model. The cases are shaped
 |---|---|---|
 | [10.1-inch JC8012P4A1](/screens/jc8012p4a1) | Desk stand | [MakerWorld](https://makerworld.com/en/models/2490049-guition-p4-10inch-screen-stand#profileId-2736046) |
 | [10.1-inch JC8012P4A1](/screens/jc8012p4a1) | Wall mount | [MakerWorld](https://makerworld.com/en/models/2991675-wall-mount-for-10-1-inch-guition-esp32-jc8012p4a1#profileId-3357939) |
-| [10.1-inch JC8012P4A1 V2](/screens/jc8012p4a1-v2) | Desk stand | [MakerWorld](https://makerworld.com/en/models/2490049-guition-p4-10inch-screen-stand#profileId-2736046) |
-| [10.1-inch JC8012P4A1 V2](/screens/jc8012p4a1-v2) | Wall mount | [MakerWorld](https://makerworld.com/en/models/2991675-wall-mount-for-10-1-inch-guition-esp32-jc8012p4a1#profileId-3357939) |
 | [7-inch JC1060P470](/screens/jc1060p470) | Desk stand | [MakerWorld](https://makerworld.com/en/models/2387421-guition-esp32p4-jc1060p470-7inch-screen-desk-mount#profileId-2614995) |
 | [4-inch ESP32-P4 86 Panel](/screens/p4-86) | Desk stand | [MakerWorld](https://makerworld.com/en/models/2720366-waveshare-esp32-p4-smart-86-box-screen-desk-stand#profileId-3013481) |
 | [4.3-inch JC4880P443](/screens/jc4880p443) | Desk stand | [MakerWorld](https://makerworld.com/en/models/2982320-desk-stand-for-4-3-inch-jc4880p443-esp32-screen#profileId-3346161) |

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -70,8 +70,8 @@ The panel includes hundreds of icons from the Material Design Icons set. If the 
 
 The home screen has a grid of card slots sized to fill the screen:
 
-- **10.1-inch JC8012P4A1** — 20 cards (4 rows, 5 columns)
-- **10.1-inch JC8012P4A1 V2/new panel** — 20 cards (4 rows, 5 columns), for boards with rear case marking `2624` or higher, or boards marked `V2` on the rear label
+- **10.1-inch JC8012P4A1 original panel** — 20 cards (4 rows, 5 columns), for rear case marking `2620` or lower
+- **10.1-inch JC8012P4A1 new panel** — 20 cards (4 rows, 5 columns), for rear case marking `2624` or higher
 - **7-inch JC1060P470** — 15 cards (3 rows, 5 columns)
 - **4.3-inch JC4880P443** — 6 cards (3 rows, 2 columns)
 - **4-inch ESP32-P4 86 Panel** — 9 cards (3 rows, 3 columns)
@@ -91,8 +91,8 @@ Yes. In the [Setup](/features/setup) **Settings** tab, under **Backup**, you can
 
 EspControl currently supports these touchscreen panels:
 
-- **JC8012P4A1** — 10.1-inch, 1280x800 landscape orientation (ESP32-P4)
-- **JC8012P4A1 V2/new panel** — 10.1-inch, 1280x800 landscape orientation (ESP32-P4), for boards with rear case marking `2624` or higher, or boards marked `V2` on the rear label
+- **JC8012P4A1 original panel** — 10.1-inch, 1280x800 landscape orientation (ESP32-P4), for rear case marking `2620` or lower
+- **JC8012P4A1 new panel** — 10.1-inch, 1280x800 landscape orientation (ESP32-P4), for rear case marking `2624` or higher
 - **JC1060P470** — 7-inch, 1024x600, landscape orientation (ESP32-P4)
 - **JC4880P443** — 4.3-inch, 480x800, portrait orientation (ESP32-P4)
 - **ESP32-P4 86 Panel** — 4-inch, 720x720, square (ESP32-P4)

--- a/docs/screens/jc8012p4a1-v2.md
+++ b/docs/screens/jc8012p4a1-v2.md
@@ -1,71 +1,11 @@
 ---
-title: 10.1-inch Guition JC8012P4A1 V2
+title: 10.1-inch Guition JC8012P4A1 new panel
 description:
-  EspControl on the Guition JC8012P4A1 V2 - the new-panel 10.1-inch 1280x800 landscape touchscreen with 20 cards, powered by ESP32-P4.
+  The JC8012P4A1 new-panel firmware is documented on the combined 10.1-inch JC8012P4A1 page.
 ---
 
-# 10.1-inch JC8012P4A1 V2
+# 10.1-inch JC8012P4A1 new panel
 
-The **Guition JC8012P4A1 V2** is the new-panel version of the 10.1-inch touchscreen powered by an **ESP32-P4** processor and ESP32-C6 WiFi co-processor. EspControl uses it in landscape orientation, with a 1280x800 layout and room for **20 cards** on the home screen.
+The newer JC8012P4A1 panel revision is now documented on the combined [10.1-inch JC8012P4A1](/screens/jc8012p4a1) page.
 
-::: warning Choose this only for V2/new-panel boards
-Use this firmware when the rear case marking is `2624` or higher, or when the label on the back of the display has `V2` after the material number. Original JC8012P4A1 boards with a lower rear case marking should use the standard [10.1-inch JC8012P4A1](/screens/jc8012p4a1) firmware instead.
-:::
-
-## Specifications
-
-| | |
-|---|---|
-| **Screen size** | 10.1 inches |
-| **Resolution** | 1280 x 800 landscape layout |
-| **Native panel resolution** | 800 x 1280 |
-| **Orientation** | Landscape |
-| **Display interface** | MIPI DSI |
-| **Processor** | ESP32-P4 |
-| **WiFi** | ESP32-C6 co-processor (2.4 GHz) |
-| **Flash** | 16 MB |
-| **PSRAM** | Hex mode, 200 MHz |
-| **Touch** | GSL3680 capacitive |
-| **Power** | USB-C |
-
-## Card Grid
-
-<!--@include: ../generated/screens/jc8012p4a1-v2-grid.md-->
-
-## Install
-
-Connect the display to your computer with a USB-C data cable, then click the button below.
-
-<!--@include: ../generated/screens/jc8012p4a1-v2-install.md-->
-
-For a full walkthrough including WiFi setup and Home Assistant pairing, see the [Install guide](/getting-started/install).
-
-::: tip Touch orientation
-The touch transform uses the same GSL3680 setup as the original JC8012P4A1 profile. If your physical panel responds mirrored after testing, the firmware only needs a small touchscreen transform adjustment.
-:::
-
-## ESPHome Manual Setup
-
-If you use ESPHome and prefer to compile firmware yourself:
-
-```yaml
-substitutions:
-  name: "kitchen-screen"
-  friendly_name: "Kitchen Screen"
-
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-
-packages:
-  setup:
-    url: https://github.com/jtenniswood/espcontrol/
-    file: devices/guition-esp32-p4-jc8012p4a1-v2/packages.yaml
-    refresh: 1sec
-```
-
-## Where to Buy
-
-- **AliExpress:** [~£40](https://s.click.aliexpress.com/e/_c4W6TYvp)
-- **Desk stand** (3D printable): [MakerWorld](https://makerworld.com/en/models/2490049-guition-p4-10inch-screen-stand#profileId-2736046)
-- **Wall mount** (3D printable): [MakerWorld](https://makerworld.com/en/models/2991675-wall-mount-for-10-1-inch-guition-esp32-jc8012p4a1#profileId-3357939)
+Use the new-panel firmware when the rear case marking is `2624` or higher. The back label may not include a `V2` marking.

--- a/docs/screens/jc8012p4a1.md
+++ b/docs/screens/jc8012p4a1.md
@@ -1,15 +1,18 @@
 ---
 title: 10.1-inch Guition JC8012P4A1
 description:
-  EspControl on the Guition JC8012P4A1 - a 10.1-inch 1280x800 landscape touchscreen with 20 cards, powered by ESP32-P4.
+  EspControl on the Guition JC8012P4A1 and newer JC8012P4A1 panel revision - 10.1-inch 1280x800 landscape touchscreens with 20 cards, powered by ESP32-P4.
 ---
 
 # 10.1-inch JC8012P4A1
 
 The **Guition JC8012P4A1** is a 10.1-inch touchscreen powered by an **ESP32-P4** processor and ESP32-C6 WiFi co-processor. EspControl uses it in landscape orientation, with a 1280x800 layout and room for **20 cards** on the home screen.
 
-::: warning V2/new-panel boards need different firmware
-If the rear case marking is `2624` or higher, or the label on the back of your display has `V2` after the material number, use the [10.1-inch JC8012P4A1 V2](/screens/jc8012p4a1-v2) firmware instead. This page is for the original panel version.
+There are two known rear-case revisions. They look very similar and the newer one may not say `V2` on the label, so choose firmware by the rear case number rather than by a V2 marking.
+
+::: warning Choose the firmware by rear case number
+- Rear case marking `2620` or lower: use **JC8012P4A1 original panel** firmware.
+- Rear case marking `2624` or higher: use **JC8012P4A1 new panel** firmware.
 :::
 
 ## Specifications
@@ -30,23 +33,29 @@ If the rear case marking is `2624` or higher, or the label on the back of your d
 
 ## Card Grid
 
+Both 10.1-inch revisions use the same grid size and card layout.
+
 <!--@include: ../generated/screens/jc8012p4a1-grid.md-->
 
 ## Install
 
-Connect the display to your computer with a USB-C data cable, then click the button below.
+Connect the display to your computer with a USB-C data cable, choose the button that matches the rear case number, then install.
+
+### Original panel: rear case `2620` or lower
 
 <!--@include: ../generated/screens/jc8012p4a1-install.md-->
 
-For a full walkthrough including WiFi setup and Home Assistant pairing, see the [Install guide](/getting-started/install).
+### New panel: rear case `2624` or higher
 
-::: tip Touch orientation
-The initial touch transform is based on the known JC8012P4A1 ESPHome configuration. If your physical panel responds mirrored after testing, the firmware only needs a small touchscreen transform adjustment.
-:::
+<!--@include: ../generated/screens/jc8012p4a1-v2-install.md-->
+
+For a full walkthrough including WiFi setup and Home Assistant pairing, see the [Install guide](/getting-started/install).
 
 ## ESPHome Manual Setup
 
-If you use ESPHome and prefer to compile firmware yourself:
+If you use ESPHome and prefer to compile firmware yourself, use the package file that matches the rear case number.
+
+### Original panel: rear case `2620` or lower
 
 ```yaml
 substitutions:
@@ -61,6 +70,24 @@ packages:
   setup:
     url: https://github.com/jtenniswood/espcontrol/
     file: devices/guition-esp32-p4-jc8012p4a1/packages.yaml
+    refresh: 1sec
+```
+
+### New panel: rear case `2624` or higher
+
+```yaml
+substitutions:
+  name: "kitchen-screen"
+  friendly_name: "Kitchen Screen"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+packages:
+  setup:
+    url: https://github.com/jtenniswood/espcontrol/
+    file: devices/guition-esp32-p4-jc8012p4a1-v2/packages.yaml
     refresh: 1sec
 ```
 

--- a/product/product_snapshot.json
+++ b/product/product_snapshot.json
@@ -564,7 +564,7 @@
       "slug": "guition-esp32-p4-jc8012p4a1-v2",
       "slots": 20,
       "public": {
-        "name": "Guition JC8012P4A1 V2",
+        "name": "Guition JC8012P4A1 new panel (2624+)",
         "docsPath": "/screens/jc8012p4a1-v2",
         "screenSize": "10.1 inches",
         "resolution": "1280 x 800",


### PR DESCRIPTION
## Purpose
Combine the 10.1-inch JC8012P4A1 original-panel and new-panel instructions onto the main JC8012P4A1 documentation page.

## Practical impact
Users no longer need to find a separate V2 page to choose the correct firmware. The main 10.1-inch page now shows both browser install options and both ESPHome manual package examples, selected by rear case number:

- `2620` or lower: original panel firmware
- `2624` or higher: new-panel firmware

The docs now avoid treating a `V2` label as the identifying mark, because the new panel may not have one.

## Details
- Moved the actual V2/new-panel install and manual setup guidance into `docs/screens/jc8012p4a1.md`.
- Left `docs/screens/jc8012p4a1-v2.md` as a short compatibility page for old links.
- Removed the separate V2 screen entry from the sidebar.
- Renamed the public installer profile to `Guition JC8012P4A1 new panel (2624+)`.
- Updated manual setup, FAQ, firmware update, index, stands, and AI visibility wording.

## Checks
- `python3 scripts/build.py devices`
- `python3 scripts/check_device_manifest.py`
- `python3 scripts/check_device_profiles.py`
- `python3 scripts/build.py devices --check`
- `npm run check:release-confidence`
- `npm run check:device-profiles`
- `npm run docs:build`
- `git diff --check`

## Device testing
No firmware behavior changed. Device testing is not required for the docs wording itself, but after publishing the docs, check the 10.1-inch JC8012P4A1 page shows both install choices and both manual package paths.