### PR TITLE
Migrate dim and clock display lifecycle

### DIFF
--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -89,6 +89,8 @@ globals:
     initial_value: 'false'
   - id: display_mode_shadow_observer
     type: espcontrol::DisplayModeShadowObserver
+  - id: display_mode_controller
+    type: espcontrol::DisplayModeController
   - id: setup_screen_dimmed_shadow_active
     type: bool
     initial_value: 'false'
@@ -152,6 +154,322 @@ esphome:
       - lambda: 'id(clock_brightness_legacy_sync_ready) = true;'
 
 script:
+  # The controller owns decisions; this adapter is the only path that applies
+  # migrated ACTIVE, SETUP_DIMMED, DIMMED, and CLOCK transitions.
+  - id: display_mode_apply_transition
+    mode: restart
+    parameters:
+      generation: int
+      target_mode: int
+      previous_mode: int
+    then:
+      - if:
+          condition:
+            lambda: |-
+              return id(display_mode_controller).transition_is_current(
+                  static_cast<uint32_t>(generation),
+                  static_cast<espcontrol::DisplayMode>(target_mode));
+          then:
+            - if:
+                condition:
+                  lambda: 'return target_mode == static_cast<int>(espcontrol::DisplayMode::ACTIVE);'
+                then:
+                  - globals.set: { id: display_asleep, value: 'false' }
+                  - globals.set: { id: screensaver_dimmed_active, value: 'false' }
+                  - globals.set: { id: setup_screen_dimmed_shadow_active, value: 'false' }
+                  - lambda: 'id(is_clock_showing) = false;'
+                  - script.execute:
+                      id: display_mode_effect_active
+                      generation: !lambda 'return generation;'
+                      previous_mode: !lambda 'return previous_mode;'
+                  - script.wait: display_mode_effect_active
+                  - if:
+                      condition:
+                        lambda: |-
+                              return id(display_mode_controller).transition_is_current(
+                                  static_cast<uint32_t>(generation), espcontrol::DisplayMode::ACTIVE);
+                      then:
+                        - lambda: |-
+                            id(display_mode_controller).complete_transition(
+                                static_cast<uint32_t>(generation), espcontrol::DisplayMode::ACTIVE);
+                else:
+                  - if:
+                      condition:
+                        lambda: 'return target_mode == static_cast<int>(espcontrol::DisplayMode::SETUP_DIMMED);'
+                      then:
+                        - globals.set: { id: display_asleep, value: 'true' }
+                        - globals.set: { id: screensaver_dimmed_active, value: 'false' }
+                        - globals.set: { id: setup_screen_dimmed_shadow_active, value: 'true' }
+                        - lambda: 'id(is_clock_showing) = false;'
+                        - script.execute:
+                            id: display_mode_effect_setup_dimmed
+                            generation: !lambda 'return generation;'
+                        - script.wait: display_mode_effect_setup_dimmed
+                        - lambda: |-
+                            id(display_mode_controller).complete_transition(
+                                static_cast<uint32_t>(generation), espcontrol::DisplayMode::SETUP_DIMMED);
+                      else:
+                        - if:
+                            condition:
+                              lambda: 'return target_mode == static_cast<int>(espcontrol::DisplayMode::DIMMED);'
+                            then:
+                              - script.execute: screensaver_dimmed_refresh_brightness
+                              - script.wait: screensaver_dimmed_refresh_brightness
+                              - if:
+                                  condition:
+                                    lambda: |-
+                                      return id(display_mode_controller).transition_is_current(
+                                          static_cast<uint32_t>(generation), espcontrol::DisplayMode::DIMMED);
+                                  then:
+                                    - globals.set: { id: display_asleep, value: 'true' }
+                                    - globals.set: { id: screen_schedule_asleep, value: 'false' }
+                                    - globals.set: { id: screensaver_display_off_active, value: 'false' }
+                                    - globals.set: { id: screensaver_dimmed_active, value: 'true' }
+                                    - globals.set: { id: setup_screen_dimmed_shadow_active, value: 'false' }
+                                    - lambda: 'id(is_clock_showing) = false;'
+                                    - script.execute:
+                                        id: show_dimmed_view
+                                        generation: !lambda 'return generation;'
+                                    - script.wait: show_dimmed_view
+                                    - lambda: |-
+                                        id(display_mode_controller).complete_transition(
+                                            static_cast<uint32_t>(generation), espcontrol::DisplayMode::DIMMED);
+                            else:
+                              - if:
+                                  condition:
+                                    lambda: 'return target_mode == static_cast<int>(espcontrol::DisplayMode::CLOCK);'
+                                  then:
+                                    - script.execute: clock_screensaver_refresh_brightness
+                                    - script.wait: clock_screensaver_refresh_brightness
+                                    - if:
+                                        condition:
+                                          lambda: |-
+                                            return id(display_mode_controller).transition_is_current(
+                                                static_cast<uint32_t>(generation), espcontrol::DisplayMode::CLOCK);
+                                        then:
+                                          - globals.set: { id: display_asleep, value: 'true' }
+                                          - globals.set: { id: screensaver_display_off_active, value: 'false' }
+                                          - globals.set: { id: screensaver_dimmed_active, value: 'false' }
+                                          - globals.set: { id: setup_screen_dimmed_shadow_active, value: 'false' }
+                                          - lambda: 'id(is_clock_showing) = true;'
+                                          - script.execute:
+                                              id: show_clock_view
+                                              generation: !lambda 'return generation;'
+                                          - script.wait: show_clock_view
+                                          - lambda: |-
+                                              id(display_mode_controller).complete_transition(
+                                                  static_cast<uint32_t>(generation), espcontrol::DisplayMode::CLOCK);
+                                  else:
+                                    # Display-off and cover-art effects remain legacy-owned until
+                                    # their staged migrations. The adapter still clears the flags
+                                    # owned by the modes migrated in this PR.
+                                    - globals.set: { id: screensaver_dimmed_active, value: 'false' }
+                                    - globals.set: { id: setup_screen_dimmed_shadow_active, value: 'false' }
+                                    - lambda: 'id(is_clock_showing) = false;'
+                                    - lvgl.widget.hide: dim_screensaver_touch_guard
+                                    - script.execute: hide_clock_view
+
+  - id: display_mode_effect_active
+    mode: restart
+    parameters:
+      generation: int
+      previous_mode: int
+    then:
+      - lvgl.resume:
+      - lvgl.widget.hide: dim_screensaver_touch_guard
+      - if:
+          condition:
+            lambda: 'return previous_mode == static_cast<int>(espcontrol::DisplayMode::CLOCK);'
+          then:
+            - script.execute: clock_bar_apply
+            - if:
+                condition:
+                  lambda: 'return lv_scr_act() == id(screen_off_page)->obj;'
+                then:
+                  - script.execute: navigate_after_api
+            - script.execute: backlight_apply_brightness
+            - delay: 300ms
+            - lambda: |-
+                if (!id(display_mode_controller).transition_is_current(
+                      static_cast<uint32_t>(generation), espcontrol::DisplayMode::ACTIVE)) {
+                  id(display_mode_effect_active).stop();
+                }
+            - script.execute: hide_clock_view
+          else:
+            - script.execute: hide_clock_view
+            - delay: 100ms
+            - lambda: |-
+                if (!id(display_mode_controller).transition_is_current(
+                      static_cast<uint32_t>(generation), espcontrol::DisplayMode::ACTIVE)) {
+                  id(display_mode_effect_active).stop();
+                }
+            - if:
+                condition:
+                  lambda: 'return lv_scr_act() == id(screen_off_page)->obj;'
+                then:
+                  - script.execute: navigate_after_api
+            - delay: 50ms
+            - lambda: |-
+                if (!id(display_mode_controller).transition_is_current(
+                      static_cast<uint32_t>(generation), espcontrol::DisplayMode::ACTIVE)) {
+                  id(display_mode_effect_active).stop();
+                }
+            - script.execute: clock_bar_apply
+            - script.execute: backlight_apply_brightness
+
+  - id: display_mode_effect_setup_dimmed
+    mode: restart
+    parameters:
+      generation: int
+    then:
+      - if:
+          condition:
+            lambda: |-
+              return id(display_mode_controller).transition_is_current(
+                  static_cast<uint32_t>(generation), espcontrol::DisplayMode::SETUP_DIMMED);
+          then:
+            - light.turn_on:
+                id: display_backlight
+                brightness: 50%
+                transition_length: 2s
+
+  # Mirror sources scheduled for later PRs so their established priority still
+  # blocks migrated effects. Only migrated request sources are changed outside
+  # this reconciliation point.
+  - id: display_mode_reconcile
+    mode: restart
+    then:
+      - lambda: |-
+          auto &controller = id(display_mode_controller);
+          auto set_request = [&controller](espcontrol::DisplayRequestSource source,
+                                           bool active,
+                                           espcontrol::DisplayMode mode) {
+            if (active) controller.request(source, mode);
+            else controller.clear(source);
+          };
+
+          auto now = panel_time_or_fallback(id(panel_time).now(), id(homeassistant_time).now());
+          const bool waiting_for_time = screen_schedule_waiting_for_time(
+              id(screen_schedule_trigger).state, id(schedule_enabled).state, now.is_valid());
+
+          set_request(espcontrol::DisplayRequestSource::BOOT_GUARD, waiting_for_time,
+                      espcontrol::DisplayMode::DISPLAY_OFF);
+          set_request(espcontrol::DisplayRequestSource::MANUAL_SLEEP,
+                      id(backlight_manual_off), espcontrol::DisplayMode::DISPLAY_OFF);
+          set_request(espcontrol::DisplayRequestSource::USER_WAKE,
+                      id(manual_wake_ms) != 0, espcontrol::DisplayMode::ACTIVE);
+          // The existing schedule scripts remain authoritative until PR 4.
+          // Mirroring their compatibility marker preserves priority without
+          // moving schedule calculation into this migration early.
+          if (id(screen_schedule_asleep)) {
+            const auto schedule_mode = id(schedule_mode_always_on)
+                ? espcontrol::DisplayMode::ACTIVE
+                : (id(schedule_mode_clock) ? espcontrol::DisplayMode::CLOCK
+                                           : espcontrol::DisplayMode::DISPLAY_OFF);
+            controller.request(espcontrol::DisplayRequestSource::SCREEN_SCHEDULE,
+                               schedule_mode);
+          } else {
+            controller.clear(espcontrol::DisplayRequestSource::SCREEN_SCHEDULE);
+          }
+          set_request(espcontrol::DisplayRequestSource::MEDIA_PLAYBACK,
+                      id(cover_art_screensaver_active), espcontrol::DisplayMode::COVER_ART);
+
+          const bool interactive = id(display_takeover_suspended);
+          if (interactive != controller.takeover_active(
+                                 espcontrol::DisplayTakeoverKind::INTERACTIVE)) {
+            if (interactive) controller.begin_takeover(
+                espcontrol::DisplayTakeoverKind::INTERACTIVE);
+            else controller.end_takeover(espcontrol::DisplayTakeoverKind::INTERACTIVE);
+          }
+          const bool critical = alarm_display_takeover_active();
+          if (critical != controller.takeover_active(
+                              espcontrol::DisplayTakeoverKind::CRITICAL)) {
+            if (critical) controller.begin_takeover(espcontrol::DisplayTakeoverKind::CRITICAL);
+            else controller.end_takeover(espcontrol::DisplayTakeoverKind::CRITICAL);
+          }
+
+          const auto transition = controller.resolve();
+          const bool migrated_target =
+              transition.target_mode == espcontrol::DisplayMode::ACTIVE ||
+              transition.target_mode == espcontrol::DisplayMode::SETUP_DIMMED ||
+              transition.target_mode == espcontrol::DisplayMode::DIMMED ||
+              transition.target_mode == espcontrol::DisplayMode::CLOCK;
+
+          bool compatibility_mismatch = false;
+          switch (transition.target_mode) {
+            case espcontrol::DisplayMode::ACTIVE:
+              compatibility_mismatch = id(display_asleep) ||
+                  id(screensaver_dimmed_active) || id(is_clock_showing);
+              break;
+            case espcontrol::DisplayMode::SETUP_DIMMED:
+              compatibility_mismatch = !id(display_asleep) ||
+                  !id(setup_screen_dimmed_shadow_active);
+              break;
+            case espcontrol::DisplayMode::DIMMED:
+              compatibility_mismatch = !id(display_asleep) ||
+                  !id(screensaver_dimmed_active) || id(is_clock_showing);
+              break;
+            case espcontrol::DisplayMode::CLOCK:
+              compatibility_mismatch = !id(display_asleep) ||
+                  id(screensaver_dimmed_active) || !id(is_clock_showing);
+              break;
+            case espcontrol::DisplayMode::COVER_ART:
+            case espcontrol::DisplayMode::DISPLAY_OFF:
+              compatibility_mismatch = id(screensaver_dimmed_active) ||
+                  id(setup_screen_dimmed_shadow_active) || id(is_clock_showing);
+              break;
+            default:
+              break;
+          }
+          if ((!migrated_target || !controller.transition_required(transition)) &&
+              !compatibility_mismatch) return;
+          id(display_mode_apply_transition).execute(
+              static_cast<int32_t>(transition.generation),
+              static_cast<int32_t>(transition.target_mode),
+              static_cast<int32_t>(transition.previous_mode));
+
+  - id: display_mode_request_automatic
+    mode: restart
+    parameters:
+      target_mode: int
+    then:
+      - lambda: |-
+          auto &controller = id(display_mode_controller);
+          const auto source = id(screensaver_sensor_sleep_pending)
+              ? espcontrol::DisplayRequestSource::PRESENCE_SENSOR
+              : espcontrol::DisplayRequestSource::IDLE_TIMER;
+          const auto other = source == espcontrol::DisplayRequestSource::PRESENCE_SENSOR
+              ? espcontrol::DisplayRequestSource::IDLE_TIMER
+              : espcontrol::DisplayRequestSource::PRESENCE_SENSOR;
+          controller.clear(other);
+          controller.request(source, static_cast<espcontrol::DisplayMode>(target_mode));
+      - script.execute: display_mode_reconcile
+
+  - id: display_mode_clear_automatic
+    mode: restart
+    then:
+      - lambda: |-
+          id(display_mode_controller).clear(espcontrol::DisplayRequestSource::IDLE_TIMER);
+          id(display_mode_controller).clear(espcontrol::DisplayRequestSource::PRESENCE_SENSOR);
+      - script.execute: display_mode_reconcile
+
+  - id: display_mode_request_setup_dimmed
+    mode: restart
+    then:
+      - lambda: |-
+          id(display_mode_controller).request(
+              espcontrol::DisplayRequestSource::SETUP_TIMEOUT,
+              espcontrol::DisplayMode::SETUP_DIMMED);
+      - script.execute: display_mode_reconcile
+
+  - id: display_mode_clear_setup_dimmed
+    mode: restart
+    then:
+      - lambda: |-
+          id(display_mode_controller).clear(
+              espcontrol::DisplayRequestSource::SETUP_TIMEOUT);
+      - script.execute: display_mode_reconcile
+
   # Single ownership point for camera/image modal takeover. Keeping this here
   # prevents every device slot from reaching into cover-art internals directly.
   - id: display_takeover_suspend
