### PR TITLE
Fix accidental button presses when waking from Display Off

### DIFF
--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -990,6 +990,23 @@ script:
           id(screensaver_wake_restore_pending) =
               !id(display_mode_controller).target_mode_is(
                   espcontrol::DisplayMode::ACTIVE);
+          id(screensaver_wake_touch_guard_skip_once) =
+              id(display_mode_controller).target_mode_is(
+                  espcontrol::DisplayMode::COVER_ART) ||
+              id(display_mode_controller).target_mode_is(
+                  espcontrol::DisplayMode::DISPLAY_OFF);
+      - if:
+          condition:
+            lambda: 'return id(screensaver_wake_touch_guard_skip_once);'
+          then:
+            - globals.set:
+                id: screensaver_wake_touch_guard_active
+                value: 'true'
+            - lambda: 'screensaver_fill_screen(id(screensaver_wake_touch_guard));'
+            - lvgl.widget.show: screensaver_wake_touch_guard
+            - lambda: 'lv_obj_move_foreground(id(screensaver_wake_touch_guard));'
+            - script.execute: screensaver_wake_touch_block
+      - lambda: |-
           id(display_mode_controller).clear(espcontrol::DisplayRequestSource::IDLE_TIMER);
           id(display_mode_controller).clear(espcontrol::DisplayRequestSource::PRESENCE_SENSOR);
           id(display_mode_controller).clear(espcontrol::DisplayRequestSource::SETUP_TIMEOUT);
@@ -1019,21 +1036,6 @@ script:
       - if:
           condition:
             lambda: |-
-              return id(display_mode_controller).target_mode_is(
-                  espcontrol::DisplayMode::COVER_ART);
-          then:
-            - globals.set:
-                id: screensaver_wake_touch_guard_skip_once
-                value: 'true'
-            - globals.set:
-                id: screensaver_wake_touch_guard_active
-                value: 'true'
-            - lvgl.widget.show: cover_art_wake_touch_guard
-            - lambda: 'lv_obj_move_foreground(id(cover_art_wake_touch_guard));'
-            - script.execute: cover_art_wake_touch_block
-      - if:
-          condition:
-            lambda: |-
               const bool restore_pending = id(screensaver_wake_restore_pending);
               id(screensaver_wake_restore_pending) = false;
               return restore_pending ||
@@ -1044,14 +1046,11 @@ script:
             - if:
                 condition:
                   lambda: |-
-                    bool keep_cover_art_guard =
-                        id(display_mode_controller).target_mode_is(
-                            espcontrol::DisplayMode::COVER_ART) &&
-                        id(screensaver_wake_touch_guard_skip_once);
+                    bool keep_wake_guard = id(screensaver_wake_touch_guard_skip_once);
                     id(screensaver_wake_touch_guard_skip_once) = false;
-                    return keep_cover_art_guard;
+                    return keep_wake_guard;
                 then:
-                  - lambda: 'ESP_LOGD("screensaver", "Keeping cover art wake guard until touch release");'
+                  - lambda: 'ESP_LOGD("screensaver", "Keeping wake guard until touch release");'
                 else:
                   - script.stop: screensaver_wake_touch_guard_clear
                   - globals.set:
@@ -1085,6 +1084,46 @@ script:
                      !alarm_display_takeover_active();
           then:
             - script.execute: cover_art_start_delay
+
+  - id: screensaver_wake_touch_block
+    mode: restart
+    then:
+      - globals.set:
+          id: screensaver_wake_touch_guard_active
+          value: 'true'
+      - lambda: 'screensaver_fill_screen(id(screensaver_wake_touch_guard));'
+      - lvgl.widget.show: screensaver_wake_touch_guard
+      - lambda: 'lv_obj_move_foreground(id(screensaver_wake_touch_guard));'
+      - wait_until:
+          condition:
+            lambda: |-
+              lv_indev_t *indev = nullptr;
+              while ((indev = lv_indev_get_next(indev)) != nullptr) {
+                if (lv_indev_get_type(indev) == LV_INDEV_TYPE_POINTER &&
+                    lv_indev_get_state(indev) == LV_INDEV_STATE_PRESSED) {
+                  return true;
+                }
+              }
+              return false;
+          timeout: 150ms
+      - wait_until:
+          condition:
+            lambda: |-
+              lv_indev_t *indev = nullptr;
+              while ((indev = lv_indev_get_next(indev)) != nullptr) {
+                if (lv_indev_get_type(indev) == LV_INDEV_TYPE_POINTER &&
+                    lv_indev_get_state(indev) == LV_INDEV_STATE_PRESSED) {
+                  return false;
+                }
+              }
+              return true;
+          timeout: 2s
+      - delay: 250ms
+      - script.stop: screensaver_wake_touch_guard_clear
+      - globals.set:
+          id: screensaver_wake_touch_guard_active
+          value: 'false'
+      - lvgl.widget.hide: screensaver_wake_touch_guard
 
   - id: screensaver_wake_touch_guard_clear
     mode: restart

