### PR TITLE
Fix release notes checkout on self-hosted runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
     if: github.event_name == 'release' || inputs.release_tag != ''
     runs-on: self-hosted
     steps:
+      - name: Prepare self-hosted workspace
+        run: |
+          rm -rf "${GITHUB_WORKSPACE:?}/"* "${GITHUB_WORKSPACE:?}/".[!.]* "${GITHUB_WORKSPACE:?}/"..?* 2>/dev/null ||
+            sudo rm -rf "${GITHUB_WORKSPACE:?}/"* "${GITHUB_WORKSPACE:?}/".[!.]* "${GITHUB_WORKSPACE:?}/"..?*
+
       - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Purpose

Ensure release notes are generated from a complete checkout on reused self-hosted runners.

## Practical impact

The release workflow now clears stale workspace state before checking out the release tag, matching the protection already used by the other self-hosted release jobs. This prevents tracked tools such as `scripts/release_changelog.py` from being unexpectedly absent.

## Checks

- `git diff --check`
- `actionlint .github/workflows/release.yml`
- `python3 scripts/check_release_changelog.py`
- `python3 scripts/check_dev_docs.py`

## Testing notes

Automated checks validate the workflow and changelog generator. No physical device testing is required. The final confirmation is a successful release-notes job when the release workflow is dispatched for an existing tag.