### PR TITLE
Route checks from changed files

### DIFF
--- a/dev-docs/check-matrix.md
+++ b/dev-docs/check-matrix.md
@@ -32,7 +32,7 @@ This detailed routing table is generated directly from `scripts/check_tasks_data
 | `product-snapshot` | product | `common/config/**`<br>`common/assets/**`<br>`devices/**`<br>`compatibility/**` | `npm run check:product-snapshot` |
 | `local-artifacts` | workflow | `scripts/check_local_artifacts.py` | `npm run check:local-artifacts` |
 | `local-esphome` | firmware, workflow | `scripts/local_esphome.py` | `npm run check:local-esphome` |
-| `dev-docs` | docs | `dev-docs/**`<br>`scripts/check_dev_docs.py` | `npm run check:dev-docs` |
+| `dev-docs` | docs | `dev-docs/**`<br>`DEVELOPERS.md`<br>`README.md`<br>`product/README.md`<br>`scripts/check_dev_docs.py` | `npm run check:dev-docs` |
 | `pr-process` | workflow | `.github/**`<br>`scripts/check_pr_process.py` | `npm run check:pr-process` |
 | `pr-testing-guidance` | workflow | `.github/**`<br>`scripts/pr_testing_guidance.py` | `npm run check:pr-testing-guidance` |
 | `config` | product, web | `common/config/**`<br>`src/webserver/**`<br>`scripts/check_config_formats.js` | `npm run check:config` |
@@ -58,5 +58,5 @@ This detailed routing table is generated directly from `scripts/check_tasks_data
 | `timezones` | firmware, web | `common/**`<br>`src/webserver/**`<br>`scripts/check_timezones.py` | `npm run check:timezones` |
 | `public-firmware-script` | firmware, workflow | `scripts/**`<br>`docs/public/**` | `npm run check:public-firmware-script` |
 | `web-browser-smoke` | web | `src/webserver/**`<br>`scripts/check_web_browser_smoke.js`<br>`package-lock.json` | `npm run check:web-browser-smoke` |
-| `docs-build` | docs | `docs/**`<br>`package-lock.json` | `python3 scripts/check_tasks.py run-task docs-build` |
+| `docs-build` | docs | `docs/**`<br>`dev-docs/**`<br>`DEVELOPERS.md`<br>`README.md`<br>`product/README.md`<br>`package-lock.json` | `python3 scripts/check_tasks.py run-task docs-build` |
 <!-- END GENERATED CHECK MATRIX -->

--- a/dev-docs/check-matrix.md
+++ b/dev-docs/check-matrix.md
@@ -47,7 +47,7 @@ This detailed routing table is generated directly from `scripts/check_tasks_data
 | `firmware-display-tokens` | firmware | `components/**`<br>`scripts/check_firmware_display_tokens.py` | `npm run check:firmware-display-tokens` |
 | `firmware-ha-bindings` | firmware | `components/**`<br>`devices/**`<br>`scripts/check_firmware_ha_bindings.py` | `npm run check:firmware-ha-bindings` |
 | `firmware-card-runtime` | firmware, product | `components/**`<br>`common/config/card_contract.json`<br>`scripts/check_firmware_card_runtime.py` | `npm run check:firmware-card-runtime` |
-| `firmware-release` | firmware, workflow | `builds/**`<br>`devices/**`<br>`.github/workflows/release.yml`<br>`scripts/check_firmware_release.py` | `npm run check:firmware-release` |
+| `firmware-release` | firmware, workflow | `builds/**`<br>`devices/**`<br>`.github/esphome.env`<br>`.github/workflows/release.yml`<br>`scripts/check_firmware_release.py` | `npm run check:firmware-release` |
 | `device-matrix` | firmware, product | `builds/**`<br>`devices/**`<br>`scripts/check_device_matrix.py` | `npm run check:device-matrix` |
 | `device-profiles` | firmware, product | `devices/**`<br>`scripts/check_device_profiles.py` | `npm run check:device-profiles` |
 | `release-confidence` | product, workflow | `builds/**`<br>`devices/**`<br>`scripts/check_release_confidence.py` | `npm run check:release-confidence` |

--- a/dev-docs/checks-and-releases.md
+++ b/dev-docs/checks-and-releases.md
@@ -25,10 +25,10 @@ committed, staged, unstaged, renamed, deleted, and untracked files, run:
 python3 scripts/check_tasks.py changed --explain
 ```
 
-This command never reduces CI coverage. Unknown paths and changes to the task
-runner, registry, package lock, or workflow definitions select the complete fast
-profile. Profiles can also be narrowed explicitly by domain, for example
-`python3 scripts/check_tasks.py run ci --domain web`.
+This command never reduces CI coverage. Unknown paths and changes to generators,
+validators, the task runner, registry, package lock, or workflow definitions
+select the complete fast profile. Profiles can also be narrowed explicitly by
+domain, for example `python3 scripts/check_tasks.py run ci --domain web`.
 
 ## Common Checks
 

--- a/dev-docs/checks-and-releases.md
+++ b/dev-docs/checks-and-releases.md
@@ -18,6 +18,18 @@ Use `python3 scripts/check_tasks.py list` to see registered tasks or
 running it. The registry in `scripts/check_tasks_data.py` is the maintained source
 for task commands, dependencies, profiles, domains, and input paths.
 
+For an advisory local route based on everything changed from `main`, including
+committed, staged, unstaged, renamed, deleted, and untracked files, run:
+
+```bash
+python3 scripts/check_tasks.py changed --explain
+```
+
+This command never reduces CI coverage. Unknown paths and changes to the task
+runner, registry, package lock, or workflow definitions select the complete fast
+profile. Profiles can also be narrowed explicitly by domain, for example
+`python3 scripts/check_tasks.py run ci --domain web`.
+
 ## Common Checks
 
 | Command | Use when |

--- a/dev-docs/checks-and-releases.md
+++ b/dev-docs/checks-and-releases.md
@@ -25,10 +25,11 @@ committed, staged, unstaged, renamed, deleted, and untracked files, run:
 python3 scripts/check_tasks.py changed --explain
 ```
 
-This command never reduces CI coverage. Unknown paths and changes to generators,
-validators, the task runner, registry, package lock, or workflow definitions
-select the complete fast profile. Profiles can also be narrowed explicitly by
-domain, for example `python3 scripts/check_tasks.py run ci --domain web`.
+This command never reduces CI coverage. Unknown paths and changes to shared
+script helpers, generators, validators, the task runner, registry, package lock,
+or workflow definitions select the complete fast profile. Profiles can also be
+narrowed explicitly by domain, for example
+`python3 scripts/check_tasks.py run ci --domain web`.
 
 ## Common Checks
 

--- a/scripts/check_tasks.py
+++ b/scripts/check_tasks.py
@@ -214,10 +214,12 @@ def parse_name_status(output: str) -> set[str]:
 
 
 def changed_paths(root: Path, merge_base: str) -> list[str]:
+    committed = git_output(root, "diff", "--name-status", "-z", "-M", f"{merge_base}..HEAD")
     tracked = git_output(root, "diff", "--name-status", "-z", "-M", merge_base)
     staged = git_output(root, "diff", "--cached", "--name-status", "-z", "-M", merge_base)
     untracked = git_output(root, "ls-files", "--others", "--exclude-standard", "-z")
-    paths = parse_name_status(tracked)
+    paths = parse_name_status(committed)
+    paths.update(parse_name_status(tracked))
     paths.update(parse_name_status(staged))
     paths.update(path for path in untracked.split("\0") if path)
     return sorted(paths)
@@ -714,6 +716,7 @@ def self_test() -> None:
         (repo / "docs/guide.md").write_text("committed\n")
         run_git("add", "docs/guide.md")
         run_git("commit", "-m", "docs change")
+        run_git("restore", "--source=main", "--staged", "--worktree", "docs/guide.md")
         run_git("mv", "src/webserver/old.js", "src/webserver/new.js")
         (repo / "components/espcontrol/example.h").unlink()
         (repo / "devices/catalog.json").write_text('{"changed": true}\n')

--- a/scripts/check_tasks.py
+++ b/scripts/check_tasks.py
@@ -215,8 +215,10 @@ def parse_name_status(output: str) -> set[str]:
 
 def changed_paths(root: Path, merge_base: str) -> list[str]:
     tracked = git_output(root, "diff", "--name-status", "-z", "-M", merge_base)
+    staged = git_output(root, "diff", "--cached", "--name-status", "-z", "-M", merge_base)
     untracked = git_output(root, "ls-files", "--others", "--exclude-standard", "-z")
     paths = parse_name_status(tracked)
+    paths.update(parse_name_status(staged))
     paths.update(path for path in untracked.split("\0") if path)
     return sorted(paths)
 
@@ -649,6 +651,7 @@ def self_test() -> None:
         run_git("config", "user.email", "check-graph@example.invalid")
         initial = {
             "docs/guide.md": "initial\n",
+            "docs/staged-then-reverted.md": "initial\n",
             "src/webserver/old.js": "initial\n",
             "components/espcontrol/example.h": "initial\n",
             "devices/catalog.json": "{}\n",
@@ -678,12 +681,17 @@ def self_test() -> None:
         (repo / "components/espcontrol/example.h").unlink()
         (repo / "devices/catalog.json").write_text('{"changed": true}\n')
         run_git("add", "devices/catalog.json")
+        staged_then_reverted = repo / "docs/staged-then-reverted.md"
+        staged_then_reverted.write_text("staged\n")
+        run_git("add", "docs/staged-then-reverted.md")
+        staged_then_reverted.write_text("initial\n")
         (repo / "untracked.txt").write_text("untracked\n")
 
         _, merge_base = resolve_changed_base(repo)
         discovered = set(changed_paths(repo, merge_base))
         expected_paths = {
             "docs/guide.md",
+            "docs/staged-then-reverted.md",
             "src/webserver/old.js",
             "src/webserver/new.js",
             "components/espcontrol/example.h",

--- a/scripts/check_tasks.py
+++ b/scripts/check_tasks.py
@@ -244,6 +244,10 @@ def changed_plan(
         "scripts/check_tasks_data.py",
         "package-lock.json",
     )
+    sensitive_patterns = (
+        "scripts/check_*",
+        "scripts/generate_*",
+    )
 
     for path in paths:
         path_matches = []
@@ -252,7 +256,12 @@ def changed_plan(
             if any(matches_input(path, pattern) for pattern in patterns):
                 matched.setdefault(item.id, []).append(path)
                 path_matches.append(item.id)
-        if path in sensitive or matches_input(path, ".github/workflows/**"):
+        if (
+            path in sensitive
+            or path == "scripts/build.py"
+            or any(matches_input(path, pattern) for pattern in sensitive_patterns)
+            or matches_input(path, ".github/workflows/**")
+        ):
             force_fast.append(path)
         elif not path_matches:
             unmatched.append(path)
@@ -662,6 +671,18 @@ def self_test() -> None:
     workflow_selected, _, workflow_fallback = changed_plan([".github/workflows/example.yml"])
     if workflow_fallback is None or task_ids(workflow_selected) != task_ids(plan("fast")):
         raise AssertionError("workflow changes do not fall back to the full fast profile")
+
+    for safety_script in (
+        "scripts/build.py",
+        "scripts/check_device_manifest.py",
+        "scripts/check_web_smoke.js",
+        "scripts/generate_device_manifest.py",
+    ):
+        script_selected, _, script_fallback = changed_plan([safety_script])
+        if script_fallback is None or task_ids(script_selected) != task_ids(plan("fast")):
+            raise AssertionError(
+                f"generator or validator change {safety_script} does not select the full fast profile"
+            )
 
     broadened_selected, _, broadened_fallback = changed_plan([
         "docs/reference/faq.md",

--- a/scripts/check_tasks.py
+++ b/scripts/check_tasks.py
@@ -632,8 +632,16 @@ def self_test() -> None:
         return {item.id for item in selected}
 
     docs_selected, _, docs_fallback = changed_plan(["dev-docs/README.md"])
-    if docs_fallback is not None or "dev-docs" not in task_ids(docs_selected):
+    if docs_fallback is not None or not {"dev-docs", "docs-build"} <= task_ids(docs_selected):
         raise AssertionError("docs-only changes do not select documentation checks")
+
+    for maintainer_doc in ("README.md", "DEVELOPERS.md", "product/README.md"):
+        maintainer_selected, _, maintainer_fallback = changed_plan([maintainer_doc])
+        if (
+            maintainer_fallback is not None
+            or not {"dev-docs", "docs-build"} <= task_ids(maintainer_selected)
+        ):
+            raise AssertionError(f"{maintainer_doc} does not select maintainer documentation checks")
 
     web_selected, _, web_fallback = changed_plan(["src/webserver/modules/example.js"])
     if web_fallback is not None or "web-smoke" not in task_ids(web_selected):

--- a/scripts/check_tasks.py
+++ b/scripts/check_tasks.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 from datetime import datetime, timezone
+from fnmatch import fnmatchcase
 import json
 import os
 import signal
@@ -117,6 +118,164 @@ def plan_task(task_id: str, tasks: tuple[Task, ...] = TASKS) -> list[Task]:
 
     emit(task_id)
     return ordered
+
+
+def plan_task_ids(task_ids: set[str], tasks: tuple[Task, ...] = TASKS) -> list[Task]:
+    registry = validate_registry(tasks)
+    unknown = task_ids - set(registry)
+    if unknown:
+        raise ConfigurationError(f"unknown task IDs: {sorted(unknown)}")
+    selected = set(task_ids)
+
+    def add_dependencies(task_id: str) -> None:
+        for dependency in registry[task_id].dependencies:
+            if dependency not in selected:
+                selected.add(dependency)
+                add_dependencies(dependency)
+
+    for task_id in tuple(selected):
+        add_dependencies(task_id)
+
+    ordered: list[Task] = []
+    emitted: set[str] = set()
+
+    def emit(task_id: str) -> None:
+        if task_id in emitted:
+            return
+        for dependency in registry[task_id].dependencies:
+            emit(dependency)
+        emitted.add(task_id)
+        ordered.append(registry[task_id])
+
+    for item in tasks:
+        if item.id in selected:
+            emit(item.id)
+    return ordered
+
+
+def git_output(root: Path, *args: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as error:
+        raise ConfigurationError("git executable not found") from error
+    except subprocess.CalledProcessError as error:
+        message = error.stderr.strip() or error.stdout.strip() or "git command failed"
+        raise ConfigurationError(message) from error
+    return result.stdout
+
+
+def resolve_changed_base(root: Path, requested: str | None = None) -> tuple[str, str]:
+    candidates = (requested,) if requested else ("origin/main", "main")
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        exists = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", f"{candidate}^{{commit}}"],
+            cwd=root,
+            capture_output=True,
+        )
+        if exists.returncode == 0:
+            merge_base = subprocess.run(
+                ["git", "merge-base", "HEAD", candidate],
+                cwd=root,
+                capture_output=True,
+                text=True,
+            )
+            if merge_base.returncode == 0 and merge_base.stdout.strip():
+                return candidate, merge_base.stdout.strip()
+            if requested:
+                raise ConfigurationError(f"could not find merge base with {candidate}")
+    if requested:
+        raise ConfigurationError(f"changed-file base ref does not exist: {requested}")
+    raise ConfigurationError("changed-file routing requires origin/main or local main")
+
+
+def parse_name_status(output: str) -> set[str]:
+    fields = output.split("\0")
+    if fields and fields[-1] == "":
+        fields.pop()
+    paths: set[str] = set()
+    index = 0
+    while index < len(fields):
+        status = fields[index]
+        index += 1
+        path_count = 2 if status.startswith(("R", "C")) else 1
+        if index + path_count > len(fields):
+            raise ConfigurationError("git returned malformed changed-path data")
+        paths.update(fields[index:index + path_count])
+        index += path_count
+    return {path for path in paths if path}
+
+
+def changed_paths(root: Path, merge_base: str) -> list[str]:
+    tracked = git_output(root, "diff", "--name-status", "-z", "-M", merge_base)
+    untracked = git_output(root, "ls-files", "--others", "--exclude-standard", "-z")
+    paths = parse_name_status(tracked)
+    paths.update(path for path in untracked.split("\0") if path)
+    return sorted(paths)
+
+
+def matches_input(path: str, pattern: str) -> bool:
+    patterns = {pattern}
+    if "/**/" in pattern:
+        patterns.add(pattern.replace("/**/", "/"))
+    return any(fnmatchcase(path, candidate) for candidate in patterns)
+
+
+def changed_plan(
+    paths: list[str], tasks: tuple[Task, ...] = TASKS
+) -> tuple[list[Task], dict[str, list[str]], str | None]:
+    validate_registry(tasks)
+    matched: dict[str, list[str]] = {}
+    unmatched: list[str] = []
+    force_fast: list[str] = []
+    sensitive = (
+        "scripts/check_tasks.py",
+        "scripts/check_tasks_data.py",
+        "package-lock.json",
+    )
+
+    for path in paths:
+        path_matches = []
+        for item in tasks:
+            patterns = item.inputs + item.generated_inputs
+            if any(matches_input(path, pattern) for pattern in patterns):
+                matched.setdefault(item.id, []).append(path)
+                path_matches.append(item.id)
+        if path in sensitive or matches_input(path, ".github/workflows/**"):
+            force_fast.append(path)
+        elif not path_matches:
+            unmatched.append(path)
+
+    fallback_paths = sorted(set(force_fast + unmatched))
+    if fallback_paths:
+        selected = plan("fast", tasks=tasks)
+        reason = "full fast profile required by " + ", ".join(fallback_paths)
+        reasons = {item.id: [reason] for item in selected}
+        return selected, reasons, reason
+
+    direct_ids = set(matched)
+    selected = plan_task_ids(direct_ids, tasks)
+    reasons: dict[str, list[str]] = {}
+    for item in selected:
+        if item.id in matched:
+            reasons[item.id] = [f"input matched {path}" for path in sorted(matched[item.id])]
+            continue
+        consumers = sorted(
+            task_id for task_id in direct_ids
+            if item.id in {dependency.id for dependency in plan_task(task_id, tasks)[:-1]}
+        )
+        reasons[item.id] = [
+            f"dependency of {task_id} selected by {', '.join(sorted(matched[task_id]))}"
+            for task_id in consumers
+        ]
+    return selected, reasons, None
 
 
 def task_json(item: Task) -> dict[str, object]:
@@ -445,6 +604,111 @@ def self_test() -> None:
         if interrupted.returncode != 0:
             raise AssertionError("interrupts are not forwarded to the active child process")
 
+    def task_ids(selected: list[Task]) -> set[str]:
+        return {item.id for item in selected}
+
+    docs_selected, _, docs_fallback = changed_plan(["dev-docs/README.md"])
+    if docs_fallback is not None or "dev-docs" not in task_ids(docs_selected):
+        raise AssertionError("docs-only changes do not select documentation checks")
+
+    web_selected, _, web_fallback = changed_plan(["src/webserver/modules/example.js"])
+    if web_fallback is not None or "web-smoke" not in task_ids(web_selected):
+        raise AssertionError("web changes do not select web checks")
+
+    firmware_selected, _, firmware_fallback = changed_plan(["components/espcontrol/example.h"])
+    if firmware_fallback is not None or "firmware-parser" not in task_ids(firmware_selected):
+        raise AssertionError("firmware changes do not select firmware checks")
+
+    generated_selected, _, generated_fallback = changed_plan(["components/espcontrol/i18n_generated.h"])
+    if generated_fallback is not None or "generated" not in task_ids(generated_selected):
+        raise AssertionError("generated inputs do not select their validation task")
+
+    unknown_selected, _, unknown_fallback = changed_plan(["unexpected-area/file.xyz"])
+    if unknown_fallback is None or task_ids(unknown_selected) != task_ids(plan("fast")):
+        raise AssertionError("unknown paths do not fall back to the full fast profile")
+
+    workflow_selected, _, workflow_fallback = changed_plan([".github/workflows/example.yml"])
+    if workflow_fallback is None or task_ids(workflow_selected) != task_ids(plan("fast")):
+        raise AssertionError("workflow changes do not fall back to the full fast profile")
+
+    clean_selected, clean_reasons, clean_fallback = changed_plan([])
+    if clean_selected or clean_reasons or clean_fallback is not None:
+        raise AssertionError("clean trees should not select changed-file checks")
+
+    if not task_ids(plan("ci", "web")) < task_ids(plan("ci")):
+        raise AssertionError("profile and domain combinations do not narrow direct selection")
+
+    with TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+
+        def run_git(*args: str) -> None:
+            subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+        run_git("init", "-b", "main")
+        run_git("config", "user.name", "Check Graph Test")
+        run_git("config", "user.email", "check-graph@example.invalid")
+        initial = {
+            "docs/guide.md": "initial\n",
+            "src/webserver/old.js": "initial\n",
+            "components/espcontrol/example.h": "initial\n",
+            "devices/catalog.json": "{}\n",
+        }
+        for relative, content in initial.items():
+            destination = repo / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_text(content)
+        run_git("add", ".")
+        run_git("commit", "-m", "initial")
+        run_git("update-ref", "refs/remotes/origin/main", "main")
+
+        base_ref, merge_base = resolve_changed_base(repo)
+        if base_ref != "origin/main" or changed_paths(repo, merge_base):
+            raise AssertionError("clean repository base discovery is incorrect")
+        run_git("update-ref", "-d", "refs/remotes/origin/main")
+        fallback_ref, fallback_merge_base = resolve_changed_base(repo)
+        if fallback_ref != "main" or fallback_merge_base != merge_base:
+            raise AssertionError("local main is not used when origin/main is unavailable")
+        run_git("update-ref", "refs/remotes/origin/main", "main")
+
+        run_git("switch", "-c", "feature")
+        (repo / "docs/guide.md").write_text("committed\n")
+        run_git("add", "docs/guide.md")
+        run_git("commit", "-m", "docs change")
+        run_git("mv", "src/webserver/old.js", "src/webserver/new.js")
+        (repo / "components/espcontrol/example.h").unlink()
+        (repo / "devices/catalog.json").write_text('{"changed": true}\n')
+        run_git("add", "devices/catalog.json")
+        (repo / "untracked.txt").write_text("untracked\n")
+
+        _, merge_base = resolve_changed_base(repo)
+        discovered = set(changed_paths(repo, merge_base))
+        expected_paths = {
+            "docs/guide.md",
+            "src/webserver/old.js",
+            "src/webserver/new.js",
+            "components/espcontrol/example.h",
+            "devices/catalog.json",
+            "untracked.txt",
+        }
+        if not expected_paths <= discovered:
+            raise AssertionError(f"changed paths omit workspace states: {sorted(expected_paths - discovered)}")
+
+    with TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        subprocess.run(["git", "init", "-b", "feature"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Check Graph Test"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "check-graph@example.invalid"], cwd=repo, check=True)
+        (repo / "README.md").write_text("initial\n")
+        subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-m", "initial"], cwd=repo, check=True, capture_output=True)
+        try:
+            resolve_changed_base(repo)
+        except ConfigurationError as error:
+            if "origin/main or local main" not in str(error):
+                raise
+        else:
+            raise AssertionError("missing default changed-file bases were accepted")
+
     print(f"check task registry self-test passed ({len(TASKS)} tasks, {len(PROFILES)} profiles)")
 
 
@@ -468,6 +732,10 @@ def parse_args() -> argparse.Namespace:
     task_parser = subparsers.add_parser("run-task", help="run one task and its dependencies")
     task_parser.add_argument("task_id")
     task_parser.add_argument("--summary-json", type=Path)
+    changed_parser = subparsers.add_parser("changed", help="plan checks from branch and workspace changes")
+    changed_parser.add_argument("--base")
+    changed_parser.add_argument("--explain", action="store_true")
+    changed_parser.add_argument("--json", action="store_true")
     return parser.parse_args()
 
 
@@ -514,7 +782,39 @@ def main() -> int:
             print_summary(summary)
             write_summary(summary, args.summary_json)
             return exit_code
-        print("choose 'list', 'plan', 'run', or 'run-task', or use --self-test", file=sys.stderr)
+        if args.command == "changed":
+            base_ref, merge_base = resolve_changed_base(ROOT, args.base)
+            paths = changed_paths(ROOT, merge_base)
+            selected, reasons, fallback = changed_plan(paths)
+            if args.json:
+                print(json.dumps({
+                    "base": base_ref,
+                    "merge_base": merge_base,
+                    "paths": paths,
+                    "fallback": fallback,
+                    "tasks": [
+                        {**task_json(item), "reasons": reasons.get(item.id, [])}
+                        for item in selected
+                    ],
+                }, indent=2))
+            else:
+                print(f"Base: {base_ref} ({merge_base[:12]})")
+                if not paths:
+                    print("No changed files; no tasks selected.")
+                    return 0
+                print("Changed files:")
+                for path in paths:
+                    print(f"  {path}")
+                if fallback:
+                    print(f"Fallback: {fallback}")
+                print("Selected tasks:")
+                for index, item in enumerate(selected, 1):
+                    print(f"{index:2}. {item.id}")
+                    if args.explain:
+                        for reason in reasons.get(item.id, []):
+                            print(f"    - {reason}")
+            return 0
+        print("choose 'list', 'plan', 'run', 'run-task', or 'changed', or use --self-test", file=sys.stderr)
         return 2
     except ConfigurationError as error:
         print(f"check task configuration error: {error}", file=sys.stderr)

--- a/scripts/check_tasks.py
+++ b/scripts/check_tasks.py
@@ -257,9 +257,29 @@ def changed_plan(
 
     fallback_paths = sorted(set(force_fast + unmatched))
     if fallback_paths:
-        selected = plan("fast", tasks=tasks)
+        fast_ids = {item.id for item in plan("fast", tasks=tasks)}
+        direct_ids = set(matched)
+        selected = plan_task_ids(fast_ids | direct_ids, tasks)
         reason = "full fast profile required by " + ", ".join(fallback_paths)
-        reasons = {item.id: [reason] for item in selected}
+        reasons: dict[str, list[str]] = {}
+        for item in selected:
+            item_reasons = []
+            if item.id in fast_ids:
+                item_reasons.append(reason)
+            if item.id in matched:
+                item_reasons.extend(
+                    f"input matched {path}" for path in sorted(matched[item.id])
+                )
+            if not item_reasons:
+                consumers = sorted(
+                    task_id for task_id in direct_ids
+                    if item.id in {dependency.id for dependency in plan_task(task_id, tasks)[:-1]}
+                )
+                item_reasons.extend(
+                    f"dependency of {task_id} selected by {', '.join(sorted(matched[task_id]))}"
+                    for task_id in consumers
+                )
+            reasons[item.id] = item_reasons
         return selected, reasons, reason
 
     direct_ids = set(matched)
@@ -632,6 +652,23 @@ def self_test() -> None:
     workflow_selected, _, workflow_fallback = changed_plan([".github/workflows/example.yml"])
     if workflow_fallback is None or task_ids(workflow_selected) != task_ids(plan("fast")):
         raise AssertionError("workflow changes do not fall back to the full fast profile")
+
+    broadened_selected, _, broadened_fallback = changed_plan([
+        "docs/reference/faq.md",
+        "unexpected-area/file.xyz",
+    ])
+    broadened_ids = task_ids(broadened_selected)
+    if (
+        broadened_fallback is None
+        or not task_ids(plan("fast")) <= broadened_ids
+        or "docs-build" not in broadened_ids
+    ):
+        raise AssertionError("fallback discards directly matched tasks outside the fast profile")
+
+    lock_selected, _, lock_fallback = changed_plan(["package-lock.json"])
+    lock_ids = task_ids(lock_selected)
+    if lock_fallback is None or not {"docs-build", "web-browser-smoke", "types"} <= lock_ids:
+        raise AssertionError("package lock fallback discards declared consumers")
 
     clean_selected, clean_reasons, clean_fallback = changed_plan([])
     if clean_selected or clean_reasons or clean_fallback is not None:

--- a/scripts/check_tasks.py
+++ b/scripts/check_tasks.py
@@ -248,6 +248,7 @@ def changed_plan(
         "scripts/check_*",
         "scripts/generate_*",
     )
+    catch_all_task_ids = {"public-firmware-script"}
 
     for path in paths:
         path_matches = []
@@ -263,7 +264,7 @@ def changed_plan(
             or matches_input(path, ".github/workflows/**")
         ):
             force_fast.append(path)
-        elif not path_matches:
+        elif not (set(path_matches) - catch_all_task_ids):
             unmatched.append(path)
 
     fallback_paths = sorted(set(force_fast + unmatched))
@@ -683,6 +684,10 @@ def self_test() -> None:
             raise AssertionError(
                 f"generator or validator change {safety_script} does not select the full fast profile"
             )
+
+    helper_selected, _, helper_fallback = changed_plan(["scripts/device_matrix.py"])
+    if helper_fallback is None or task_ids(helper_selected) != task_ids(plan("fast")):
+        raise AssertionError("shared script helpers matched only by a catch-all do not select fast")
 
     broadened_selected, _, broadened_fallback = changed_plan([
         "docs/reference/faq.md",

--- a/scripts/check_tasks.py
+++ b/scripts/check_tasks.py
@@ -689,6 +689,10 @@ def self_test() -> None:
     if helper_fallback is None or task_ids(helper_selected) != task_ids(plan("fast")):
         raise AssertionError("shared script helpers matched only by a catch-all do not select fast")
 
+    esphome_selected, _, esphome_fallback = changed_plan([".github/esphome.env"])
+    if esphome_fallback is not None or "firmware-release" not in task_ids(esphome_selected):
+        raise AssertionError("ESPHome version changes do not select firmware release checks")
+
     broadened_selected, _, broadened_fallback = changed_plan([
         "docs/reference/faq.md",
         "unexpected-area/file.xyz",

--- a/scripts/check_tasks_data.py
+++ b/scripts/check_tasks_data.py
@@ -42,6 +42,7 @@ PRODUCT = ("product", "fast", "ci", "all", "release")
 FAST = ("fast", "ci", "all")
 CI = ("ci", "all")
 RELEASE = ("release",)
+MAINTAINER_DOCS = ("dev-docs/**", "DEVELOPERS.md", "README.md", "product/README.md")
 
 
 # Declaration order is the stable tie-breaker used by the planner.
@@ -67,7 +68,7 @@ TASKS = (
     task("local-esphome", ("python3", "scripts/local_esphome.py", "--self-test"), profiles=FAST,
          domains=("firmware", "workflow"), inputs=("scripts/local_esphome.py",), cache="never"),
     task("dev-docs", ("python3", "scripts/check_dev_docs.py", "--check"), profiles=FAST,
-         domains=("docs",), inputs=("dev-docs/**", "scripts/check_dev_docs.py")),
+         domains=("docs",), inputs=MAINTAINER_DOCS + ("scripts/check_dev_docs.py",)),
     task("pr-process", ("python3", "scripts/check_pr_process.py", "--self-test"), profiles=FAST,
          domains=("workflow",), inputs=(".github/**", "scripts/check_pr_process.py"), cache="never"),
     task("pr-testing-guidance", ("python3", "scripts/pr_testing_guidance.py", "--self-test"), profiles=FAST,
@@ -127,5 +128,6 @@ TASKS = (
     task("web-browser-smoke", ("node", "scripts/check_web_browser_smoke.js"), dependencies=("generated", "device-manifest-output"), profiles=CI,
          domains=("web",), inputs=("src/webserver/**", "scripts/check_web_browser_smoke.js", "package-lock.json"), cache="never"),
     task("docs-build", ("npm", "run", "docs:build"), dependencies=("generated",), profiles=("all", "release"),
-         domains=("docs",), inputs=("docs/**", "package-lock.json"), generated_inputs=("docs/generated/**",)),
+         domains=("docs",), inputs=("docs/**",) + MAINTAINER_DOCS + ("package-lock.json",),
+         generated_inputs=("docs/generated/**",)),
 )

--- a/scripts/check_tasks_data.py
+++ b/scripts/check_tasks_data.py
@@ -102,7 +102,7 @@ TASKS = (
          ("python3", "scripts/check_firmware_card_runtime.py", "--self-test"), dependencies=("generated",), profiles=PRODUCT,
          domains=("firmware", "product"), inputs=("components/**", "common/config/card_contract.json", "scripts/check_firmware_card_runtime.py")),
     task("firmware-release", ("python3", "scripts/check_firmware_release.py"), profiles=FAST + RELEASE,
-         domains=("firmware", "workflow"), inputs=("builds/**", "devices/**", ".github/workflows/release.yml", "scripts/check_firmware_release.py")),
+         domains=("firmware", "workflow"), inputs=("builds/**", "devices/**", ".github/esphome.env", ".github/workflows/release.yml", "scripts/check_firmware_release.py")),
     task("device-matrix", ("python3", "scripts/check_device_matrix.py"), profiles=FAST,
          domains=("firmware", "product"), inputs=("builds/**", "devices/**", "scripts/check_device_matrix.py")),
     task("device-profiles", ("python3", "scripts/check_device_profiles.py"), dependencies=("generated", "device-slots"), profiles=PRODUCT,


### PR DESCRIPTION
## Summary

- Add `check_tasks.py changed` to select local checks from committed and workspace changes.
- Resolve the default comparison from the merge base with `origin/main`, falling back to local `main`.
- Include staged, unstaged, renamed, deleted, and untracked paths.
- Match authored and generated input globs, then add dependency closure in stable graph order.
- Fall back safely to the complete fast profile for unknown paths and changes to the runner, registry, package lock, or workflows.
- Add human explanations and structured JSON output.
- Document that changed-file routing is advisory and never reduces CI coverage.

Continues #1002 as stage 4.

## Practical impact

Maintainers can now ask the graph which checks are relevant to their complete local branch and workspace without manually assembling commands:

```text
python3 scripts/check_tasks.py changed --explain
python3 scripts/check_tasks.py changed --json
```

CI continues running complete profiles. Firmware and user-facing device behaviour are unchanged.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Updated the internal checks-and-releases guide with changed-file routing, safety fallbacks, and profile/domain examples.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [ ] Device testing is required before merge.
- [x] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- None.

## Notes for testing

Passed locally:

- `python3 scripts/check_tasks.py --self-test`
- `python3 scripts/check_tasks.py changed --explain`
- `python3 scripts/check_tasks.py changed --json`
- invalid explicit base exit-code verification
- `npm run check:fast`
- `npm run check:ci`, including browser smoke checks for all six generated layouts
- `python3 scripts/check_dev_docs.py --check`
- `npm run docs:build`
- Python syntax and whitespace checks

Characterization coverage includes docs-only, web, firmware, generated inputs, committed changes, staged changes, unstaged deletion, renames, untracked files, clean repositories, unknown-path fallback, workflow fallback, local-main fallback, missing-base errors, and profile/domain combinations.

No physical device testing is required because this changes local developer check selection only.

## PR status

- [x] Checks running or waiting.
- [ ] Needs automated fix.
- [ ] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.
