### PR TITLE
Hide cover art for external inputs

### DIFF
--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -334,6 +334,7 @@ inline void clear_media_cover_art(MediaNowPlayingCtx *ctx) {
     ctx->cover_art->end_display_takeover = nullptr;
     ctx->cover_art->diagnostics_enabled = false;
     ctx->cover_art->media_artwork = false;
+    ctx->cover_art->media_artwork_suppressed = false;
     ctx->cover_art->media_overlay = nullptr;
     ctx->cover_art->media_overlay_artwork_tint = false;
     ctx->cover_art->media_artwork_applied = nullptr;
@@ -401,6 +402,7 @@ inline void setup_media_cover_art(BtnSlot &s, const ParsedCfg &p,
   art->end_display_takeover = cfg.end_display_takeover;
   art->modal_fit = false;
   art->media_artwork = true;
+  art->media_artwork_suppressed = media_ctx->external_source;
   art->media_overlay = overlay;
   art->media_overlay_artwork_tint = show_track_details;
   art->media_artwork_applied = [media_ctx]() {
@@ -416,11 +418,7 @@ inline void setup_media_cover_art(BtnSlot &s, const ParsedCfg &p,
   media_ctx->cover_overlay = overlay;
   if (image_only && media_ctx->btn) lv_obj_set_user_data(media_ctx->btn, art);
   if (art->image_ready) {
-    image_card_set_widget_source(img, art->image);
-    if (overlay) {
-      image_card_apply_media_overlay_tint(art);
-      lv_obj_clear_flag(overlay, LV_OBJ_FLAG_HIDDEN);
-    }
+    image_card_sync_media_artwork_visibility(art);
   }
   media_cover_art_refresh_geometry(media_ctx);
   image_card_log_diagnostics(art, "bind-media-artwork");

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -402,7 +402,8 @@ inline void setup_media_cover_art(BtnSlot &s, const ParsedCfg &p,
   art->end_display_takeover = cfg.end_display_takeover;
   art->modal_fit = false;
   art->media_artwork = true;
-  art->media_artwork_suppressed = media_ctx->external_source;
+  art->media_artwork_suppressed =
+    !media_ctx->source_known || media_ctx->external_source;
   art->media_overlay = overlay;
   art->media_overlay_artwork_tint = show_track_details;
   art->media_artwork_applied = [media_ctx]() {

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -70,6 +70,7 @@ struct ImageCardCtx {
   bool diagnostics_enabled = false;
   bool access_token_request_pending = false;
   bool media_artwork = false;
+  bool media_artwork_suppressed = false;
   lv_obj_t *media_overlay = nullptr;
   bool media_overlay_artwork_tint = false;
   std::function<void()> media_artwork_applied;
@@ -473,6 +474,39 @@ inline void image_card_hide(ImageCardCtx *ctx) {
   if (ctx->widget) lv_obj_add_flag(ctx->widget, LV_OBJ_FLAG_HIDDEN);
 }
 
+inline void image_card_apply_media_overlay_tint(ImageCardCtx *ctx);
+
+inline void image_card_sync_media_artwork_visibility(ImageCardCtx *ctx) {
+  if (!ctx || !ctx->media_artwork || !ctx->widget) return;
+  if (ctx->media_artwork_suppressed || !ctx->image_ready || !ctx->image) {
+    lv_obj_add_flag(ctx->widget, LV_OBJ_FLAG_HIDDEN);
+    if (ctx->media_overlay) {
+      lv_obj_add_flag(ctx->media_overlay, LV_OBJ_FLAG_HIDDEN);
+    }
+  } else {
+    image_card_set_widget_source(ctx->widget, ctx->image);
+    lv_obj_clear_flag(ctx->widget, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_move_background(ctx->widget);
+    if (ctx->media_overlay) {
+      image_card_apply_media_overlay_tint(ctx);
+      lv_obj_clear_flag(ctx->media_overlay, LV_OBJ_FLAG_HIDDEN);
+      lv_obj_move_foreground(ctx->media_overlay);
+    }
+    if (ctx->media_artwork_applied) ctx->media_artwork_applied();
+  }
+  lv_obj_invalidate(ctx->widget);
+  if (ctx->btn) lv_obj_invalidate(ctx->btn);
+  notify_dashboard_content_changed();
+}
+
+inline void image_card_set_media_artwork_suppressed(ImageCardCtx *ctx,
+                                                     bool suppressed) {
+  if (!ctx || !ctx->media_artwork) return;
+  if (ctx->media_artwork_suppressed == suppressed) return;
+  ctx->media_artwork_suppressed = suppressed;
+  image_card_sync_media_artwork_visibility(ctx);
+}
+
 inline void image_card_clear_media_artwork(ImageCardCtx *ctx) {
   if (!ctx || !ctx->media_artwork) return;
   image_card_release_download_slot(ctx);
@@ -634,18 +668,16 @@ inline void image_card_apply_downloaded(ImageCardCtx *ctx) {
   }
   image_card_log_diagnostics(ctx, "tile-download-applied");
   image_card_hide_loading(ctx);
-  image_card_set_widget_source(ctx->widget, ctx->image);
-  lv_obj_clear_flag(ctx->widget, LV_OBJ_FLAG_HIDDEN);
-  lv_obj_move_background(ctx->widget);
-  if (ctx->media_overlay) {
-    image_card_apply_media_overlay_tint(ctx);
-    lv_obj_clear_flag(ctx->media_overlay, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_move_foreground(ctx->media_overlay);
+  if (ctx->media_artwork) {
+    image_card_sync_media_artwork_visibility(ctx);
+  } else {
+    image_card_set_widget_source(ctx->widget, ctx->image);
+    lv_obj_clear_flag(ctx->widget, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_move_background(ctx->widget);
+    lv_obj_invalidate(ctx->widget);
+    if (ctx->btn) lv_obj_invalidate(ctx->btn);
+    notify_dashboard_content_changed();
   }
-  if (ctx->media_artwork_applied) ctx->media_artwork_applied();
-  lv_obj_invalidate(ctx->widget);
-  if (ctx->btn) lv_obj_invalidate(ctx->btn);
-  notify_dashboard_content_changed();
 }
 
 inline void image_card_handle_download_error(ImageCardCtx *ctx) {
@@ -828,6 +860,7 @@ inline void reset_image_card_pool(const GridConfig &cfg) {
     contexts[i].diagnostics_enabled = false;
     contexts[i].access_token_request_pending = false;
     contexts[i].media_artwork = false;
+    contexts[i].media_artwork_suppressed = false;
     contexts[i].media_overlay = nullptr;
     contexts[i].media_overlay_artwork_tint = false;
     contexts[i].media_artwork_applied = nullptr;
@@ -2214,6 +2247,7 @@ inline bool image_card_bind_runtime(BtnSlot &s, const ParsedCfg &p,
   ctx->end_display_takeover = cfg.end_display_takeover;
   ctx->modal_fit = image_card_modal_fit_enabled(p);
   ctx->media_artwork = false;
+  ctx->media_artwork_suppressed = false;
   ctx->media_overlay = nullptr;
   ctx->pending_fallback_picture.clear();
   ctx->media_artwork_retry_mask = 0;

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -479,6 +479,7 @@ struct MediaPlaybackState {
   bool has_state = false;
   bool available = true;
   bool playing = false;
+  bool source_known = false;
   bool external_source = false;
   bool has_duration = false;
   bool has_position = false;
@@ -632,6 +633,7 @@ inline void media_playback_reset_state(MediaPlaybackState *state,
   state->has_state = false;
   state->available = true;
   state->playing = false;
+  state->source_known = false;
   state->external_source = false;
   state->has_duration = false;
   state->has_position = false;
@@ -824,10 +826,11 @@ inline void media_playback_apply_state_to_buttons(MediaPlaybackState *state) {
 inline void media_playback_apply_state_to_now_playing(MediaPlaybackState *state,
                                                       MediaNowPlayingCtx *ctx) {
   if (!state || !ctx) return;
+  ctx->source_known = state->source_known;
   ctx->external_source = state->external_source;
   if (ctx->cover_art) {
     image_card_set_media_artwork_suppressed(
-      ctx->cover_art, ctx->external_source);
+      ctx->cover_art, !ctx->source_known || ctx->external_source);
   }
   if (ctx->title_lbl) {
     const std::string title = state->title.empty() ? std::string("--") : state->title;
@@ -1241,9 +1244,10 @@ inline void media_playback_subscribe_source(MediaPlaybackState *state) {
   auto handle_media_source = [state, generation](esphome::StringRef source) {
     if (!media_playback_generation_valid(state, generation)) return;
     bool external = media_external_source_input(media_metadata_text(source, ""));
-    if (external == state->external_source) return;
+    bool changed = !state->source_known || external != state->external_source;
+    state->source_known = true;
     state->external_source = external;
-    media_playback_apply_metadata_consumers(state);
+    if (changed) media_playback_apply_metadata_consumers(state);
   };
   ha_subscribe_attribute(
     entity_id, std::string("source"),

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -219,6 +219,7 @@ inline void media_playback_detach_slider(SliderCtx *ctx);
 inline void media_playback_attach_control(MediaPlaybackState *state, MediaControlCtx *ctx);
 inline void media_playback_subscribe_playback_state(MediaPlaybackState *state);
 inline void media_playback_subscribe_metadata(MediaPlaybackState *state);
+inline void media_playback_subscribe_source(MediaPlaybackState *state);
 inline void media_playback_subscribe_progress(
   MediaPlaybackState *state,
   uint32_t scope = HA_SUBSCRIPTION_SCOPE_DEFAULT);
@@ -460,6 +461,7 @@ struct MediaPlaybackState {
   bool used = false;
   bool state_subscribed = false;
   bool metadata_subscribed = false;
+  bool source_subscribed = false;
   bool progress_subscribed = false;
   uint32_t progress_subscription_scope = 0;
   bool volume_subscribed = false;
@@ -612,6 +614,7 @@ inline void media_playback_reset_state(MediaPlaybackState *state,
   state->used = true;
   state->state_subscribed = false;
   state->metadata_subscribed = false;
+  state->source_subscribed = false;
   state->progress_subscribed = false;
   state->progress_subscription_scope = 0;
   state->volume_subscribed = false;
@@ -821,6 +824,11 @@ inline void media_playback_apply_state_to_buttons(MediaPlaybackState *state) {
 inline void media_playback_apply_state_to_now_playing(MediaPlaybackState *state,
                                                       MediaNowPlayingCtx *ctx) {
   if (!state || !ctx) return;
+  ctx->external_source = state->external_source;
+  if (ctx->cover_art) {
+    image_card_set_media_artwork_suppressed(
+      ctx->cover_art, ctx->external_source);
+  }
   if (ctx->title_lbl) {
     const std::string title = state->title.empty() ? std::string("--") : state->title;
     lv_label_set_text(ctx->title_lbl, title.c_str());
@@ -828,7 +836,6 @@ inline void media_playback_apply_state_to_now_playing(MediaPlaybackState *state,
   if (ctx->artist_lbl) {
     std::strncpy(ctx->artist, state->artist.c_str(), sizeof(ctx->artist) - 1);
     ctx->artist[sizeof(ctx->artist) - 1] = '\0';
-    ctx->external_source = state->external_source;
     media_apply_now_playing_artist_text(ctx);
   }
   media_position_now_playing_artist(ctx);
@@ -1223,6 +1230,14 @@ inline void media_playback_subscribe_metadata(MediaPlaybackState *state) {
       })
   );
 
+  media_playback_subscribe_source(state);
+}
+
+inline void media_playback_subscribe_source(MediaPlaybackState *state) {
+  if (!state || state->source_subscribed || state->entity_id.empty()) return;
+  state->source_subscribed = true;
+  const std::string entity_id = state->entity_id;
+  const uint32_t generation = state->generation;
   auto handle_media_source = [state, generation](esphome::StringRef source) {
     if (!media_playback_generation_valid(state, generation)) return;
     bool external = media_external_source_input(media_metadata_text(source, ""));
@@ -2960,6 +2975,15 @@ inline void subscribe_media_now_playing_state(MediaNowPlayingCtx *ctx,
     media_playback_attach_button(state, ctx->btn, nullptr);
     media_playback_subscribe_playback_state(state);
   }
+}
+
+inline void subscribe_media_cover_art_source_state(
+    MediaNowPlayingCtx *ctx, const std::string &entity_id) {
+  if (!ctx || entity_id.empty()) return;
+  MediaPlaybackState *state = media_playback_ensure_state(entity_id);
+  if (!state) return;
+  media_playback_attach_now_playing(state, ctx);
+  media_playback_subscribe_source(state);
 }
 
 inline MediaVolumeCtx *create_media_volume_context(lv_obj_t *btn,

--- a/components/espcontrol/button_grid_media_driver.h
+++ b/components/espcontrol/button_grid_media_driver.h
@@ -237,6 +237,8 @@ inline bool media_driver_bind_data(
     if (mode == "now_playing" ||
         (mode == "cover_art" && media_cover_art_details_enabled(config))) {
       subscribe_media_now_playing_state(now_playing, config.entity);
+    } else {
+      subscribe_media_cover_art_source_state(now_playing, config.entity);
     }
     subscribe_media_cover_art(now_playing, config.entity);
     if (mode == "cover_art" &&

--- a/components/espcontrol/button_grid_sliders.h
+++ b/components/espcontrol/button_grid_sliders.h
@@ -4,6 +4,10 @@
 
 // Internal implementation detail for button_grid.h. Include button_grid.h from device YAML.
 
+struct ImageCardCtx;
+inline void image_card_set_media_artwork_suppressed(ImageCardCtx *ctx,
+                                                     bool suppressed);
+
 // ── Slider widgets ───────────────────────────────────────────────────
 
 // Context attached to each LVGL slider via user_data

--- a/components/espcontrol/button_grid_sliders.h
+++ b/components/espcontrol/button_grid_sliders.h
@@ -61,6 +61,7 @@ struct MediaNowPlayingCtx {
   lv_obj_t *cover_overlay = nullptr;
   lv_obj_t *btn = nullptr;
   char artist[HA_STATE_TEXT_MAX_LEN + 1] = {};
+  bool source_known = false;
   bool external_source = false;
   bool play_pause_background = false;
   bool artist_below_title = false;

--- a/docs/card-types/media.md
+++ b/docs/card-types/media.md
@@ -72,6 +72,8 @@ Now Playing works best on wider or larger cards because it has more room for tra
 
 Cover Art shows the current artwork reported by the selected media player. Choose a square card size: **1x1**, **2x2**, or **3x3**. EspControl crops the image to fill the tile without stretching it.
 
+When the media player source is **TV** or **Line-in**, the card hides any previously cached artwork so it does not show the last music track while an external input is playing. The latest artwork returns automatically when the media player switches back to a normal media source.
+
 Enable **Show Track Details** to place the current title and artist over the artwork. EspControl adds an artwork-derived dark tint so the text remains readable. If artwork is unavailable, the title and artist remain visible on the card's normal background. The setting is off by default, so existing Cover Art cards remain image-only.
 
 Choose what happens when the artwork is tapped:

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -474,6 +474,54 @@ def firmware_media_card_availability_errors(firmware_dir: Path, root: Path) -> l
     return errors
 
 
+def firmware_media_cover_art_external_input_errors(
+    firmware_dir: Path, root: Path
+) -> list[str]:
+    paths = {
+        name: firmware_dir / name
+        for name in (
+            "button_grid_media.h",
+            "button_grid_media_driver.h",
+            "button_grid_image.h",
+            "button_grid_grid.h",
+        )
+    }
+    if not all(path.exists() for path in paths.values()):
+        return []
+    media = paths["button_grid_media.h"].read_text(encoding="utf-8")
+    driver = paths["button_grid_media_driver.h"].read_text(encoding="utf-8")
+    image = paths["button_grid_image.h"].read_text(encoding="utf-8")
+    grid = paths["button_grid_grid.h"].read_text(encoding="utf-8")
+    rel = paths["button_grid_media.h"].relative_to(root)
+    errors: list[str] = []
+
+    if (
+        "source_subscribed" not in media
+        or "media_playback_subscribe_source" not in media
+        or 'std::string("source")' not in media
+    ):
+        errors.append(f"{rel}: keep media source tracking independent from title and artist metadata")
+    if (
+        "subscribe_media_cover_art_source_state" not in media
+        or "subscribe_media_cover_art_source_state(now_playing, config.entity)" not in driver
+    ):
+        errors.append(f"{rel}: subscribe image-only cover art cards to media source changes")
+    if (
+        "image_card_set_media_artwork_suppressed(" not in media
+        or "media_artwork_suppressed" not in image
+        or "image_card_sync_media_artwork_visibility" not in image
+    ):
+        errors.append(f"{rel}: hide media card artwork while an external input is active")
+    if (
+        "if (ctx->media_artwork)" not in image
+        or "image_card_sync_media_artwork_visibility(ctx);" not in image
+        or "art->media_artwork_suppressed = media_ctx->external_source;" not in grid
+        or "image_card_sync_media_artwork_visibility(art);" not in grid
+    ):
+        errors.append(f"{rel}: prevent cached or late artwork downloads from bypassing suppression")
+    return errors
+
+
 def firmware_action_card_script_fields_errors(firmware_dir: Path, root: Path) -> list[str]:
     path = firmware_dir / "button_grid_actions.h"
     if not path.exists():
@@ -2909,6 +2957,7 @@ def run_scan() -> int:
     errors.extend(firmware_action_card_availability_errors(FIRMWARE_DIR, ROOT))
     errors.extend(firmware_card_disabled_state_errors(FIRMWARE_DIR, ROOT))
     errors.extend(firmware_media_card_availability_errors(FIRMWARE_DIR, ROOT))
+    errors.extend(firmware_media_cover_art_external_input_errors(FIRMWARE_DIR, ROOT))
     errors.extend(firmware_action_card_script_fields_errors(FIRMWARE_DIR, ROOT))
     errors.extend(firmware_local_sensor_binding_order_errors(FIRMWARE_DIR, ROOT))
     errors.extend(firmware_time_reconnect_errors(TIME_ADDON_PATH, ROOT))
@@ -3085,6 +3134,23 @@ def expect_media_card_availability_errors(name: str, text: str, expected: tuple[
         (firmware_dir / "button_grid_media.h").write_text(text, encoding="utf-8")
 
         errors = firmware_media_card_availability_errors(firmware_dir, root)
+        for item in expected:
+            assert any(item in error for error in errors), f"{name}: missing {item!r} in {errors!r}"
+        if not expected:
+            assert not errors, f"{name}: expected no errors, got {errors!r}"
+
+
+def expect_media_cover_art_external_input_errors(
+    name: str, files: dict[str, str], expected: tuple[str, ...]
+) -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        firmware_dir = root / "components" / "espcontrol"
+        firmware_dir.mkdir(parents=True)
+        for filename, text in files.items():
+            (firmware_dir / filename).write_text(text, encoding="utf-8")
+
+        errors = firmware_media_cover_art_external_input_errors(firmware_dir, root)
         for item in expected:
             assert any(item in error for error in errors), f"{name}: missing {item!r} in {errors!r}"
         if not expected:
@@ -3742,6 +3808,47 @@ def expect_c6_update_status_errors(name: str, text: str, expected: tuple[str, ..
 
 
 def run_self_test() -> int:
+    expect_media_cover_art_external_input_errors(
+        "missing media cover art external-input handling",
+        {
+            "button_grid_media.h": "",
+            "button_grid_media_driver.h": "",
+            "button_grid_image.h": "",
+            "button_grid_grid.h": "",
+        },
+        (
+            "keep media source tracking independent",
+            "subscribe image-only cover art cards",
+            "hide media card artwork",
+            "prevent cached or late artwork downloads",
+        ),
+    )
+    expect_media_cover_art_external_input_errors(
+        "media cover art external-input handling present",
+        {
+            "button_grid_media.h": (
+                "bool source_subscribed = false;\n"
+                "inline void media_playback_subscribe_source() { std::string(\"source\"); }\n"
+                "inline void subscribe_media_cover_art_source_state() {}\n"
+                "inline void apply() { image_card_set_media_artwork_suppressed(ctx, external); }\n"
+            ),
+            "button_grid_media_driver.h": (
+                "subscribe_media_cover_art_source_state(now_playing, config.entity);\n"
+            ),
+            "button_grid_image.h": (
+                "bool media_artwork_suppressed = false;\n"
+                "inline void image_card_sync_media_artwork_visibility() {}\n"
+                "inline void apply() {\n"
+                "  if (ctx->media_artwork) image_card_sync_media_artwork_visibility(ctx);\n"
+                "}\n"
+            ),
+            "button_grid_grid.h": (
+                "art->media_artwork_suppressed = media_ctx->external_source;\n"
+                "image_card_sync_media_artwork_visibility(art);\n"
+            ),
+        },
+        (),
+    )
     valid_backlight_off_handler = (
         "script:\n"
         "  - id: display_backlight_handle_off\n"

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -497,6 +497,7 @@ def firmware_media_cover_art_external_input_errors(
 
     if (
         "source_subscribed" not in media
+        or "source_known" not in media
         or "media_playback_subscribe_source" not in media
         or 'std::string("source")' not in media
     ):
@@ -515,10 +516,13 @@ def firmware_media_cover_art_external_input_errors(
     if (
         "if (ctx->media_artwork)" not in image
         or "image_card_sync_media_artwork_visibility(ctx);" not in image
-        or "art->media_artwork_suppressed = media_ctx->external_source;" not in grid
+        or "!media_ctx->source_known || media_ctx->external_source" not in grid
+        or "!ctx->source_known || ctx->external_source" not in media
         or "image_card_sync_media_artwork_visibility(art);" not in grid
     ):
-        errors.append(f"{rel}: prevent cached or late artwork downloads from bypassing suppression")
+        errors.append(
+            f"{rel}: prevent cached, pending-source, or late artwork from bypassing suppression"
+        )
     return errors
 
 
@@ -3820,7 +3824,7 @@ def run_self_test() -> int:
             "keep media source tracking independent",
             "subscribe image-only cover art cards",
             "hide media card artwork",
-            "prevent cached or late artwork downloads",
+            "prevent cached, pending-source, or late artwork",
         ),
     )
     expect_media_cover_art_external_input_errors(
@@ -3828,9 +3832,13 @@ def run_self_test() -> int:
         {
             "button_grid_media.h": (
                 "bool source_subscribed = false;\n"
+                "bool source_known = false;\n"
                 "inline void media_playback_subscribe_source() { std::string(\"source\"); }\n"
                 "inline void subscribe_media_cover_art_source_state() {}\n"
-                "inline void apply() { image_card_set_media_artwork_suppressed(ctx, external); }\n"
+                "inline void apply() {\n"
+                "  image_card_set_media_artwork_suppressed(\n"
+                "    ctx, !ctx->source_known || ctx->external_source);\n"
+                "}\n"
             ),
             "button_grid_media_driver.h": (
                 "subscribe_media_cover_art_source_state(now_playing, config.entity);\n"
@@ -3843,7 +3851,8 @@ def run_self_test() -> int:
                 "}\n"
             ),
             "button_grid_grid.h": (
-                "art->media_artwork_suppressed = media_ctx->external_source;\n"
+                "art->media_artwork_suppressed =\n"
+                "  !media_ctx->source_known || media_ctx->external_source;\n"
                 "image_card_sync_media_artwork_visibility(art);\n"
             ),
         },


### PR DESCRIPTION
## Summary

- Hide Cover Art card images and their artwork tint while Home Assistant reports the media source as `TV`, `Line-in`, or `Line in` (case-insensitive).
- Subscribe every Cover Art card to source updates, including image-only cards.
- Keep cached/downloaded artwork in memory and restore it when normal media playback resumes.
- Prevent cached artwork and late download completions from appearing while suppression is active.
- Document the behavior and add regression guard coverage.

Fixes #1232.

## Practical impact

- External inputs no longer show stale artwork from the previously playing track.
- Cards with track details keep those details visible; image-only cards show their normal empty background.
- Tap actions are unchanged.
- No configuration or saved-card changes are required.

## Documentation decision

- [x] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [ ] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Updated the Media Cover Art card guidance with the TV/line-in behavior and artwork restoration.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.
- [ ] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- Cover Art cards on all displays.
- Representative compile coverage: Guition JC1060P470, Guition JC4880P443, and Guition 4848S040.

## Notes for testing

Automated checks completed:

- `npm run test:firmware` — all 13 firmware tests passed.
- Firmware Home Assistant binding checks and their self-tests passed.
- `npm run check:fast` — passed.
- ESPHome 2026.7.0 factory firmware compiled successfully for:
  - Guition JC1060P470 (ESP32-P4)
  - Guition JC4880P443 (ESP32-P4)
  - Guition 4848S040 (ESP32-S3)

Physical device testing still required:

1. Add one Cover Art card with track details and one without.
2. Start normal music and confirm artwork appears.
3. Switch music → TV and music → line-in; confirm artwork/tint disappears immediately.
4. Confirm details remain on the details card, the image-only card shows its empty background, and both cards remain tappable.
5. Switch back to music and confirm the latest artwork returns.
6. If practical, switch source while new artwork is downloading and confirm it stays hidden.

## PR status

- [ ] Checks running or waiting.
- [ ] Needs automated fix.
- [x] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.

<!-- espcontrol-pr-testing-guidance -->
## Automated testing guidance

Device testing is expected before merge because this change affects firmware and the on-device Cover Art experience.

Suggested checks:
- Confirm the device boots normally and does not restart repeatedly.
- Confirm Cover Art cards with and without details respond to source changes.
- Confirm touch actions still work while artwork is hidden.
- Confirm there is no obvious clipping, blank screen, or stale artwork.