### PR TITLE
Update docs for recent functionality

### DIFF
--- a/docs/card-types/covers.md
+++ b/docs/card-types/covers.md
@@ -14,7 +14,7 @@ A cover card lets you control a Home Assistant cover entity — blinds, shutters
 
 1. Select a card and change its type to **Cover**.
 2. Choose the interaction:
-   - **All Controls** opens a full-screen control with tabs for simple controls, position, and tilt.
+   - **All Controls** opens a full-screen control with tabs for simple controls, position, tilt, and position presets.
    - **Slider: Position** lets you drag to a precise cover position.
    - **Slider: Tilt** lets you drag to a precise cover tilt position.
    - **Toggle** opens or closes the cover with a tap.
@@ -36,6 +36,7 @@ A cover card lets you control a Home Assistant cover entity — blinds, shutters
 - The **Simple Controls** tab shows the supported actions: **Up**, **Stop**, and **Down**. For tilt-only covers, these use Home Assistant's tilt commands.
 - The **Position** tab lets you drag the cover position from 0 to 100 percent, and is hidden when the entity does not support position control.
 - The **Tilt** tab appears only when the Home Assistant cover entity supports tilt, and lets you drag the cover tilt from 0 to 100 percent.
+- The **Presets** tab appears when position control is supported and provides one-tap positions at 0, 25, 50, 75, and 100 percent.
 - Position and tilt update when Home Assistant reports `current_position` and `current_tilt_position`.
 
 ### Slider Interaction

--- a/docs/features/firmware-updates.md
+++ b/docs/features/firmware-updates.md
@@ -17,6 +17,8 @@ These are configured from the **Settings** tab in the [Setup](/features/setup) u
 - **Previous firmware** — open this panel to choose and install one of the available previous stable versions.
 - **Check for Update** — press this button to check for a new version right now, regardless of the automatic schedule.
 
+When either a panel firmware update or WiFi co-processor update is available, the collapsed **Firmware** section shows an **Update available** badge so you do not need to open each update panel to check.
+
 Manual Ethernet builds can be different. If you used the advanced Ethernet setup with `disable_updates: "true"`, these built-in GitHub update controls are removed from the panel firmware. Use ESPHome OTA or USB from your ESPHome setup to update that display instead.
 
 ## What Happens During an Update

--- a/docs/features/setup.md
+++ b/docs/features/setup.md
@@ -93,6 +93,7 @@ Right-click a card and open **Size** to choose:
 - **Extra Large** - spans a 3 x 3 area and is available for Media cover-art cards.
 - **Max wide** - spans a 3 x 2 area and is available for Camera cards.
 - **Max tall** - spans a 2 x 3 area and is available for Camera cards.
+- **Portrait** - spans a 3 x 4 area and is available for Camera and Media cover-art cards on both 10.1-inch panels.
 
 If a card already occupies the space needed for a larger size, the setup page tries to move it to the next available slot. If there is not enough room, the size change is not applied.
 


### PR DESCRIPTION
## Summary

- Document the Cover card's position presets.
- Add the 10.1-inch Portrait (3x4) size for Camera and Media cover-art cards.
- Explain the collapsed Firmware section's update badge for panel and WiFi firmware updates.

## Practical impact

The public docs now cover the user-visible functionality added during the last two weeks. This PR changes documentation only; it does not change firmware or device behaviour.

## Documentation decision

- [x] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [ ] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Updated the relevant user-facing docs for functionality added in the last two weeks.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [ ] Device testing is required before merge.
- [x] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- Documentation site only.

Checks run:

- `npm run docs:build`
- `git diff --check`

## Notes for testing

- This is a documentation-only change. Confirm the wording matches the setup page and device controls; no firmware or physical display behaviour changed.

## PR status

- [ ] Checks running or waiting.
- [ ] Needs automated fix.
- [ ] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [x] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.
