### PR TITLE
Protect announcements during alarm cleanup

### DIFF
--- a/devices/esp32-p4-86/device/voice_assistant.yaml
+++ b/devices/esp32-p4-86/device/voice_assistant.yaml
@@ -568,7 +568,13 @@ script:
                   - media_player.stop:
                       id: voice_media_player
                       announcement: true
-            - speaker.stop: voice_announcement_mixing_input
+            - if:
+                condition:
+                  not:
+                    media_player.is_announcing:
+                      id: voice_media_player
+                then:
+                  - speaker.stop: voice_announcement_mixing_input
             - if:
                 condition:
                   lambda: return id(alarm_delay_volume_overridden);


### PR DESCRIPTION
## Summary

- Prevent alarm-delay cleanup from stopping an unrelated Voice Media Player announcement.
- Follow up the final review feedback from merged PR #1254.

## Practical impact

- Spoken announcements that are not part of the alarm delay can continue playing when the alarm session ends.
- Raw alarm-tone cleanup still runs when the announcement channel is otherwise idle.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this is an internal cleanup guard with no setting or workflow change.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Existing alarm audio documentation remains accurate.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.
- [ ] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- ESP32-P4 8.6-inch display (`esp32-p4-86`)

## Notes for testing

- Flash this branch to the affected display.
- Confirm cancelling an entry or exit delay still stops raw alarm beeps.
- While a separate spoken announcement is active, end the alarm-delay session and confirm that unrelated speech is not cut off.
- Local checks: `npm run check:fast` passed; ESPHome 2026.7.0 configuration validation passed; the three-device firmware compile matrix completed successfully before this guard-only follow-up.

## PR status

- [ ] Checks running or waiting.
- [ ] Needs automated fix.
- [x] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.