@@ -172,21 +490,21 @@ script:
       - script.stop: show_dimmed_view
       - script.stop: clock_screensaver_refresh_brightness
       - script.stop: screensaver_dimmed_refresh_brightness
-      - globals.set: { id: display_asleep, value: 'false' }
       - globals.set: { id: cover_art_screensaver_active, value: 'false' }
       - globals.set: { id: screensaver_display_off_active, value: 'false' }
-      - globals.set: { id: screensaver_dimmed_active, value: 'false' }
       - lvgl.widget.hide: cover_art_screensaver
       - lvgl.widget.hide: cover_art_accent_overlay
       - lvgl.widget.hide: cover_art_track_panel
       - lvgl.widget.hide: cover_art_progress_bar
       - lvgl.widget.hide: dim_screensaver_touch_guard
-      - script.execute: backlight_apply_brightness
+      - script.execute: display_mode_reconcile
+      - script.wait: display_mode_apply_transition
 
   - id: display_takeover_resume
     mode: restart
     then:
       - globals.set: { id: display_takeover_suspended, value: 'false' }
+      - script.execute: display_mode_reconcile
       - script.execute: display_takeover_resume_restore
 
   # Screensaver idle timer (restartable)
@@ -272,18 +590,22 @@ script:
                             condition:
                               lambda: 'return id(screensaver_action_clock);'
                             then:
