### PR TITLE
Keep P4 hosted network buffers reliable on ESPHome 2026.6.5

### DIFF
--- a/dev-docs/p4-86-audio-stack-test.md
+++ b/dev-docs/p4-86-audio-stack-test.md
@@ -54,7 +54,7 @@ Audio configuration:
 Network and memory workaround:
 
 - `network.enable_high_performance: false`
-- ESP hosted mempool disabled.
+- ESP hosted transport mempool placed in PSRAM.
 - Hosted task stack placed in PSRAM.
 - WiFi/LWIP allocations are biased towards PSRAM.
 - Normal ESP WiFi and hosted WiFi remote buffer counts are reduced.

--- a/devices/esp32-p4-86/device/device.yaml
+++ b/devices/esp32-p4-86/device/device.yaml
@@ -44,12 +44,8 @@ esp32:
       # Keep the ESP32 task watchdog long enough for display startup while
       # remaining compatible with ESPHome 2026.4 and newer.
       CONFIG_ESP_TASK_WDT_TIMEOUT_S: "30"
-      # ESPHome 2026.5 / ESP-IDF 5.5.2 can make ESP-Hosted preallocate a
-      # large internal DMA buffer pool before ESPHome starts. On P4 display
-      # builds this can fail with "HS_MP: mempool create failed: no mem" and
-      # trigger OTA rollback, so use dynamic buffers and keep hosted task
-      # stacks in PSRAM.
-      CONFIG_ESP_HOSTED_USE_MEMPOOL: "n"
+      # Keep hosted task stacks in PSRAM so the display and audio paths retain
+      # enough internal memory for DMA-capable allocations.
       CONFIG_ESP_HOSTED_DFLT_TASK_FROM_SPIRAM: "y"
       # The ESP32-C6 hosted WiFi link shares scarce internal/DMA memory with
       # the full-duplex TDM audio path. Keep network bursts small while testing

--- a/devices/esp32-p4-86/device/network_coprocessor.yaml
+++ b/devices/esp32-p4-86/device/network_coprocessor.yaml
@@ -7,6 +7,9 @@
 
 esp32_hosted:
   variant: esp32c6
+  # Keep the preallocated transport receive buffers for reliable inbound
+  # connections, but place them in PSRAM to protect scarce internal memory.
+  use_psram: true
   reset_pin: GPIO54
   cmd_pin: GPIO19
   clk_pin: GPIO18


### PR DESCRIPTION
<!-- espcontrol-pr-testing-guidance -->
## Automated testing guidance

Device testing is required before merge because this changes how the P4-86 allocates its ESP32-C6 hosted-WiFi transport buffers.

Suggested device to test:

- ESP32-P4 86 Panel

Suggested checks:

- Confirm the device boots normally and remains online.
- Confirm Home Assistant stays connected for at least 10 minutes.
- Confirm the web interface remains reachable for at least 10 minutes.
- Exercise voice, text-to-speech, and media playback after the network soak to confirm audio remains stable.

Suggested PR status: Ready for device test once automated checks pass.

Changed firmware files considered:

- `devices/esp32-p4-86/device/device.yaml`
- `devices/esp32-p4-86/device/network_coprocessor.yaml`

## Summary

Keep ESPHome 2026.6.5 and restore the P4-86 hosted network receive-buffer pool, while placing that pool in PSRAM instead of scarce internal memory.

This is a focused fix for the inbound Home Assistant API and web-interface connection failures reported in issue #1099. It retains the smaller Wi-Fi buffers and other audio-memory safeguards already used by the P4-86.

## Practical impact

The P4-86 should have reliable preallocated receive buffers for inbound connections without taking internal memory away from the display and full-duplex audio paths. Other displays and the project-wide ESPHome version are unchanged.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this is an internal firmware memory-allocation change with no user-visible configuration change.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- The internal P4-86 audio-stack test note was updated to describe the new buffer placement accurately.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.
- [ ] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- ESP32-P4 86 Panel

## Notes for testing

- Full ESP32-P4 86 Panel factory firmware compile passed with ESPHome 2026.6.5.
- Generated ESP-IDF configuration confirms the hosted transport buffer pool and hosted task stacks are allocated from PSRAM.
- Device manifest, profile, development-documentation, local ESPHome helper, and firmware release checks passed.
- The generated web-bundle check could not run locally because this worktree does not have its Node dependencies installed; pull request CI will run the repository-wide validation.
- Physical hardware testing is still required; a successful compile does not prove that connections remain stable on a real display.

## PR status

- [ ] Checks running or waiting.
- [ ] Needs automated fix.
- [x] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.

Refs #1099
