### PR TITLE
Add display mode controller shadow

### DIFF
--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -578,6 +578,13 @@ script:
     mode: restart
     then:
       - script.stop: setup_screen_dim
+      - if:
+          condition:
+            lambda: 'return id(setup_screen_dimmed_shadow_active);'
+          then:
+            - globals.set:
+                id: display_asleep
+                value: 'false'
       - globals.set:
           id: setup_screen_dimmed_shadow_active
           value: 'false'

--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -87,6 +87,8 @@ globals:
   - id: screensaver_action_dimmed
     type: bool
     initial_value: 'false'
+  - id: display_mode_shadow_observer
+    type: espcontrol::DisplayModeShadowObserver
 
 esphome:
   on_boot:
@@ -1067,6 +1069,53 @@ interval:
   - interval: 1s
     then:
       - script.execute: clock_screensaver_keep_on_top
+      - lambda: |-
+          espcontrol::LegacyDisplayState legacy;
+          legacy.display_asleep = id(display_asleep);
+          legacy.screen_schedule_asleep = id(screen_schedule_asleep);
+          legacy.backlight_manual_off = id(backlight_manual_off);
+          legacy.temporary_user_wake = id(manual_wake_ms) != 0;
+          legacy.display_off_active = id(screensaver_display_off_active);
+          legacy.dimmed_active = id(screensaver_dimmed_active);
+          legacy.clock_showing = id(is_clock_showing);
+          legacy.cover_art_active = id(cover_art_screensaver_active);
+          legacy.interactive_takeover = id(display_takeover_suspended);
+          legacy.critical_takeover = alarm_display_takeover_active();
+
+          auto now = panel_time_or_fallback(id(panel_time).now(), id(homeassistant_time).now());
+          const bool boot_guard_active = screen_schedule_waiting_for_time(
+              id(screen_schedule_trigger).state, id(schedule_enabled).state, now.is_valid());
+          const bool schedule_night = screen_schedule_night_active(
+              id(screen_schedule_trigger).state,
+              id(schedule_enabled).state,
+              id(presence_detected),
+              now.is_valid(),
+              now.is_valid() ? now.hour : 0,
+              (int) id(schedule_on_hour).state,
+              (int) id(schedule_off_hour).state);
+          const bool schedule_active_ui = schedule_night && id(schedule_mode_always_on);
+          const bool presence_owned_sleep = id(screensaver_mode).state == "sensor";
+
+          const auto observation = id(display_mode_shadow_observer).observe(
+              legacy, presence_owned_sleep, boot_guard_active, schedule_active_ui);
+          if (observation.mismatch &&
+              (observation.mismatch_changed || observation.decision_changed)) {
+            ESP_LOGW("display_mode_shadow",
+                     "Mismatch: controller=%s source=%s takeover=%s legacy=%s stable=%s generation=%u",
+                     espcontrol::display_mode_name(observation.decision.target_mode),
+                     espcontrol::display_request_source_name(observation.decision.winning_source),
+                     espcontrol::display_takeover_name(observation.decision.winning_takeover),
+                     espcontrol::display_mode_name(observation.legacy.mode),
+                     observation.legacy.stable ? "true" : "false",
+                     (unsigned) observation.decision.generation);
+          } else if (observation.decision_changed) {
+            ESP_LOGI("display_mode_shadow",
+                     "Decision: mode=%s source=%s takeover=%s generation=%u",
+                     espcontrol::display_mode_name(observation.decision.target_mode),
+                     espcontrol::display_request_source_name(observation.decision.winning_source),
+                     espcontrol::display_takeover_name(observation.decision.winning_takeover),
+                     (unsigned) observation.decision.generation);
+          }
   - interval: 30s
     then:
       - if:

--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -89,6 +89,9 @@ globals:
     initial_value: 'false'
   - id: display_mode_shadow_observer
     type: espcontrol::DisplayModeShadowObserver
+  - id: setup_screen_dimmed_shadow_active
+    type: bool
+    initial_value: 'false'
 
 esphome:
   on_boot:
@@ -574,6 +577,9 @@ script:
   - id: setup_screen_dim
     mode: restart
     then:
+      - globals.set:
+          id: setup_screen_dimmed_shadow_active
+          value: 'false'
       - delay: 120s
       - if:
           condition:
@@ -587,6 +593,9 @@ script:
           then:
             - script.execute: backlight_force_display_off
           else:
+            - globals.set:
+                id: setup_screen_dimmed_shadow_active
+                value: 'true'
             - globals.set:
                 id: display_asleep
                 value: 'true'
@@ -1081,6 +1090,13 @@ interval:
           legacy.cover_art_active = id(cover_art_screensaver_active);
           legacy.interactive_takeover = id(display_takeover_suspended);
           legacy.critical_takeover = alarm_display_takeover_active();
