### PR TITLE
Compose 10-inch device profiles

### DIFF
--- a/devices/catalog.json
+++ b/devices/catalog.json
@@ -3,11 +3,210 @@
     "largeSensorUnitOffsetPercent": -10
   },
   "profiles": {
-    "platform": {},
-    "display": {},
-    "fonts": {},
-    "network": {},
-    "artwork": {},
+    "platform": {
+      "esp32-p4": {
+        "firmware": {
+          "build": {
+            "chip": "ESP32-P4"
+          }
+        }
+      }
+    },
+    "display": {
+      "jc8012p4a1-1280x800": {
+        "slots": 20,
+        "public": {
+          "screenSize": "10.1 inches",
+          "resolution": "1280 x 800",
+          "orientation": "Landscape"
+        },
+        "layout": {
+          "cols": 5,
+          "rows": 4,
+          "firmwareGrid": "5x4",
+          "portraitCols": 4
+        },
+        "rotation": {
+          "enabled": true,
+          "options": [
+            "0",
+            "90",
+            "180",
+            "270"
+          ],
+          "displayOffset": 180
+        },
+        "web": {
+          "dragMode": "swap",
+          "dragAnimation": true,
+          "screen": {
+            "width": "100%",
+            "aspect": "1280/800"
+          },
+          "portrait": {
+            "cols": 4,
+            "rows": 5,
+            "screen": {
+              "width": "63%",
+              "aspect": "800/1280"
+            }
+          },
+          "topbar": {
+            "height": 3.59,
+            "padding": "0.47cqw",
+            "fontSize": 1.72
+          },
+          "grid": {
+            "top": 4.7,
+            "compactTop": 0.39,
+            "left": 0.39,
+            "right": 0.39,
+            "bottom": 0.39,
+            "gap": 0.76,
+            "fr": "1fr"
+          },
+          "btn": {
+            "radius": 0.86,
+            "padding": 1.41,
+            "iconSize": 4.1,
+            "labelSize": 1.88,
+            "labelLines": 2,
+            "labelLinesDouble": 3
+          },
+          "emptyCell": {
+            "radius": 0.86
+          },
+          "sensorBadge": {
+            "top": 0.86,
+            "right": 0.86,
+            "fontSize": 1.41
+          },
+          "subpageBadge": {
+            "bottom": 0.86,
+            "right": 0.86,
+            "fontSize": 1.56
+          }
+        },
+        "firmware": {
+          "display": {
+            "wrapTallLabels": true,
+            "imageCardDownloaders": 6,
+            "imageCardDiagnostics": true,
+            "subpageChevronX": 4,
+            "subpageChevronY": -2
+          },
+          "package": {
+            "firmwareVersion": "dev",
+            "substitutions": {
+              "screen_width": "\"1280\"",
+              "screen_height": "\"800\"",
+              "content_width": "\"760\"",
+              "setup_icon_font_id": "font_icon_main",
+              "setup_title_font_id": "font_text_title",
+              "setup_body_font_id": "font_text_body",
+              "setup_pad_row": "\"20\"",
+              "setup_loading_pad_row": "\"40\"",
+              "setup_action_button_width": "\"200\"",
+              "setup_action_button_height": "\"56\"",
+              "setup_action_button_radius": "\"12\"",
+              "icon_font": "font_icon_main",
+              "subpage_chevron_font": "font_icon_status",
+              "label_font": "font_text_body",
+              "media_title_font": "font_text_title",
+              "unit_font": "font_text_body",
+              "sensor_value_font": "font_number_value",
+              "padding": "18px",
+              "radius": "11px",
+              "main_page_card_gap": "\"10\"",
+              "main_page_pad_top": "\"46\"",
+              "main_page_compact_pad_top": "\"5\"",
+              "clock_bar_item_gap": "\"78\"",
+              "clock_bar_visual_gap": "\"10\"",
+              "clock_font_size": "\"220\"",
+              "clock_cx": "\"640\"",
+              "clock_cy": "\"400\"",
+              "screen_saver_clock_min_brightness": "\"1\"",
+              "screen_saver_clock_default_brightness": "\"35\"",
+              "screen_schedule_clock_min_brightness": "\"1\"",
+              "screen_schedule_clock_default_brightness": "\"10\""
+            }
+          }
+        }
+      }
+    },
+    "fonts": {
+      "large-panel-p4": {
+        "firmware": {
+          "fonts": {
+            "icon": "font_icon_main",
+            "sensor": "font_number_value",
+            "largeSensor": "font_number_value_large",
+            "mediaTitle": "font_text_title",
+            "mediaControlTitle": "font_cover_art_title",
+            "volumeNumber": "font_number_value_large",
+            "volumeLabel": "font_text_large",
+            "climateCardIcon": "font_icon_card",
+            "subpageChevron": "font_icon_status",
+            "climateOptionTitle": "font_text_body",
+            "climateOptionValue": "font_text_body"
+          },
+          "package": {
+            "deviceFontPackageKey": "fonts_device"
+          }
+        }
+      }
+    },
+    "network": {
+      "c6-firmware-update": {
+        "firmware": {
+          "package": {
+            "esp32C6FirmwareUpdate": true
+          }
+        }
+      }
+    },
+    "artwork": {
+      "landscape-1280x800": {
+        "firmware": {
+          "display": {
+            "coverArt": {
+              "cover_art_size": "800",
+              "cover_art_decode_size": "800",
+              "cover_art_x": "0",
+              "cover_art_y": "0",
+              "cover_art_accent_x": "800",
+              "cover_art_accent_y": "0",
+              "cover_art_accent_width": "480",
+              "cover_art_accent_height": "800",
+              "cover_art_accent_bg_opa": "100%",
+              "cover_art_accent_opa": "100%",
+              "cover_art_panel_x": "840",
+              "cover_art_panel_y": "40",
+              "cover_art_panel_width": "400",
+              "cover_art_panel_height": "720",
+              "cover_art_panel_pad_top": "0",
+              "cover_art_panel_pad_bottom": "0",
+              "cover_art_panel_pad_left": "0",
+              "cover_art_panel_pad_right": "0",
+              "cover_art_panel_pad_row": "0",
+              "cover_art_title_font": "font_cover_art_title",
+              "cover_art_title_max_height": "506",
+              "cover_art_title_line_space": "0",
+              "cover_art_artist_font": "font_cover_art_artist",
+              "cover_art_artist_pad_top": "4",
+              "cover_art_artist_long_mode": "wrap",
+              "cover_art_time_font": "font_cover_art_time",
+              "cover_art_time_pad_top": "12",
+              "cover_art_progress_width": "1280",
+              "cover_art_progress_height": "4",
+              "cover_art_text_color": "0xFFF5E0",
+              "cover_art_square_overlay": "false",
+              "cover_art_live_image_updates": "false"
+            }
+          }
+        }
+      }
+    },
     "audio": {},
     "input": {}
   },
