### PR TITLE
Tune P4-86 voice audio response

### DIFF
--- a/devices/esp32-p4-86/device/voice_assistant.yaml
+++ b/devices/esp32-p4-86/device/voice_assistant.yaml
@@ -17,13 +17,19 @@ external_components:
 esp_afe:
   id: voice_afe_processor
   type: fd
-  mode: low_cost
+  mode: high_perf
   mic_num: 1
   aec_enabled: true
   aec_filter_length: 4
   ns_enabled: true
   vad_enabled: false
+  vad_mode: 2
+  vad_min_speech_ms: 96
+  vad_min_noise_ms: 600
+  vad_delay_ms: 160
   agc_enabled: true
+  agc_target_level: 6
+  task_priority: 8
 
 esp_audio_stack:
   id: voice_audio_stack
@@ -111,7 +117,7 @@ media_player:
     id: voice_media_player
     name: Voice Media Player
     icon: mdi:speaker
-    buffer_size: 4000000
+    buffer_size: 1000000
     task_stack_in_psram: true
     files:
       - id: voice_wake_chime


### PR DESCRIPTION
## Purpose

This adjusts the ESP32-P4 86 voice audio settings so the new audio stack behaves closer to the previous audio configuration while keeping the stable single-mic setup.

## Practical impact

- Uses high-performance full-duplex AFE mode for the P4-86 voice path.
- Tunes VAD timing so speech detection is less abrupt and closer to the previous behaviour.
- Raises the AGC target level and AFE task priority for steadier voice response handling.
- Reduces the voice media player buffer to lower memory pressure during longer responses.

## Testing

- Built `devices/esp32-p4-86/dev.yaml` locally with ESPHome `2026.6.5`.
- The build completed successfully and produced the OTA firmware image.
- Ran the full audio testing suite (wake word detection, barge in, timer setting, media playback, barge in during media playback).

## Notes
I cannot get _mic_num = 2_ and _se_enabled = true_ to compile without segfaulting the device, so instead I've gone through the Espressif AFE documentation and tuned/tweaked/massaged the device settings to the absolute best of my abilities to give an end result that I feel is on a par with the old audio model.