### PR TITLE
Support Python 3.8 in fixture generator

### DIFF
--- a/scripts/generate_saved_config_parser_test.py
+++ b/scripts/generate_saved_config_parser_test.py
@@ -11,6 +11,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 CONFIG_DIR = ROOT / "common" / "config"
 FIELDS = ("entity", "label", "icon", "icon_on", "sensor", "unit", "type", "precision", "options")
+FIXTURE_SUFFIX = "_card_normalization_fixtures.json"
 
 
 def cpp_string(value: str) -> str:
@@ -20,8 +21,8 @@ def cpp_string(value: str) -> str:
 def fixture_groups() -> list[tuple[str, list[dict]]]:
     shared = json.loads((CONFIG_DIR / "card_normalization_fixtures.json").read_text(encoding="utf-8"))
     groups = [(label, fixtures) for label, fixtures in sorted(shared.items())]
-    for path in sorted(CONFIG_DIR.glob("*_card_normalization_fixtures.json")):
-        label = path.name.removesuffix("_card_normalization_fixtures.json").replace("_", " ")
+    for path in sorted(CONFIG_DIR.glob(f"*{FIXTURE_SUFFIX}")):
+        label = path.name[:-len(FIXTURE_SUFFIX)].replace("_", " ")
         groups.append((label, json.loads(path.read_text(encoding="utf-8"))))
     return groups
 


### PR DESCRIPTION
## Summary

- Restore compatibility with the Python 3.8 environment used by the post-merge CI runner.
- Replace `str.removesuffix()` with equivalent suffix slicing supported by Python 3.8.

## Practical impact

- The saved-configuration fixture generator can run on both the repository's local Python versions and the older CI runner.
- No firmware or device behavior changes.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- This is a CI tooling compatibility correction only.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [ ] Device testing is required before merge.
- [x] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- None; test-generation tooling only.

## Notes for testing

- Generator passed inside an actual `python:3.8-slim` container.
- All six compiled firmware host tests passed.
- Physical device behavior and firmware sources are unchanged.

## PR status

- [x] Checks running or waiting.
- [ ] Needs automated fix.
- [ ] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.