-                              - globals.set:
-                                  id: display_asleep
-                                  value: 'true'
-                              - script.execute: show_clock_view
+                              - script.execute:
+                                  id: display_mode_request_automatic
+                                  target_mode: !lambda 'return static_cast<int>(espcontrol::DisplayMode::CLOCK);'
                             else:
                               - script.execute: hide_cover_art_view
                               - if:
                                   condition:
                                     lambda: 'return id(screensaver_action_dimmed);'
                                   then:
-                                    - script.execute: show_dimmed_view
+                                    - script.execute:
+                                        id: display_mode_request_automatic
+                                        target_mode: !lambda 'return static_cast<int>(espcontrol::DisplayMode::DIMMED);'
                                   else:
+                                    - script.execute:
+                                        id: display_mode_request_automatic
+                                        target_mode: !lambda 'return static_cast<int>(espcontrol::DisplayMode::DISPLAY_OFF);'
                                     - script.execute: screensaver_sleep_display_off
                 else:
                   - lambda: 'ESP_LOGD("screensaver", "Skipping automatic sleep while image modal is active");'
@@ -501,9 +823,6 @@ script:
                 id: screensaver_display_off_active
                 value: 'true'
             - globals.set:
-                id: screensaver_dimmed_active
-                value: 'false'
-            - globals.set:
                 id: cover_art_screensaver_active
                 value: 'false'
             - lvgl.resume:
@@ -537,9 +856,6 @@ script:
             - script.stop: cover_art_delay_timer
             - script.execute: hide_cover_art_view
             - script.execute: hide_clock_view
-            - globals.set:
-                id: screensaver_dimmed_active
-                value: 'false'
             - lvgl.widget.hide: dim_screensaver_touch_guard
             - lvgl.page.show: screen_off_page
             - script.execute: clock_bar_hide
@@ -571,6 +887,7 @@ script:
       - globals.set:
           id: manual_wake_ms
           value: '0'
+      - script.execute: display_mode_reconcile
       - script.execute: backlight_schedule_display_off
 
   # Setup screen burn-in protection
@@ -578,23 +895,12 @@ script:
     mode: restart
     then:
       - script.stop: setup_screen_dim
