### PR TITLE
Allow screensaver sleep when cover art is disabled

### DIFF
--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -554,7 +554,8 @@ script:
                     return id(display_mode_controller).target_mode_is(
                                espcontrol::DisplayMode::COVER_ART) ||
                            alarm_display_takeover_active() ||
-                           (id(media_player_sleep_prevention_enabled).state &&
+                           (id(cover_art_screensaver_enabled).state &&
+                            id(media_player_sleep_prevention_enabled).state &&
                             id(media_player_playing));
                 then:
                   - script.execute: screensaver_idle_check

--- a/docs/features/media-cover-art.md
+++ b/docs/features/media-cover-art.md
@@ -18,7 +18,7 @@ You will find these controls in **Settings > Sleep & Schedule > Media Cover Art*
 - **Show After** also controls how long cover art waits before returning after you dismiss it by touch. The countdown restarts after every touch, so cover art returns only after the selected time has passed since your most recent touch.
 - **Show Track Details For** - controls how long track information is shown over the artwork on the 4-inch square displays.
 - **Advanced Options** - contains playback, source, and filtering controls you may not need every day.
-- **Keep Screen Awake During Playback** - is on by default and prevents the display from sleeping while media plays. It does not bypass the **Show After** delay.
+- **Keep Screen Awake During Playback** - is on by default and prevents the display from sleeping while media plays when **Show Cover Art** is enabled. It does not bypass the **Show After** delay, and has no effect while cover art is disabled.
 - **Hide for external source inputs** - hides cover art when the selected media player source is `TV` or `Line-in`.
 - **Advanced Filtering** - reveals **Only Show When**, which limits cover art to matching media player attributes, such as `app_id=com.apple.TVMusic` or `app_id=com.apple.TVMusic; media_content_type=music`.
 

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -1151,18 +1151,22 @@ def firmware_media_sleep_prevention_errors(
             errors.append(f"{rel}: missing screensaver_idle_check script")
         else:
             if (
-                "id(media_player_sleep_prevention_enabled).state &&" not in idle_body
+                "id(cover_art_screensaver_enabled).state &&" not in idle_body
+                or "id(media_player_sleep_prevention_enabled).state &&" not in idle_body
                 or "id(media_player_playing)" not in idle_body
             ):
-                errors.append(f"{rel}: keep media playback awake only through the media sleep prevention setting")
+                errors.append(
+                    f"{rel}: keep media playback awake only while cover art and media sleep prevention are enabled"
+                )
             if "id(cover_art_media_playing)" in idle_body:
                 errors.append(f"{rel}: use the dedicated media sleep prevention playback state")
             if re.search(
-                r"id\(cover_art_screensaver_enabled\)\.state[\s\S]{0,160}"
+                r"\(id\(media_player_sleep_prevention_enabled\)\.state\s*\|\|\s*"
+                r"id\(cover_art_screensaver_enabled\)\.state\)\s*&&\s*"
                 r"id\(media_player_playing\)",
                 idle_body,
             ):
-                errors.append(f"{rel}: do not let cover art alone keep the idle timer awake")
+                errors.append(f"{rel}: require both cover art and media sleep prevention to keep the idle timer awake")
         sleep_body = yaml_script_body(text, "screensaver_sleep_timer")
         if sleep_body is not None:
             if "id(cover_art_media_playing)" in sleep_body and not re.search(
@@ -4903,13 +4907,13 @@ def run_self_test() -> int:
         "    then:\n"
         "      - script.execute: cover_art_start_delay\n",
         (
-            "do not let cover art alone keep the idle timer awake",
+            "require both cover art and media sleep prevention to keep the idle timer awake",
             "do not turn on media sleep prevention",
             "let cover art use its own delay",
         ),
     )
     expect_media_sleep_prevention_errors(
-        "media sleep prevention is independent from cover art",
+        "playback cannot block sleep while cover art is disabled",
         "script:\n"
         "  - id: screensaver_idle_check\n"
         "    then:\n"
@@ -4918,6 +4922,22 @@ def run_self_test() -> int:
         "            lambda: |-\n"
         "              return id(display_mode_controller).target_mode_is(espcontrol::DisplayMode::COVER_ART) ||\n"
         "                     (id(media_player_sleep_prevention_enabled).state &&\n"
+        "                      id(media_player_playing));\n",
+        "",
+        "",
+        ("keep media playback awake only while cover art and media sleep prevention are enabled",),
+    )
+    expect_media_sleep_prevention_errors(
+        "media sleep prevention applies while cover art is enabled",
+        "script:\n"
+        "  - id: screensaver_idle_check\n"
+        "    then:\n"
+        "      - if:\n"
+        "          condition:\n"
+        "            lambda: |-\n"
+        "              return id(display_mode_controller).target_mode_is(espcontrol::DisplayMode::COVER_ART) ||\n"
+        "                     (id(cover_art_screensaver_enabled).state &&\n"
+        "                      id(media_player_sleep_prevention_enabled).state &&\n"
         "                      id(media_player_playing));\n"
         "  - id: screensaver_wake\n"
         "    then:\n"
@@ -4960,7 +4980,8 @@ def run_self_test() -> int:
         "          condition:\n"
         "            lambda: |-\n"
         "              return id(display_mode_controller).target_mode_is(espcontrol::DisplayMode::COVER_ART) ||\n"
-        "                     (id(media_player_sleep_prevention_enabled).state &&\n"
+        "                     (id(cover_art_screensaver_enabled).state &&\n"
+        "                      id(media_player_sleep_prevention_enabled).state &&\n"
         "                      id(media_player_playing));\n"
         "  - id: screensaver_sleep_timer\n"
         "    then:\n"
@@ -5009,7 +5030,8 @@ def run_self_test() -> int:
         "          condition:\n"
         "            lambda: |-\n"
         "              return id(display_mode_controller).target_mode_is(espcontrol::DisplayMode::COVER_ART) ||\n"
-        "                     (id(media_player_sleep_prevention_enabled).state &&\n"
+        "                     (id(cover_art_screensaver_enabled).state &&\n"
+        "                      id(media_player_sleep_prevention_enabled).state &&\n"
         "                      id(media_player_playing));\n"
         "  - id: screensaver_sleep_timer\n"
         "    then:\n"


### PR DESCRIPTION
## Summary

Stops music playback from holding the normal screen awake when the cover-art screen saver is disabled.

## Practical impact

- Timer and presence screen savers can sleep while music is playing if Show Cover Art is off.
- Keep Screen Awake During Playback still works when Show Cover Art is enabled.
- The saved keep-awake preference is preserved, so it becomes effective again if cover art is re-enabled.

## Documentation decision

- [x] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [ ] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Clarified that playback sleep prevention applies only while cover art is enabled.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.
- [ ] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- All supported displays.

## Notes for testing

- Disable Show Cover Art, play music on the configured media player, and confirm the selected timer or presence screensaver still activates.
- Re-enable Show Cover Art and confirm Keep Screen Awake During Playback still prevents normal sleep while music is playing.
- Automated fast checks passed, including all 10 firmware tests, generated configuration checks, web checks, and the new regression guard.

## PR status

- [ ] Checks running or waiting.
- [ ] Needs automated fix.
- [x] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.