### PR TITLE
Fix 10.1-inch media card lag

### DIFF
--- a/components/espcontrol/artwork_controller.h
+++ b/components/espcontrol/artwork_controller.h
@@ -64,6 +64,15 @@ constexpr bool source_response_can_apply_immediately(bool local_response,
   return local_response && usable_url;
 }
 
+// Duplicate Home Assistant callbacks do not need to restart artwork work that
+// is already queued or downloading. When idle, the same URL must remain
+// processable so explicit refreshes and download recovery can try again.
+constexpr bool artwork_response_needs_processing(bool source_changed,
+                                                 bool download_active,
+                                                 bool debounce_pending) {
+  return source_changed || (!download_active && !debounce_pending);
+}
+
 // Owns the ordering rules for Home Assistant's remote and local artwork URLs.
 // A new remote URL starts a new artwork generation, so any cached local URL is
 // discarded until the matching local attribute arrives.

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -2109,7 +2109,7 @@ inline void image_card_handle_media_artwork_picture(ImageCardCtx *ctx,
   std::string url = image_card_join_url(image_card_base_url(ctx), raw);
   // These two attribute requests run independently. A delayed remote callback
   // must not discard a newer local proxy URL that has already arrived.
-  ctx->media_artwork_sources.update(
+  bool source_changed = ctx->media_artwork_sources.update(
       local, url,
       espcontrol::artwork::RemoteUpdatePolicy::PRESERVE_LOCAL);
   if (local) {
@@ -2120,6 +2120,11 @@ inline void image_card_handle_media_artwork_picture(ImageCardCtx *ctx,
     if (!url.empty() && url != ctx->source_url) {
       ctx->startup_download_errors = 0;
     }
+  }
+  if (!espcontrol::artwork::artwork_response_needs_processing(
+          source_changed, ctx->download_active,
+          ctx->media_artwork_timer != nullptr)) {
+    return;
   }
   if (espcontrol::artwork::source_response_can_apply_immediately(local, !url.empty())) {
     if (ctx->media_artwork_timer) {

--- a/devices/catalog.json
+++ b/devices/catalog.json
@@ -102,7 +102,6 @@
         "firmware": {
           "display": {
             "wrapTallLabels": true,
-            "imageCardDiagnostics": true,
             "subpageChevronX": 4,
             "subpageChevronY": -2
           },

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/device/sensors.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/device/sensors.yaml
@@ -93,7 +93,6 @@ script:
           cfg.image_card_images = image_card_downloaders;
           cfg.image_card_modal_image = id(image_card_modal_download_1);
           cfg.image_card_image_count = 6;
-          cfg.image_card_diagnostics = true;
           cfg.home_assistant_base_url = []() {
             std::string base = id(cover_art_home_assistant_base_url);
             while (!base.empty() && base.back() == '/') base.pop_back();
@@ -201,7 +200,6 @@ esphome:
             cfg.image_card_images = image_card_downloaders;
             cfg.image_card_modal_image = id(image_card_modal_download_1);
             cfg.image_card_image_count = 6;
-            cfg.image_card_diagnostics = true;
             cfg.home_assistant_base_url = []() {
               std::string base = id(cover_art_home_assistant_base_url);
               while (!base.empty() && base.back() == '/') base.pop_back();
@@ -378,7 +376,6 @@ esphome:
             cfg.image_card_images = image_card_downloaders;
             cfg.image_card_modal_image = id(image_card_modal_download_1);
             cfg.image_card_image_count = 6;
-            cfg.image_card_diagnostics = true;
             cfg.home_assistant_base_url = []() {
               std::string base = id(cover_art_home_assistant_base_url);
               while (!base.empty() && base.back() == '/') base.pop_back();

--- a/devices/guition-esp32-p4-jc8012p4a1/device/sensors.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/sensors.yaml
@@ -93,7 +93,6 @@ script:
           cfg.image_card_images = image_card_downloaders;
           cfg.image_card_modal_image = id(image_card_modal_download_1);
           cfg.image_card_image_count = 6;
-          cfg.image_card_diagnostics = true;
           cfg.home_assistant_base_url = []() {
             std::string base = id(cover_art_home_assistant_base_url);
             while (!base.empty() && base.back() == '/') base.pop_back();
@@ -201,7 +200,6 @@ esphome:
             cfg.image_card_images = image_card_downloaders;
             cfg.image_card_modal_image = id(image_card_modal_download_1);
             cfg.image_card_image_count = 6;
-            cfg.image_card_diagnostics = true;
             cfg.home_assistant_base_url = []() {
               std::string base = id(cover_art_home_assistant_base_url);
               while (!base.empty() && base.back() == '/') base.pop_back();
@@ -378,7 +376,6 @@ esphome:
             cfg.image_card_images = image_card_downloaders;
             cfg.image_card_modal_image = id(image_card_modal_download_1);
             cfg.image_card_image_count = 6;
-            cfg.image_card_diagnostics = true;
             cfg.home_assistant_base_url = []() {
               std::string base = id(cover_art_home_assistant_base_url);
               while (!base.empty() && base.back() == '/') base.pop_back();

--- a/devices/manifest.json
+++ b/devices/manifest.json
@@ -484,7 +484,6 @@
         },
         "display": {
           "wrapTallLabels": true,
-          "imageCardDiagnostics": true,
           "subpageChevronX": 4,
           "subpageChevronY": -2,
           "modal": {
@@ -673,7 +672,6 @@
         },
         "display": {
           "wrapTallLabels": true,
-          "imageCardDiagnostics": true,
           "subpageChevronX": 4,
           "subpageChevronY": -2,
           "modal": {

--- a/product/product_snapshot.json
+++ b/product/product_snapshot.json
@@ -510,7 +510,6 @@
         },
         "display": {
           "wrapTallLabels": true,
-          "imageCardDiagnostics": true,
           "subpageChevronX": 4,
           "subpageChevronY": -2,
           "modal": {
@@ -704,7 +703,6 @@
         },
         "display": {
           "wrapTallLabels": true,
-          "imageCardDiagnostics": true,
           "subpageChevronX": 4,
           "subpageChevronY": -2,
           "modal": {

--- a/tests/firmware/artwork_controller_test.cpp
+++ b/tests/firmware/artwork_controller_test.cpp
@@ -12,6 +12,7 @@ using espcontrol::artwork::artwork_source_failed_mask;
 using espcontrol::artwork::artwork_source_mark_received;
 using espcontrol::artwork::artwork_source_request_mask;
 using espcontrol::artwork::artwork_picture_response_clears_retry;
+using espcontrol::artwork::artwork_response_needs_processing;
 using espcontrol::artwork::source_response_can_apply_immediately;
 using espcontrol::cover_art::RuntimeState;
 using espcontrol::cover_art::media_card_artwork_suppressed;
@@ -62,6 +63,14 @@ int main() {
   assert(source_response_can_apply_immediately(true, true));
   assert(!source_response_can_apply_immediately(false, true));
   assert(!source_response_can_apply_immediately(true, false));
+
+  // Repeated callbacks must not restart artwork work that is already pending,
+  // while changed sources and idle recovery attempts must still be processed.
+  assert(!artwork_response_needs_processing(false, true, false));
+  assert(!artwork_response_needs_processing(false, false, true));
+  assert(artwork_response_needs_processing(false, false, false));
+  assert(artwork_response_needs_processing(true, true, false));
+  assert(artwork_response_needs_processing(true, false, true));
 
   // A partial queue failure retries only the source that failed. Reads that
   // were already accepted must not accumulate duplicate deferred callbacks.


### PR DESCRIPTION
## Purpose

Reduce severe touch and UI lag on the 10.1-inch JC8012P4A1 when a media card with artwork is present.

Related to #1263. The issue should remain open until the fix is confirmed on marking 2619.

## Root cause

Repeated Home Assistant callbacks containing the same media artwork URL could repeatedly bypass the debounce path while artwork was already downloading. Each callback restarted image-card processing and emitted detailed diagnostics, creating a burst of work and serial logging on the display loop.

## Changes

- Ignore unchanged artwork callbacks while a download or debounce operation is already active.
- Keep unchanged URLs processable while idle so reconnect and failed-download recovery still work.
- Preserve immediate handling of genuinely new local artwork.
- Return the original and v2 10.1-inch profiles to the default-off image-card diagnostics setting.
- Add firmware regression coverage for duplicate, pending, recovery, and changed-source behaviour.

## Automated validation

- `npm run test:firmware` — 16/16 tests passed.
- `npm run check:firmware-card-runtime:legacy` — checks and self-tests passed.
- ESPHome 2026.7.0 factory compile: `guition-esp32-p4-jc8012p4a1` — passed.
- ESPHome 2026.7.0 factory compile: `guition-esp32-p4-jc8012p4a1-v2` — passed.

## Physical device testing required

Flash the original JC8012P4A1 build to marking 2619 and configure the reported media card plus two light cards. Confirm:

- Artwork loads and updates between tracks.
- Media and light controls respond on the first tap without multi-second freezes.
- Responsiveness remains stable with an ESPHome log client connected.
- Artwork recovers after a reconnect or temporary download failure.

Do not merge or close #1263 until this device test is confirmed.