+          const bool setup_dim_shape = legacy.display_asleep &&
+              !legacy.screen_schedule_asleep && !legacy.backlight_manual_off &&
+              !legacy.display_off_active && !legacy.dimmed_active &&
+              !legacy.clock_showing && !legacy.cover_art_active &&
+              !legacy.interactive_takeover && !legacy.critical_takeover;
+          if (!setup_dim_shape) id(setup_screen_dimmed_shadow_active) = false;
+          legacy.setup_screen = setup_dim_shape && id(setup_screen_dimmed_shadow_active);
 
           auto now = panel_time_or_fallback(id(panel_time).now(), id(homeassistant_time).now());
           const bool boot_guard_active = screen_schedule_waiting_for_time(

--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -574,6 +574,14 @@ script:
       - script.execute: backlight_schedule_display_off
 
   # Setup screen burn-in protection
+  - id: setup_screen_dim_cancel
+    mode: restart
+    then:
+      - script.stop: setup_screen_dim
+      - globals.set:
+          id: setup_screen_dimmed_shadow_active
+          value: 'false'
+
   - id: setup_screen_dim
     mode: restart
     then:

--- a/common/addon/connectivity.yaml
+++ b/common/addon/connectivity.yaml
@@ -40,7 +40,7 @@ wifi:
     - script.execute: network_status_refresh
     - script.execute: ntp_servers_apply_after_network
     - script.stop: wifi_reconnect_flow
-    - script.stop: setup_screen_dim
+    - script.execute: setup_screen_dim_cancel
     - lambda: |-
         ESP_LOGI("connectivity", "WiFi connected (%lu ms)", millis());
         lv_label_set_text(id(loading_status_label), espcontrol_i18n("Connected"));
@@ -89,7 +89,7 @@ script:
                       condition:
                         lambda: 'return id(button_order).state.empty();'
                       then:
-                        - script.stop: setup_screen_dim
+                        - script.execute: setup_screen_dim_cancel
                         - script.execute: clock_bar_hide
                         - lvgl.page.show: ha_actions_page
                       else:
@@ -181,7 +181,7 @@ script:
   - id: navigate_after_api
     mode: restart
     then:
-      - script.stop: setup_screen_dim
+      - script.execute: setup_screen_dim_cancel
       - if:
           condition:
             lambda: 'return !id(button_order).state.empty();'

--- a/common/addon/connectivity_deployed.yaml
+++ b/common/addon/connectivity_deployed.yaml
@@ -12,7 +12,7 @@ wifi:
     - script.execute: network_status_refresh
     - script.execute: ntp_servers_apply_after_network
     - script.stop: wifi_reconnect_flow
-    - script.stop: setup_screen_dim
+    - script.execute: setup_screen_dim_cancel
     - lambda: |-
         ESP_LOGI("connectivity", "WiFi connected (%lu ms)", millis());
         lv_label_set_text(id(loading_status_label), espcontrol_i18n("Connected"));
@@ -61,7 +61,7 @@ script:
                       condition:
                         lambda: 'return id(button_order).state.empty();'
                       then:
-                        - script.stop: setup_screen_dim
+                        - script.execute: setup_screen_dim_cancel
                         - script.execute: clock_bar_hide
                         - lvgl.page.show: ha_actions_page
                       else:
@@ -125,7 +125,7 @@ script:
   - id: navigate_after_api
     mode: restart
     then:
-      - script.stop: setup_screen_dim
+      - script.execute: setup_screen_dim_cancel
       - if:
           condition:
             lambda: 'return !id(button_order).state.empty();'

--- a/common/addon/connectivity_ethernet.yaml
+++ b/common/addon/connectivity_ethernet.yaml
@@ -17,7 +17,7 @@ ethernet:
   phy_addr: 1
   on_connect:
     - script.execute: ntp_servers_apply_after_network
-    - script.stop: setup_screen_dim
+    - script.execute: setup_screen_dim_cancel
     - lambda: |-
         ESP_LOGI("connectivity", "Ethernet connected (%lu ms)", millis());
         lv_label_set_text(id(loading_status_label), espcontrol_i18n("Connected"));
@@ -67,7 +67,7 @@ script:
                       condition:
                         lambda: 'return id(button_order).state.empty();'
                       then:
-                        - script.stop: setup_screen_dim
+                        - script.execute: setup_screen_dim_cancel
                         - script.execute: clock_bar_hide
                         - lvgl.page.show: ha_actions_page
                       else:
@@ -97,7 +97,7 @@ script:
   - id: navigate_after_api
     mode: restart
     then:
-      - script.stop: setup_screen_dim
+      - script.execute: setup_screen_dim_cancel
       - if:
           condition:
             lambda: 'return !id(button_order).state.empty();'

--- a/common/addon/firmware_update.yaml
+++ b/common/addon/firmware_update.yaml
@@ -61,7 +61,7 @@ script:
     then:
       - script.stop: screensaver_idle_check
       - script.stop: home_screen_idle_check
-      - script.stop: setup_screen_dim
+      - script.execute: setup_screen_dim_cancel
       - lambda: |-
           media_volume_hide_modal();
           climate_control_hide_modal();
@@ -103,7 +103,7 @@ script:
   - id: show_update_complete_next_boot
     mode: single
     then:
-      - script.stop: setup_screen_dim
+      - script.execute: setup_screen_dim_cancel
       - lambda: |-
           lv_label_set_text(id(loading_status_icon), "${icon_check}");
           lv_label_set_text(id(loading_status_title), espcontrol_i18n("Update complete"));

--- a/common/addon/firmware_update_disabled.yaml
+++ b/common/addon/firmware_update_disabled.yaml
@@ -54,7 +54,7 @@ script:
     then:
       - script.stop: screensaver_idle_check
       - script.stop: home_screen_idle_check
-      - script.stop: setup_screen_dim
+      - script.execute: setup_screen_dim_cancel
       - lambda: |-
           media_volume_hide_modal();
           climate_control_hide_modal();
@@ -93,7 +93,7 @@ script:
   - id: show_update_complete_next_boot
     mode: single
     then:
-      - script.stop: setup_screen_dim
+      - script.execute: setup_screen_dim_cancel
       - lambda: |-
           lv_label_set_text(id(loading_status_icon), "${icon_check}");
           lv_label_set_text(id(loading_status_title), espcontrol_i18n("Update complete"));

--- a/common/device/screen_button_setup.yaml
+++ b/common/device/screen_button_setup.yaml
@@ -21,7 +21,7 @@ lvgl:
             clickable: true
             on_press:
               then:
-                - script.stop: setup_screen_dim
+                - script.execute: setup_screen_dim_cancel
                 - light.turn_on:
                     id: display_backlight
                     brightness: 90%

--- a/common/device/screen_ethernet_setup.yaml
+++ b/common/device/screen_ethernet_setup.yaml
@@ -21,7 +21,7 @@ lvgl:
             clickable: true
             on_press:
               then:
-                - script.stop: setup_screen_dim
+                - script.execute: setup_screen_dim_cancel
                 - light.turn_on:
                     id: display_backlight
                     brightness: 90%

--- a/common/device/screen_ha_actions.yaml
+++ b/common/device/screen_ha_actions.yaml
@@ -22,7 +22,7 @@ lvgl:
             clickable: true
             on_press:
               then:
-                - script.stop: setup_screen_dim
+                - script.execute: setup_screen_dim_cancel
                 - light.turn_on:
                     id: display_backlight
                     brightness: 90%

--- a/common/device/screen_ha_setup.yaml
+++ b/common/device/screen_ha_setup.yaml
@@ -23,7 +23,7 @@ lvgl:
             clickable: true
             on_press:
               then:
-                - script.stop: setup_screen_dim
+                - script.execute: setup_screen_dim_cancel
                 - light.turn_on:
                     id: display_backlight
                     brightness: 90%

--- a/common/device/screen_wifi_setup.yaml
+++ b/common/device/screen_wifi_setup.yaml
@@ -21,7 +21,7 @@ lvgl:
             clickable: true
             on_press:
               then:
-                - script.stop: setup_screen_dim
+                - script.execute: setup_screen_dim_cancel
                 - light.turn_on:
                     id: display_backlight
                     brightness: 90%

--- a/components/espcontrol/backlight.h
+++ b/components/espcontrol/backlight.h
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include "esphome/components/lvgl/lvgl_esphome.h"
 #include "clock_bar.h"
+#include "display_mode_controller.h"
 #include "sun_calc.h"
 #include "temperature_unit.h"
 

--- a/components/espcontrol/display_mode_controller.h
+++ b/components/espcontrol/display_mode_controller.h
@@ -46,8 +46,25 @@ class DisplayModeController {
 
   bool request(DisplayRequestSource source, DisplayMode mode) {
     if (!request_is_valid(source, mode)) return false;
+
+    Request &manual_sleep = requests_[source_index(DisplayRequestSource::MANUAL_SLEEP)];
+    if (source == DisplayRequestSource::USER_WAKE && manual_sleep.active) return false;
+
+    bool changed = false;
+    if (source == DisplayRequestSource::MANUAL_SLEEP) {
+      Request &user_wake = requests_[source_index(DisplayRequestSource::USER_WAKE)];
+      if (user_wake.active) {
+        user_wake.active = false;
+        user_wake.sequence = ++sequence_;
+        changed = true;
+      }
+    }
+
     Request &entry = requests_[source_index(source)];
-    if (entry.active && entry.mode == mode) return false;
+    if (entry.active && entry.mode == mode) {
+      if (changed) advance_generation();
+      return changed;
+    }
     entry.active = true;
     entry.mode = mode;
     entry.sequence = ++sequence_;
@@ -282,7 +299,8 @@ class DisplayModeShadowObserver {
 
     set_request(DisplayRequestSource::MANUAL_SLEEP, state.backlight_manual_off,
                 DisplayMode::DISPLAY_OFF);
-    set_request(DisplayRequestSource::USER_WAKE, state.temporary_user_wake,
+    set_request(DisplayRequestSource::USER_WAKE,
+                state.temporary_user_wake && !state.backlight_manual_off,
                 DisplayMode::ACTIVE);
     set_request(DisplayRequestSource::BOOT_GUARD, boot_guard_active,
                 DisplayMode::DISPLAY_OFF);

--- a/components/espcontrol/display_mode_controller.h
+++ b/components/espcontrol/display_mode_controller.h
@@ -1,0 +1,393 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+namespace espcontrol {
+
+enum class DisplayMode : uint8_t {
+  ACTIVE,
+  SETUP_DIMMED,
+  DIMMED,
+  CLOCK,
+  COVER_ART,
+  DISPLAY_OFF,
+};
+
+enum class DisplayRequestSource : uint8_t {
+  BOOT_GUARD,
+  IDLE_TIMER,
+  PRESENCE_SENSOR,
+  SCREEN_SCHEDULE,
+  MANUAL_SLEEP,
+  MEDIA_PLAYBACK,
+  SETUP_TIMEOUT,
+  USER_WAKE,
+};
+
+enum class DisplayTakeoverKind : uint8_t {
+  INTERACTIVE,
+  CRITICAL,
+};
+
+struct DisplayTransition {
+  DisplayMode previous_mode{DisplayMode::ACTIVE};
+  DisplayMode target_mode{DisplayMode::ACTIVE};
+  std::optional<DisplayRequestSource> winning_source;
+  std::optional<DisplayTakeoverKind> winning_takeover;
+  uint32_t generation{0};
+};
+
+class DisplayModeController {
+ public:
+  DisplayModeController() = default;
+
+  bool request(DisplayRequestSource source, DisplayMode mode) {
+    if (!request_is_valid(source, mode)) return false;
+    Request &entry = requests_[source_index(source)];
+    if (entry.active && entry.mode == mode) return false;
+    entry.active = true;
+    entry.mode = mode;
+    entry.sequence = ++sequence_;
+    advance_generation();
+    return true;
+  }
+
+  bool clear(DisplayRequestSource source) {
+    Request &entry = requests_[source_index(source)];
+    if (!entry.active) return false;
+    entry.active = false;
+    entry.sequence = ++sequence_;
+    advance_generation();
+    return true;
+  }
+
+  bool begin_takeover(DisplayTakeoverKind kind) {
+    uint16_t &depth = takeover_depth_[takeover_index(kind)];
+    if (depth == UINT16_MAX) return false;
+    ++depth;
+    advance_generation();
+    return true;
+  }
+
+  bool end_takeover(DisplayTakeoverKind kind) {
+    uint16_t &depth = takeover_depth_[takeover_index(kind)];
+    if (depth == 0) return false;
+    --depth;
+    advance_generation();
+    return true;
+  }
+
+  bool takeover_active(DisplayTakeoverKind kind) const {
+    return takeover_depth_[takeover_index(kind)] != 0;
+  }
+
+  DisplayTransition resolve() const {
+    DisplayTransition result;
+    result.previous_mode = current_mode_;
+    result.generation = generation_;
+
+    if (takeover_active(DisplayTakeoverKind::CRITICAL)) {
+      result.target_mode = DisplayMode::ACTIVE;
+      result.winning_takeover = DisplayTakeoverKind::CRITICAL;
+      return result;
+    }
+
+    if (apply_source(DisplayRequestSource::MANUAL_SLEEP, result)) return result;
+    if (apply_source(DisplayRequestSource::USER_WAKE, result)) return result;
+    if (apply_source(DisplayRequestSource::BOOT_GUARD, result)) return result;
+    if (apply_source(DisplayRequestSource::SCREEN_SCHEDULE, result)) return result;
+
+    if (takeover_active(DisplayTakeoverKind::INTERACTIVE)) {
+      result.target_mode = DisplayMode::ACTIVE;
+      result.winning_takeover = DisplayTakeoverKind::INTERACTIVE;
+      return result;
+    }
+
+    if (apply_source(DisplayRequestSource::MEDIA_PLAYBACK, result)) return result;
+    if (apply_most_recent(DisplayRequestSource::IDLE_TIMER,
+                          DisplayRequestSource::PRESENCE_SENSOR, result)) {
+      return result;
+    }
+    if (apply_source(DisplayRequestSource::SETUP_TIMEOUT, result)) return result;
+
+    result.target_mode = DisplayMode::ACTIVE;
+    return result;
+  }
+
+  bool complete_transition(const DisplayTransition &transition) {
+    if (!generation_is_current(transition.generation)) return false;
+    const DisplayTransition current = resolve();
+    if (transition.target_mode != current.target_mode ||
+        transition.winning_source != current.winning_source ||
+        transition.winning_takeover != current.winning_takeover) {
+      return false;
+    }
+    current_mode_ = transition.target_mode;
+    return true;
+  }
+
+  bool generation_is_current(uint32_t generation) const {
+    return generation != 0 && generation == generation_;
+  }
+
+  uint32_t generation() const { return generation_; }
+  DisplayMode current_mode() const { return current_mode_; }
+
+  static bool request_is_valid(DisplayRequestSource source, DisplayMode mode) {
+    switch (source) {
+      case DisplayRequestSource::BOOT_GUARD:
+      case DisplayRequestSource::MANUAL_SLEEP:
+        return mode == DisplayMode::DISPLAY_OFF;
+      case DisplayRequestSource::USER_WAKE:
+        return mode == DisplayMode::ACTIVE;
+      case DisplayRequestSource::MEDIA_PLAYBACK:
+        return mode == DisplayMode::COVER_ART;
+      case DisplayRequestSource::SETUP_TIMEOUT:
+        return mode == DisplayMode::SETUP_DIMMED;
+      case DisplayRequestSource::SCREEN_SCHEDULE:
+        return mode == DisplayMode::ACTIVE || mode == DisplayMode::CLOCK ||
+               mode == DisplayMode::DISPLAY_OFF;
+      case DisplayRequestSource::IDLE_TIMER:
+      case DisplayRequestSource::PRESENCE_SENSOR:
+        return mode == DisplayMode::DIMMED || mode == DisplayMode::CLOCK ||
+               mode == DisplayMode::DISPLAY_OFF;
+    }
+    return false;
+  }
+
+ private:
+  struct Request {
+    DisplayMode mode{DisplayMode::ACTIVE};
+    uint32_t sequence{0};
+    bool active{false};
+  };
+
+  static constexpr std::size_t kRequestCount = 8;
+  static constexpr std::size_t kTakeoverCount = 2;
+
+  static constexpr std::size_t source_index(DisplayRequestSource source) {
+    return static_cast<std::size_t>(source);
+  }
+
+  static constexpr std::size_t takeover_index(DisplayTakeoverKind kind) {
+    return static_cast<std::size_t>(kind);
+  }
+
+  bool apply_source(DisplayRequestSource source, DisplayTransition &result) const {
+    const Request &entry = requests_[source_index(source)];
+    if (!entry.active) return false;
+    result.target_mode = entry.mode;
+    result.winning_source = source;
+    return true;
+  }
+
+  bool apply_most_recent(DisplayRequestSource first,
+                         DisplayRequestSource second,
+                         DisplayTransition &result) const {
+    const Request &a = requests_[source_index(first)];
+    const Request &b = requests_[source_index(second)];
+    if (!a.active && !b.active) return false;
+    return apply_source(!b.active || (a.active && a.sequence >= b.sequence) ? first : second,
+                        result);
+  }
+
+  void advance_generation() {
+    ++generation_;
+    if (generation_ == 0) ++generation_;
+  }
+
+  std::array<Request, kRequestCount> requests_{};
+  std::array<uint16_t, kTakeoverCount> takeover_depth_{};
+  uint32_t sequence_{0};
+  uint32_t generation_{1};
+  DisplayMode current_mode_{DisplayMode::ACTIVE};
+};
+
+struct LegacyDisplayState {
+  bool display_asleep{false};
+  bool screen_schedule_asleep{false};
+  bool backlight_manual_off{false};
+  bool temporary_user_wake{false};
+  bool display_off_active{false};
+  bool dimmed_active{false};
+  bool clock_showing{false};
+  bool cover_art_active{false};
+  bool interactive_takeover{false};
+  bool critical_takeover{false};
+  bool setup_screen{false};
+};
+
+struct LegacyModeResult {
+  DisplayMode mode{DisplayMode::ACTIVE};
+  bool stable{true};
+};
+
+inline LegacyModeResult derive_legacy_display_mode(const LegacyDisplayState &state) {
+  if (state.critical_takeover || state.interactive_takeover) {
+    const bool clean = !state.display_asleep && !state.display_off_active &&
+                       !state.dimmed_active && !state.clock_showing &&
+                       !state.cover_art_active;
+    return {DisplayMode::ACTIVE, clean};
+  }
+
+  const unsigned visible_count = static_cast<unsigned>(state.display_off_active) +
+                                 static_cast<unsigned>(state.dimmed_active) +
+                                 static_cast<unsigned>(state.clock_showing) +
+                                 static_cast<unsigned>(state.cover_art_active);
+  const bool presentation_consistent = visible_count <= 1 &&
+      (visible_count == 0 || state.display_asleep);
+
+  if (state.display_off_active) return {DisplayMode::DISPLAY_OFF, presentation_consistent};
+  if (state.dimmed_active) return {DisplayMode::DIMMED, presentation_consistent};
+  if (state.clock_showing) return {DisplayMode::CLOCK, presentation_consistent};
+  if (state.cover_art_active) return {DisplayMode::COVER_ART, presentation_consistent};
+  if (state.display_asleep && state.setup_screen) return {DisplayMode::SETUP_DIMMED, true};
+  if (state.display_asleep) return {DisplayMode::SETUP_DIMMED, false};
+  return {DisplayMode::ACTIVE, presentation_consistent};
+}
+
+inline const char *display_mode_name(DisplayMode mode) {
+  switch (mode) {
+    case DisplayMode::ACTIVE: return "active";
+    case DisplayMode::SETUP_DIMMED: return "setup_dimmed";
+    case DisplayMode::DIMMED: return "dimmed";
+    case DisplayMode::CLOCK: return "clock";
+    case DisplayMode::COVER_ART: return "cover_art";
+    case DisplayMode::DISPLAY_OFF: return "display_off";
+  }
+  return "unknown";
+}
+
+struct DisplayShadowObservation {
+  DisplayTransition decision;
+  LegacyModeResult legacy;
+  bool decision_changed{false};
+  bool mismatch{false};
+  bool mismatch_changed{false};
+};
+
+class DisplayModeShadowObserver {
+ public:
+  DisplayShadowObservation observe(const LegacyDisplayState &state,
+                                   bool presence_owned_sleep = false,
+                                   bool boot_guard_active = false,
+                                   bool schedule_active_ui = false) {
+    set_takeover(DisplayTakeoverKind::CRITICAL, state.critical_takeover,
+                 critical_takeover_active_);
+    set_takeover(DisplayTakeoverKind::INTERACTIVE, state.interactive_takeover,
+                 interactive_takeover_active_);
+
+    set_request(DisplayRequestSource::MANUAL_SLEEP, state.backlight_manual_off,
+                DisplayMode::DISPLAY_OFF);
+    set_request(DisplayRequestSource::USER_WAKE, state.temporary_user_wake,
+                DisplayMode::ACTIVE);
+    set_request(DisplayRequestSource::BOOT_GUARD, boot_guard_active,
+                DisplayMode::DISPLAY_OFF);
+
+    const bool schedule_visible = state.screen_schedule_asleep &&
+                                  (state.display_off_active || state.clock_showing);
+    const DisplayMode schedule_mode = state.clock_showing ? DisplayMode::CLOCK
+                                                          : DisplayMode::DISPLAY_OFF;
+    set_request(DisplayRequestSource::SCREEN_SCHEDULE,
+                schedule_visible || schedule_active_ui,
+                schedule_active_ui ? DisplayMode::ACTIVE : schedule_mode);
+    set_request(DisplayRequestSource::MEDIA_PLAYBACK, state.cover_art_active,
+                DisplayMode::COVER_ART);
+
+    const bool automatic_sleep = state.display_asleep && !state.screen_schedule_asleep &&
+                                 !state.backlight_manual_off && !state.cover_art_active &&
+                                 (state.display_off_active || state.dimmed_active ||
+                                  state.clock_showing);
+    DisplayMode automatic_mode = DisplayMode::DISPLAY_OFF;
+    if (state.dimmed_active) automatic_mode = DisplayMode::DIMMED;
+    if (state.clock_showing) automatic_mode = DisplayMode::CLOCK;
+    set_request(DisplayRequestSource::PRESENCE_SENSOR,
+                automatic_sleep && presence_owned_sleep, automatic_mode);
+    set_request(DisplayRequestSource::IDLE_TIMER,
+                automatic_sleep && !presence_owned_sleep, automatic_mode);
+    set_request(DisplayRequestSource::SETUP_TIMEOUT,
+                state.display_asleep && state.setup_screen,
+                DisplayMode::SETUP_DIMMED);
+
+    DisplayShadowObservation observation;
+    observation.decision = controller_.resolve();
+    observation.legacy = derive_legacy_display_mode(state);
+    observation.mismatch = !observation.legacy.stable ||
+                           observation.decision.target_mode != observation.legacy.mode;
+    observation.decision_changed = !has_previous_decision_ ||
+        observation.decision.target_mode != previous_mode_ ||
+        observation.decision.winning_source != previous_source_ ||
+        observation.decision.winning_takeover != previous_takeover_;
+    observation.mismatch_changed = !has_previous_decision_ ||
+        observation.mismatch != previous_mismatch_ ||
+        observation.legacy.mode != previous_legacy_mode_ ||
+        observation.legacy.stable != previous_legacy_stable_;
+
+    previous_mode_ = observation.decision.target_mode;
+    previous_source_ = observation.decision.winning_source;
+    previous_takeover_ = observation.decision.winning_takeover;
+    previous_mismatch_ = observation.mismatch;
+    previous_legacy_mode_ = observation.legacy.mode;
+    previous_legacy_stable_ = observation.legacy.stable;
+    has_previous_decision_ = true;
+    controller_.complete_transition(observation.decision);
+    return observation;
+  }
+
+ private:
+  void set_request(DisplayRequestSource source, bool active, DisplayMode mode) {
+    if (active) {
+      controller_.request(source, mode);
+    } else {
+      controller_.clear(source);
+    }
+  }
+
+  void set_takeover(DisplayTakeoverKind kind, bool active, bool &tracked) {
+    if (active == tracked) return;
+    if (active) {
+      controller_.begin_takeover(kind);
+    } else {
+      controller_.end_takeover(kind);
+    }
+    tracked = active;
+  }
+
+  DisplayModeController controller_;
+  bool critical_takeover_active_{false};
+  bool interactive_takeover_active_{false};
+  bool has_previous_decision_{false};
+  DisplayMode previous_mode_{DisplayMode::ACTIVE};
+  std::optional<DisplayRequestSource> previous_source_;
+  std::optional<DisplayTakeoverKind> previous_takeover_;
+  bool previous_mismatch_{false};
+  DisplayMode previous_legacy_mode_{DisplayMode::ACTIVE};
+  bool previous_legacy_stable_{true};
+};
+
+inline const char *display_request_source_name(
+    const std::optional<DisplayRequestSource> &source) {
+  if (!source) return "default";
+  switch (*source) {
+    case DisplayRequestSource::BOOT_GUARD: return "boot_guard";
+    case DisplayRequestSource::IDLE_TIMER: return "idle_timer";
+    case DisplayRequestSource::PRESENCE_SENSOR: return "presence_sensor";
+    case DisplayRequestSource::SCREEN_SCHEDULE: return "screen_schedule";
+    case DisplayRequestSource::MANUAL_SLEEP: return "manual_sleep";
+    case DisplayRequestSource::MEDIA_PLAYBACK: return "media_playback";
+    case DisplayRequestSource::SETUP_TIMEOUT: return "setup_timeout";
+    case DisplayRequestSource::USER_WAKE: return "user_wake";
+  }
+  return "unknown";
+}
+
+inline const char *display_takeover_name(
+    const std::optional<DisplayTakeoverKind> &takeover) {
+  if (!takeover) return "none";
+  return *takeover == DisplayTakeoverKind::CRITICAL ? "critical" : "interactive";
+}
+
+}  // namespace espcontrol

--- a/scripts/check_firmware_parser.py
+++ b/scripts/check_firmware_parser.py
@@ -37,6 +37,7 @@ SAVED_CONFIG_WEBHOOK_HEADER = ROOT / "components" / "espcontrol" / "button_grid_
 SAVED_CONFIG_SUBPAGE_HEADER = ROOT / "components" / "espcontrol" / "button_grid_saved_config_subpage_generated.h"
 SAVED_CONFIG_SWITCH_HEADER = ROOT / "components" / "espcontrol" / "button_grid_saved_config_switch_generated.h"
 BACKLIGHT_HEADER = ROOT / "components" / "espcontrol" / "backlight.h"
+DISPLAY_MODE_CONTROLLER_HEADER = ROOT / "components" / "espcontrol" / "display_mode_controller.h"
 CLOCK_BAR_HEADER = ROOT / "components" / "espcontrol" / "clock_bar.h"
 LAYOUT_HEADER = ROOT / "components" / "espcontrol" / "button_grid_layout.h"
 LIMITS_HEADER = ROOT / "components" / "espcontrol" / "button_grid_limits.h"
@@ -733,6 +734,7 @@ def main() -> int:
         shutil.copy2(SAVED_CONFIG_SWITCH_HEADER, tmp_path / "button_grid_saved_config_switch_generated.h")
         shutil.copy2(CLOCK_BAR_HEADER, tmp_path / "clock_bar.h")
         shutil.copy2(BACKLIGHT_HEADER, tmp_path / "backlight.h")
+        shutil.copy2(DISPLAY_MODE_CONTROLLER_HEADER, tmp_path / "display_mode_controller.h")
         shutil.copy2(LAYOUT_HEADER, tmp_path / "button_grid_layout.h")
         shutil.copy2(LIMITS_HEADER, tmp_path / "button_grid_limits.h")
         shutil.copy2(STRING_HEADER, tmp_path / "button_grid_string.h")

--- a/tests/firmware/CMakeLists.txt
+++ b/tests/firmware/CMakeLists.txt
@@ -17,6 +17,12 @@ target_include_directories(button_grid_foundations_test PRIVATE
 )
 add_test(NAME button_grid_foundations_test COMMAND button_grid_foundations_test)
 
+add_executable(display_mode_controller_test display_mode_controller_test.cpp)
+target_compile_features(display_mode_controller_test PRIVATE cxx_std_17)
+target_compile_options(display_mode_controller_test PRIVATE -Wall -Wextra -Werror)
+target_include_directories(display_mode_controller_test PRIVATE ../../components/espcontrol)
+add_test(NAME display_mode_controller_test COMMAND display_mode_controller_test)
+
 add_executable(ha_read_coordinator_test ha_read_coordinator_test.cpp)
 target_compile_features(ha_read_coordinator_test PRIVATE cxx_std_17)
 target_compile_options(ha_read_coordinator_test PRIVATE -Wall -Wextra -Werror)

--- a/tests/firmware/display_mode_controller_test.cpp
+++ b/tests/firmware/display_mode_controller_test.cpp
@@ -1,0 +1,193 @@
+#include <cstdlib>
+
+#include "display_mode_controller.h"
+
+using namespace espcontrol;
+
+#define CHECK(condition) do { if (!(condition)) return EXIT_FAILURE; } while (false)
+
+static bool decision_is(const DisplayModeController &controller, DisplayMode mode,
+                        std::optional<DisplayRequestSource> source = std::nullopt,
+                        std::optional<DisplayTakeoverKind> takeover = std::nullopt) {
+  const auto decision = controller.resolve();
+  return decision.target_mode == mode && decision.winning_source == source &&
+         decision.winning_takeover == takeover;
+}
+
+static void activate_priority(DisplayModeController &controller, int priority) {
+  switch (priority) {
+    case 1: controller.begin_takeover(DisplayTakeoverKind::CRITICAL); break;
+    case 2: controller.request(DisplayRequestSource::MANUAL_SLEEP, DisplayMode::DISPLAY_OFF); break;
+    case 3: controller.request(DisplayRequestSource::USER_WAKE, DisplayMode::ACTIVE); break;
+    case 4: controller.request(DisplayRequestSource::SCREEN_SCHEDULE, DisplayMode::CLOCK); break;
+    case 5: controller.begin_takeover(DisplayTakeoverKind::INTERACTIVE); break;
+    case 6: controller.request(DisplayRequestSource::MEDIA_PLAYBACK, DisplayMode::COVER_ART); break;
+    case 7: controller.request(DisplayRequestSource::IDLE_TIMER, DisplayMode::DIMMED); break;
+    case 8: controller.request(DisplayRequestSource::SETUP_TIMEOUT, DisplayMode::SETUP_DIMMED); break;
+    default: break;
+  }
+}
+
+static DisplayMode expected_mode_for_priority(int priority) {
+  const DisplayMode modes[] = {
+      DisplayMode::ACTIVE, DisplayMode::ACTIVE, DisplayMode::DISPLAY_OFF,
+      DisplayMode::ACTIVE, DisplayMode::CLOCK, DisplayMode::ACTIVE,
+      DisplayMode::COVER_ART, DisplayMode::DIMMED, DisplayMode::SETUP_DIMMED};
+  return modes[priority];
+}
+
+int main() {
+  DisplayModeController controller;
+  CHECK(decision_is(controller, DisplayMode::ACTIVE));
+
+  // Every higher-priority policy beats every lower-priority policy.
+  for (int higher = 1; higher <= 8; ++higher) {
+    for (int lower = higher + 1; lower <= 9; ++lower) {
+      DisplayModeController pair;
+      activate_priority(pair, lower);
+      activate_priority(pair, higher);
+      CHECK(pair.resolve().target_mode == expected_mode_for_priority(higher));
+    }
+  }
+
+  CHECK(controller.request(DisplayRequestSource::SETUP_TIMEOUT, DisplayMode::SETUP_DIMMED));
+  CHECK(decision_is(controller, DisplayMode::SETUP_DIMMED,
+                    DisplayRequestSource::SETUP_TIMEOUT));
+  CHECK(controller.request(DisplayRequestSource::IDLE_TIMER, DisplayMode::CLOCK));
+  CHECK(decision_is(controller, DisplayMode::CLOCK, DisplayRequestSource::IDLE_TIMER));
+  CHECK(controller.request(DisplayRequestSource::PRESENCE_SENSOR, DisplayMode::DIMMED));
+  CHECK(decision_is(controller, DisplayMode::DIMMED,
+                    DisplayRequestSource::PRESENCE_SENSOR));
+  CHECK(controller.request(DisplayRequestSource::MEDIA_PLAYBACK, DisplayMode::COVER_ART));
+  CHECK(decision_is(controller, DisplayMode::COVER_ART,
+                    DisplayRequestSource::MEDIA_PLAYBACK));
+
+  CHECK(controller.begin_takeover(DisplayTakeoverKind::INTERACTIVE));
+  CHECK(decision_is(controller, DisplayMode::ACTIVE, std::nullopt,
+                    DisplayTakeoverKind::INTERACTIVE));
+  CHECK(controller.request(DisplayRequestSource::SCREEN_SCHEDULE, DisplayMode::CLOCK));
+  CHECK(decision_is(controller, DisplayMode::CLOCK,
+                    DisplayRequestSource::SCREEN_SCHEDULE));
+  CHECK(controller.request(DisplayRequestSource::USER_WAKE, DisplayMode::ACTIVE));
+  CHECK(decision_is(controller, DisplayMode::ACTIVE, DisplayRequestSource::USER_WAKE));
+  CHECK(controller.request(DisplayRequestSource::MANUAL_SLEEP, DisplayMode::DISPLAY_OFF));
+  CHECK(decision_is(controller, DisplayMode::DISPLAY_OFF,
+                    DisplayRequestSource::MANUAL_SLEEP));
+
+  CHECK(controller.begin_takeover(DisplayTakeoverKind::CRITICAL));
+  CHECK(decision_is(controller, DisplayMode::ACTIVE, std::nullopt,
+                    DisplayTakeoverKind::CRITICAL));
+  CHECK(controller.end_takeover(DisplayTakeoverKind::CRITICAL));
+  CHECK(decision_is(controller, DisplayMode::DISPLAY_OFF,
+                    DisplayRequestSource::MANUAL_SLEEP));
+  CHECK(controller.clear(DisplayRequestSource::MANUAL_SLEEP));
+  CHECK(decision_is(controller, DisplayMode::ACTIVE, DisplayRequestSource::USER_WAKE));
+  CHECK(controller.clear(DisplayRequestSource::USER_WAKE));
+  CHECK(decision_is(controller, DisplayMode::CLOCK,
+                    DisplayRequestSource::SCREEN_SCHEDULE));
+  CHECK(controller.clear(DisplayRequestSource::SCREEN_SCHEDULE));
+  CHECK(decision_is(controller, DisplayMode::ACTIVE, std::nullopt,
+                    DisplayTakeoverKind::INTERACTIVE));
+  CHECK(controller.end_takeover(DisplayTakeoverKind::INTERACTIVE));
+  CHECK(decision_is(controller, DisplayMode::COVER_ART,
+                    DisplayRequestSource::MEDIA_PLAYBACK));
+
+  // Boot guard is the schedule-level fail-dark request and rejects invalid time.
+  CHECK(controller.request(DisplayRequestSource::BOOT_GUARD, DisplayMode::DISPLAY_OFF));
+  CHECK(decision_is(controller, DisplayMode::DISPLAY_OFF,
+                    DisplayRequestSource::BOOT_GUARD));
+  CHECK(!controller.request(DisplayRequestSource::BOOT_GUARD, DisplayMode::CLOCK));
+  CHECK(controller.clear(DisplayRequestSource::BOOT_GUARD));
+
+  // Every request source accepts its documented mode and returns to default
+  // after its clear path when tested independently.
+  struct SourceMode { DisplayRequestSource source; DisplayMode mode; };
+  const SourceMode clear_paths[] = {
+      {DisplayRequestSource::BOOT_GUARD, DisplayMode::DISPLAY_OFF},
+      {DisplayRequestSource::IDLE_TIMER, DisplayMode::DIMMED},
+      {DisplayRequestSource::PRESENCE_SENSOR, DisplayMode::CLOCK},
+      {DisplayRequestSource::SCREEN_SCHEDULE, DisplayMode::ACTIVE},
+      {DisplayRequestSource::MANUAL_SLEEP, DisplayMode::DISPLAY_OFF},
+      {DisplayRequestSource::MEDIA_PLAYBACK, DisplayMode::COVER_ART},
+      {DisplayRequestSource::SETUP_TIMEOUT, DisplayMode::SETUP_DIMMED},
+      {DisplayRequestSource::USER_WAKE, DisplayMode::ACTIVE},
+  };
+  for (const auto &path : clear_paths) {
+    DisplayModeController isolated;
+    CHECK(isolated.request(path.source, path.mode));
+    CHECK(isolated.resolve().winning_source == path.source);
+    CHECK(isolated.clear(path.source));
+    CHECK(decision_is(isolated, DisplayMode::ACTIVE));
+  }
+
+  // Each effective change invalidates older delayed work, including cover-art work.
+  const DisplayTransition stale_cover_art = controller.resolve();
+  CHECK(controller.clear(DisplayRequestSource::MEDIA_PLAYBACK));
+  CHECK(!controller.complete_transition(stale_cover_art));
+  const DisplayTransition idle_transition = controller.resolve();
+  CHECK(controller.complete_transition(idle_transition));
+  CHECK(controller.current_mode() == DisplayMode::DIMMED);
+  CHECK(!controller.clear(DisplayRequestSource::MEDIA_PLAYBACK));
+  CHECK(!controller.request(DisplayRequestSource::PRESENCE_SENSOR, DisplayMode::DIMMED));
+
+  DisplayModeController rapid;
+  CHECK(rapid.request(DisplayRequestSource::SCREEN_SCHEDULE, DisplayMode::DISPLAY_OFF));
+  const auto off_generation = rapid.resolve();
+  CHECK(rapid.request(DisplayRequestSource::SCREEN_SCHEDULE, DisplayMode::CLOCK));
+  const auto clock_generation = rapid.resolve();
+  CHECK(clock_generation.generation > off_generation.generation);
+  CHECK(!rapid.complete_transition(off_generation));
+  CHECK(rapid.complete_transition(clock_generation));
+
+  // Nested takeovers only finish when every owner has ended its takeover.
+  CHECK(controller.begin_takeover(DisplayTakeoverKind::INTERACTIVE));
+  CHECK(controller.begin_takeover(DisplayTakeoverKind::INTERACTIVE));
+  CHECK(controller.end_takeover(DisplayTakeoverKind::INTERACTIVE));
+  CHECK(controller.takeover_active(DisplayTakeoverKind::INTERACTIVE));
+  CHECK(controller.end_takeover(DisplayTakeoverKind::INTERACTIVE));
+  CHECK(!controller.end_takeover(DisplayTakeoverKind::INTERACTIVE));
+
+  LegacyDisplayState legacy;
+  CHECK(derive_legacy_display_mode(legacy).mode == DisplayMode::ACTIVE);
+  legacy.display_asleep = true;
+  legacy.clock_showing = true;
+  CHECK(derive_legacy_display_mode(legacy).mode == DisplayMode::CLOCK);
+  CHECK(derive_legacy_display_mode(legacy).stable);
+  legacy.display_off_active = true;
+  CHECK(!derive_legacy_display_mode(legacy).stable);
+  legacy = {};
+  legacy.display_asleep = true;
+  CHECK(!derive_legacy_display_mode(legacy).stable);
+  legacy.setup_screen = true;
+  CHECK(derive_legacy_display_mode(legacy).stable);
+  CHECK(derive_legacy_display_mode(legacy).mode == DisplayMode::SETUP_DIMMED);
+
+  DisplayModeShadowObserver observer;
+  legacy = {};
+  auto observation = observer.observe(legacy);
+  CHECK(observation.decision_changed);
+  CHECK(!observation.mismatch);
+  observation = observer.observe(legacy);
+  CHECK(!observation.decision_changed);
+  legacy.display_asleep = true;
+  legacy.display_off_active = true;
+  observation = observer.observe(legacy);
+  CHECK(observation.decision.target_mode == DisplayMode::DISPLAY_OFF);
+  CHECK(!observation.mismatch);
+  legacy.backlight_manual_off = true;
+  legacy.temporary_user_wake = true;
+  observation = observer.observe(legacy);
+  CHECK(observation.decision.winning_source == DisplayRequestSource::MANUAL_SLEEP);
+  legacy = {};
+  legacy.critical_takeover = true;
+  observation = observer.observe(legacy);
+  CHECK(observation.decision.winning_takeover == DisplayTakeoverKind::CRITICAL);
+  legacy.critical_takeover = false;
+  legacy.cover_art_active = true;
+  legacy.display_asleep = true;
+  observation = observer.observe(legacy);
+  CHECK(observation.decision.target_mode == DisplayMode::COVER_ART);
+  CHECK(!observation.mismatch);
+
+  return EXIT_SUCCESS;
+}

--- a/tests/firmware/display_mode_controller_test.cpp
+++ b/tests/firmware/display_mode_controller_test.cpp
@@ -81,8 +81,6 @@ int main() {
   CHECK(decision_is(controller, DisplayMode::DISPLAY_OFF,
                     DisplayRequestSource::MANUAL_SLEEP));
   CHECK(controller.clear(DisplayRequestSource::MANUAL_SLEEP));
-  CHECK(decision_is(controller, DisplayMode::ACTIVE, DisplayRequestSource::USER_WAKE));
-  CHECK(controller.clear(DisplayRequestSource::USER_WAKE));
   CHECK(decision_is(controller, DisplayMode::CLOCK,
                     DisplayRequestSource::SCREEN_SCHEDULE));
   CHECK(controller.clear(DisplayRequestSource::SCREEN_SCHEDULE));
@@ -98,6 +96,21 @@ int main() {
                     DisplayRequestSource::BOOT_GUARD));
   CHECK(!controller.request(DisplayRequestSource::BOOT_GUARD, DisplayMode::CLOCK));
   CHECK(controller.clear(DisplayRequestSource::BOOT_GUARD));
+
+  // Manual sleep removes a temporary wake regardless of request order, so
+  // clearing manual sleep always re-resolves the live schedule.
+  DisplayModeController manual_sleep;
+  CHECK(manual_sleep.request(DisplayRequestSource::SCREEN_SCHEDULE, DisplayMode::CLOCK));
+  CHECK(manual_sleep.request(DisplayRequestSource::USER_WAKE, DisplayMode::ACTIVE));
+  CHECK(manual_sleep.request(DisplayRequestSource::MANUAL_SLEEP, DisplayMode::DISPLAY_OFF));
+  CHECK(manual_sleep.clear(DisplayRequestSource::MANUAL_SLEEP));
+  CHECK(decision_is(manual_sleep, DisplayMode::CLOCK,
+                    DisplayRequestSource::SCREEN_SCHEDULE));
+  CHECK(manual_sleep.request(DisplayRequestSource::MANUAL_SLEEP, DisplayMode::DISPLAY_OFF));
+  CHECK(!manual_sleep.request(DisplayRequestSource::USER_WAKE, DisplayMode::ACTIVE));
+  CHECK(manual_sleep.clear(DisplayRequestSource::MANUAL_SLEEP));
+  CHECK(decision_is(manual_sleep, DisplayMode::CLOCK,
+                    DisplayRequestSource::SCREEN_SCHEDULE));
 
   // Every request source accepts its documented mode and returns to default
   // after its clear path when tested independently.


### PR DESCRIPTION
## Summary

- Add the pure shared `DisplayModeController` defined by the display-lifecycle contract.
- Cover request priorities, clear paths, takeovers, transition completion, and stale-generation rejection with host tests.
- Run the controller in observation-only shadow mode, comparing its decision with the existing display flags and logging only decision changes or mismatches.

This is PR 2 of the sequential work for #999. Existing ESPHome scripts and compatibility flags remain authoritative; this PR does not change any public entity, API, or display effect.

## Practical impact

- Establishes one testable place for future display-mode decisions without changing what users should see today.
- Gives later migration PRs a generation check that can reject delayed work after a newer display request wins.
- Adds diagnostic shadow logs so disagreements can be found on real devices before the controller is allowed to drive effects.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- The internal lifecycle contract added in PR #1082 is the source for this implementation. No public behaviour or configuration changed.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.
- [ ] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- Shared firmware used by every supported display.
- Required physical checks: 10-inch P4 and 4-inch S3.

Automated checks completed:

- `npm run check:fast`
- Host controller tests covering every priority pairing and request-clear path
- Factory firmware compile: Guition JC1060P470
- Factory firmware compile: Guition JC4880P443
- Factory firmware compile: Guition JC8012P4A1
- Factory firmware compile: Guition JC8012P4A1 v2
- Factory firmware compile: ESP32-P4 86 Panel
- Factory firmware compile: Guition 4848S040

## Notes for testing

Please test both the 10-inch P4 and 4-inch S3 before merge:

1. Confirm normal boot and ordinary touch/navigation.
2. Exercise idle screen off, dimmed, and clock modes used by the device.
3. Exercise scheduled off/clock and temporary touch wake.
4. Exercise cover art and wake from cover art.
5. Open and close an image-style modal; confirm automatic sleep resumes correctly afterward.
6. If available, exercise alarm arming/triggered takeover.
7. Check logs for `display_mode_shadow`. Decision messages are expected when the visible mode changes; report any `Mismatch` message together with the action that produced it.

The shadow controller does not apply display effects in this PR, so visible behaviour should match `main`.

## PR status

- [ ] Checks running or waiting.
- [ ] Needs automated fix.
- [x] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.

<!-- espcontrol-pr-testing-guidance -->
## Automated testing guidance

Device testing is expected before merge because this change affects shared firmware lifecycle code. The required coverage for #999 is the 10-inch P4 and 4-inch S3, using the checks above.
