### PR TITLE
Document firmware choice for JC8012P4A1 date code 2622

### DIFF
--- a/docs/getting-started/manual-esphome-setup.md
+++ b/docs/getting-started/manual-esphome-setup.md
@@ -25,7 +25,7 @@ Each screen uses a different ESPHome package file. Pick the one that matches you
 
 | Panel | Package file |
 | --- | --- |
-| 10.1-inch JC8012P4A1 original panel, rear case `2620` or lower | `devices/guition-esp32-p4-jc8012p4a1/packages.yaml` |
+| 10.1-inch JC8012P4A1 original panel, rear case `2622` or lower | `devices/guition-esp32-p4-jc8012p4a1/packages.yaml` |
 | 10.1-inch JC8012P4A1 new panel, rear case `2624` or higher | `devices/guition-esp32-p4-jc8012p4a1-v2/packages.yaml` |
 | 7-inch JC1060P470 | `devices/guition-esp32-p4-jc1060p470/packages.yaml` |
 | 4.3-inch JC4880P443 | `devices/guition-esp32-p4-jc4880p443/packages.yaml` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ See [Card Types](/card-types/) for examples and setup notes.
 
 | Screen | Panel | 3D printable mount |
 |---|---|---|
-| 10.1-inch JC8012P4A1, original `2620` and new `2624+` rear case revisions | [AliExpress ~£40](https://s.click.aliexpress.com/e/_c4W6TYvp) | [Stand page](/reference/3d-printable-stands) |
+| 10.1-inch JC8012P4A1, original `2622` and new `2624+` rear case revisions | [AliExpress ~£40](https://s.click.aliexpress.com/e/_c4W6TYvp) | [Stand page](/reference/3d-printable-stands) |
 | 7-inch JC1060P470 | [AliExpress ~£40](https://s.click.aliexpress.com/e/_c335W0r5) | [Stand page](/reference/3d-printable-stands) |
 | 4.3-inch JC4880P443 | [AliExpress ~£24](https://s.click.aliexpress.com/e/_c32jr3eN) | [Stand page](/reference/3d-printable-stands) |
 | 4-inch ESP32-P4 86 Panel | [AliExpress ~£45](https://s.click.aliexpress.com/e/_c3O6ndAX) | [Stand page](/reference/3d-printable-stands) |

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -70,7 +70,7 @@ The panel includes hundreds of icons from the Material Design Icons set. If the 
 
 The home screen has a grid of card slots sized to fill the screen:
 
-- **10.1-inch JC8012P4A1 original panel** — 20 cards (4 rows, 5 columns), for rear case marking `2620` or lower
+- **10.1-inch JC8012P4A1 original panel** — 20 cards (4 rows, 5 columns), for rear case marking `2622` or lower
 - **10.1-inch JC8012P4A1 new panel** — 20 cards (4 rows, 5 columns), for rear case marking `2624` or higher
 - **7-inch JC1060P470** — 15 cards (3 rows, 5 columns)
 - **4.3-inch JC4880P443** — 6 cards (3 rows, 2 columns)
@@ -91,7 +91,7 @@ Yes. In the [Setup](/features/setup) **Settings** tab, under **Backup**, you can
 
 EspControl currently supports these touchscreen panels:
 
-- **JC8012P4A1 original panel** — 10.1-inch, 1280x800 landscape orientation (ESP32-P4), for rear case marking `2620` or lower
+- **JC8012P4A1 original panel** — 10.1-inch, 1280x800 landscape orientation (ESP32-P4), for rear case marking `2622` or lower
 - **JC8012P4A1 new panel** — 10.1-inch, 1280x800 landscape orientation (ESP32-P4), for rear case marking `2624` or higher
 - **JC1060P470** — 7-inch, 1024x600, landscape orientation (ESP32-P4)
 - **JC4880P443** — 4.3-inch, 480x800, portrait orientation (ESP32-P4)

--- a/docs/screens/jc8012p4a1.md
+++ b/docs/screens/jc8012p4a1.md
@@ -11,7 +11,7 @@ The **Guition JC8012P4A1** is a 10.1-inch touchscreen powered by an **ESP32-P4**
 There are two known rear-case revisions. They look very similar and the newer one may not say `V2` on the label, so choose firmware by the rear case number rather than by a V2 marking.
 
 ::: warning Choose the firmware by rear case number
-- Rear case marking `2620` or lower: use **JC8012P4A1 original panel** firmware.
+- Rear case marking `2622` or lower: use **JC8012P4A1 original panel** firmware.
 - Rear case marking `2624` or higher: use **JC8012P4A1 new panel** firmware.
 :::
 
@@ -41,7 +41,7 @@ Both 10.1-inch revisions use the same grid size and card layout.
 
 Connect the display to your computer with a USB-C data cable, choose the button that matches the rear case number, then install.
 
-### Original panel: rear case `2620` or lower
+### Original panel: rear case `2622` or lower
 
 <!--@include: ../generated/screens/jc8012p4a1-install.md-->
 
@@ -55,7 +55,7 @@ For a full walkthrough including WiFi setup and Home Assistant pairing, see the 
 
 If you use ESPHome and prefer to compile firmware yourself, use the package file that matches the rear case number.
 
-### Original panel: rear case `2620` or lower
+### Original panel: rear case `2622` or lower
 
 ```yaml
 substitutions:


### PR DESCRIPTION
## Summary

- Document rear case marking `2622` as using the JC8012P4A1 original-panel firmware.
- Keep `2624` or higher on the new-panel firmware.
- Apply the same guidance across the screen page, install instructions, FAQ, and supported-screen overview.

## Practical impact

Owners of a JC8012P4A1 marked `2622` now have a clear firmware choice instead of falling into the previous documentation gap.

Related to #1088.

## Documentation decision

- [x] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [ ] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Updated all public pages that stated the original-panel rear-case boundary.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.
- [ ] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- 10.1-inch Guition JC8012P4A1 with rear case marking `2622`

## Notes for testing

- Documentation build passed with `npm run docs:build`.
- On a `2622` unit using the original-panel firmware, confirm WiFi and Home Assistant setup complete and the touchscreen works normally.

## PR status

- [ ] Checks running or waiting.
- [ ] Needs automated fix.
- [x] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.
