### PR TITLE
Fix S3 display framebuffer wrap

### DIFF
--- a/devices/guition-esp32-s3-4848s040/device/device.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/device.yaml
@@ -35,9 +35,9 @@ esp32:
       # and LVGL buffers are initialized.
       CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM: "8"
       CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP: "y"
-      # Keep RGB panel scan-out stable during flash writes and recover display
-      # timing at VSYNC when the ESP-IDF RGB driver needs to restart the panel.
-      CONFIG_LCD_RGB_RESTART_IN_VSYNC: "y"
+      # The RGB driver already restarts after a genuine DMA underflow. Restarting
+      # on every VSYNC can instead shift the framebuffer by one bounce-buffer block.
+      CONFIG_LCD_RGB_RESTART_IN_VSYNC: "n"
       CONFIG_LCD_RGB_ISR_IRAM_SAFE: "y"
       CONFIG_SPIRAM_FETCH_INSTRUCTIONS: "y"
       CONFIG_SPIRAM_RODATA: "y"


### PR DESCRIPTION
## Summary

- Disable the ESP-IDF option that restarts RGB transmission on every vertical refresh for the Guition ESP32-S3-4848S040.
- Keep genuine DMA-underflow recovery and all existing PSRAM/interrupt-safety settings unchanged.
- Prevent the framebuffer from shifting by one 20-row bounce-buffer block and wrapping its bottom strip to the top.

## Root cause and upstream evidence

The setting enabled in #980 asks ESP-IDF to restart RGB transmission on every VSYNC. Espressif documents the same shifted/wrapped RGB framebuffer behaviour in [espressif/esp-idf#16893](https://github.com/espressif/esp-idf/issues/16893), where disabling `CONFIG_LCD_RGB_RESTART_IN_VSYNC` prevents the shift.

This PR explicitly sets the option to `"n"` so a future framework default cannot silently re-enable it. The driver's separate recovery path for genuine DMA underflows remains intact.

Related to #1248. The issue should remain open until physical panel testing confirms the fix.

## Automated checks

- `npm run check:fast`
- ESPHome 2026.7.0 Docker compile:
  - Guition ESP32-P4 JC1060P470
  - Guition ESP32-P4 JC4880P443
  - Guition ESP32-S3-4848S040
- Generated S3 SDK configuration verified:
  - `CONFIG_LCD_RGB_RESTART_IN_VSYNC` is disabled
  - `CONFIG_LCD_RGB_ISR_IRAM_SAFE=y`
  - `CONFIG_SPIRAM_FETCH_INSTRUCTIONS=y`
  - `CONFIG_SPIRAM_RODATA=y`
- [Complete six-device firmware matrix](https://github.com/jtenniswood/espcontrol/actions/runs/29810078891) and firmware compile gate passed
- Standard PR CI and testing-guidance checks passed

These are automated checks only; they do not prove behaviour on the physical RGB panel.

## Physical device testing required

Flash one Guition ESP32-S3-4848S040 and confirm:

- no wrapped strip after boot or repeated power cycles
- main and subpage grids remain fully visible
- all four rotations render correctly and touch stays aligned
- configuration saves, sustained Wi-Fi activity, repeated artwork changes, and an OTA update cause no shifting, scanlines, flicker, freezes, or reboots

## Documentation

No public API, configuration interface, generated file, or user-facing documentation changes are needed for this internal display-driver stability fix.