### PR TITLE
Ensure CMake is available in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,20 @@ jobs:
         with:
           node-version: 24
 
+      - name: Ensure CMake is available
+        shell: bash
+        run: |
+          if command -v cmake >/dev/null 2>&1; then
+            cmake --version
+            exit 0
+          fi
+
+          CMAKE_VENV="${RUNNER_TEMP}/espcontrol-cmake"
+          python3 -m venv "${CMAKE_VENV}"
+          "${CMAKE_VENV}/bin/python" -m pip install --disable-pip-version-check --no-cache-dir "cmake==3.31.10"
+          echo "${CMAKE_VENV}/bin" >> "${GITHUB_PATH}"
+          "${CMAKE_VENV}/bin/cmake" --version
+
       - name: Install dependencies
         run: |
           NPM_CACHE="${HOME}/.cache/espcontrol-actions/npm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,8 +147,14 @@ jobs:
         shell: bash
         run: |
           if command -v cmake >/dev/null 2>&1; then
-            cmake --version
-            exit 0
+            CMAKE_VERSION="$(cmake --version | awk 'NR == 1 { print $3 }')"
+            if python3 -c \
+              'import sys; sys.exit(0 if tuple(map(int, sys.argv[1].split(".")[:2])) >= (3, 20) else 1)' \
+              "${CMAKE_VERSION}"; then
+              cmake --version
+              exit 0
+            fi
+            echo "CMake ${CMAKE_VERSION} is older than the required version 3.20; installing the pinned fallback."
           fi
 
           CMAKE_VENV="${RUNNER_TEMP}/espcontrol-cmake"


### PR DESCRIPTION
## Summary

- Add a pinned CMake fallback to the validation workflow when a runner does not already provide CMake.
- Keep the existing hosted pull-request and self-hosted main-branch runner arrangement.

## Practical impact

- Main-branch validation can run on the self-hosted runner instead of stopping immediately with `executable not found: cmake`.
- Firmware and device behavior are unchanged.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- This only makes a required CI build tool available and does not change user-visible behavior.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [ ] Device testing is required before merge.
- [x] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- None.

## Notes for testing

- Reproduced the missing-CMake environment locally.
- Installed the pinned fallback, CMake 3.31.10, without administrator access.
- Ran `npm run test:firmware`; all three native firmware tests passed, including the saved-configuration parser test.
- The pull-request workflow will also run the complete required check graph.

## PR status

- [x] Checks running or waiting.
- [ ] Needs automated fix.
- [ ] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.

Related to #998.