### PR TITLE
mipi_rgb: fix parallel-RGB models for ESPHome 2026.7 (swap_xy=UNDEFINED removed)

### DIFF
--- a/components/mipi_rgb/models/rpi.py
+++ b/components/mipi_rgb/models/rpi.py
@@ -1,9 +1,9 @@
 from esphome.components.mipi import DriverChip
-from esphome.config_validation import UNDEFINED
+from esphome.const import CONF_MIRROR_X, CONF_MIRROR_Y
 
 # A driver chip for Raspberry Pi MIPI RGB displays. These require no init sequence
 DriverChip(
     "RPI",
-    swap_xy=UNDEFINED,
+    transforms={CONF_MIRROR_X, CONF_MIRROR_Y},
     initsequence=(),
 )

--- a/components/mipi_rgb/models/sunton.py
+++ b/components/mipi_rgb/models/sunton.py
@@ -1,10 +1,10 @@
 from esphome.components.mipi import DriverChip
-from esphome.config_validation import UNDEFINED
+from esphome.const import CONF_MIRROR_X, CONF_MIRROR_Y
 
 # fmt: off
 sunton = DriverChip(
     "ESP32-8048S070",
-    swap_xy=UNDEFINED,
+    transforms={CONF_MIRROR_X, CONF_MIRROR_Y},
     initsequence=(),
     width=800,
     height=480,
@@ -28,7 +28,7 @@ sunton = DriverChip(
 
 sunton.extend(
     "ESP32-8048S050",
-    swap_xy=UNDEFINED,
+    transforms={CONF_MIRROR_X, CONF_MIRROR_Y},
     initsequence=(),
     width=800,
     height=480,

--- a/components/mipi_rgb/models/waveshare.py
+++ b/components/mipi_rgb/models/waveshare.py
@@ -1,12 +1,12 @@
 from esphome.components.mipi import DriverChip, delay
-from esphome.config_validation import UNDEFINED
+from esphome.const import CONF_MIRROR_X, CONF_MIRROR_Y
 
 from .st7701s import st7701s
 
 # fmt: off
 wave_4_3 = DriverChip(
     "ESP32-S3-TOUCH-LCD-4.3",
-    swap_xy=UNDEFINED,
+    transforms={CONF_MIRROR_X, CONF_MIRROR_Y},
     initsequence=(),
     width=800,
     height=480,


### PR DESCRIPTION
## Problem

ESPHome 2026.7 removed support for `swap_xy=UNDEFINED` on the mipi `DriverChip` base. `DriverChip.transforms` now raises instead of falling back:

```
ValueError: Setting 'swap_xy' to 'cv.UNDEFINED' is no longer supported; set 'transforms' instead
```

The `mipi_rgb` parallel-RGB models that derive directly from the base `DriverChip` still set `swap_xy=UNDEFINED`, so they fail to configure on ESPHome 2026.7+:

- `waveshare.py` — `wave_4_3` (and everything extending it: the 4.3", 5", and 7" 800×480 panels)
- `sunton.py` — `ESP32-8048S070`, `ESP32-8048S050`
- `rpi.py` — `RPI`

The `ST7701S` SPI models are unaffected — that subclass overrides `transforms` and never consults `swap_xy`, so guition / lilygo etc. still build.

## Fix

Replace `swap_xy=UNDEFINED` with `transforms={CONF_MIRROR_X, CONF_MIRROR_Y}` on the affected base models. This is exactly the set the old base class returned for `swap_xy=UNDEFINED` (see the pre-2026.7 `DriverChip.transforms`: `swap_xy == UNDEFINED` → `{CONF_MIRROR_X, CONF_MIRROR_Y}`), so it's behavior-preserving: mirror on both axes, no hardware axis swap.

## Testing

- `esphome config` on **ESPHome 2026.7.0** passes for `ESP32-S3-TOUCH-LCD-7-800X480` and `ESP32-8048S070` (both failed before this change).
- The `ESP32-S3-TOUCH-LCD-7-800X480` build was flashed and confirmed running on hardware (display, touch, WiFi all up).

I could hardware-verify only the Waveshare 7" panel; the sunton/rpi changes are the identical mechanical substitution.