@@ -373,356 +572,32 @@
       }
     },
     "guition-esp32-p4-jc8012p4a1": {
-      "profiles": {},
+      "profiles": {
+        "platform": "esp32-p4",
+        "display": "jc8012p4a1-1280x800",
+        "fonts": "large-panel-p4",
+        "network": "c6-firmware-update",
+        "artwork": "landscape-1280x800"
+      },
       "config": {
-        "slots": 20,
         "public": {
           "name": "Guition JC8012P4A1",
-          "docsPath": "/screens/jc8012p4a1",
-          "screenSize": "10.1 inches",
-          "resolution": "1280 x 800",
-          "orientation": "Landscape"
-        },
-        "layout": {
-          "cols": 5,
-          "rows": 4,
-          "firmwareGrid": "5x4",
-          "portraitCols": 4
-        },
-        "rotation": {
-          "enabled": true,
-          "options": [
-            "0",
-            "90",
-            "180",
-            "270"
-          ],
-          "displayOffset": 180
-        },
-        "web": {
-          "dragMode": "swap",
-          "dragAnimation": true,
-          "screen": {
-            "width": "100%",
-            "aspect": "1280/800"
-          },
-          "portrait": {
-            "cols": 4,
-            "rows": 5,
-            "screen": {
-              "width": "63%",
-              "aspect": "800/1280"
-            }
-          },
-          "topbar": {
-            "height": 3.59,
-            "padding": "0.47cqw",
-            "fontSize": 1.72
-          },
-          "grid": {
-            "top": 4.7,
-            "compactTop": 0.39,
-            "left": 0.39,
-            "right": 0.39,
-            "bottom": 0.39,
-            "gap": 0.76,
-            "fr": "1fr"
-          },
-          "btn": {
-            "radius": 0.86,
-            "padding": 1.41,
-            "iconSize": 4.1,
-            "labelSize": 1.88,
-            "labelLines": 2,
-            "labelLinesDouble": 3
-          },
-          "emptyCell": {
-            "radius": 0.86
-          },
-          "sensorBadge": {
-            "top": 0.86,
-            "right": 0.86,
-            "fontSize": 1.41
-          },
-          "subpageBadge": {
-            "bottom": 0.86,
-            "right": 0.86,
-            "fontSize": 1.56
-          }
-        },
-        "firmware": {
-          "build": {
-            "chip": "ESP32-P4"
-          },
-          "fonts": {
-            "icon": "font_icon_main",
-            "sensor": "font_number_value",
-            "largeSensor": "font_number_value_large",
-            "mediaTitle": "font_text_title",
-            "mediaControlTitle": "font_cover_art_title",
-            "volumeNumber": "font_number_value_large",
-            "volumeLabel": "font_text_large",
-            "climateCardIcon": "font_icon_card",
-            "subpageChevron": "font_icon_status",
-            "climateOptionTitle": "font_text_body",
-            "climateOptionValue": "font_text_body"
-          },
-          "display": {
-            "wrapTallLabels": true,
-            "imageCardDownloaders": 6,
-            "imageCardDiagnostics": true,
-            "subpageChevronX": 4,
-            "subpageChevronY": -2,
-            "coverArt": {
-              "cover_art_size": "800",
-              "cover_art_decode_size": "800",
-              "cover_art_x": "0",
-              "cover_art_y": "0",
-              "cover_art_accent_x": "800",
-              "cover_art_accent_y": "0",
-              "cover_art_accent_width": "480",
-              "cover_art_accent_height": "800",
-              "cover_art_accent_bg_opa": "100%",
-              "cover_art_accent_opa": "100%",
-              "cover_art_panel_x": "840",
-              "cover_art_panel_y": "40",
-              "cover_art_panel_width": "400",
-              "cover_art_panel_height": "720",
-              "cover_art_panel_pad_top": "0",
-              "cover_art_panel_pad_bottom": "0",
-              "cover_art_panel_pad_left": "0",
-              "cover_art_panel_pad_right": "0",
-              "cover_art_panel_pad_row": "0",
-              "cover_art_title_font": "font_cover_art_title",
-              "cover_art_title_max_height": "506",
-              "cover_art_title_line_space": "0",
-              "cover_art_artist_font": "font_cover_art_artist",
-              "cover_art_artist_pad_top": "4",
-              "cover_art_artist_long_mode": "wrap",
-              "cover_art_time_font": "font_cover_art_time",
-              "cover_art_time_pad_top": "12",
-              "cover_art_progress_width": "1280",
-              "cover_art_progress_height": "4",
-              "cover_art_text_color": "0xFFF5E0",
-              "cover_art_square_overlay": "false",
-              "cover_art_live_image_updates": "false"
-            }
-          },
-          "package": {
-            "firmwareVersion": "dev",
-            "substitutions": {
-              "screen_width": "\"1280\"",
-              "screen_height": "\"800\"",
-              "content_width": "\"760\"",
-              "setup_icon_font_id": "font_icon_main",
-              "setup_title_font_id": "font_text_title",
-              "setup_body_font_id": "font_text_body",
-              "setup_pad_row": "\"20\"",
-              "setup_loading_pad_row": "\"40\"",
-              "setup_action_button_width": "\"200\"",
-              "setup_action_button_height": "\"56\"",
-              "setup_action_button_radius": "\"12\"",
-              "icon_font": "font_icon_main",
-              "subpage_chevron_font": "font_icon_status",
-              "label_font": "font_text_body",
-              "media_title_font": "font_text_title",
-              "unit_font": "font_text_body",
-              "sensor_value_font": "font_number_value",
-              "padding": "18px",
-              "radius": "11px",
-              "main_page_card_gap": "\"10\"",
-              "main_page_pad_top": "\"46\"",
-              "main_page_compact_pad_top": "\"5\"",
-              "clock_bar_item_gap": "\"78\"",
-              "clock_bar_visual_gap": "\"10\"",
-              "clock_font_size": "\"220\"",
-              "clock_cx": "\"640\"",
-              "clock_cy": "\"400\"",
-              "screen_saver_clock_min_brightness": "\"1\"",
-              "screen_saver_clock_default_brightness": "\"35\"",
-              "screen_schedule_clock_min_brightness": "\"1\"",
-              "screen_schedule_clock_default_brightness": "\"10\""
-            },
-            "deviceFontPackageKey": "fonts_device",
-            "esp32C6FirmwareUpdate": true
-          }
+          "docsPath": "/screens/jc8012p4a1"
         }
       }
     },
     "guition-esp32-p4-jc8012p4a1-v2": {
-      "profiles": {},
+      "profiles": {
+        "platform": "esp32-p4",
+        "display": "jc8012p4a1-1280x800",
+        "fonts": "large-panel-p4",
+        "network": "c6-firmware-update",
+        "artwork": "landscape-1280x800"
+      },
       "config": {
-        "slots": 20,
         "public": {
           "name": "Guition JC8012P4A1 new panel (2624+)",
-          "docsPath": "/screens/jc8012p4a1-v2",
-          "screenSize": "10.1 inches",
-          "resolution": "1280 x 800",
-          "orientation": "Landscape"
-        },
-        "layout": {
-          "cols": 5,
-          "rows": 4,
-          "firmwareGrid": "5x4",
-          "portraitCols": 4
-        },
-        "rotation": {
-          "enabled": true,
-          "options": [
-            "0",
-            "90",
-            "180",
-            "270"
-          ],
-          "displayOffset": 180
-        },
-        "web": {
-          "dragMode": "swap",
-          "dragAnimation": true,
-          "screen": {
-            "width": "100%",
-            "aspect": "1280/800"
-          },
-          "portrait": {
-            "cols": 4,
-            "rows": 5,
-            "screen": {
-              "width": "63%",
-              "aspect": "800/1280"
-            }
-          },
-          "topbar": {
-            "height": 3.59,
-            "padding": "0.47cqw",
-            "fontSize": 1.72
-          },
-          "grid": {
-            "top": 4.7,
-            "compactTop": 0.39,
-            "left": 0.39,
-            "right": 0.39,
-            "bottom": 0.39,
-            "gap": 0.76,
-            "fr": "1fr"
-          },
-          "btn": {
-            "radius": 0.86,
-            "padding": 1.41,
-            "iconSize": 4.1,
-            "labelSize": 1.88,
-            "labelLines": 2,
-            "labelLinesDouble": 3
-          },
-          "emptyCell": {
-            "radius": 0.86
-          },
-          "sensorBadge": {
-            "top": 0.86,
-            "right": 0.86,
-            "fontSize": 1.41
-          },
-          "subpageBadge": {
-            "bottom": 0.86,
-            "right": 0.86,
-            "fontSize": 1.56
-          }
-        },
-        "firmware": {
-          "build": {
-            "chip": "ESP32-P4"
-          },
-          "fonts": {
-            "icon": "font_icon_main",
-            "sensor": "font_number_value",
-            "largeSensor": "font_number_value_large",
-            "mediaTitle": "font_text_title",
-            "mediaControlTitle": "font_cover_art_title",
-            "volumeNumber": "font_number_value_large",
-            "volumeLabel": "font_text_large",
-            "climateCardIcon": "font_icon_card",
-            "subpageChevron": "font_icon_status",
-            "climateOptionTitle": "font_text_body",
-            "climateOptionValue": "font_text_body"
-          },
-          "display": {
-            "wrapTallLabels": true,
-            "imageCardDownloaders": 6,
-            "imageCardDiagnostics": true,
-            "subpageChevronX": 4,
-            "subpageChevronY": -2,
-            "coverArt": {
-              "cover_art_size": "800",
-              "cover_art_decode_size": "800",
-              "cover_art_x": "0",
-              "cover_art_y": "0",
-              "cover_art_accent_x": "800",
-              "cover_art_accent_y": "0",
-              "cover_art_accent_width": "480",
-              "cover_art_accent_height": "800",
-              "cover_art_accent_bg_opa": "100%",
-              "cover_art_accent_opa": "100%",
-              "cover_art_panel_x": "840",
-              "cover_art_panel_y": "40",
-              "cover_art_panel_width": "400",
-              "cover_art_panel_height": "720",
-              "cover_art_panel_pad_top": "0",
-              "cover_art_panel_pad_bottom": "0",
-              "cover_art_panel_pad_left": "0",
-              "cover_art_panel_pad_right": "0",
-              "cover_art_panel_pad_row": "0",
-              "cover_art_title_font": "font_cover_art_title",
-              "cover_art_title_max_height": "506",
-              "cover_art_title_line_space": "0",
-              "cover_art_artist_font": "font_cover_art_artist",
-              "cover_art_artist_pad_top": "4",
-              "cover_art_artist_long_mode": "wrap",
-              "cover_art_time_font": "font_cover_art_time",
-              "cover_art_time_pad_top": "12",
-              "cover_art_progress_width": "1280",
-              "cover_art_progress_height": "4",
-              "cover_art_text_color": "0xFFF5E0",
-              "cover_art_square_overlay": "false",
-              "cover_art_live_image_updates": "false"
-            }
-          },
-          "package": {
-            "firmwareVersion": "dev",
-            "substitutions": {
-              "screen_width": "\"1280\"",
-              "screen_height": "\"800\"",
-              "content_width": "\"760\"",
-              "setup_icon_font_id": "font_icon_main",
-              "setup_title_font_id": "font_text_title",
-              "setup_body_font_id": "font_text_body",
-              "setup_pad_row": "\"20\"",
-              "setup_loading_pad_row": "\"40\"",
-              "setup_action_button_width": "\"200\"",
-              "setup_action_button_height": "\"56\"",
-              "setup_action_button_radius": "\"12\"",
-              "icon_font": "font_icon_main",
-              "subpage_chevron_font": "font_icon_status",
-              "label_font": "font_text_body",
-              "media_title_font": "font_text_title",
-              "unit_font": "font_text_body",
-              "sensor_value_font": "font_number_value",
-              "padding": "18px",
-              "radius": "11px",
-              "main_page_card_gap": "\"10\"",
-              "main_page_pad_top": "\"46\"",
-              "main_page_compact_pad_top": "\"5\"",
-              "clock_bar_item_gap": "\"78\"",
-              "clock_bar_visual_gap": "\"10\"",
-              "clock_font_size": "\"220\"",
-              "clock_cx": "\"640\"",
-              "clock_cy": "\"400\"",
-              "screen_saver_clock_min_brightness": "\"1\"",
-              "screen_saver_clock_default_brightness": "\"35\"",
-              "screen_schedule_clock_min_brightness": "\"1\"",
-              "screen_schedule_clock_default_brightness": "\"10\""
-            },
-            "deviceFontPackageKey": "fonts_device",
-            "esp32C6FirmwareUpdate": true
-          }
+          "docsPath": "/screens/jc8012p4a1-v2"
         }
       }
     },