--- a/common/device/screen_clock.yaml
+++ b/common/device/screen_clock.yaml
@@ -55,3 +55,17 @@ lvgl:
           on_press:
             then:
               - script.execute: screensaver_wake
+      - obj:
+          id: screensaver_wake_touch_guard
+          x: 0
+          y: 0
+          width: 100%
+          height: 100%
+          bg_opa: 0%
+          radius: 0
+          border_width: 0
+          pad_all: 0
+          scrollable: false
+          scrollbar_mode: "off"
+          clickable: true
+          hidden: true

--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -331,21 +331,6 @@ lvgl:
                 indicator:
                   bg_color: ${cover_art_text_color}
                   radius: 0
-      - obj:
-          id: cover_art_wake_touch_guard
-          x: 0
-          y: 0
-          width: 100%
-          height: 100%
-          bg_opa: 0%
-          radius: 0
-          border_width: 0
-          pad_all: 0
-          scrollable: false
-          scrollbar_mode: "off"
-          clickable: true
-          hidden: true
-
 script:
   - id: cover_art_pause_after_touch
     mode: restart
@@ -372,45 +357,6 @@ script:
                 id(cover_art_manual_pause_until_ms) = millis() + duration_ms;
                 ESP_LOGI("cover_art", "Waiting %.0fs to show cover art again after touch", seconds);
 
-  - id: cover_art_wake_touch_block
-    mode: restart
-    then:
-      - globals.set:
-          id: screensaver_wake_touch_guard_active
-          value: 'true'
-      - lvgl.widget.show: cover_art_wake_touch_guard
-      - lambda: 'lv_obj_move_foreground(id(cover_art_wake_touch_guard));'
-      - wait_until:
-          condition:
-            lambda: |-
-              lv_indev_t *indev = nullptr;
-              while ((indev = lv_indev_get_next(indev)) != nullptr) {
-                if (lv_indev_get_type(indev) == LV_INDEV_TYPE_POINTER &&
-                    lv_indev_get_state(indev) == LV_INDEV_STATE_PRESSED) {
-                  return true;
-                }
-              }
-              return false;
-          timeout: 150ms
-      - wait_until:
-          condition:
-            lambda: |-
-              lv_indev_t *indev = nullptr;
-              while ((indev = lv_indev_get_next(indev)) != nullptr) {
-                if (lv_indev_get_type(indev) == LV_INDEV_TYPE_POINTER &&
-                    lv_indev_get_state(indev) == LV_INDEV_STATE_PRESSED) {
-                  return false;
-                }
-              }
-              return true;
-          timeout: 2s
-      - delay: 250ms
-      - script.stop: screensaver_wake_touch_guard_clear
-      - globals.set:
-          id: screensaver_wake_touch_guard_active
-          value: 'false'
-      - lvgl.widget.hide: cover_art_wake_touch_guard
-
   - id: cover_art_apply_responsive_layout
     mode: restart
     then:
@@ -428,8 +374,8 @@ script:
           auto set_fullscreen_size = [](int width, int height) {
             lv_obj_set_pos(id(cover_art_screensaver), 0, 0);
             lv_obj_set_size(id(cover_art_screensaver), width, height);
-            lv_obj_set_pos(id(cover_art_wake_touch_guard), 0, 0);
-            lv_obj_set_size(id(cover_art_wake_touch_guard), width, height);
+            lv_obj_set_pos(id(screensaver_wake_touch_guard), 0, 0);
+            lv_obj_set_size(id(screensaver_wake_touch_guard), width, height);
             lv_obj_set_size(id(cover_art_progress_bar), width, ${cover_art_progress_height});
             lv_obj_align(id(cover_art_progress_bar), LV_ALIGN_BOTTOM_MID, 0, 0);
           };
