### PR TITLE
Improve S3 artwork stability

### DIFF
--- a/components/artwork_image/artwork_image.cpp
+++ b/components/artwork_image/artwork_image.cpp
@@ -22,7 +22,7 @@
 
 static const char *const TAG = "artwork_image";
 static const char *const CONTENT_TYPE_HEADER_NAME = "content-type";
-static constexpr uint32_t RETIRED_BUFFER_GRACE_MS = 3000;
+static constexpr uint32_t RETIRED_BUFFER_GRACE_MS = 300;
 static constexpr size_t MAX_RETIRED_IMAGE_BUFFERS = 1;
 static constexpr size_t MAX_DOWNLOAD_BUFFER_SIZE = 2 * 1024 * 1024;
 static constexpr int LOCAL_ARTWORK_HTTP_TIMEOUT_MS = 6500;
@@ -590,6 +590,16 @@ void ArtworkImage::loop() {
     this->finish_download_();
     return;
   }
+  if (this->decoder_->is_decoding()) {
+    if (!this->decode_buffered_data_()) {
+      this->fail_download_();
+      return;
+    }
+    if (this->decoder_->is_finished()) {
+      this->finish_download_();
+    }
+    return;
+  }
   if (this->downloader_ == nullptr) {
     ESP_LOGE(TAG, "Downloader not instantiated; cannot download");
     return;
@@ -632,6 +642,9 @@ void ArtworkImage::loop() {
     }
     if (this->decoder_->is_finished()) {
       this->finish_download_();
+      return;
+    }
+    if (this->decoder_->is_decoding()) {
       return;
     }
     ESP_LOGE(TAG, "HTTP transfer finished before image decoder completed");

--- a/components/artwork_image/artwork_image.h
+++ b/components/artwork_image/artwork_image.h
@@ -59,6 +59,8 @@ class ArtworkImage : public PollingComponent,
               image::ImageType type, image::Transparency transparency, uint32_t buffer_size, bool is_big_endian,
               bool allow_insecure_local_urls);
 
+  ~ArtworkImage() { this->decoder_.reset(); }
+
   void draw(int x, int y, display::Display *display, Color color_on, Color color_off) override;
 
   void update() override;

--- a/components/artwork_image/image_decoder.cpp
+++ b/components/artwork_image/image_decoder.cpp
@@ -116,7 +116,7 @@ size_t DownloadBuffer::read(size_t len) {
     len = this->unread_;
   }
   this->unread_ -= len;
