### PR TITLE
Prevent browser caching of webserver pages

### DIFF
--- a/components/web_server_idf/web_server_idf.cpp
+++ b/components/web_server_idf/web_server_idf.cpp
@@ -119,6 +119,12 @@ bool handle_firmware_version_request(AsyncWebServerRequest *request) {
   return true;
 }
 
+void apply_no_cache_headers(httpd_req_t *req) {
+  httpd_resp_set_hdr(req, "Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
+  httpd_resp_set_hdr(req, "Pragma", "no-cache");
+  httpd_resp_set_hdr(req, "Expires", "0");
+}
+
 // Non-blocking send function to prevent watchdog timeouts when TCP buffers are full
 /**
  * Sends data on a socket in non-blocking mode.
@@ -352,6 +358,7 @@ void AsyncWebServerRequest::redirect(const std::string &url) {
   httpd_resp_set_status(*this, "302 Found");
   httpd_resp_set_hdr(*this, "Location", url.c_str());
   httpd_resp_set_hdr(*this, "Connection", "close");
+  apply_no_cache_headers(*this);
   httpd_resp_send(*this, nullptr, 0);
 }
 
@@ -378,6 +385,7 @@ void AsyncWebServerRequest::init_response_(AsyncWebServerResponse *rsp, int code
     httpd_resp_set_type(*this, content_type);
   }
   httpd_resp_set_hdr(*this, "Accept-Ranges", "none");
+  apply_no_cache_headers(*this);
 
   for (const auto &header : DefaultHeaders::Instance().headers_) {
     httpd_resp_set_hdr(*this, header.name, header.value);


### PR DESCRIPTION
## Purpose
Prevent browsers from reusing stale EspControl webserver pages or API responses when a user opens the device web UI.

## Practical impact
The device webserver now sends explicit no-cache headers on normal responses and redirects, so browsers should request a fresh page each time instead of serving an old cached copy.

## Checks
- npm run check:fast

<!-- espcontrol-pr-testing-guidance -->
## Automated testing guidance

Device testing is expected before merge because this change may affect firmware or the on-device experience.

Suggested devices to test:
- ESP32-P4 86 Panel (4 inches, Square)
- Guition JC1060P470 (7 inches, Landscape)
- Guition JC4880P443 (4.3 inches, Portrait)
- Guition JC8012P4A1 (10.1 inches, Landscape)
- Guition JC8012P4A1 V2 (10.1 inches, Landscape)
- Guition 4848S040 (4 inches, Square)

Suggested checks:
- Confirm the device boots normally and does not restart repeatedly.
- Open the device webserver page, refresh/reopen it, and confirm the current UI loads without manually clearing the browser cache.
- Confirm touch/navigation still works where the changed area is interactive.
- Confirm there is no obvious text overlap, clipping, blank screen, or missing icon.

Suggested PR status: Ready for device test once automated checks pass.

Changed files considered:
- `components/web_server_idf/web_server_idf.cpp`