--- a/scripts/check_device_manifest.py
+++ b/scripts/check_device_manifest.py
@@ -66,6 +66,7 @@ def run_self_test() -> int:
     }
     composed = compose_catalog_data(catalog)
     assert list(composed["devices"]) == ["example"]
+    assert list(composed["devices"]["example"]) == ["slots", "layout", "firmware", "tags"]
     assert composed["devices"]["example"]["layout"]["cols"] == 5
     assert composed["devices"]["example"]["tags"] == ["override"]
 

--- a/scripts/device_profiles.py
+++ b/scripts/device_profiles.py
@@ -83,6 +83,30 @@ PROFILE_CATEGORIES = (
     "audio",
     "input",
 )
+CANONICAL_DEVICE_KEYS = (
+    "slots",
+    "public",
+    "layout",
+    "rotation",
+    "internalRelays",
+    "web",
+    "firmware",
+)
+CANONICAL_PUBLIC_KEYS = ("name", "docsPath", "screenSize", "resolution", "orientation")
+CANONICAL_FIRMWARE_KEYS = ("build", "fonts", "display", "package")
+CANONICAL_PACKAGE_KEYS = (
+    "firmwareVersion",
+    "subpageConfigChunks",
+    "substitutions",
+    "deviceFontPackageKey",
+    "touchscreenPackage",
+    "networkCoprocessor",
+    "esp32C6FirmwareUpdate",
+    "ethernetSelectable",
+    "extraPackages",
+    "backlightPwmFrequency",
+    "apiNavigateAction",
+)
 
 
 def rel(path: Path) -> str:
@@ -191,6 +215,27 @@ def _apply_overrides(target: dict[str, Any], overrides: dict[str, Any], slug: st
             target[key] = copy.deepcopy(value)
 
 
+def _ordered_object(value: dict[str, Any], keys: tuple[str, ...]) -> dict[str, Any]:
+    ordered = {key: value[key] for key in keys if key in value}
+    ordered.update((key, child) for key, child in value.items() if key not in ordered)
+    return ordered
+
+
+def canonicalize_device(device: dict[str, Any]) -> dict[str, Any]:
+    device = _ordered_object(device, CANONICAL_DEVICE_KEYS)
+    public = device.get("public")
+    if isinstance(public, dict):
+        device["public"] = _ordered_object(public, CANONICAL_PUBLIC_KEYS)
+    firmware = device.get("firmware")
+    if isinstance(firmware, dict):
+        firmware = _ordered_object(firmware, CANONICAL_FIRMWARE_KEYS)
+        package = firmware.get("package")
+        if isinstance(package, dict):
+            firmware["package"] = _ordered_object(package, CANONICAL_PACKAGE_KEYS)
+        device["firmware"] = firmware
+    return device
+
+
 def compose_catalog_data(data: Any) -> dict[str, Any]:
     if not isinstance(data, dict):
         raise DeviceProfileError("devices/catalog.json must contain a JSON object")
@@ -251,7 +296,7 @@ def compose_catalog_data(data: Any) -> dict[str, Any]:
                 _merge_profile(composed, profile, slug, contributor, owners)
         _apply_overrides(composed, overrides, slug)
         _merge_config(composed, config, slug)
-        expanded["devices"][slug] = composed
+        expanded["devices"][slug] = canonicalize_device(composed)
     return expanded
 
 


### PR DESCRIPTION
## Summary

- Add reusable profiles for the ESP32-P4 platform, JC8012P4A1 1280×800 display/web geometry, large-panel P4 fonts, C6 firmware updates, and 1280×800 landscape artwork.
- Migrate both JC8012P4A1 revisions to those profiles.
- Keep only each revision's public name and documentation path in its device entry.
- Canonicalize established device, public, firmware, and package key ordering after composition.

Part of #1006 (PR 2 of 3). This intentionally does not close the issue.

## Practical impact

The two 10.1-inch devices now prove the reusable-profile model without changing their expanded configuration. Their compatibility manifest, generated firmware inputs, web configuration, documentation outputs, and hardware YAML remain unchanged.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- This is an internal catalog migration with no user-visible behavior change.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [ ] Device testing is required before merge.
- [x] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- Guition JC8012P4A1
- Guition JC8012P4A1 new panel/V2 (2624+)

## Notes for testing

- `npm run check:fast`
- `python3 scripts/generate_device_manifest.py --check`
- Confirmed `devices/manifest.json` is byte-for-byte identical to the pre-migration file.
- Confirmed no generated YAML, web bundle, public profile, documentation, or hardware YAML changed.
- Docker/ESPHome 2026.6.5 factory compile passed for both JC8012P4A1 variants.
- Physical flashing is optional because the expanded firmware inputs are unchanged.

<!-- espcontrol-pr-testing-guidance -->
## Automated testing guidance

Automated checks should confirm catalog composition, compatibility-manifest freshness, generated-output freshness, and both 10.1-inch firmware builds. If physically tested as an extra confidence check, confirm normal boot, display output, and touch navigation on either 10.1-inch revision.

Suggested PR status: ready for review; physical flashing is optional after automated checks pass.

## PR status

- [x] Checks running or waiting.
- [ ] Needs automated fix.
- [ ] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.