-  if (this->unread_ > 0) {
+  if (len > 0 && this->unread_ > 0) {
     memmove(this->data(), this->data(len), this->unread_);
   }
   return this->unread_;

--- a/components/artwork_image/image_decoder.h
+++ b/components/artwork_image/image_decoder.h
@@ -90,6 +90,7 @@ class ImageDecoder {
   bool is_finished() const { return this->download_size_ > 0 && this->decoded_bytes_ >= this->download_size_; }
   bool has_unknown_download_size() const { return this->download_size_ == 0; }
   void set_download_size(size_t download_size) { this->download_size_ = download_size; }
+  virtual bool is_decoding() const { return false; }
 
  protected:
   ArtworkImage *image_;

--- a/components/artwork_image/jpeg_image.cpp
+++ b/components/artwork_image/jpeg_image.cpp
@@ -3,6 +3,7 @@
 
 #include "esphome/components/display/display_buffer.h"
 #include "esphome/core/application.h"
+#include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "esp_heap_caps.h"
@@ -10,19 +11,13 @@
 #include <climits>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 
 #include "artwork_image.h"
 static const char *const TAG = "artwork_image.jpeg";
 
 namespace esphome {
 namespace artwork_image {
-
-/// Custom error manager that longjmps instead of calling exit()
-struct JpegErrorMgr {
-  jpeg_error_mgr pub;
-  jmp_buf setjmp_buffer;
-  char message[JMSG_LENGTH_MAX];
-};
 
 static void jpeg_error_exit(j_common_ptr cinfo) {
   auto *err = reinterpret_cast<JpegErrorMgr *>(cinfo->err);
@@ -31,6 +26,10 @@ static void jpeg_error_exit(j_common_ptr cinfo) {
 }
 
 static constexpr size_t MAX_JPEG_DOWNLOAD_SIZE = 2 * 1024 * 1024;  // 2 MB
+static constexpr uint32_t JPEG_DECODE_BUDGET_MS = 12;
+static constexpr int JPEG_SCANLINE_BATCH = 8;
+
+JpegDecoder::~JpegDecoder() { this->cleanup_(); }
 
 int JpegDecoder::prepare(size_t download_size) {
   if (download_size > MAX_JPEG_DOWNLOAD_SIZE) {
@@ -56,43 +55,49 @@ int HOT JpegDecoder::decode(uint8_t *buffer, size_t size) {
     ESP_LOGV(TAG, "Download not complete. Size: %zu/%zu", size, this->download_size_);
     return 0;
   }
+  if (!this->decode_started_) {
+    int ret = this->start_decode_(buffer, size);
+    if (ret < 0) {
+      return ret;
+    }
+  }
+  return this->decode_scanlines_();
+}
+
+int JpegDecoder::start_decode_(uint8_t *buffer, size_t size) {
   ESP_LOGD(TAG, "JPEG decode start: %zu bytes", size);
 
-  jpeg_decompress_struct cinfo;
-  JpegErrorMgr jerr{};
+  std::memset(&this->cinfo_, 0, sizeof(this->cinfo_));
+  std::memset(&this->jerr_, 0, sizeof(this->jerr_));
+  this->cinfo_.err = jpeg_std_error(&this->jerr_.pub);
+  this->jerr_.pub.error_exit = jpeg_error_exit;
 
-  cinfo.err = jpeg_std_error(&jerr.pub);
-  jerr.pub.error_exit = jpeg_error_exit;
-
-  // Raw pointer for longjmp safety — unique_ptr destructors are skipped by longjmp
-  uint8_t *row_buffer = nullptr;
-
-  if (setjmp(jerr.setjmp_buffer)) {
-    ESP_LOGE(TAG, "JPEG decode error: %s", jerr.message);
-    free(row_buffer);
-    jpeg_destroy_decompress(&cinfo);
+  if (setjmp(this->jerr_.setjmp_buffer)) {
+    ESP_LOGE(TAG, "JPEG decode error: %s", this->jerr_.message);
+    this->cleanup_();
     return DECODE_ERROR_UNSUPPORTED_FORMAT;
   }
 
-  jpeg_create_decompress(&cinfo);
-  jpeg_mem_src(&cinfo, buffer, size);
+  jpeg_create_decompress(&this->cinfo_);
+  this->cinfo_created_ = true;
+  jpeg_mem_src(&this->cinfo_, buffer, size);
 
-  if (jpeg_read_header(&cinfo, TRUE) != JPEG_HEADER_OK) {
+  if (jpeg_read_header(&this->cinfo_, TRUE) != JPEG_HEADER_OK) {
     ESP_LOGE(TAG, "Could not read JPEG header");
-    jpeg_destroy_decompress(&cinfo);
+    this->cleanup_();
     return DECODE_ERROR_INVALID_TYPE;
   }
 
-  int src_w = cinfo.image_width;
-  int src_h = cinfo.image_height;
+  int src_w = this->cinfo_.image_width;
+  int src_h = this->cinfo_.image_height;
   ESP_LOGD(TAG, "JPEG header: %dx%d, components=%d, progressive=%s",
-           src_w, src_h, cinfo.num_components,
-           cinfo.progressive_mode ? "yes" : "no");
+           src_w, src_h, this->cinfo_.num_components,
+           this->cinfo_.progressive_mode ? "yes" : "no");
   // Request RGB output regardless of input colorspace
-  cinfo.out_color_space = JCS_RGB;
+  this->cinfo_.out_color_space = JCS_RGB;
   // Use fast integer IDCT — slightly lower quality but faster on ESP32
   // and avoids pulling in the float IDCT code path.
-  cinfo.dct_method = JDCT_IFAST;
+  this->cinfo_.dct_method = JDCT_IFAST;
 
   // Use IDCT scaling to downscale during decode.
   int target_w = this->image_->get_fixed_width();
@@ -108,11 +113,11 @@ int HOT JpegDecoder::decode(uint8_t *buffer, size_t size) {
     long best_score = LONG_MAX;
     uint64_t best_area = UINT64_MAX;
     for (unsigned int denom : denoms) {
-      cinfo.scale_num = 1;
-      cinfo.scale_denom = denom;
-      jpeg_calc_output_dimensions(&cinfo);
-      int candidate_w = static_cast<int>(cinfo.output_width);
-      int candidate_h = static_cast<int>(cinfo.output_height);
+      this->cinfo_.scale_num = 1;
+      this->cinfo_.scale_denom = denom;
+      jpeg_calc_output_dimensions(&this->cinfo_);
+      int candidate_w = static_cast<int>(this->cinfo_.output_width);
+      int candidate_h = static_cast<int>(this->cinfo_.output_height);
       long score = std::labs(candidate_w - target_w) + std::labs(candidate_h - target_h);
       uint64_t area = static_cast<uint64_t>(candidate_w) * static_cast<uint64_t>(candidate_h);
       if (score < best_score || (score == best_score && area < best_area)) {
@@ -123,93 +128,128 @@ int HOT JpegDecoder::decode(uint8_t *buffer, size_t size) {
         best_h = candidate_h;
       }
     }
-    cinfo.scale_num = 1;
-    cinfo.scale_denom = best_denom;
-    jpeg_calc_output_dimensions(&cinfo);
+    this->cinfo_.scale_num = 1;
+    this->cinfo_.scale_denom = best_denom;
+    jpeg_calc_output_dimensions(&this->cinfo_);
     if (best_denom > 1 && (best_w < target_w || best_h < target_h)) {
       ESP_LOGD(TAG, "Using smaller JPEG decode to reduce memory peak: target=%dx%d",
                target_w, target_h);
     }
-    if (cinfo.output_width == 0 || cinfo.output_height == 0) {
-      cinfo.scale_denom = 1;
-      jpeg_calc_output_dimensions(&cinfo);
+    if (this->cinfo_.output_width == 0 || this->cinfo_.output_height == 0) {
+      this->cinfo_.scale_denom = 1;
+      jpeg_calc_output_dimensions(&this->cinfo_);
     }
   } else {
-    jpeg_calc_output_dimensions(&cinfo);
+    jpeg_calc_output_dimensions(&this->cinfo_);
   }
 
-  int out_w = cinfo.output_width;
-  int out_h = cinfo.output_height;
-  if (out_w != src_w || out_h != src_h) {
-    ESP_LOGD(TAG, "Using IDCT downscale: %dx%d -> %dx%d", src_w, src_h, out_w, out_h);
+  this->out_w_ = this->cinfo_.output_width;
+  this->out_h_ = this->cinfo_.output_height;
+  if (this->out_w_ != src_w || this->out_h_ != src_h) {
+    ESP_LOGD(TAG, "Using IDCT downscale: %dx%d -> %dx%d", src_w, src_h, this->out_w_, this->out_h_);
   }
 
-  if (!this->set_size(out_w, out_h)) {
-    jpeg_destroy_decompress(&cinfo);
+  if (!this->set_size(this->out_w_, this->out_h_)) {
+    this->cleanup_();
     return DECODE_ERROR_OUT_OF_MEMORY;
   }
 
-  jpeg_start_decompress(&cinfo);
+  jpeg_start_decompress(&this->cinfo_);
 
-  // Allocate row buffers (raw pointers — safe across longjmp)
-  size_t row_stride = static_cast<size_t>(out_w) * 3;
-  row_buffer = static_cast<uint8_t *>(heap_caps_malloc(row_stride, MALLOC_CAP_8BIT));
-  if (row_buffer == nullptr) {
+  size_t row_stride = static_cast<size_t>(this->out_w_) * 3;
+  this->row_buffer_ = static_cast<uint8_t *>(heap_caps_malloc(row_stride, MALLOC_CAP_8BIT));
+  if (this->row_buffer_ == nullptr) {
     ESP_LOGE(TAG, "JPEG row buffer allocation failed: %zu bytes", row_stride);
-    jpeg_destroy_decompress(&cinfo);
+    this->cleanup_();
     return DECODE_ERROR_OUT_OF_MEMORY;
   }
 
-  bool use_rgb565 = (this->image_->image_type() == image::ImageType::IMAGE_TYPE_RGB565);
-  bool big_endian = this->image_->is_big_endian();
+  this->use_rgb565_ = (this->image_->image_type() == image::ImageType::IMAGE_TYPE_RGB565);
+  this->big_endian_ = this->image_->is_big_endian();
+  this->source_size_ = size;
+  this->y_ = 0;
+  this->decode_started_ = true;
+  return 0;
+}
 
-  int y = 0;
-  while (cinfo.output_scanline < cinfo.output_height) {
-    uint8_t *row_ptr = row_buffer;
-    jpeg_read_scanlines(&cinfo, &row_ptr, 1);
-
-    if ((y & 63) == 0) {
-      App.feed_wdt();
-    }
-
-    if (use_rgb565) {
-      // Convert RGB888 -> RGB565 in-place (2 bpp fits within the 3 bpp
-      // source buffer, so no separate allocation needed).  We read forward
-      // and write forward; the write pointer never overtakes the read
-      // pointer because 2 < 3.
-      uint8_t *dst = row_buffer;
-      for (int x = 0; x < out_w; x++) {
-        uint8_t r = row_buffer[x * 3 + 0];
-        uint8_t g = row_buffer[x * 3 + 1];
-        uint8_t b = row_buffer[x * 3 + 2];
-        uint16_t rgb565 = ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3);
-        if (big_endian) {
-          dst[0] = rgb565 >> 8;
-          dst[1] = rgb565 & 0xFF;
-        } else {
-          dst[0] = rgb565 & 0xFF;
-          dst[1] = rgb565 >> 8;
-        }
-        dst += 2;
-      }
-      this->draw_rgb565_block(0, y, out_w, 1, row_buffer);
-    } else {
-      // Per-pixel draw for other image types
-      for (int x = 0; x < out_w; x++) {
-        Color color(row_buffer[x * 3 + 0], row_buffer[x * 3 + 1], row_buffer[x * 3 + 2]);
-        this->draw(x, y, 1, 1, color);
-      }
-    }
-    y++;
+int JpegDecoder::decode_scanlines_() {
+  if (setjmp(this->jerr_.setjmp_buffer)) {
+    ESP_LOGE(TAG, "JPEG decode error: %s", this->jerr_.message);
+    this->cleanup_();
+    return DECODE_ERROR_UNSUPPORTED_FORMAT;
   }
 
-  jpeg_finish_decompress(&cinfo);
-  jpeg_destroy_decompress(&cinfo);
-  free(row_buffer);
+  const uint32_t start = millis();
+  while (this->cinfo_.output_scanline < this->cinfo_.output_height) {
+    for (int i = 0; i < JPEG_SCANLINE_BATCH && this->cinfo_.output_scanline < this->cinfo_.output_height; i++) {
+      uint8_t *row_ptr = this->row_buffer_;
+      jpeg_read_scanlines(&this->cinfo_, &row_ptr, 1);
 
-  this->decoded_bytes_ = size;
-  ESP_LOGD(TAG, "JPEG decode finished: output=%dx%d", out_w, out_h);
-  return size;
+      if (this->use_rgb565_) {
+        // Convert RGB888 -> RGB565 in-place (2 bpp fits within the 3 bpp
+        // source buffer, so no separate allocation needed). We read forward
+        // and write forward; the write pointer never overtakes the read
+        // pointer because 2 < 3.
+        uint8_t *dst = this->row_buffer_;
+        for (int x = 0; x < this->out_w_; x++) {
+          uint8_t r = this->row_buffer_[x * 3 + 0];
+          uint8_t g = this->row_buffer_[x * 3 + 1];
+          uint8_t b = this->row_buffer_[x * 3 + 2];
+          uint16_t rgb565 = ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3);
+          if (this->big_endian_) {
+            dst[0] = rgb565 >> 8;
+            dst[1] = rgb565 & 0xFF;
+          } else {
+            dst[0] = rgb565 & 0xFF;
+            dst[1] = rgb565 >> 8;
+          }
+          dst += 2;
+        }
+        this->draw_rgb565_block(0, this->y_, this->out_w_, 1, this->row_buffer_);
+      } else {
+        for (int x = 0; x < this->out_w_; x++) {
+          Color color(this->row_buffer_[x * 3 + 0], this->row_buffer_[x * 3 + 1], this->row_buffer_[x * 3 + 2]);
+          this->draw(x, this->y_, 1, 1, color);
+        }
+      }
+      this->y_++;
+    }
+    App.feed_wdt();
+    if (millis() - start >= JPEG_DECODE_BUDGET_MS) {
+      break;
+    }
+  }
+
+  if (this->cinfo_.output_scanline < this->cinfo_.output_height) {
+    return 0;
+  }
+
+  jpeg_finish_decompress(&this->cinfo_);
+  ESP_LOGD(TAG, "JPEG decode finished: output=%dx%d", this->out_w_, this->out_h_);
+  size_t decoded = this->source_size_;
+  this->decoded_bytes_ = decoded;
+  this->cleanup_();
+  return static_cast<int>(decoded);
+}
+
+void JpegDecoder::cleanup_() {
+  if (this->row_buffer_ != nullptr) {
+    free(this->row_buffer_);
+    this->row_buffer_ = nullptr;
+  }
+  if (this->cinfo_created_) {
+    if (setjmp(this->jerr_.setjmp_buffer) == 0) {
+      jpeg_destroy_decompress(&this->cinfo_);
+    }
+    this->cinfo_created_ = false;
+  }
+  this->decode_started_ = false;
+  this->source_size_ = 0;
+  this->out_w_ = 0;
+  this->out_h_ = 0;
+  this->y_ = 0;
+  this->use_rgb565_ = false;
+  this->big_endian_ = false;
 }
 
 }  // namespace artwork_image

--- a/components/artwork_image/jpeg_image.cpp
+++ b/components/artwork_image/jpeg_image.cpp
@@ -78,8 +78,8 @@ int JpegDecoder::start_decode_(uint8_t *buffer, size_t size) {
     return DECODE_ERROR_UNSUPPORTED_FORMAT;
   }
 
-  jpeg_create_decompress(&this->cinfo_);
   this->cinfo_created_ = true;
+  jpeg_create_decompress(&this->cinfo_);
   jpeg_mem_src(&this->cinfo_, buffer, size);
 
   if (jpeg_read_header(&this->cinfo_, TRUE) != JPEG_HEADER_OK) {

--- a/components/artwork_image/jpeg_image.h
+++ b/components/artwork_image/jpeg_image.h
@@ -5,9 +5,17 @@
 #ifdef USE_ARTWORK_IMAGE_JPEG_SUPPORT
 #include <jpeglib.h>
 #include <csetjmp>
+#include <cstddef>
+#include <cstdint>
 
 namespace esphome {
 namespace artwork_image {
+
+struct JpegErrorMgr {
+  jpeg_error_mgr pub;
+  jmp_buf setjmp_buffer;
+  char message[JMSG_LENGTH_MAX];
+};
 
 /**
  * @brief Image decoder specialization for JPEG images.
@@ -20,10 +28,28 @@ class JpegDecoder : public ImageDecoder {
    * @param display The image to decode the stream into.
    */
   JpegDecoder(ArtworkImage *image) : ImageDecoder(image) {}
-  ~JpegDecoder() override {}
+  ~JpegDecoder() override;
 
   int prepare(size_t download_size) override;
   int HOT decode(uint8_t *buffer, size_t size) override;
+  bool is_decoding() const override { return this->decode_started_ && !this->is_finished(); }
+
+ protected:
+  int start_decode_(uint8_t *buffer, size_t size);
+  int decode_scanlines_();
+  void cleanup_();
+
+  jpeg_decompress_struct cinfo_{};
+  JpegErrorMgr jerr_{};
+  uint8_t *row_buffer_{nullptr};
+  size_t source_size_{0};
+  int out_w_{0};
+  int out_h_{0};
+  int y_{0};
+  bool cinfo_created_{false};
+  bool decode_started_{false};
+  bool use_rgb565_{false};
+  bool big_endian_{false};
 };
 
 }  // namespace artwork_image

--- a/devices/guition-esp32-s3-4848s040/device/device.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/device.yaml
@@ -35,6 +35,12 @@ esp32:
       # and LVGL buffers are initialized.
       CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM: "8"
       CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP: "y"
+      # Keep RGB panel scan-out stable during flash writes and recover display
+      # timing at VSYNC when the ESP-IDF RGB driver needs to restart the panel.
+      CONFIG_LCD_RGB_RESTART_IN_VSYNC: "y"
+      CONFIG_LCD_RGB_ISR_IRAM_SAFE: "y"
+      CONFIG_SPIRAM_FETCH_INSTRUCTIONS: "y"
+      CONFIG_SPIRAM_RODATA: "y"
 
 # ---------------------------------------------------------------------------
 # External component


### PR DESCRIPTION
## Summary

- Decode JPEG artwork incrementally over repeated loop passes so album art decoding does not monopolize the device loop.
- Keep EspControl's existing JPEG downscale selection logic while moving decoder state into `JpegDecoder` for safer incremental cleanup.
- Let artwork decoding continue after the HTTP download has completed, reduce retired artwork buffer grace time, and avoid a no-op download-buffer memmove during idle decoder passes.
- Add S3 RGB panel / PSRAM sdkconfig stability options for the Guition ESP32-S3 4848S040.

This intentionally does **not** include the RGB panel restart-after-large-redraw change from the reference PR. That should stay as a follow-up only if scanlines remain after physical testing.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Internal artwork decode and S3 display stability change; no user-facing setup or behavior documentation changed.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.
- [ ] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- Guition ESP32-S3 4848S040

Automated/local checks:

- Passed: `python3 scripts/check_firmware_ha_bindings.py`
- Passed: `python3 scripts/check_device_matrix.py`
- Passed: Docker compile with ESPHome 2026.6.2 for:
  - `esp32-p4-86`
  - `guition-esp32-p4-jc1060p470`
  - `guition-esp32-p4-jc4880p443`
  - `guition-esp32-p4-jc8012p4a1`
  - `guition-esp32-p4-jc8012p4a1-v2`
  - `guition-esp32-s3-4848s040`
- Verified generated S3 sdkconfig contains:
  - `CONFIG_LCD_RGB_RESTART_IN_VSYNC=y`
  - `CONFIG_LCD_RGB_ISR_IRAM_SAFE=y`
  - `CONFIG_SPIRAM_FETCH_INSTRUCTIONS=y`
  - `CONFIG_SPIRAM_RODATA=y`
- Verified the generated S3 build source includes the incremental JPEG decoder path.

## Notes for testing

- Physical S3 display testing has not been run here. Before merge, please test repeated album-art track changes on the Guition ESP32-S3 4848S040 and confirm there are no long freezes, obvious scanlines/banding, or reboots during artwork updates or preference saves.

## PR status

- [ ] Checks running or waiting.
- [ ] Needs automated fix.
- [x] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.