-      - if:
-          condition:
-            lambda: 'return id(setup_screen_dimmed_shadow_active);'
-          then:
-            - globals.set:
-                id: display_asleep
-                value: 'false'
-      - globals.set:
-          id: setup_screen_dimmed_shadow_active
-          value: 'false'
+      - script.execute: display_mode_clear_setup_dimmed
 
   - id: setup_screen_dim
     mode: restart
     then:
-      - globals.set:
-          id: setup_screen_dimmed_shadow_active
-          value: 'false'
+      - script.execute: display_mode_clear_setup_dimmed
       - delay: 120s
       - if:
           condition:
@@ -608,16 +914,7 @@ script:
           then:
             - script.execute: backlight_force_display_off
           else:
-            - globals.set:
-                id: setup_screen_dimmed_shadow_active
-                value: 'true'
-            - globals.set:
-                id: display_asleep
-                value: 'true'
-            - light.turn_on:
-                id: display_backlight
-                brightness: 50%
-                transition_length: 2s
+            - script.execute: display_mode_request_setup_dimmed
 
   # Home screen return timer (restartable)
   - id: home_screen_idle_check
@@ -720,6 +1017,9 @@ script:
       - script.stop: cover_art_delay_timer
       - script.stop: cover_art_show_track_overlay
       - lambda: |-
