### PR TITLE
Keep unavailable media cards normally styled

### DIFF
--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -782,7 +782,6 @@ inline void media_playback_apply_state_to_control(MediaPlaybackState *state,
     }
   }
 
-  media_control_apply_availability(ctx->btn, ctx->btn, ctx->available);
   set_card_checked_state(ctx->btn, ctx->available && ctx->playing);
   media_control_refresh_parent_card(ctx);
   MediaControlModalUi &ui = media_control_modal_ui();
@@ -1728,7 +1727,6 @@ inline void media_control_refresh_modal(MediaControlCtx *ctx) {
   std::string artist = media_control_artist_text(ctx);
   if (ui.title_lbl) lv_label_set_text(ui.title_lbl, title.c_str());
   if (ui.artist_lbl) lv_label_set_text(ui.artist_lbl, artist.c_str());
-  media_control_apply_availability(ui.panel, ui.panel, ctx->available, false);
   media_control_refresh_play_icon(ctx);
   media_control_refresh_progress(ctx);
   media_control_refresh_volume(ctx);

--- a/docs/card-types/media.md
+++ b/docs/card-types/media.md
@@ -26,6 +26,8 @@ A Media card controls a Home Assistant `media_player` entity. It can work as a s
 3. Enter the media player entity, for example `media_player.living_room`.
 4. Set a label or icon if the selected type shows those fields.
 
+If Home Assistant reports the media player as unavailable, the card keeps its normal appearance. A card set to show the live state can still say **Unavailable**, and controls will work again when Home Assistant can accept actions for the player.
+
 ## Playback Buttons
 
 **Play/Pause Button**, **Previous Button**, and **Next Button** send the matching Home Assistant media player action when tapped.

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -388,6 +388,22 @@ def firmware_card_disabled_state_errors(firmware_dir: Path, root: Path) -> list[
     return errors
 
 
+def firmware_media_card_availability_errors(firmware_dir: Path, root: Path) -> list[str]:
+    path = firmware_dir / "button_grid_media.h"
+    if not path.exists():
+        return []
+    rel = path.relative_to(root)
+    text = path.read_text(encoding="utf-8")
+    errors: list[str] = []
+
+    if "media_control_apply_availability(ctx->btn, ctx->btn" in text:
+        errors.append(f"{rel}: do not dim or disable media cards for unavailable entity states")
+    if "media_control_apply_availability(ui.panel, ui.panel" in text:
+        errors.append(f"{rel}: do not dim the media control panel for unavailable entity states")
+
+    return errors
+
+
 def firmware_action_card_script_fields_errors(firmware_dir: Path, root: Path) -> list[str]:
     path = firmware_dir / "button_grid_actions.h"
     if not path.exists():
@@ -1809,6 +1825,7 @@ def run_scan() -> int:
     errors.extend(firmware_todo_disconnect_errors(FIRMWARE_DIR, CORE_INFRA_PATH, ROOT))
     errors.extend(firmware_action_card_availability_errors(FIRMWARE_DIR, ROOT))
     errors.extend(firmware_card_disabled_state_errors(FIRMWARE_DIR, ROOT))
+    errors.extend(firmware_media_card_availability_errors(FIRMWARE_DIR, ROOT))
     errors.extend(firmware_action_card_script_fields_errors(FIRMWARE_DIR, ROOT))
     errors.extend(firmware_local_sensor_binding_order_errors(FIRMWARE_DIR, ROOT))
     errors.extend(firmware_time_reconnect_errors(TIME_ADDON_PATH, ROOT))
@@ -1957,6 +1974,20 @@ def expect_action_card_availability_errors(name: str, text: str, expected: tuple
         (firmware_dir / "button_grid_grid.h").write_text(text, encoding="utf-8")
 
         errors = firmware_action_card_availability_errors(firmware_dir, root)
+        for item in expected:
+            assert any(item in error for error in errors), f"{name}: missing {item!r} in {errors!r}"
+        if not expected:
+            assert not errors, f"{name}: expected no errors, got {errors!r}"
+
+
+def expect_media_card_availability_errors(name: str, text: str, expected: tuple[str, ...]) -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        firmware_dir = root / "components" / "espcontrol"
+        firmware_dir.mkdir(parents=True)
+        (firmware_dir / "button_grid_media.h").write_text(text, encoding="utf-8")
+
+        errors = firmware_media_card_availability_errors(firmware_dir, root)
         for item in expected:
             assert any(item in error for error in errors), f"{name}: missing {item!r} in {errors!r}"
         if not expected:
@@ -3116,6 +3147,27 @@ def run_self_test() -> int:
         "if (sb_cfg.type == \"push\") {\n"
         "  std::string push_label = sb_cfg.label.empty() ? espcontrol_i18n(std::string(\"Push\")) : sb_cfg.label;\n"
         "  continue;\n"
+        "}\n",
+        (),
+    )
+    expect_media_card_availability_errors(
+        "unavailable entity dims media card",
+        "inline void media_playback_apply_state_to_control(MediaPlaybackState *state, MediaControlCtx *ctx) {\n"
+        "  media_control_apply_availability(ctx->btn, ctx->btn, ctx->available);\n"
+        "}\n",
+        ("do not dim or disable media cards",),
+    )
+    expect_media_card_availability_errors(
+        "unavailable entity dims media panel",
+        "inline void media_control_refresh_modal(MediaControlCtx *ctx) {\n"
+        "  media_control_apply_availability(ui.panel, ui.panel, ctx->available, false);\n"
+        "}\n",
+        ("do not dim the media control panel",),
+    )
+    expect_media_card_availability_errors(
+        "media progress remains guarded",
+        "inline void media_control_refresh_progress(MediaControlCtx *ctx) {\n"
+        "  media_control_apply_availability(ui.progress_slider, ui.progress_slider, has_duration);\n"
         "}\n",
         (),
     )


### PR DESCRIPTION
## Summary

- Keep Media All Controls cards at their normal brightness and enabled appearance when Home Assistant reports the media player as unavailable.
- Keep the live `Unavailable` status text and control-specific safety checks, so the card remains truthful without looking globally offline.
- Add a regression check that prevents unavailable-state styling from being reapplied to the parent card or media control panel.

Addresses #1093.

## Practical impact

- Media cards no longer become greyed out or look disabled during a temporary Home Assistant or media-player outage. Their controls become usable again automatically when Home Assistant can accept actions.

## Documentation decision

- [x] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [ ] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Updated the Media card guide to explain the normal unavailable-state appearance and the optional live `Unavailable` label.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.
- [ ] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- All supported displays because this is shared media-card firmware. Compile-checked on the 7-inch P4, 4.3-inch P4, and 4-inch S3 factory configurations.

Automated checks:

- Firmware Home Assistant binding checks and self-tests
- Firmware card runtime checks and self-tests
- Firmware parser checks and self-tests
- Device profile and translation-output checks
- Product checks
- Documentation build
- ESPHome 2026.6.5 compile for all three supported factory firmware targets
- Diff whitespace check

Physical device testing has not yet been performed.

## Notes for testing

1. Install the PR firmware on the display you want to test.
2. Configure a Media card using **All Controls** and, if useful, set its label to show the live state.
3. Temporarily make that Home Assistant media player entity unavailable.
4. Confirm the card and its control panel keep their normal appearance instead of becoming greyed out or disabled. The live label may still say **Unavailable**.
5. Restore the media player and confirm its controls work again.

## PR status

- [ ] Checks running or waiting.
- [ ] Needs automated fix.
- [x] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.
