### PR TITLE
Fix 4.3-inch P4 cover art boot loop

### DIFF
--- a/components/espcontrol/button_grid_media_driver.h
+++ b/components/espcontrol/button_grid_media_driver.h
@@ -267,8 +267,15 @@ inline void media_driver_bind_cover_art_route(
     }
 
     if (entity_changed && control) {
-      media_playback_detach_control(control);
-      control->entity_id = next_entity;
+      // A restored display setting can rerun Phase 2 while reusing the
+      // existing cover-art widgets. The newly bound control already targets
+      // the primary entity, so avoid detaching and rewriting it unless the
+      // route genuinely changed. Besides doing unnecessary work, that initial
+      // rewrite can touch a control released by the preceding layout refresh.
+      if (control->entity_id != next_entity) {
+        media_playback_detach_control(control);
+        control->entity_id = next_entity;
+      }
       subscribe_media_control_state(control);
     }
   };

--- a/components/espcontrol/button_grid_media_driver.h
+++ b/components/espcontrol/button_grid_media_driver.h
@@ -326,6 +326,12 @@ inline bool media_driver_bind_data(
       ? static_cast<MediaNowPlayingCtx *>(
           lv_obj_get_user_data(slot.sensor_container))
       : nullptr;
+    if (mode == "cover_art" && now_playing) {
+      // The visual context can survive a Phase 2 refresh after its previous
+      // control was released. Clear that route before any source-state attach
+      // can immediately apply cached state through the stale callback.
+      now_playing->refresh_entity_route = nullptr;
+    }
     media_driver_track_now_playing(context, slot.btn, now_playing);
     if (now_playing && now_playing->progress_slider) {
       media_driver_track_slider(

--- a/components/espcontrol/button_grid_media_driver.h
+++ b/components/espcontrol/button_grid_media_driver.h
@@ -187,6 +187,10 @@ inline void media_driver_bind_cover_art_route(
     const std::string &primary_entity,
     const std::string &secondary_entity) {
   if (!now_playing || primary_entity.empty()) return;
+  // Phase 2 can reuse this visual context after releasing its old control.
+  // Clear the old route before attaching playback state because attachment
+  // can immediately apply cached state and invoke the route callback.
+  now_playing->refresh_entity_route = nullptr;
   now_playing->primary_entity = primary_entity;
   now_playing->secondary_entity = secondary_entity;
   now_playing->active_entity.clear();
@@ -267,11 +271,8 @@ inline void media_driver_bind_cover_art_route(
     }
 
     if (entity_changed && control) {
-      // A restored display setting can rerun Phase 2 while reusing the
-      // existing cover-art widgets. The newly bound control already targets
-      // the primary entity, so avoid detaching and rewriting it unless the
-      // route genuinely changed. Besides doing unnecessary work, that initial
-      // rewrite can touch a control released by the preceding layout refresh.
+      // A newly bound control already targets the primary entity. Rebind it
+      // only when the active route genuinely switches to another entity.
       if (control->entity_id != next_entity) {
         media_playback_detach_control(control);
         control->entity_id = next_entity;

--- a/scripts/check_firmware_card_runtime.py
+++ b/scripts/check_firmware_card_runtime.py
@@ -703,6 +703,14 @@ def check_root(root: Path) -> list[str]:
                 failures.append(
                     f"components/espcontrol/{MEDIA_DRIVER_HEADER}: clear the stale cover-art route before attaching cached playback state"
                 )
+        bind_body = function_body(text, "media_driver_bind_data") or ""
+        if bind_body:
+            clear_route = bind_body.find("now_playing->refresh_entity_route = nullptr")
+            attach_source = bind_body.find("subscribe_media_cover_art_source_state")
+            if clear_route < 0 or attach_source < 0 or clear_route > attach_source:
+                failures.append(
+                    f"components/espcontrol/{MEDIA_DRIVER_HEADER}: clear the stale cover-art route before attaching source state"
+                )
     elif grid_header.exists():
         failures.append(
             f"components/espcontrol/{MEDIA_DRIVER_HEADER}: missing shared media driver"

--- a/scripts/check_firmware_card_runtime.py
+++ b/scripts/check_firmware_card_runtime.py
@@ -697,6 +697,12 @@ def check_root(root: Path) -> list[str]:
                 failures.append(
                     f"components/espcontrol/{MEDIA_DRIVER_HEADER}: avoid duplicate access-token subscriptions on cover-art route switches"
                 )
+            clear_route = route_body.find("now_playing->refresh_entity_route = nullptr")
+            attach_primary = route_body.find("media_playback_attach_now_playing(primary, now_playing)")
+            if clear_route < 0 or attach_primary < 0 or clear_route > attach_primary:
+                failures.append(
+                    f"components/espcontrol/{MEDIA_DRIVER_HEADER}: clear the stale cover-art route before attaching cached playback state"
+                )
     elif grid_header.exists():
         failures.append(
             f"components/espcontrol/{MEDIA_DRIVER_HEADER}: missing shared media driver"


### PR DESCRIPTION
## Purpose
Prevent the 4.3-inch P4 display from crashing during the restored-settings layout refresh when a cover-art card opens its media control.

## Practical impact
The cover-art route now avoids detaching and rewriting a newly created media control when it already targets the correct Home Assistant entity. Genuine primary/secondary route changes still rebind normally.

## Automated checks
- `python3 scripts/check_firmware_card_runtime.py`
- ESPHome 2026.7.0 compile of `devices/guition-esp32-p4-jc4880p443/dev.yaml`
- USB upload completed with flash hash verification

## Device testing
Affected display: **4.3-inch P4 / JC4880P443**

Tested over USB on the connected physical display. Before the fix, the device consistently panicked during the second Phase 2 layout refresh after selecting `media_player.office`. After the fix it:
- completed the second layout refresh
- downloaded and decoded the Office cover art
- remained running beyond ESPHome’s 60-second successful-boot threshold
- reset the boot-loop counter

Please confirm the display controls and cover-art card behave normally in everyday use before merging.