### PR TITLE
Fix alarm TTS satellite targeting

### DIFF
--- a/devices/esp32-p4-86/device/voice_assistant.yaml
+++ b/devices/esp32-p4-86/device/voice_assistant.yaml
@@ -515,15 +515,24 @@ script:
                   # Render in Home Assistant so this remains a native boolean.
                   preannounce: "{{ false }}"
                   entity_id: >-
-                    {% set suffixed = 'assist_satellite.' ~ node_slug ~ '_assist_satellite' %}
-                    {% set plain = 'assist_satellite.' ~ node_slug %}
-                    {{ suffixed if states(suffixed) != 'unknown' else plain }}
+                    {% set wanted_mac = device_mac | lower
+                        | replace(':', '') | replace('-', '') %}
+                    {% set match = namespace(entity_id='') %}
+                    {% for satellite in states.assist_satellite %}
+                      {% for connection in
+                          device_attr(satellite.entity_id, 'connections') or [] %}
+                        {% set connection_mac = connection[1] | lower
+                            | replace(':', '') | replace('-', '') %}
+                        {% if connection[0] == 'mac' and
+                              connection_mac == wanted_mac %}
+                          {% set match.entity_id = satellite.entity_id %}
+                        {% endif %}
+                      {% endfor %}
+                    {% endfor %}
+                    {{ match.entity_id }}
                   message: "{{ announcement_message }}"
                 variables:
-                  node_slug: !lambda |-
-                    std::string value = App.get_name().str();
-                    std::replace(value.begin(), value.end(), '-', '_');
-                    return value;
+                  device_mac: !lambda return get_mac_address();
                   announcement_message: !lambda |-
                     return entry_delay
                       ? id(alarm_delay_entry_announcement).state


### PR DESCRIPTION
## Summary

This fixes the remaining alarm-delay TTS problem reported in #1242.

The alarm announcement previously guessed the panel's Assist Satellite entity ID from its internal hostname. Home Assistant creates that entity through its device registry, so the guessed ID could be wrong and the panel would wait five seconds for speech that never started.

The announcement now finds the Assist Satellite belonging to the same physical panel by matching its MAC address. This also keeps working if the Home Assistant device or entity has been renamed.

## Practical impact

- Entry and exit alarm-delay announcements should now play before the beeps.
- Existing beep timing and volume behaviour are unchanged.
- Affected device: ESP32-P4 86 Panel.

## Checks completed

- `npm run check:fast`
- ESPHome 2026.7.0 full compile of `builds/esp32-p4-86.factory.yaml`
- Firmware image compiled successfully with 58% of the app partition free.
- Physical device testing has not yet been completed.

<!-- espcontrol-pr-testing-guidance -->
## Device testing

Please flash this branch to an ESP32-P4 86 Panel, then:

- Enable **Alarm Delay: Audio** and **Alarm Delay: TTS**.
- Trigger both exit and entry delays.
- Confirm the configured announcement plays before the beeps.
- Confirm the beeps remain regular, including the faster final countdown.
- Confirm the device boots normally and voice assistant responses still play.

Relates to #1242.