### PR TITLE
Run checks through the dependency graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,48 @@ jobs:
 
       - run: npm run check:ci
 
+  check-graph-shadow:
+    name: Check Graph Shadow
+    needs: sync-icons
+    if: >-
+      always() &&
+      (github.event_name == 'pull_request' || needs.sync-icons.outputs.changed != 'true')
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
+    steps:
+      - name: Prepare self-hosted workspace
+        run: |
+          rm -rf "${GITHUB_WORKSPACE:?}/"* "${GITHUB_WORKSPACE:?}/".[!.]* "${GITHUB_WORKSPACE:?}/"..?* 2>/dev/null ||
+            sudo rm -rf "${GITHUB_WORKSPACE:?}/"* "${GITHUB_WORKSPACE:?}/".[!.]* "${GITHUB_WORKSPACE:?}/"..?*
+
+      - uses: actions/checkout@v7.0.0
+      - run: git sparse-checkout disable || true
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: |
+          NPM_CACHE="${HOME}/.cache/espcontrol-actions/npm"
+          mkdir -p "${NPM_CACHE}"
+          npm ci --prefer-offline --cache "${NPM_CACHE}"
+          bash scripts/prune_actions_cache.sh "${NPM_CACHE}" "${ESPCONTROL_NPM_CACHE_MAX_MB}" --strategy reset
+
+      - name: Install browser runtime
+        run: npx playwright install --with-deps chromium
+
+      - name: Run task graph shadow
+        continue-on-error: true
+        run: python3 scripts/check_tasks.py run ci --summary-json check-task-summary.json
+
+      - name: Upload task graph summary
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: check-task-graph-summary
+          path: check-task-summary.json
+          if-no-files-found: warn
+
   docs:
     name: Build Docs
     needs: [sync-icons, validate]

--- a/scripts/check_tasks.py
+++ b/scripts/check_tasks.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python3
-"""Plan EspControl validation tasks without changing existing check execution."""
+"""Plan and run the EspControl validation task graph."""
 
 from __future__ import annotations
 
 import argparse
+from datetime import datetime, timezone
 import json
+import os
+import signal
+import subprocess
 import sys
+import time
 from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import TextIO
 
 from check_tasks_data import DOMAINS, PROFILES, TASKS, Task
 
@@ -17,6 +24,10 @@ FIXTURE = ROOT / "scripts" / "fixtures" / "check_tasks_legacy_coverage.json"
 
 class ConfigurationError(ValueError):
     pass
+
+
+SUMMARY_SCHEMA_VERSION = 1
+TASK_STATUSES = ("passed", "failed", "blocked", "not_run", "cached")
 
 
 def validate_registry(tasks: tuple[Task, ...] = TASKS) -> dict[str, Task]:
@@ -89,6 +100,25 @@ def plan(profile: str, domain: str | None = None, tasks: tuple[Task, ...] = TASK
     return ordered
 
 
+def plan_task(task_id: str, tasks: tuple[Task, ...] = TASKS) -> list[Task]:
+    registry = validate_registry(tasks)
+    if task_id not in registry:
+        raise ConfigurationError(f"unknown task ID: {task_id}")
+    ordered: list[Task] = []
+    emitted: set[str] = set()
+
+    def emit(selected_id: str) -> None:
+        if selected_id in emitted:
+            return
+        for dependency in registry[selected_id].dependencies:
+            emit(dependency)
+        emitted.add(selected_id)
+        ordered.append(registry[selected_id])
+
+    emit(task_id)
+    return ordered
+
+
 def task_json(item: Task) -> dict[str, object]:
     return {
         "id": item.id,
@@ -100,6 +130,160 @@ def task_json(item: Task) -> dict[str, object]:
         "generated_inputs": list(item.generated_inputs),
         "cache": item.cache,
     }
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def git_revision(root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+    return result.stdout.strip() or None
+
+
+def depends_on(task_id: str, failed_id: str, registry: dict[str, Task]) -> bool:
+    return failed_id in registry[task_id].dependencies or any(
+        depends_on(dependency, failed_id, registry)
+        for dependency in registry[task_id].dependencies
+    )
+
+
+def run_command(command: tuple[str, ...], root: Path) -> int:
+    process: subprocess.Popen[bytes] | None = None
+    interrupted = False
+    previous_handlers: dict[int, object] = {}
+
+    def forward(signum: int, _frame: object) -> None:
+        nonlocal interrupted
+        interrupted = True
+        if process is None or process.poll() is not None:
+            return
+        try:
+            os.killpg(process.pid, signum)
+        except (ProcessLookupError, PermissionError):
+            process.send_signal(signum)
+
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        previous_handlers[signum] = signal.getsignal(signum)
+        signal.signal(signum, forward)
+    try:
+        try:
+            process = subprocess.Popen(command, cwd=root, start_new_session=True)
+        except FileNotFoundError:
+            print(f"error: executable not found: {command[0]}", file=sys.stderr)
+            return 1
+        return_code = process.wait()
+        return 130 if interrupted or return_code < 0 else return_code
+    finally:
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+
+
+def execute_tasks(
+    selected: list[Task],
+    root: Path,
+    *,
+    profile: str | None,
+    domain: str | None,
+    requested_task: str | None,
+) -> tuple[int, dict[str, object]]:
+    started_at = utc_now()
+    run_started = time.monotonic()
+    results: list[dict[str, object]] = []
+    failed_id: str | None = None
+    exit_code = 0
+    registry = validate_registry(tuple(selected))
+
+    for item in selected:
+        if failed_id is not None:
+            status = "blocked" if depends_on(item.id, failed_id, registry) else "not_run"
+            results.append({
+                "id": item.id,
+                "status": status,
+                "duration_seconds": 0.0,
+                "exit_code": None,
+                "commands": [list(command) for command in item.commands],
+            })
+            continue
+
+        print(f"\n==> {item.id}", flush=True)
+        task_started = time.monotonic()
+        task_exit = 0
+        for command in item.commands:
+            print(f"$ {' '.join(command)}", flush=True)
+            task_exit = run_command(command, root)
+            if task_exit != 0:
+                break
+        duration = round(time.monotonic() - task_started, 3)
+        status = "passed" if task_exit == 0 else "failed"
+        results.append({
+            "id": item.id,
+            "status": status,
+            "duration_seconds": duration,
+            "exit_code": task_exit,
+            "commands": [list(command) for command in item.commands],
+        })
+        if task_exit != 0:
+            failed_id = item.id
+            exit_code = 130 if task_exit == 130 else 1
+
+    duration = round(time.monotonic() - run_started, 3)
+    summary: dict[str, object] = {
+        "schema_version": SUMMARY_SCHEMA_VERSION,
+        "profile": profile,
+        "domain": domain,
+        "requested_task": requested_task,
+        "git_revision": git_revision(root),
+        "started_at": started_at,
+        "finished_at": utc_now(),
+        "duration_seconds": duration,
+        "cache": {"enabled": False, "reason": "result caching is not implemented in this stage"},
+        "status": "passed" if exit_code == 0 else "interrupted" if exit_code == 130 else "failed",
+        "exit_code": exit_code,
+        "tasks": results,
+    }
+    return exit_code, summary
+
+
+def summary_markdown(summary: dict[str, object]) -> str:
+    lines = [
+        "## Check task graph",
+        "",
+        f"Overall: **{summary['status']}** in {summary['duration_seconds']:.3f}s",
+        "",
+        "| Task | Status | Duration |",
+        "| --- | --- | ---: |",
+    ]
+    for result in summary["tasks"]:
+        lines.append(f"| `{result['id']}` | {result['status']} | {result['duration_seconds']:.3f}s |")
+    return "\n".join(lines) + "\n"
+
+
+def print_summary(summary: dict[str, object], output: TextIO = sys.stdout) -> None:
+    print("\nCheck task summary", file=output)
+    print(f"{'TASK':28} {'STATUS':10} {'SECONDS':>8}", file=output)
+    for result in summary["tasks"]:
+        print(f"{result['id']:28} {result['status']:10} {result['duration_seconds']:8.3f}", file=output)
+    print(f"Overall: {summary['status']} ({summary['duration_seconds']:.3f}s)", file=output)
+
+
+def write_summary(summary: dict[str, object], path: Path | None) -> None:
+    if path is not None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    github_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if github_summary:
+        with Path(github_summary).open("a", encoding="utf-8") as handle:
+            handle.write(summary_markdown(summary))
 
 
 def self_test() -> None:
@@ -163,6 +347,74 @@ def self_test() -> None:
     if [item.id for item in plan("fast", tasks=ordered)] != ["shared", "consumer", "independent"]:
         raise AssertionError("dependency ordering or de-duplication is not stable")
 
+    if [item.id for item in plan_task("consumer", ordered)] != ["shared", "consumer"]:
+        raise AssertionError("run-task dependency closure is incorrect")
+
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        marker = root / "marker.txt"
+        fake_tasks = [
+            Task("pass", ((sys.executable, "-c", f"from pathlib import Path; Path({str(marker)!r}).write_text('pass')"),)),
+            Task("fail", ((sys.executable, "-c", "raise SystemExit(7)"),), dependencies=("pass",)),
+            Task("blocked", ((sys.executable, "-c", "raise SystemExit(0)"),), dependencies=("fail",)),
+            Task("not-run", ((sys.executable, "-c", "raise SystemExit(0)"),)),
+        ]
+        code, summary = execute_tasks(fake_tasks, root, profile="fast", domain=None, requested_task=None)
+        statuses = {item["id"]: item["status"] for item in summary["tasks"]}
+        if code != 1 or statuses != {"pass": "passed", "fail": "failed", "blocked": "blocked", "not-run": "not_run"}:
+            raise AssertionError(f"fail-fast execution is incorrect: {code}, {statuses}")
+        if marker.read_text() != "pass":
+            raise AssertionError("successful fake command did not execute")
+        if summary["schema_version"] != SUMMARY_SCHEMA_VERSION or summary["exit_code"] != 1:
+            raise AssertionError("JSON summary schema or exit code is incorrect")
+        markdown = summary_markdown(summary)
+        if "| `blocked` | blocked |" not in markdown:
+            raise AssertionError("Markdown summary omits blocked tasks")
+
+        missing_code, missing_summary = execute_tasks(
+            [Task("missing", (("executable-that-does-not-exist",),))],
+            root,
+            profile=None,
+            domain=None,
+            requested_task="missing",
+        )
+        if missing_code != 1 or missing_summary["tasks"][0]["status"] != "failed":
+            raise AssertionError("missing executables are not reported as task failures")
+
+        summary_path = root / "summary.json"
+        markdown_path = root / "github-summary.md"
+        previous_github_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+        os.environ["GITHUB_STEP_SUMMARY"] = str(markdown_path)
+        try:
+            write_summary(summary, summary_path)
+        finally:
+            if previous_github_summary is None:
+                os.environ.pop("GITHUB_STEP_SUMMARY", None)
+            else:
+                os.environ["GITHUB_STEP_SUMMARY"] = previous_github_summary
+        if json.loads(summary_path.read_text())["schema_version"] != SUMMARY_SCHEMA_VERSION:
+            raise AssertionError("JSON summary file has the wrong schema version")
+        if "## Check task graph" not in markdown_path.read_text():
+            raise AssertionError("GitHub Markdown summary was not written")
+
+        interrupt_test = (
+            "import os, signal, sys, threading; "
+            "from pathlib import Path; "
+            "from check_tasks import run_command; "
+            "threading.Timer(0.1, lambda: os.kill(os.getpid(), signal.SIGINT)).start(); "
+            "child = \"import os, signal, time; signal.signal(signal.SIGINT, lambda *_: os._exit(130)); time.sleep(30)\"; "
+            "code = run_command((sys.executable, '-c', child), Path.cwd()); "
+            "raise SystemExit(0 if code == 130 else 1)"
+        )
+        interrupted = subprocess.run(
+            [sys.executable, "-c", interrupt_test],
+            cwd=ROOT,
+            env={**os.environ, "PYTHONPATH": str(ROOT / "scripts")},
+            timeout=5,
+        )
+        if interrupted.returncode != 0:
+            raise AssertionError("interrupts are not forwarded to the active child process")
+
     print(f"check task registry self-test passed ({len(TASKS)} tasks, {len(PROFILES)} profiles)")
 
 
@@ -177,6 +429,15 @@ def parse_args() -> argparse.Namespace:
     plan_parser.add_argument("--domain", choices=DOMAINS)
     plan_parser.add_argument("--json", action="store_true")
     plan_parser.add_argument("--explain", action="store_true")
+    run_parser = subparsers.add_parser("run", help="run the tasks selected by a profile")
+    run_parser.add_argument("profile", choices=PROFILES)
+    run_parser.add_argument("--domain", choices=DOMAINS)
+    run_parser.add_argument("--jobs", type=int, default=1)
+    run_parser.add_argument("--no-cache", action="store_true")
+    run_parser.add_argument("--summary-json", type=Path)
+    task_parser = subparsers.add_parser("run-task", help="run one task and its dependencies")
+    task_parser.add_argument("task_id")
+    task_parser.add_argument("--summary-json", type=Path)
     return parser.parse_args()
 
 
@@ -205,7 +466,25 @@ def main() -> int:
                         reason = f"  ({'dependency' if args.profile not in item.profiles else 'profile'})"
                     print(f"{index:2}. {item.id}{reason}")
             return 0
-        print("choose 'list' or 'plan', or use --self-test", file=sys.stderr)
+        if args.command == "run":
+            if args.jobs != 1:
+                raise ConfigurationError("only --jobs 1 is available until parallel execution is introduced")
+            selected = plan(args.profile, args.domain)
+            exit_code, summary = execute_tasks(
+                selected, ROOT, profile=args.profile, domain=args.domain, requested_task=None
+            )
+            print_summary(summary)
+            write_summary(summary, args.summary_json)
+            return exit_code
+        if args.command == "run-task":
+            selected = plan_task(args.task_id)
+            exit_code, summary = execute_tasks(
+                selected, ROOT, profile=None, domain=None, requested_task=args.task_id
+            )
+            print_summary(summary)
+            write_summary(summary, args.summary_json)
+            return exit_code
+        print("choose 'list', 'plan', 'run', or 'run-task', or use --self-test", file=sys.stderr)
         return 2
     except ConfigurationError as error:
         print(f"check task configuration error: {error}", file=sys.stderr)


### PR DESCRIPTION
## Purpose

Continues #1002 by adding sequential execution and reporting to the dependency-aware check graph. Existing npm check commands remain unchanged and required CI still uses the legacy command while equivalence evidence is collected.

## What changed

- Added `run <profile>` and `run-task <task-id>` execution using argument arrays rather than shell command strings.
- Preserved sequential, fail-fast behavior and dependency de-duplication.
- Streamed each validator's existing output and added a concise final task/duration table.
- Added versioned JSON summaries with profile, domain, Git revision, timing, cache state, exit code, and per-task status.
- Added automatic Markdown output when GitHub's step-summary file is available.
- Added clean missing-executable handling and signal forwarding to active child process groups.
- Added a non-required CI shadow job that runs the new `ci` graph beside the unchanged required legacy command and uploads its JSON summary.
- Expanded self-tests for execution order, dependency closure, fail-fast blocking, `not_run` status, missing executables, summary formats, and interruption handling.

Parallel execution and result caching remain disabled until their later rollout stages.

## Automated checks

- `python3 scripts/check_tasks.py --self-test`
- `python3 scripts/check_tasks.py run-task device-manifest-output --summary-json ...`
- `python3 scripts/check_tasks.py run ci --summary-json ...` — all 33 selected tasks passed, including browser smoke checks for six generated layouts
- `npm run check:ci` — unchanged legacy path passed
- CI workflow YAML parse and whitespace validation

## Failure-path verification

An intentionally stale `devices/manifest.json` was used temporarily. The graph failed at `device-manifest-output`, marked dependent consumers as `blocked`, left unrelated remaining work as `not_run`, returned exit code 1, and did not run consumers. The manifest was restored and revalidated afterward.

## Device testing

Not required. This changes developer check orchestration and CI observation only; firmware and user-facing device behavior are unchanged.

## Testing notes

Useful local commands:

```text
python3 scripts/check_tasks.py run product
python3 scripts/check_tasks.py run ci --summary-json check-task-summary.json
python3 scripts/check_tasks.py run-task device-profiles
```

This is stage 2 of #1002. The shadow job must collect agreement across at least 10 successful PR runs over at least 14 days before stage 3 removes the legacy required path.