+          id(display_mode_controller).clear(espcontrol::DisplayRequestSource::IDLE_TIMER);
+          id(display_mode_controller).clear(espcontrol::DisplayRequestSource::PRESENCE_SENSOR);
+          id(display_mode_controller).clear(espcontrol::DisplayRequestSource::SETUP_TIMEOUT);
           id(backlight_manual_off) = false;
           if (id(schedule_enabled).state) {
             auto now = panel_time_or_fallback(id(panel_time).now(), id(homeassistant_time).now());
@@ -784,9 +1084,6 @@ script:
                 id: screensaver_display_off_active
                 value: 'false'
             - globals.set:
-                id: screensaver_dimmed_active
-                value: 'false'
-            - globals.set:
                 id: cover_art_screensaver_active
                 value: 'false'
             - globals.set:
@@ -795,39 +1092,9 @@ script:
             - globals.set:
                 id: backlight_force_next_write
                 value: 'true'
-            - lvgl.resume:
-            - lvgl.widget.hide: dim_screensaver_touch_guard
             - script.execute: hide_cover_art_view
-            - if:
-                condition:
-                  lambda: 'return id(is_clock_showing);'
-                then:
-                  - globals.set:
-                      id: display_asleep
-                      value: 'false'
-                  - script.execute: clock_bar_apply
-                  - if:
-                      condition:
-                        lambda: 'return lv_scr_act() == id(screen_off_page)->obj;'
-                      then:
-                        - script.execute: navigate_after_api
-                  - script.execute: backlight_apply_brightness
-                  - delay: 300ms
-                  - script.execute: hide_clock_view
-                else:
-                  - script.execute: hide_clock_view
-                  - delay: 100ms
-                  - if:
-                      condition:
-                        lambda: 'return lv_scr_act() == id(screen_off_page)->obj;'
-                      then:
-                        - script.execute: navigate_after_api
-                  - delay: 50ms
-                  - globals.set:
-                      id: display_asleep
-                      value: 'false'
-                  - script.execute: clock_bar_apply
-                  - script.execute: backlight_apply_brightness
+            - script.execute: display_mode_reconcile
+            - script.wait: display_mode_apply_transition
       - script.execute: screensaver_idle_check
       - script.execute: home_screen_idle_check
       - if:
@@ -889,28 +1156,24 @@ script:
   # Keep the normal UI visible but lower the backlight and catch the first tap.
   - id: show_dimmed_view
     mode: restart
+    parameters:
+      generation: int
     then:
       - if:
           condition:
-            lambda: 'return !id(display_takeover_suspended);'
+            lambda: |-
+              return !id(display_takeover_suspended) &&
+                  id(display_mode_controller).transition_is_current(
+                      static_cast<uint32_t>(generation), espcontrol::DisplayMode::DIMMED);
           then:
-            - script.execute: screensaver_dimmed_refresh_brightness
-            - script.wait: screensaver_dimmed_refresh_brightness
-            - globals.set:
-                id: display_asleep
-                value: 'true'
-            - globals.set:
-                id: screen_schedule_asleep
-                value: 'false'
-            - globals.set:
-                id: screensaver_display_off_active
-                value: 'false'
-            - globals.set:
-                id: screensaver_dimmed_active
-                value: 'true'
             - lvgl.resume:
             - script.execute: clock_bar_hide
             - script.wait: clock_bar_hide
+            - lambda: |-
+                if (!id(display_mode_controller).transition_is_current(
+                      static_cast<uint32_t>(generation), espcontrol::DisplayMode::DIMMED)) {
+                  id(show_dimmed_view).stop();
+                }
             - script.execute: hide_clock_view
             - lambda: 'refresh_screensaver_fullscreen(id(clock_screensaver), id(dim_screensaver_touch_guard));'
             - lvgl.widget.show: dim_screensaver_touch_guard
@@ -990,21 +1253,20 @@ script:
 
   # Show the clock screensaver overlay
   - id: show_clock_view
-    mode: single
+    mode: restart
+    parameters:
+      generation: int
     then:
       - if:
           condition:
-            lambda: 'return !id(display_takeover_suspended);'
+            lambda: |-
+              return !id(display_takeover_suspended) &&
+                  id(display_mode_controller).transition_is_current(
+                      static_cast<uint32_t>(generation), espcontrol::DisplayMode::CLOCK);
           then:
             - lambda: 'navigation_return_home(id(main_page)->obj);'
-            - globals.set:
-                id: screensaver_dimmed_active
-                value: 'false'
             - lvgl.widget.hide: dim_screensaver_touch_guard
-            - script.execute: clock_screensaver_refresh_brightness
-            - script.wait: clock_screensaver_refresh_brightness
             - lambda: |-
-                id(is_clock_showing) = true;
                 apply_clock_screensaver_text_color(id(clock_label), id(schedule_clock_text_color).state);
                 auto time = panel_time_or_fallback(id(panel_time).now(), id(homeassistant_time).now());
                 if (time.is_valid()) {
@@ -1017,8 +1279,18 @@ script:
                 }
             - script.execute: clock_bar_hide
             - script.wait: clock_bar_hide
+            - lambda: |-
+                if (!id(display_mode_controller).transition_is_current(
+                      static_cast<uint32_t>(generation), espcontrol::DisplayMode::CLOCK)) {
+                  id(show_clock_view).stop();
+                }
             - script.execute: backlight_fade_current_ui_to_black
             - script.wait: backlight_fade_current_ui_to_black
+            - lambda: |-
+                if (!id(display_mode_controller).transition_is_current(
+                      static_cast<uint32_t>(generation), espcontrol::DisplayMode::CLOCK)) {
+                  id(show_clock_view).stop();
+                }
             - lambda: |-
                 lv_obj_t *temperature_labels[] = {
                   id(temperatures),
@@ -1034,26 +1306,56 @@ script:
                 id: gpio_backlight_pwm
                 level: 0%
             - delay: 50ms
+            - lambda: |-
+                if (!id(display_mode_controller).transition_is_current(
+                      static_cast<uint32_t>(generation), espcontrol::DisplayMode::CLOCK)) {
+                  id(show_clock_view).stop();
+                }
             - output.set_level:
                 id: gpio_backlight_pwm
                 level: !lambda 'return id(screensaver_clock_target_level) * 0.20f;'
             - delay: 50ms
+            - lambda: |-
+                if (!id(display_mode_controller).transition_is_current(
+                      static_cast<uint32_t>(generation), espcontrol::DisplayMode::CLOCK)) {
+                  id(show_clock_view).stop();
+                }
             - output.set_level:
                 id: gpio_backlight_pwm
                 level: !lambda 'return id(screensaver_clock_target_level) * 0.40f;'
             - delay: 50ms
+            - lambda: |-
+                if (!id(display_mode_controller).transition_is_current(
+                      static_cast<uint32_t>(generation), espcontrol::DisplayMode::CLOCK)) {
+                  id(show_clock_view).stop();
+                }
             - output.set_level:
                 id: gpio_backlight_pwm
                 level: !lambda 'return id(screensaver_clock_target_level) * 0.60f;'
             - delay: 50ms
+            - lambda: |-
+                if (!id(display_mode_controller).transition_is_current(
+                      static_cast<uint32_t>(generation), espcontrol::DisplayMode::CLOCK)) {
+                  id(show_clock_view).stop();
+                }
             - output.set_level:
                 id: gpio_backlight_pwm
                 level: !lambda 'return id(screensaver_clock_target_level) * 0.80f;'
             - delay: 50ms
+            - lambda: |-
+                if (!id(display_mode_controller).transition_is_current(
+                      static_cast<uint32_t>(generation), espcontrol::DisplayMode::CLOCK)) {
+                  id(show_clock_view).stop();
+                }
             - output.set_level:
                 id: gpio_backlight_pwm
                 level: !lambda 'return id(screensaver_clock_target_level);'
             - delay: 50ms
+            - lambda: |-
+                if (!id(display_mode_controller).transition_is_current(
+                      static_cast<uint32_t>(generation), espcontrol::DisplayMode::CLOCK)) {
+                  id(show_clock_view).stop();
+                }
             - light.turn_on:
                 id: display_backlight
                 brightness: !lambda 'return id(screensaver_clock_target_level);'
@@ -1065,7 +1367,6 @@ script:
   - id: hide_clock_view
     mode: single
     then:
-      - lambda: 'id(is_clock_showing) = false;'
       - lvgl.widget.hide: clock_screensaver
       - script.execute: clock_bar_apply
 
@@ -1093,6 +1394,7 @@ interval:
   - interval: 1s
     then:
       - script.execute: clock_screensaver_keep_on_top
+      - script.execute: display_mode_reconcile
       - lambda: |-
           espcontrol::LegacyDisplayState legacy;
           legacy.display_asleep = id(display_asleep);
@@ -1110,7 +1412,6 @@ interval:
               !legacy.display_off_active && !legacy.dimmed_active &&
               !legacy.clock_showing && !legacy.cover_art_active &&
               !legacy.interactive_takeover && !legacy.critical_takeover;
-          if (!setup_dim_shape) id(setup_screen_dimmed_shadow_active) = false;
           legacy.setup_screen = setup_dim_shape && id(setup_screen_dimmed_shadow_active);
 
           auto now = panel_time_or_fallback(id(panel_time).now(), id(homeassistant_time).now());

--- a/common/addon/backlight_schedule.yaml
+++ b/common/addon/backlight_schedule.yaml
@@ -485,6 +485,11 @@ script:
   - id: screen_schedule_sleep
     mode: restart
     then:
+      # Publish the schedule marker before reconciliation so the controller
+      # cannot clear this higher-priority request while the off effect runs.
+      - globals.set:
+          id: screen_schedule_asleep
+          value: 'true'
       - lambda: |-
           id(display_mode_controller).request(
               espcontrol::DisplayRequestSource::SCREEN_SCHEDULE,
@@ -505,9 +510,6 @@ script:
           value: '0'
       - script.execute: backlight_sleep_display_off
       - script.wait: backlight_sleep_display_off
-      - globals.set:
-          id: screen_schedule_asleep
-          value: 'true'
       - lambda: 'global_preferences->sync();'
 
   # ---------------------------------------------------------------------------

--- a/common/addon/backlight_schedule.yaml
+++ b/common/addon/backlight_schedule.yaml
@@ -456,6 +456,7 @@ script:
               return waiting_for_time ||
                      (!id(schedule_mode_always_on) && !id(schedule_mode_clock));
           then:
+            - script.execute: display_mode_reconcile
             - globals.set:
                 id: display_asleep
                 value: 'true'
@@ -484,6 +485,11 @@ script:
   - id: screen_schedule_sleep
     mode: restart
     then:
+      - lambda: |-
+          id(display_mode_controller).request(
+              espcontrol::DisplayRequestSource::SCREEN_SCHEDULE,
+              espcontrol::DisplayMode::DISPLAY_OFF);
+      - script.execute: display_mode_reconcile
       - lambda: 'backlight_close_modals_for_display_takeover();'
       - script.stop: screensaver_idle_check
       - script.stop: home_screen_idle_check
@@ -519,9 +525,6 @@ script:
           id: screensaver_display_off_active
           value: 'false'
       - globals.set:
-          id: screensaver_dimmed_active
-          value: 'false'
-      - globals.set:
           id: cover_art_screensaver_active
           value: 'false'
       - globals.set:
@@ -534,21 +537,9 @@ script:
           id: backlight_force_next_write
           value: 'true'
       - lambda: 'global_preferences->sync();'
-      - lvgl.resume:
-      - script.execute: hide_clock_view
       - script.execute: hide_cover_art_view
-      - lvgl.widget.hide: dim_screensaver_touch_guard
-      - if:
-          condition:
-            lambda: 'return lv_scr_act() == id(screen_off_page)->obj;'
-          then:
-            - script.execute: navigate_after_api
-      - delay: 100ms
-      - globals.set:
-          id: display_asleep
-          value: 'false'
-      - script.execute: clock_bar_apply
-      - script.execute: backlight_apply_brightness
+      - script.execute: display_mode_reconcile
+      - script.wait: display_mode_apply_transition
       - script.execute: screensaver_idle_check
       - script.execute: home_screen_idle_check
 
@@ -567,9 +558,6 @@ script:
           id: screensaver_display_off_active
           value: 'false'
       - globals.set:
-          id: screensaver_dimmed_active
-          value: 'false'
-      - globals.set:
           id: cover_art_screensaver_active
           value: 'false'
       - globals.set:
@@ -581,21 +569,9 @@ script:
       - globals.set:
           id: backlight_force_next_write
           value: 'true'
-      - lvgl.resume:
-      - script.execute: hide_clock_view
       - script.execute: hide_cover_art_view
-      - lvgl.widget.hide: dim_screensaver_touch_guard
-      - if:
-          condition:
-            lambda: 'return lv_scr_act() == id(screen_off_page)->obj;'
-          then:
-            - script.execute: navigate_after_api
-      - delay: 50ms
-      - globals.set:
-          id: display_asleep
-          value: 'false'
-      - script.execute: clock_bar_apply
-      - script.execute: backlight_apply_brightness
+      - script.execute: display_mode_reconcile
+      - script.wait: display_mode_apply_transition
       - script.execute: home_screen_idle_check
 
   # ---------------------------------------------------------------------------
@@ -621,18 +597,11 @@ script:
           id: screensaver_display_off_active
           value: 'false'
       - globals.set:
-          id: screensaver_dimmed_active
-          value: 'false'
-      - globals.set:
           id: cover_art_screensaver_active
           value: 'false'
-      - globals.set:
-          id: display_asleep
-          value: 'true'
-      - lvgl.resume:
-      - lvgl.widget.hide: dim_screensaver_touch_guard
       - script.execute: hide_cover_art_view
-      - script.execute: show_clock_view
+      - script.execute: display_mode_reconcile
+      - script.wait: display_mode_apply_transition
       - lambda: 'global_preferences->sync();'
 
   # ---------------------------------------------------------------------------

--- a/common/addon/connectivity.yaml
+++ b/common/addon/connectivity.yaml
@@ -114,20 +114,16 @@ script:
     then:
       - lvgl.resume:
       - globals.set:
-          id: display_asleep
-          value: 'false'
-      - globals.set:
           id: screen_schedule_asleep
           value: 'false'
       - globals.set:
           id: screensaver_display_off_active
           value: 'false'
       - globals.set:
-          id: screensaver_dimmed_active
-          value: 'false'
-      - globals.set:
           id: backlight_manual_off
           value: 'false'
+      - script.execute: display_mode_reconcile
+      - script.wait: display_mode_apply_transition
       - script.execute: clock_bar_hide
       - lambda: |-
           std::string msg = std::string(espcontrol_i18n("Connect to WiFi")) +

--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -1303,9 +1303,8 @@ script:
       - globals.set:
           id: screensaver_display_off_active
           value: 'false'
-      - globals.set:
-          id: screensaver_dimmed_active
-          value: 'false'
+      - script.execute: display_mode_reconcile
+      - script.wait: display_mode_apply_transition
       - lvgl.resume:
       - lambda: 'navigation_return_home(id(main_page)->obj);'
       - script.execute: hide_clock_view
@@ -2152,20 +2151,10 @@ script:
   - id: cover_art_return_home_after_playback
     mode: restart
     then:
-      - if:
-          condition:
-            lambda: |-
-              return id(cover_art_screensaver_active) &&
-                     !id(screen_schedule_asleep) &&
-                     !id(screensaver_display_off_active) &&
-                     !id(screensaver_dimmed_active) &&
-                     !id(is_clock_showing);
-          then:
-            - globals.set:
-                id: display_asleep
-                value: 'false'
       - script.execute: hide_cover_art_view
       - script.wait: hide_cover_art_view
+      - script.execute: display_mode_reconcile
+      - script.wait: display_mode_apply_transition
       - if:
           condition:
             lambda: |-

--- a/common/device/screen_loading.yaml
+++ b/common/device/screen_loading.yaml
@@ -85,17 +85,13 @@ esphome:
                 - lambda: 'return !wifi::global_wifi_component->has_sta();'
             then:
               - globals.set:
-                  id: display_asleep
-                  value: 'false'
-              - globals.set:
                   id: screen_schedule_asleep
                   value: 'false'
               - globals.set:
                   id: screensaver_display_off_active
                   value: 'false'
-              - globals.set:
-                  id: screensaver_dimmed_active
-                  value: 'false'
+              - script.execute: display_mode_reconcile
+              - script.wait: display_mode_apply_transition
               - lambda: |-
                   lv_label_set_text(id(loading_status_icon), "${icon_wifi}");
                   lv_label_set_text(id(loading_status_title), espcontrol_i18n("WiFi Setup"));

--- a/components/espcontrol/display_mode_controller.h
+++ b/components/espcontrol/display_mode_controller.h
@@ -143,7 +143,25 @@ class DisplayModeController {
       return false;
     }
     current_mode_ = transition.target_mode;
+    current_source_ = transition.winning_source;
+    current_takeover_ = transition.winning_takeover;
     return true;
+  }
+
+  bool transition_is_current(uint32_t generation, DisplayMode target_mode) const {
+    if (!generation_is_current(generation)) return false;
+    return resolve().target_mode == target_mode;
+  }
+
+  bool complete_transition(uint32_t generation, DisplayMode target_mode) {
+    if (!transition_is_current(generation, target_mode)) return false;
+    return complete_transition(resolve());
+  }
+
+  bool transition_required(const DisplayTransition &transition) const {
+    return transition.target_mode != current_mode_ ||
+           transition.winning_source != current_source_ ||
+           transition.winning_takeover != current_takeover_;
   }
 
   bool generation_is_current(uint32_t generation) const {
@@ -152,6 +170,12 @@ class DisplayModeController {
 
   uint32_t generation() const { return generation_; }
   DisplayMode current_mode() const { return current_mode_; }
+  const std::optional<DisplayRequestSource> &current_source() const {
+    return current_source_;
+  }
+  const std::optional<DisplayTakeoverKind> &current_takeover() const {
+    return current_takeover_;
+  }
 
   static bool request_is_valid(DisplayRequestSource source, DisplayMode mode) {
     switch (source) {
@@ -221,6 +245,8 @@ class DisplayModeController {
   uint32_t sequence_{0};
   uint32_t generation_{1};
   DisplayMode current_mode_{DisplayMode::ACTIVE};
+  std::optional<DisplayRequestSource> current_source_;
+  std::optional<DisplayTakeoverKind> current_takeover_;
 };
 
 struct LegacyDisplayState {

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -1352,13 +1352,22 @@ def firmware_clock_screensaver_overlay_errors(backlight_path: Path, root: Path) 
     rel = backlight_path.relative_to(root)
     text = backlight_path.read_text(encoding="utf-8")
     sleep_body = yaml_script_body(text, "screensaver_sleep_timer")
+    adapter_body = yaml_script_body(text, "display_mode_apply_transition")
     show_body = yaml_script_body(text, "show_clock_view")
     keep_on_top_body = yaml_script_body(text, "clock_screensaver_keep_on_top")
 
     if sleep_body is None:
         errors.append(f"{rel}: missing screensaver_sleep_timer script")
     else:
-        show_index = sleep_body.find("script.execute: show_clock_view")
+        activation_markers = (
+            "script.execute: show_clock_view",
+            "espcontrol::DisplayMode::CLOCK",
+        )
+        activation_indexes = [
+            sleep_body.find(marker) for marker in activation_markers
+            if sleep_body.find(marker) != -1
+        ]
+        show_index = min(activation_indexes) if activation_indexes else -1
         if show_index == -1:
             errors.append(f"{rel}: keep clock screensaver activation explicit")
         else:
@@ -1374,6 +1383,11 @@ def firmware_clock_screensaver_overlay_errors(backlight_path: Path, root: Path) 
             )
             if any(token in pre_clock_show for token in cleanup_tokens):
                 errors.append(f"{rel}: let the clock screensaver overlay the existing UI without closing it")
+
+        if "espcontrol::DisplayMode::CLOCK" in sleep_body and (
+            adapter_body is None or "id: show_clock_view" not in adapter_body
+        ):
+            errors.append(f"{rel}: route controller clock decisions through show_clock_view")
 
     if show_body is None:
         errors.append(f"{rel}: missing show_clock_view script")

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -1491,6 +1491,25 @@ def firmware_screen_schedule_screensaver_override_errors(backlight_path: Path, r
     ):
         errors.append(f"{rel}: screen schedule display-off should clear cover art before forcing the screen off")
 
+    schedule_path = backlight_path.with_name("backlight_schedule.yaml")
+    if schedule_path.exists():
+        schedule_rel = schedule_path.relative_to(root)
+        schedule_text = schedule_path.read_text(encoding="utf-8")
+        sleep_body = yaml_script_body(schedule_text, "screen_schedule_sleep")
+        if sleep_body is None:
+            errors.append(f"{schedule_rel}: missing screen_schedule_sleep script")
+        else:
+            asleep_index = sleep_body.find("id: screen_schedule_asleep")
+            asleep_true_index = sleep_body.find("value: 'true'", asleep_index)
+            request_index = sleep_body.find("DisplayRequestSource::SCREEN_SCHEDULE")
+            reconcile_index = sleep_body.find("script.execute: display_mode_reconcile")
+            if not (
+                0 <= asleep_index <= asleep_true_index < request_index < reconcile_index
+            ):
+                errors.append(
+                    f"{schedule_rel}: set the schedule-asleep marker before reconciling display-off"
+                )
+
     wake_body = yaml_script_body(text, "screensaver_presence_wake")
     if wake_body is None:
         errors.append(f"{rel}: missing screensaver_presence_wake script")
@@ -2327,12 +2346,17 @@ def expect_screen_schedule_screensaver_override_errors(
     name: str,
     text: str,
     expected: tuple[str, ...],
+    schedule_text: str | None = None,
 ) -> None:
     with TemporaryDirectory() as tmp:
         root = Path(tmp)
         path = root / "common" / "addon" / "backlight.yaml"
         path.parent.mkdir(parents=True)
         path.write_text(text, encoding="utf-8")
+        if schedule_text is not None:
+            path.with_name("backlight_schedule.yaml").write_text(
+                schedule_text, encoding="utf-8"
+            )
         errors = firmware_screen_schedule_screensaver_override_errors(path, root)
         for item in expected:
             assert any(item in error for error in errors), f"{name}: missing {item!r} in {errors!r}"
@@ -4341,10 +4365,36 @@ def run_self_test() -> int:
         "      - script.stop: cover_art_delay_timer\n"
         "      - script.execute: hide_cover_art_view\n"
     )
+    valid_schedule_sleep_order = (
+        "script:\n"
+        "  - id: screen_schedule_sleep\n"
+        "    then:\n"
+        "      - globals.set:\n"
+        "          id: screen_schedule_asleep\n"
+        "          value: 'true'\n"
+        "      - lambda: |-\n"
+        "          id(display_mode_controller).request(\n"
+        "              espcontrol::DisplayRequestSource::SCREEN_SCHEDULE,\n"
+        "              espcontrol::DisplayMode::DISPLAY_OFF);\n"
+        "      - script.execute: display_mode_reconcile\n"
+    )
     expect_screen_schedule_screensaver_override_errors(
         "night schedule overrides timer and sensor screensaver",
         valid_schedule_screensaver_override,
         (),
+        valid_schedule_sleep_order,
+    )
+    expect_screen_schedule_screensaver_override_errors(
+        "schedule display-off reconciles before publishing its marker",
+        valid_schedule_screensaver_override,
+        ("set the schedule-asleep marker before reconciling display-off",),
+        valid_schedule_sleep_order.replace(
+            "      - globals.set:\n"
+            "          id: screen_schedule_asleep\n"
+            "          value: 'true'\n",
+            "",
+            1,
+        ),
     )
     expect_screen_schedule_screensaver_override_errors(
         "timer screensaver bypasses night schedule",

--- a/tests/firmware/display_mode_controller_test.cpp
+++ b/tests/firmware/display_mode_controller_test.cpp
@@ -39,6 +39,7 @@ static DisplayMode expected_mode_for_priority(int priority) {
 int main() {
   DisplayModeController controller;
   CHECK(decision_is(controller, DisplayMode::ACTIVE));
+  CHECK(!controller.transition_required(controller.resolve()));
 
   // Every higher-priority policy beats every lower-priority policy.
   for (int higher = 1; higher <= 8; ++higher) {
@@ -51,6 +52,7 @@ int main() {
   }
 
   CHECK(controller.request(DisplayRequestSource::SETUP_TIMEOUT, DisplayMode::SETUP_DIMMED));
+  CHECK(controller.transition_required(controller.resolve()));
   CHECK(decision_is(controller, DisplayMode::SETUP_DIMMED,
                     DisplayRequestSource::SETUP_TIMEOUT));
   CHECK(controller.request(DisplayRequestSource::IDLE_TIMER, DisplayMode::CLOCK));
@@ -146,11 +148,25 @@ int main() {
   DisplayModeController rapid;
   CHECK(rapid.request(DisplayRequestSource::SCREEN_SCHEDULE, DisplayMode::DISPLAY_OFF));
   const auto off_generation = rapid.resolve();
+  CHECK(rapid.transition_is_current(off_generation.generation, DisplayMode::DISPLAY_OFF));
   CHECK(rapid.request(DisplayRequestSource::SCREEN_SCHEDULE, DisplayMode::CLOCK));
   const auto clock_generation = rapid.resolve();
   CHECK(clock_generation.generation > off_generation.generation);
+  CHECK(!rapid.transition_is_current(off_generation.generation, DisplayMode::DISPLAY_OFF));
+  CHECK(rapid.transition_is_current(clock_generation.generation, DisplayMode::CLOCK));
   CHECK(!rapid.complete_transition(off_generation));
-  CHECK(rapid.complete_transition(clock_generation));
+  CHECK(rapid.complete_transition(clock_generation.generation, DisplayMode::CLOCK));
+  CHECK(!rapid.transition_required(rapid.resolve()));
+
+  // A source change at the same visible mode still needs the adapter so it can
+  // select the winning source's brightness and compatibility state.
+  CHECK(rapid.clear(DisplayRequestSource::SCREEN_SCHEDULE));
+  CHECK(rapid.request(DisplayRequestSource::IDLE_TIMER, DisplayMode::CLOCK));
+  const auto idle_clock_generation = rapid.resolve();
+  CHECK(rapid.transition_required(idle_clock_generation));
+  CHECK(rapid.complete_transition(idle_clock_generation));
+  CHECK(rapid.current_source() == DisplayRequestSource::IDLE_TIMER);
+  CHECK(!rapid.current_takeover().has_value());
 
   // Nested takeovers only finish when every owner has ended its takeover.
   CHECK(controller.begin_takeover(DisplayTakeoverKind::INTERACTIVE));


### PR DESCRIPTION
## Summary

- Route active, setup-dimmed, screensaver-dimmed, and clock decisions through the live display mode controller.
- Add one transition adapter that owns the migrated compatibility flags and calls the existing visual effects.
- Pass transition generations through delayed wake, dim, and clock effects so obsolete work stops before changing widgets or brightness.
- Keep display-off, cover-art, schedule calculation, and typed takeovers staged for their later PRs while mirroring their current priority.

This is PR 3 of the sequential work for #999.

## Practical impact

- Reduces races where a delayed clock, dim, or wake action could overwrite a newer display request.
- Keeps existing fades, brightness choices, touch guards, Home Assistant entities, and saved settings unchanged.
- Makes the transition adapter the sole writer for the migrated dimmed, clock, and setup-dim compatibility state.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Existing screensaver, clock, schedule, wake, and brightness documentation remains accurate; this is an internal reliability migration.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.
- [ ] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- Shared firmware used by every supported display.
- Required physical checks: 10-inch P4 and 4-inch S3.

Automated checks completed:

- Full fast repository check.
- Host controller tests, including stale-generation rejection and same-mode source changes.
- Firmware parser, modal, Home Assistant binding, generator, and S3 configuration checks.
- Factory firmware compile: Guition JC1060P470 — 104,080 bytes RAM / 3,910,868 bytes flash.
- Factory firmware compile: Guition JC4880P443 — 118,720 bytes RAM / 3,859,684 bytes flash.
- Factory firmware compile: Guition JC8012P4A1 — 118,852 bytes RAM / 4,226,308 bytes flash.
- Factory firmware compile: Guition JC8012P4A1 v2 — 118,852 bytes RAM / 4,226,364 bytes flash.
- Factory firmware compile: ESP32-P4 86 Panel — 116,160 bytes RAM / 6,788,830 bytes flash.
- Factory firmware compile: Guition 4848S040 — 125,160 bytes RAM / 3,587,219 bytes flash.
- S3 comparison with preceding main: +1,376 bytes RAM and +10,044 bytes flash. The increase is explained by the live controller and generation-aware transition scripts; the controller object itself is 116 bytes.

## Notes for testing

Please test both the 10-inch P4 and 4-inch S3 before merge:

1. Confirm normal boot and saved schedule, brightness, and screensaver settings are retained.
2. Test touch wake from dimmed, clock, and display-off states.
3. Repeat rapid wake/sleep changes and confirm no old clock or dim effect reappears.
4. Confirm the clock overlay, clock brightness, and drifting position behave normally.
5. Confirm Screen Dimmed keeps the normal UI visible, applies the dim brightness, and the first tap wakes without activating a control.
6. Test scheduled clock/off, manual off, and temporary off-hours wake.
7. Start and stop cover art, including waking while cover art is visible.
8. Open and close an image modal while a screensaver transition is pending.
9. If available, exercise alarm arming/triggered takeover.
10. Reconnect Home Assistant and confirm the current display mode and brightness remain correct.
11. Watch for unexpected restarts or instability, especially on the S3.

## PR status

- [ ] Checks running or waiting.
- [ ] Needs automated fix.
- [x] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.

<!-- espcontrol-pr-testing-guidance -->
## Automated testing guidance

Device testing is expected before merge because this change affects shared firmware lifecycle behavior. Test the 10-inch P4 and 4-inch S3 using the checks above.
