### PR TITLE
Reduce P4 4.3-inch modal tab icons

### DIFF
--- a/common/config/modal_layout_geometry_fixtures.json
+++ b/common/config/modal_layout_geometry_fixtures.json
@@ -19,7 +19,7 @@
         "buttonSize": 100,
         "arc": {"size": 475, "stroke": 21, "centerX": 0},
         "controlsCenterY": 192,
-        "tabs": {"size": 67, "selectedSize": 75, "gap": 16, "frameWidth": 425, "frameHeight": 93, "safeLeft": 90, "rowLeft": 294, "contentGap": 35},
+        "tabs": {"size": 67, "selectedSize": 75, "gap": 16, "frameWidth": 425, "frameHeight": 93, "safeLeft": 90, "rowLeft": 294, "contentGap": 35, "iconZoom": 180},
         "content": {"top": 150, "bottom": 531, "width": 970, "height": 381, "centerY": 64}
       }
     },
@@ -41,7 +41,7 @@
         "buttonSize": 80,
         "arc": {"size": 434, "stroke": 17, "centerX": 0},
         "controlsCenterY": 181,
-        "tabs": {"size": 58, "selectedSize": 65, "gap": 14, "frameWidth": 368, "frameHeight": 80, "safeLeft": 85, "rowLeft": 85, "contentGap": 12},
+        "tabs": {"size": 58, "selectedSize": 65, "gap": 14, "frameWidth": 368, "frameHeight": 80, "safeLeft": 85, "rowLeft": 85, "contentGap": 12, "iconZoom": 180},
         "content": {"top": 110, "bottom": 727, "width": 434, "height": 617, "centerY": 46}
       }
     },
@@ -63,7 +63,7 @@
         "buttonSize": 133,
         "arc": {"size": 643, "stroke": 28, "centerX": 0},
         "controlsCenterY": 261,
-        "tabs": {"size": 64, "selectedSize": 72, "gap": 25, "frameWidth": 444, "frameHeight": 88, "safeLeft": 121, "rowLeft": 413, "contentGap": 36},
+        "tabs": {"size": 64, "selectedSize": 72, "gap": 25, "frameWidth": 444, "frameHeight": 88, "safeLeft": 121, "rowLeft": 413, "contentGap": 36, "iconZoom": 180},
         "content": {"top": 154, "bottom": 719, "width": 1210, "height": 565, "centerY": 62}
       }
     },
@@ -85,7 +85,7 @@
         "buttonSize": 120,
         "arc": {"size": 558, "stroke": 25, "centerX": 0},
         "controlsCenterY": 225,
-        "tabs": {"size": 75, "selectedSize": 84, "gap": 18, "frameWidth": 477, "frameHeight": 105, "safeLeft": 109, "rowLeft": 113, "contentGap": 45},
+        "tabs": {"size": 75, "selectedSize": 84, "gap": 18, "frameWidth": 477, "frameHeight": 105, "safeLeft": 109, "rowLeft": 113, "contentGap": 45, "iconZoom": 220},
         "content": {"top": 177, "bottom": 627, "width": 650, "height": 450, "centerY": 75}
       }
     },
@@ -107,7 +107,7 @@
         "buttonSize": 80,
         "arc": {"size": 373, "stroke": 17, "centerX": 0},
         "controlsCenterY": 150,
-        "tabs": {"size": 48, "selectedSize": 54, "gap": 12, "frameWidth": 306, "frameHeight": 66, "safeLeft": 73, "rowLeft": 82, "contentGap": 16},
+        "tabs": {"size": 48, "selectedSize": 54, "gap": 12, "frameWidth": 306, "frameHeight": 66, "safeLeft": 73, "rowLeft": 82, "contentGap": 16, "iconZoom": 180},
         "content": {"top": 100, "bottom": 418, "width": 434, "height": 318, "centerY": 41}
       }
     }

--- a/components/espcontrol/button_grid_modal.h
+++ b/components/espcontrol/button_grid_modal.h
@@ -477,8 +477,7 @@ inline void control_modal_center_tab_icon(lv_obj_t *label) {
 }
 
 inline uint16_t control_modal_tab_icon_zoom(const ControlModalLayout &layout) {
-  return (control_modal_uses_compact_portrait_tuning(layout) ||
-          control_modal_uses_large_square_tuning(layout)) ? 220 : 180;
+  return espcontrol::modal::tab_icon_zoom(layout.profile);
 }
 
 inline void control_modal_layout_tab_button(lv_obj_t *tab_btn,

--- a/components/espcontrol/button_grid_modal_layout.h
+++ b/components/espcontrol/button_grid_modal_layout.h
@@ -244,6 +244,10 @@ constexpr int shared_tab_size(const DeviceProfile &profile,
   return control_tab_size(profile, frame, tokens);
 }
 
+constexpr int tab_icon_zoom(const DeviceProfile &profile) {
+  return uses_family(profile, LayoutFamily::LARGE_SQUARE) ? 220 : 180;
+}
+
 constexpr int tab_gap(const DeviceProfile &profile, int tab_size) {
   const bool large_landscape = uses_family(profile, LayoutFamily::LARGE_LANDSCAPE);
   int gap = large_landscape ? tab_size * 2 / 5 : tab_size / 4;

--- a/scripts/check_firmware_modal_layouts.py
+++ b/scripts/check_firmware_modal_layouts.py
@@ -119,6 +119,7 @@ def cpp_assertions(entry: dict, index: int) -> list[str]:
         f"    assert(tabs.safe_left == {tabs['safeLeft']});",
         f"    assert(tabs.row_left == {tabs['rowLeft']});",
         f"    assert(tabs.content_gap == {tabs['contentGap']});",
+        f"    assert(tab_icon_zoom(profile) == {tabs['iconZoom']});",
         "    assert(tabs.tab_size > 0);",
         "    assert(tabs.row_left >= 0);",
         "    assert(tabs.row_left + tabs.frame_width <= layout.panel_width);",


### PR DESCRIPTION
## Summary

- Reduce modal-tab icons on the Guition JC4880P443 4.3-inch P4 display from 220/256 to 180/256 scale.
- Keep the larger icon treatment on the 8.6-inch square P4 display unchanged.
- Add the expected icon scale to the modal layout profile checks.

## Practical impact

- Icons in climate, fan, media, light, and other shared modal tab bars appear about 18% smaller on the 4.3-inch P4 display.
- Tab button and touch-target sizes are unchanged.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this is a small visual adjustment with no configuration or workflow change.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- No public documentation change is needed for this sizing adjustment.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.
- [ ] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- Guition JC4880P443 (P4 4.3-inch, 480 × 800)

## Notes for testing

- Automated checks: `npm run check:fast` passed, including all 11 firmware tests and the modal layout profile checks.
- GitHub CI and documentation checks passed.
- The PR firmware was flashed over OTA to the JC4880P443 at `192.168.6.101`.
- The display rebooted successfully and the user confirmed it is ready to merge.

## PR status

- [ ] Checks running or waiting.
- [ ] Needs automated fix.
- [ ] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [x] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.