@@ -441,8 +387,8 @@ script:
                                        int title_max_height) {
             lv_obj_set_pos(id(cover_art_screensaver), 0, 0);
             lv_obj_set_size(id(cover_art_screensaver), screen_w, screen_h);
-            lv_obj_set_pos(id(cover_art_wake_touch_guard), 0, 0);
-            lv_obj_set_size(id(cover_art_wake_touch_guard), screen_w, screen_h);
+            lv_obj_set_pos(id(screensaver_wake_touch_guard), 0, 0);
+            lv_obj_set_size(id(screensaver_wake_touch_guard), screen_w, screen_h);
             lv_obj_set_size(id(cover_art_progress_bar), screen_w, ${cover_art_progress_height});
             lv_obj_align(id(cover_art_progress_bar), LV_ALIGN_BOTTOM_MID, 0, 0);
             lv_obj_set_pos(id(cover_art_backdrop), art_x, art_y);

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -16,6 +16,7 @@ CORE_INFRA_PATH = ROOT / "common" / "device" / "core_infra.yaml"
 API_NAVIGATE_PATH = ROOT / "common" / "device" / "api_navigate.yaml"
 C6_FIRMWARE_UPDATE_PATH = ROOT / "common" / "device" / "esp32_c6_firmware_update.yaml"
 COVER_ART_PATH = ROOT / "common" / "device" / "screen_cover_art.yaml"
+SCREEN_CLOCK_PATH = ROOT / "common" / "device" / "screen_clock.yaml"
 ARTWORK_IMAGE_PATH = ROOT / "components" / "artwork_image" / "artwork_image.cpp"
 BACKLIGHT_PATH = ROOT / "common" / "addon" / "backlight.yaml"
 DISPLAY_CONFIG_PATH = ROOT / "common" / "config" / "display.yaml"
@@ -1991,7 +1992,12 @@ def firmware_artwork_image_auth_errors(path: Path, root: Path) -> list[str]:
     return errors
 
 
-def firmware_screensaver_wake_guard_errors(backlight_path: Path, cover_art_path: Path, root: Path) -> list[str]:
+def firmware_screensaver_wake_guard_errors(
+    backlight_path: Path,
+    screen_clock_path: Path,
+    cover_art_path: Path,
+    root: Path,
+) -> list[str]:
     errors: list[str] = []
     if backlight_path.exists():
         rel = backlight_path.relative_to(root)
@@ -2029,22 +2035,79 @@ def firmware_screensaver_wake_guard_errors(backlight_path: Path, cover_art_path:
                     normal_wake_body,
                 ):
                     errors.append(f"{rel}: clear stale wake guard state during normal screensaver wake")
+                if "bool keep_wake_guard = id(screensaver_wake_touch_guard_skip_once);" not in normal_wake_body:
+                    errors.append(f"{rel}: preserve the shared wake guard while screensaver state is restored")
+
+            clear_marker = (
+                "id(display_mode_controller).clear("
+                "espcontrol::DisplayRequestSource::IDLE_TIMER);"
+            )
+            clear_index = body.find(clear_marker)
+            guard_execute_index = body.find("script.execute: screensaver_wake_touch_block")
+            pre_clear_body = body[:clear_index] if clear_index >= 0 else ""
+            if (
+                "id(screensaver_wake_touch_guard_skip_once) =" not in pre_clear_body
+                or "espcontrol::DisplayMode::COVER_ART" not in pre_clear_body
+                or "espcontrol::DisplayMode::DISPLAY_OFF" not in pre_clear_body
+            ):
+                errors.append(
+                    f"{rel}: arm the shared wake guard from the pre-wake Cover Art and Display Off modes"
+                )
+            if (
+                clear_index < 0
+                or guard_execute_index < 0
+                or guard_execute_index > clear_index
+            ):
+                errors.append(f"{rel}: raise the shared wake guard before clearing screensaver state")
+
+        guard_body = yaml_script_body(text, "screensaver_wake_touch_block")
+        if guard_body is None:
+            errors.append(f"{rel}: missing shared screensaver_wake_touch_block script")
+        else:
+            if not re.search(
+                r"id:\s*screensaver_wake_touch_guard_active\s*\n\s*value:\s*'true'",
+                guard_body,
+            ):
+                errors.append(f"{rel}: keep screensaver wake taps guarded")
+            if "LV_INDEV_STATE_PRESSED" not in guard_body:
+                errors.append(f"{rel}: keep the shared wake guard until the wake touch is released")
+            if "timeout: 2s" not in guard_body:
+                errors.append(f"{rel}: clear the shared wake guard after a stuck touch timeout")
+            if "delay: 250ms" not in guard_body:
+                errors.append(f"{rel}: retain the shared wake guard while touch input settles")
+            if "screensaver_fill_screen(id(screensaver_wake_touch_guard))" not in guard_body:
+                errors.append(f"{rel}: resize the shared wake guard for every display layout")
+            if "lv_obj_move_foreground(id(screensaver_wake_touch_guard))" not in guard_body:
+                errors.append(f"{rel}: raise the shared wake guard above active controls")
+            if "lvgl.widget.show: screensaver_wake_touch_guard" not in guard_body:
+                errors.append(f"{rel}: show the shared full-screen wake guard")
+            if not re.search(
+                r"id:\s*screensaver_wake_touch_guard_active\s*\n\s*value:\s*'false'",
+                guard_body,
+            ):
+                errors.append(f"{rel}: accept the first deliberate tap after wake-touch release")
+            if "lvgl.widget.hide: screensaver_wake_touch_guard" not in guard_body:
+                errors.append(f"{rel}: hide the shared wake guard after touch release")
+
+    if screen_clock_path.exists():
+        rel = screen_clock_path.relative_to(root)
+        text = screen_clock_path.read_text(encoding="utf-8")
+        widget_marker = "id: screensaver_wake_touch_guard"
+        widget_index = text.find(widget_marker)
+        widget_body = text[widget_index:] if widget_index >= 0 else ""
+        if widget_index < 0:
+            errors.append(f"{rel}: define the shared screensaver wake touch guard")
+        elif not all(
+            token in widget_body
+            for token in ("width: 100%", "height: 100%", "clickable: true", "hidden: true")
+        ):
+            errors.append(f"{rel}: keep the shared wake guard full-screen, clickable, and hidden by default")
 
     if cover_art_path.exists():
         rel = cover_art_path.relative_to(root)
         text = cover_art_path.read_text(encoding="utf-8")
-        body = yaml_script_body(text, "cover_art_wake_touch_block")
-        if body is None:
-            errors.append(f"{rel}: missing cover_art_wake_touch_block script")
-        else:
-            if not re.search(r"id:\s*screensaver_wake_touch_guard_active\s*\n\s*value:\s*'true'", body):
-                errors.append(f"{rel}: keep cover art wake taps guarded")
-            if "LV_INDEV_STATE_PRESSED" not in body:
-                errors.append(f"{rel}: keep cover art guard until the wake touch is released")
-            if not re.search(r"id:\s*screensaver_wake_touch_guard_active\s*\n\s*value:\s*'false'", body):
-                errors.append(f"{rel}: clear the cover art wake guard after touch release")
-            if "lvgl.widget.hide: cover_art_wake_touch_guard" not in body:
-                errors.append(f"{rel}: hide the cover art wake touch guard after release")
+        if "cover_art_wake_touch_guard" in text or "cover_art_wake_touch_block" in text:
+            errors.append(f"{rel}: use the shared screensaver wake guard for Cover Art")
     return errors
 
 
@@ -2756,7 +2819,11 @@ def run_scan() -> int:
     errors.extend(firmware_image_card_quality_errors(FIRMWARE_DIR, ROOT))
     errors.extend(firmware_image_card_startup_errors(FIRMWARE_DIR, CORE_INFRA_PATH, ROOT))
     errors.extend(firmware_artwork_image_auth_errors(ARTWORK_IMAGE_PATH, ROOT))
-    errors.extend(firmware_screensaver_wake_guard_errors(BACKLIGHT_PATH, COVER_ART_PATH, ROOT))
+    errors.extend(
+        firmware_screensaver_wake_guard_errors(
+            BACKLIGHT_PATH, SCREEN_CLOCK_PATH, COVER_ART_PATH, ROOT
+        )
+    )
     errors.extend(firmware_screen_wake_button_errors(BACKLIGHT_PATH, ROOT))
     errors.extend(firmware_clock_bar_pending_wake_errors(DISPLAY_CONFIG_PATH, ROOT))
     errors.extend(firmware_clock_screensaver_overlay_errors(BACKLIGHT_PATH, ROOT))
@@ -3307,19 +3374,25 @@ def expect_image_card_startup_errors(
 def expect_screensaver_wake_guard_errors(
     name: str,
     backlight_text: str,
+    screen_clock_text: str,
     cover_art_text: str,
     expected: tuple[str, ...],
 ) -> None:
     with TemporaryDirectory() as tmp:
         root = Path(tmp)
         backlight_path = root / "common" / "addon" / "backlight.yaml"
+        screen_clock_path = root / "common" / "device" / "screen_clock.yaml"
         cover_art_path = root / "common" / "device" / "screen_cover_art.yaml"
         backlight_path.parent.mkdir(parents=True)
-        cover_art_path.parent.mkdir(parents=True)
+        screen_clock_path.parent.mkdir(parents=True)
+        cover_art_path.parent.mkdir(parents=True, exist_ok=True)
         backlight_path.write_text(backlight_text, encoding="utf-8")
+        screen_clock_path.write_text(screen_clock_text, encoding="utf-8")
         cover_art_path.write_text(cover_art_text, encoding="utf-8")
 
-        errors = firmware_screensaver_wake_guard_errors(backlight_path, cover_art_path, root)
+        errors = firmware_screensaver_wake_guard_errors(
+            backlight_path, screen_clock_path, cover_art_path, root
+        )
         for item in expected:
             assert any(item in error for error in errors), f"{name}: missing {item!r} in {errors!r}"
         if not expected:
@@ -5764,23 +5837,41 @@ def run_self_test() -> int:
         "        refresh_image_cards();\n",
         (),
     )
-    valid_cover_art_wake_guard = (
-        "script:\n"
-        "  - id: cover_art_wake_touch_block\n"
+    valid_shared_wake_guard_widget = (
+        "lvgl:\n"
+        "  top_layer:\n"
+        "    widgets:\n"
+        "      - obj:\n"
+        "          id: screensaver_wake_touch_guard\n"
+        "          width: 100%\n"
+        "          height: 100%\n"
+        "          clickable: true\n"
+        "          hidden: true\n"
+    )
+    valid_shared_wake_guard_script = (
+        "  - id: screensaver_wake_touch_block\n"
         "    then:\n"
         "      - globals.set:\n"
         "          id: screensaver_wake_touch_guard_active\n"
         "          value: 'true'\n"
+        "      - lambda: 'screensaver_fill_screen(id(screensaver_wake_touch_guard));'\n"
+        "      - lvgl.widget.show: screensaver_wake_touch_guard\n"
+        "      - lambda: 'lv_obj_move_foreground(id(screensaver_wake_touch_guard));'\n"
         "      - wait_until:\n"
         "          condition:\n"
         "            lambda: 'return lv_indev_get_state(indev) == LV_INDEV_STATE_PRESSED;'\n"
+        "          timeout: 150ms\n"
+        "      - wait_until:\n"
+        "          condition:\n"
+        "            lambda: 'return lv_indev_get_state(indev) != LV_INDEV_STATE_PRESSED;'\n"
+        "          timeout: 2s\n"
+        "      - delay: 250ms\n"
         "      - globals.set:\n"
         "          id: screensaver_wake_touch_guard_active\n"
         "          value: 'false'\n"
-        "      - lvgl.widget.hide: cover_art_wake_touch_guard\n"
+        "      - lvgl.widget.hide: screensaver_wake_touch_guard\n"
     )
-    expect_screensaver_wake_guard_errors(
-        "normal wake arms delayed guard",
+    valid_shared_wake_flow = (
         "globals:\n"
         "  - id: screensaver_wake_restore_pending\n"
         "    type: bool\n"
@@ -5791,6 +5882,50 @@ def run_self_test() -> int:
         "      - lambda: |-\n"
         "          id(screensaver_wake_restore_pending) =\n"
         "              !id(display_mode_controller).target_mode_is(espcontrol::DisplayMode::ACTIVE);\n"
+        "          id(screensaver_wake_touch_guard_skip_once) =\n"
+        "              id(display_mode_controller).target_mode_is(espcontrol::DisplayMode::COVER_ART) ||\n"
+        "              id(display_mode_controller).target_mode_is(espcontrol::DisplayMode::DISPLAY_OFF);\n"
+        "      - script.execute: screensaver_wake_touch_block\n"
+        "      - lambda: |-\n"
+        "          id(display_mode_controller).clear(espcontrol::DisplayRequestSource::IDLE_TIMER);\n"
+        "      - if:\n"
+        "          condition:\n"
+        "            lambda: |-\n"
+        "              const bool restore_pending = id(screensaver_wake_restore_pending);\n"
+        "              id(screensaver_wake_restore_pending) = false;\n"
+        "              return restore_pending ||\n"
+        "                  !id(display_mode_controller).current_mode_is(espcontrol::DisplayMode::ACTIVE);\n"
+        "          then:\n"
+        "            - if:\n"
+        "                condition:\n"
+        "                  lambda: |-\n"
+        "                    bool keep_wake_guard = id(screensaver_wake_touch_guard_skip_once);\n"
+        "                    id(screensaver_wake_touch_guard_skip_once) = false;\n"
+        "                    return keep_wake_guard;\n"
+        "                else:\n"
+        "                  - globals.set:\n"
+        "                      id: screensaver_wake_touch_guard_active\n"
+        "                      value: 'false'\n"
+        + valid_shared_wake_guard_script
+    )
+    expect_screensaver_wake_guard_errors(
+        "simple timed global guard is rejected",
+        "globals:\n"
+        "  - id: screensaver_wake_restore_pending\n"
+        "    type: bool\n"
+        "    initial_value: 'false'\n"
+        "script:\n"
+        "  - id: screensaver_wake\n"
+        "    then:\n"
+        "      - lambda: |-\n"
+        "          id(screensaver_wake_restore_pending) =\n"
+        "              !id(display_mode_controller).target_mode_is(espcontrol::DisplayMode::ACTIVE);\n"
+        "          id(screensaver_wake_touch_guard_skip_once) =\n"
+        "              id(display_mode_controller).target_mode_is(espcontrol::DisplayMode::COVER_ART) ||\n"
+        "              id(display_mode_controller).target_mode_is(espcontrol::DisplayMode::DISPLAY_OFF);\n"
+        "      - script.execute: screensaver_wake_touch_block\n"
+        "      - lambda: |-\n"
+        "          id(display_mode_controller).clear(espcontrol::DisplayRequestSource::IDLE_TIMER);\n"
         "      - if:\n"
         "          condition:\n"
         "            lambda: |-\n"
@@ -5803,44 +5938,53 @@ def run_self_test() -> int:
         "                id: screensaver_wake_touch_guard_active\n"
         "                value: 'true'\n"
         "            - script.execute: screensaver_wake_touch_guard_clear\n",
-        valid_cover_art_wake_guard,
+        valid_shared_wake_guard_widget,
+        "",
         (
             "do not block the first button tap after normal screensaver wake",
             "do not arm a delayed wake guard clear for normal screensaver wake",
+            "missing shared screensaver_wake_touch_block script",
         ),
     )
     expect_screensaver_wake_guard_errors(
-        "normal wake clears stale guard while cover art remains guarded",
-        "globals:\n"
-        "  - id: screensaver_wake_restore_pending\n"
-        "    type: bool\n"
-        "    initial_value: 'false'\n"
-        "script:\n"
-        "  - id: screensaver_wake\n"
-        "    then:\n"
-        "      - lambda: |-\n"
-        "          id(screensaver_wake_restore_pending) =\n"
-        "              !id(display_mode_controller).target_mode_is(espcontrol::DisplayMode::ACTIVE);\n"
-        "      - if:\n"
-        "          condition:\n"
-        "            lambda: |-\n"
-        "              const bool restore_pending = id(screensaver_wake_restore_pending);\n"
-        "              id(screensaver_wake_restore_pending) = false;\n"
-        "              return restore_pending ||\n"
-        "                  !id(display_mode_controller).current_mode_is(espcontrol::DisplayMode::ACTIVE);\n"
-        "          then:\n"
-        "            - if:\n"
-        "                condition:\n"
-        "                  lambda: |-\n"
-        "                    bool keep_cover_art_guard = id(display_mode_controller).target_mode_is(espcontrol::DisplayMode::COVER_ART) && id(screensaver_wake_touch_guard_skip_once);\n"
-        "                    id(screensaver_wake_touch_guard_skip_once) = false;\n"
-        "                    return keep_cover_art_guard;\n"
-        "                else:\n"
-        "                  - globals.set:\n"
-        "                      id: screensaver_wake_touch_guard_active\n"
-        "                      value: 'false'\n",
-        valid_cover_art_wake_guard,
+        "shared release guard covers Display Off and Cover Art",
+        valid_shared_wake_flow,
+        valid_shared_wake_guard_widget,
+        "script:\n  - id: cover_art_apply_responsive_layout\n",
         (),
+    )
+    expect_screensaver_wake_guard_errors(
+        "Cover Art-only guard does not cover Display Off",
+        valid_shared_wake_flow.replace(
+            " ||\n              id(display_mode_controller).target_mode_is(espcontrol::DisplayMode::DISPLAY_OFF)",
+            "",
+        ),
+        valid_shared_wake_guard_widget,
+        "",
+        ("pre-wake Cover Art and Display Off modes",),
+    )
+    expect_screensaver_wake_guard_errors(
+        "release guard accepts the next deliberate tap",
+        valid_shared_wake_flow.replace(
+            "      - globals.set:\n"
+            "          id: screensaver_wake_touch_guard_active\n"
+            "          value: 'false'\n"
+            "      - lvgl.widget.hide: screensaver_wake_touch_guard\n",
+            "",
+        ),
+        valid_shared_wake_guard_widget,
+        "",
+        (
+            "accept the first deliberate tap after wake-touch release",
+            "hide the shared wake guard after touch release",
+        ),
+    )
+    expect_screensaver_wake_guard_errors(
+        "stuck touch retains a bounded fallback",
+        valid_shared_wake_flow.replace("          timeout: 2s\n", ""),
+        valid_shared_wake_guard_widget,
+        "",
+        ("clear the shared wake guard after a stuck touch timeout",),
     )
     expect_clock_screensaver_overlay_errors(
         "clock screensaver closes active UI before showing",


### PR DESCRIPTION
Fixes #888

## Summary

- Replaces the Cover Art-only wake-touch guard with one shared, full-screen guard.
- Arms the guard before Display Off or Cover Art is cleared, so the waking touch cannot reach a control underneath.
- Keeps the guard active until the touch is released and input has settled, with a bounded timeout for stuck touches.
- Preserves the existing Dimmed and Clock wake behaviour, where the first tap wakes the panel.

## Practical impact

Picking up or touching a sleeping panel should now only wake it. The same touch should no longer activate a Home Assistant control that appears underneath as the display returns.

## Root cause

Display Off restored the normal controls while the touch that woke the panel could still be held. That same touch could then be delivered to the newly visible control. Cover Art already had release-aware protection, but it was tied to that screen rather than shared by Display Off.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- The existing screensaver guide already states that touching the dark panel wakes it; this fix restores that documented behaviour without adding a new setting.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.
- [ ] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- All supported P4 panels and the Guition ESP32-S3 4848S040 panel.

Automated checks completed:

- `npm run check:fast:legacy`
- Firmware binding regression checks and self-tests
- ESPHome 2026.7.0 factory compile:
  - `guition-esp32-p4-jc1060p470`
  - `guition-esp32-p4-jc4880p443`
  - `guition-esp32-p4-jc8012p4a1`
  - `guition-esp32-p4-jc8012p4a1-v2`
  - `esp32-p4-86`
  - `guition-esp32-s3-4848s040`

All six factory targets compiled successfully.

## Notes for testing

Physical testing has not been performed yet. On one P4 panel and one S3 panel:

1. Let the screensaver enter **Display Off**.
2. Wake it with both a quick tap and a longer hold directly over a control.
3. Confirm the waking touch causes no Home Assistant action and no visible pressed state.
4. Confirm the next deliberate tap operates the control exactly once.
5. Repeat through timer, presence, schedule, and manual-sleep wake routes where practical.
6. Confirm Cover Art still consumes its waking touch, while Dimmed and Clock behaviour is unchanged.

## PR status

- [ ] Checks running or waiting.
- [ ] Needs automated fix.
- [x] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.