### PR TITLE
Support Python 3.8 across validation tooling

### DIFF
--- a/scripts/check_dev_docs.py
+++ b/scripts/check_dev_docs.py
@@ -278,7 +278,7 @@ def validate_check_guidance(value: str) -> str:
     for alias in re.findall(r"npm run (check:[\w:-]+)", value):
         if alias not in aliases:
             raise ValueError(f"developer guidance references an unregistered check alias: {alias}")
-        task_id = alias.removeprefix("check:")
+        task_id = alias[len("check:"):]
         if task_id not in task_ids and task_id not in PROFILES and alias != "check:release-preflight":
             raise ValueError(f"developer guidance references an unknown task: {task_id}")
     return value

--- a/scripts/check_tasks.py
+++ b/scripts/check_tasks.py
@@ -51,6 +51,15 @@ LOCKFILES = (
 )
 
 
+def path_is_within(path: Path, root: Path) -> bool:
+    """Return whether path is inside root without requiring Python 3.9."""
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
 def validate_registry(tasks: tuple[Task, ...] = TASKS) -> dict[str, Task]:
     registry: dict[str, Task] = {}
     for item in tasks:
@@ -527,7 +536,7 @@ class CacheKeyBuilder:
         for command in item.commands:
             if len(command) > 1 and Path(command[1]).suffix == ".py":
                 candidate = (self.root / command[1]).absolute()
-                if candidate.is_relative_to(self.root.absolute()) and candidate.exists():
+                if path_is_within(candidate, self.root.absolute()) and candidate.exists():
                     pending.append(candidate)
 
         discovered: set[Path] = set()
@@ -553,7 +562,7 @@ class CacheKeyBuilder:
                     local = next((path.absolute() for path in candidates if path.exists()), None)
                     if (
                         local is not None
-                        and local.is_relative_to(self.root.absolute())
+                        and path_is_within(local, self.root.absolute())
                         and local not in discovered
                     ):
                         pending.append(local)
@@ -1206,7 +1215,7 @@ def self_test() -> None:
     for alias, command in public_aliases.items():
         if alias in profile_aliases or alias == "check:parallel":
             continue
-        task_id = alias.removeprefix("check:")
+        task_id = alias[len("check:"):]
         if task_id not in registry:
             raise AssertionError(f"{alias} has no matching registered task")
         expected_command = f"python3 scripts/check_tasks.py run-task {task_id}"


### PR DESCRIPTION
## Summary

- Keep the validation task runner and developer-document checker compatible with Python 3.8.
- Replace Python 3.9-only string and path helpers with equivalent compatibility-safe logic.

## Practical impact

- Restores the main validation workflow on its supported Python 3.8 runner and prevents later checks from failing for the same compatibility reason.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Internal validation compatibility only; device behavior and configuration are unchanged.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [ ] Device testing is required before merge.
- [x] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- None.

## Notes for testing

- Python 3.8 Docker: task-runner self-test passed (43 tasks, 5 profiles).
- Python 3.8 Docker: developer-document validation passed.
- `npm run check:fast` passed all 40 tasks, including all six compiled firmware tests.
- No physical device test is needed because this changes development validation scripts only.

## PR status

- [x] Checks running or waiting.
- [ ] Needs automated fix.
- [ ] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.
