### PR TITLE
Restart cover art delay after every touch

### DIFF
--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -341,7 +341,9 @@ script:
     then:
       - if:
           condition:
-            lambda: 'return id(display_mode_controller).target_mode_is(espcontrol::DisplayMode::COVER_ART);'
+            lambda: |-
+              return id(display_mode_controller).target_mode_is(espcontrol::DisplayMode::COVER_ART) ||
+                     id(cover_art_manual_pause_until_ms) != 0;
           then:
             - script.stop: cover_art_delay_timer
             - lambda: |-

--- a/docs/features/media-cover-art.md
+++ b/docs/features/media-cover-art.md
@@ -15,7 +15,7 @@ You will find these controls in **Settings > Sleep & Schedule > Media Cover Art*
 - **Show Cover Art** - enables the cover art display and keeps the screen awake while artwork is shown.
 - **Media Player Entity** - chooses the media player entity to watch, such as `media_player.living_room`.
 - **Show After** - chooses whether cover art appears immediately or waits for the selected delay.
-- **Show After** also controls how long cover art waits before returning after you dismiss it by touch.
+- **Show After** also controls how long cover art waits before returning after you dismiss it by touch. The countdown restarts after every touch, so cover art returns only after the selected time has passed since your most recent touch.
 - **Show Track Details For** - controls how long track information is shown over the artwork on the 4-inch square displays.
 - **Advanced Options** - contains source and filtering controls you may not need every day.
 - **Hide for external source inputs** - hides cover art when the selected media player source is `TV` or `Line-in`.

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -902,9 +902,12 @@ def firmware_cover_art_refresh_errors(path: Path, root: Path) -> list[str]:
     pause_body = yaml_script_body(text, "cover_art_pause_after_touch")
     if pause_body is not None and (
         "target_mode_is(espcontrol::DisplayMode::COVER_ART)" not in pause_body
+        or "id(cover_art_manual_pause_until_ms) != 0" not in pause_body
         or "id(cover_art_manual_pause_until_ms) = 1;" not in pause_body
     ):
-        errors.append(f"{rel}: only arm cover art return after an active cover-art dismissal")
+        errors.append(
+            f"{rel}: arm cover art return after dismissal and restart its countdown after every touch"
+        )
     return errors
 
 
@@ -4005,6 +4008,18 @@ def run_self_test() -> int:
             "track/source metadata changes as stale artwork",
             "subscribe to and refresh the media_album_name attribute",
         ),
+    )
+    expect_cover_art_refresh_errors(
+        "cover art touch delay ignores later touches",
+        "script:\n"
+        "  - id: cover_art_pause_after_touch\n"
+        "    then:\n"
+        "      - if:\n"
+        "          condition:\n"
+        "            lambda: 'return id(display_mode_controller).target_mode_is(espcontrol::DisplayMode::COVER_ART);'\n"
+        "          then:\n"
+        "            - lambda: 'id(cover_art_manual_pause_until_ms) = 1;'\n",
+        ("restart its countdown after every touch",),
     )
     expect_cover_art_refresh_errors(
         "stale cover refresh guard present",


### PR DESCRIPTION
## Summary

- Restart the cover-art **Show After** countdown whenever the user touches the screen while a return is already pending.
- Add a regression check so later lifecycle changes cannot silently restore the initial-touch behaviour.
- Clarify the latest-touch behaviour in the public cover-art documentation.

## Practical impact

- Cover art no longer reappears while the user is still interacting with the panel. It waits for the configured delay after the most recent touch.

## Documentation decision

- [x] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [ ] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Updated the Media Cover Art settings page to explain that every touch restarts the countdown.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.
- [ ] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- All supported touchscreen displays (shared cover-art lifecycle behaviour).

## Notes for testing

- Automated: the complete fast check suite passed, including all firmware unit tests, firmware parsing, cover-art policy checks, and the new regression self-test.
- Documentation: `npm run docs:build` passed.
- Physical device test still needed: set **Show After** to a noticeable value such as 30 seconds, start media so cover art appears, dismiss it by touch, then touch the panel again before 30 seconds has elapsed. Confirm cover art stays away until 30 seconds after the latest touch rather than returning 30 seconds after the first touch.

<!-- espcontrol-pr-testing-guidance -->
## Automated testing guidance

Device testing is expected before merge because this change affects the on-device cover-art experience.

Suggested checks:

- Confirm the device boots normally and does not restart repeatedly.
- Confirm cover art still appears while the selected media player is active.
- Confirm touch and navigation continue to work while cover art is waiting to return.
- Confirm the configured **Show After** delay is measured from the most recent touch.

## PR status

- [x] Checks running or waiting.
- [ ] Needs automated fix.
- [ ] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.
