### PR TITLE
Fix stale media metadata across media types

### DIFF
--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -2000,8 +2000,10 @@ script:
                 next, id(cover_art_content_type));
               const auto decision = espcontrol::media::media_metadata_clear_decision(
                 id(cover_art_content_id), previous_kind, next, next_kind);
-              id(cover_art_content_id) = next;
-              id(cover_art_content_kind) = static_cast<uint8_t>(next_kind);
+              if (espcontrol::media::should_replace_media_metadata_identity(next)) {
+                id(cover_art_content_id) = next;
+                id(cover_art_content_kind) = static_cast<uint8_t>(next_kind);
+              }
               if (!decision.item_changed) return;
 
               id(cover_art_title).clear();

--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -44,6 +44,15 @@ globals:
   - id: cover_art_album
     type: std::string
     initial_value: '""'
+  - id: cover_art_content_id
+    type: std::string
+    initial_value: '""'
+  - id: cover_art_content_type
+    type: std::string
+    initial_value: '""'
+  - id: cover_art_content_kind
+    type: uint8_t
+    initial_value: '0'
   - id: cover_art_media_source
     type: std::string
     initial_value: '""'
@@ -746,6 +755,10 @@ script:
           id(cover_art_title).clear();
           id(cover_art_artist).clear();
           id(cover_art_album).clear();
+          id(cover_art_content_id).clear();
+          id(cover_art_content_type).clear();
+          id(cover_art_content_kind) = static_cast<uint8_t>(
+            espcontrol::media::MediaItemKind::UNKNOWN);
           id(cover_art_media_source).clear();
           id(cover_art_external_input_active) = false;
           id(cover_art_primary_external_input_active) = false;
@@ -1819,6 +1832,10 @@ script:
             id(cover_art_last_playback_state).clear();
             id(cover_art_media_source).clear();
             id(cover_art_album).clear();
+            id(cover_art_content_id).clear();
+            id(cover_art_content_type).clear();
+            id(cover_art_content_kind) = static_cast<uint8_t>(
+              espcontrol::media::MediaItemKind::UNKNOWN);
             if (!previous_entity.empty() && previous_entity != cover_entity) {
               id(cover_art_runtime).clear_image();
               id(cover_art_title).clear();
@@ -1945,6 +1962,72 @@ script:
               subscribe_secondary_content_probe(std::string("entity_picture_local"), 4u);
               subscribe_secondary_content_probe(std::string("media_content_id"), 8u);
             }
+          }
+
+          std::function<void(esphome::StringRef)> handle_media_content_type =
+            [cover_entity, subscription_generation](esphome::StringRef content_type) {
+              if (!id(cover_art_screensaver_enabled).state ||
+                  subscription_generation != id(cover_art_subscription_generation) ||
+                  cover_entity != id(cover_art_active_media_player_entity)) return;
+              std::string next = string_ref_limited(
+                content_type, HA_SHORT_STATE_MAX_LEN);
+              if (next == "unknown" || next == "unavailable") next.clear();
+              id(cover_art_content_type) = next;
+            };
+          if (!already_subscribed) {
+            bool content_type_subscribed = ha_subscribe_attribute(
+              cover_entity,
+              std::string("media_content_type"),
+              handle_media_content_type,
+              HA_SUBSCRIPTION_SCOPE_COVER_ART
+            );
+            ESP_LOGI("cover_art", "Content type subscription %s",
+                     content_type_subscribed ? "ready" : "failed");
+          }
+
+          std::function<void(esphome::StringRef)> handle_media_content_id =
+            [cover_entity, subscription_generation,
+             mark_artwork_refresh_needed](esphome::StringRef content_id) {
+              if (!id(cover_art_screensaver_enabled).state ||
+                  subscription_generation != id(cover_art_subscription_generation) ||
+                  cover_entity != id(cover_art_active_media_player_entity)) return;
+              std::string next = string_ref_limited(
+                content_id, HA_STATE_TEXT_MAX_LEN);
+              if (next == "unknown" || next == "unavailable") next.clear();
+              const auto previous_kind = static_cast<espcontrol::media::MediaItemKind>(
+                id(cover_art_content_kind));
+              const auto next_kind = espcontrol::media::media_item_kind(
+                next, id(cover_art_content_type));
+              const auto decision = espcontrol::media::media_metadata_clear_decision(
+                id(cover_art_content_id), previous_kind, next, next_kind);
+              id(cover_art_content_id) = next;
+              id(cover_art_content_kind) = static_cast<uint8_t>(next_kind);
+              if (!decision.item_changed) return;
+
+              id(cover_art_title).clear();
+              if (decision.clear_grouping) {
+                id(cover_art_artist).clear();
+                id(cover_art_album).clear();
+              }
+              mark_artwork_refresh_needed();
+              id(cover_art_sync_track_text).execute();
+              if (id(espcontrol_app).display().target_mode_is(
+                    espcontrol::DisplayMode::COVER_ART)) {
+                id(cover_art_show_track_overlay).execute();
+                id(cover_art_request_artwork).execute();
+              } else if (id(cover_art_runtime).loaded_url.empty()) {
+                id(cover_art_runtime).image_available = false;
+              }
+            };
+          if (!already_subscribed) {
+            bool content_id_subscribed = ha_subscribe_attribute(
+              cover_entity,
+              std::string("media_content_id"),
+              handle_media_content_id,
+              HA_SUBSCRIPTION_SCOPE_COVER_ART
+            );
+            ESP_LOGI("cover_art", "Content ID subscription %s",
+                     content_id_subscribed ? "ready" : "failed");
           }
 
           std::function<void(esphome::StringRef)> handle_playback_state =

--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -44,9 +44,9 @@ globals:
   - id: cover_art_album
     type: std::string
     initial_value: '""'
-  - id: cover_art_content_id
-    type: std::string
-    initial_value: '""'
+  - id: cover_art_content_fingerprint
+    type: uint64_t
+    initial_value: '0'
   - id: cover_art_content_type
     type: std::string
     initial_value: '""'
@@ -755,7 +755,7 @@ script:
           id(cover_art_title).clear();
           id(cover_art_artist).clear();
           id(cover_art_album).clear();
-          id(cover_art_content_id).clear();
+          id(cover_art_content_fingerprint) = 0;
           id(cover_art_content_type).clear();
           id(cover_art_content_kind) = static_cast<uint8_t>(
             espcontrol::media::MediaItemKind::UNKNOWN);
@@ -1832,7 +1832,7 @@ script:
             id(cover_art_last_playback_state).clear();
             id(cover_art_media_source).clear();
             id(cover_art_album).clear();
-            id(cover_art_content_id).clear();
+            id(cover_art_content_fingerprint) = 0;
             id(cover_art_content_type).clear();
             id(cover_art_content_kind) = static_cast<uint8_t>(
               espcontrol::media::MediaItemKind::UNKNOWN);
@@ -1994,14 +1994,19 @@ script:
               std::string next = string_ref_limited(
                 content_id, HA_STATE_TEXT_MAX_LEN);
               if (next == "unknown" || next == "unavailable") next.clear();
+              const uint64_t next_fingerprint = next.empty()
+                ? 0
+                : espcontrol::media::media_content_identity_fingerprint(
+                    content_id.c_str(), content_id.size());
               const auto previous_kind = static_cast<espcontrol::media::MediaItemKind>(
                 id(cover_art_content_kind));
               const auto next_kind = espcontrol::media::media_item_kind(
                 next, id(cover_art_content_type));
               const auto decision = espcontrol::media::media_metadata_clear_decision(
-                id(cover_art_content_id), previous_kind, next, next_kind);
+                id(cover_art_content_fingerprint), previous_kind,
+                next_fingerprint, next_kind);
               if (espcontrol::media::should_replace_media_metadata_identity(next)) {
-                id(cover_art_content_id) = next;
+                id(cover_art_content_fingerprint) = next_fingerprint;
                 id(cover_art_content_kind) = static_cast<uint8_t>(next_kind);
               }
               if (!decision.item_changed) return;

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -3,6 +3,7 @@
 // Internal implementation detail for button_grid.h. Include button_grid.h from device YAML.
 
 #include "cover_art.h"
+#include "media_metadata_policy.h"
 
 enum class MediaControlTab : uint8_t {
   CONTROLS = 0,
@@ -217,6 +218,7 @@ inline void media_playback_detach_now_playing(MediaNowPlayingCtx *ctx);
 inline void media_playback_detach_slider(SliderCtx *ctx);
 inline void media_playback_attach_control(MediaPlaybackState *state, MediaControlCtx *ctx);
 inline void media_playback_subscribe_playback_state(MediaPlaybackState *state);
+inline void media_playback_subscribe_content(MediaPlaybackState *state);
 inline void media_playback_subscribe_metadata(MediaPlaybackState *state);
 inline void media_playback_subscribe_source(MediaPlaybackState *state);
 inline void media_playback_subscribe_progress(
@@ -288,6 +290,7 @@ inline void subscribe_media_control_state(MediaControlCtx *ctx) {
   if (!state) return;
   media_playback_attach_control(state, ctx);
   media_playback_subscribe_playback_state(state);
+  media_playback_subscribe_content(state);
   media_playback_subscribe_metadata(state);
   media_playback_subscribe_volume(state);
 #ifndef ESPCONTROL_LOW_HEAP_MEDIA_CONTROL
@@ -476,6 +479,8 @@ struct MediaPlaybackState {
   std::string friendly_name;
   std::string current_content_id;
   std::string current_content_type;
+  espcontrol::media::MediaItemKind current_content_kind =
+    espcontrol::media::MediaItemKind::UNKNOWN;
   bool has_state = false;
   bool available = true;
   bool playing = false;
@@ -632,6 +637,7 @@ inline void media_playback_reset_state(MediaPlaybackState *state,
   state->friendly_name.clear();
   state->current_content_id.clear();
   state->current_content_type.clear();
+  state->current_content_kind = espcontrol::media::MediaItemKind::UNKNOWN;
   state->has_state = false;
   state->available = true;
   state->playing = false;
@@ -1409,32 +1415,45 @@ inline void media_playback_subscribe_content(MediaPlaybackState *state) {
   const std::string entity_id = state->entity_id;
   const uint32_t generation = state->generation;
   ha_subscribe_attribute(
-    entity_id, std::string("media_content_id"),
+    entity_id, std::string("media_content_type"),
     std::function<void(esphome::StringRef)>(
       [state, generation](esphome::StringRef value) {
         if (!media_playback_generation_valid(state, generation)) return;
-        state->current_content_id = string_ref_limited(value, HA_STATE_TEXT_MAX_LEN);
-        state->has_current_content_id =
-          !state->current_content_id.empty() &&
-          state->current_content_id != "unknown" &&
-          state->current_content_id != "unavailable";
+        state->current_content_type = media_playback_metadata_value(
+          value, HA_SHORT_STATE_MAX_LEN);
+        state->has_current_content_type = !state->current_content_type.empty();
         media_playback_apply_state_to_playlists(state);
         media_playback_apply_state_to_now_playing(state);
       })
   );
 
   ha_subscribe_attribute(
-    entity_id, std::string("media_content_type"),
+    entity_id, std::string("media_content_id"),
     std::function<void(esphome::StringRef)>(
       [state, generation](esphome::StringRef value) {
         if (!media_playback_generation_valid(state, generation)) return;
-        state->current_content_type = string_ref_limited(value, HA_SHORT_STATE_MAX_LEN);
-        state->has_current_content_type =
-          !state->current_content_type.empty() &&
-          state->current_content_type != "unknown" &&
-          state->current_content_type != "unavailable";
+        const std::string next_content_id = media_playback_metadata_value(
+          value, HA_STATE_TEXT_MAX_LEN);
+        const espcontrol::media::MediaItemKind next_kind =
+          espcontrol::media::media_item_kind(
+            next_content_id, state->current_content_type);
+        const espcontrol::media::MediaMetadataClearDecision decision =
+          espcontrol::media::media_metadata_clear_decision(
+            state->current_content_id, state->current_content_kind,
+            next_content_id, next_kind);
+
+        state->current_content_id = next_content_id;
+        state->current_content_kind = next_kind;
+        state->has_current_content_id = !state->current_content_id.empty();
+        if (decision.clear_title) state->title.clear();
+        if (decision.clear_grouping) state->artist.clear();
+
         media_playback_apply_state_to_playlists(state);
-        media_playback_apply_state_to_now_playing(state);
+        if (decision.item_changed) {
+          media_playback_apply_metadata_consumers(state);
+        } else {
+          media_playback_apply_state_to_now_playing(state);
+        }
       })
   );
 }
@@ -3011,6 +3030,7 @@ inline void subscribe_media_now_playing_state(MediaNowPlayingCtx *ctx,
   MediaPlaybackState *state = media_playback_ensure_state(entity_id);
   if (!state) return;
   if (ctx) media_playback_attach_now_playing(state, ctx);
+  media_playback_subscribe_content(state);
   media_playback_subscribe_metadata(state);
   if (ctx && ctx->progress_slider) {
     subscribe_media_slider_state(lv_obj_get_parent(ctx->progress_slider), ctx->progress_slider, entity_id);

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -478,6 +478,7 @@ struct MediaPlaybackState {
   std::string source;
   std::string friendly_name;
   std::string current_content_id;
+  uint64_t current_content_fingerprint = 0;
   std::string current_content_type;
   espcontrol::media::MediaItemKind current_content_kind =
     espcontrol::media::MediaItemKind::UNKNOWN;
@@ -636,6 +637,7 @@ inline void media_playback_reset_state(MediaPlaybackState *state,
   state->source.clear();
   state->friendly_name.clear();
   state->current_content_id.clear();
+  state->current_content_fingerprint = 0;
   state->current_content_type.clear();
   state->current_content_kind = espcontrol::media::MediaItemKind::UNKNOWN;
   state->has_state = false;
@@ -1434,18 +1436,23 @@ inline void media_playback_subscribe_content(MediaPlaybackState *state) {
         if (!media_playback_generation_valid(state, generation)) return;
         const std::string next_content_id = media_playback_metadata_value(
           value, HA_STATE_TEXT_MAX_LEN);
+        const uint64_t next_content_fingerprint = next_content_id.empty()
+          ? 0
+          : espcontrol::media::media_content_identity_fingerprint(
+              value.c_str(), value.size());
         const espcontrol::media::MediaItemKind next_kind =
           espcontrol::media::media_item_kind(
             next_content_id, state->current_content_type);
         const espcontrol::media::MediaMetadataClearDecision decision =
           espcontrol::media::media_metadata_clear_decision(
-            state->current_content_id, state->current_content_kind,
-            next_content_id, next_kind);
+            state->current_content_fingerprint, state->current_content_kind,
+            next_content_fingerprint, next_kind);
 
         state->has_current_content_id = !next_content_id.empty();
         if (espcontrol::media::should_replace_media_metadata_identity(
               next_content_id)) {
           state->current_content_id = next_content_id;
+          state->current_content_fingerprint = next_content_fingerprint;
           state->current_content_kind = next_kind;
         }
         if (decision.clear_title) state->title.clear();

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -1442,9 +1442,12 @@ inline void media_playback_subscribe_content(MediaPlaybackState *state) {
             state->current_content_id, state->current_content_kind,
             next_content_id, next_kind);
 
-        state->current_content_id = next_content_id;
-        state->current_content_kind = next_kind;
-        state->has_current_content_id = !state->current_content_id.empty();
+        state->has_current_content_id = !next_content_id.empty();
+        if (espcontrol::media::should_replace_media_metadata_identity(
+              next_content_id)) {
+          state->current_content_id = next_content_id;
+          state->current_content_kind = next_kind;
+        }
         if (decision.clear_title) state->title.clear();
         if (decision.clear_grouping) state->artist.clear();
 

--- a/components/espcontrol/button_grid_media_driver.h
+++ b/components/espcontrol/button_grid_media_driver.h
@@ -212,8 +212,8 @@ inline void media_driver_bind_cover_art_route(
   if (!primary) return;
   media_playback_attach_now_playing(primary, now_playing);
   media_playback_subscribe_playback_state(primary);
-  media_playback_subscribe_metadata(primary);
   media_playback_subscribe_content(primary);
+  media_playback_subscribe_metadata(primary);
   media_playback_subscribe_progress(primary);
 
   MediaPlaybackState *secondary = nullptr;
@@ -222,8 +222,8 @@ inline void media_driver_bind_cover_art_route(
     if (secondary) {
       media_playback_attach_now_playing(secondary, now_playing);
       media_playback_subscribe_playback_state(secondary);
-      media_playback_subscribe_metadata(secondary);
       media_playback_subscribe_content(secondary);
+      media_playback_subscribe_metadata(secondary);
       media_playback_subscribe_progress(secondary);
     }
   }

--- a/components/espcontrol/media_metadata_policy.h
+++ b/components/espcontrol/media_metadata_policy.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <string>
+#include <utility>
+
+namespace espcontrol::media {
+
+enum class MediaItemKind : uint8_t {
+  UNKNOWN = 0,
+  TRACK,
+  AUDIOBOOK,
+  PODCAST,
+  RADIO,
+  VIDEO,
+  COLLECTION,
+};
+
+struct MediaMetadataClearDecision {
+  bool item_changed = false;
+  bool clear_title = false;
+  bool clear_grouping = false;
+};
+
+inline std::string normalize_media_kind_token(std::string value) {
+  std::transform(
+    value.begin(), value.end(), value.begin(),
+    [](unsigned char ch) {
+      if (ch == '-' || ch == ' ') return '_';
+      return static_cast<char>(std::tolower(ch));
+    });
+  return value;
+}
+
+inline MediaItemKind media_item_kind_from_token(std::string token) {
+  token = normalize_media_kind_token(std::move(token));
+  if (token == "track") return MediaItemKind::TRACK;
+  if (token == "audiobook" || token == "audiobooks") {
+    return MediaItemKind::AUDIOBOOK;
+  }
+  if (token == "podcast" || token == "podcasts" ||
+      token == "podcast_episode" || token == "podcastepisode" ||
+      token == "episode") {
+    return MediaItemKind::PODCAST;
+  }
+  if (token == "radio") return MediaItemKind::RADIO;
+  if (token == "video" || token == "movie" || token == "tv" ||
+      token == "tv_show" || token == "tvshow" || token == "channel") {
+    return MediaItemKind::VIDEO;
+  }
+  if (token == "playlist" || token == "album" || token == "artist" ||
+      token == "collection") {
+    return MediaItemKind::COLLECTION;
+  }
+  return MediaItemKind::UNKNOWN;
+}
+
+inline std::string media_item_kind_token_from_uri(const std::string &content_id) {
+  const size_t scheme_end = content_id.find("://");
+  if (scheme_end == std::string::npos) return {};
+  const std::string scheme = normalize_media_kind_token(
+    content_id.substr(0, scheme_end));
+  if (scheme == "http" || scheme == "https") return {};
+  const size_t token_start = scheme_end + 3;
+  const size_t token_end = content_id.find_first_of("/?#", token_start);
+  if (token_start >= content_id.size() || token_end == token_start) return {};
+  return content_id.substr(token_start, token_end - token_start);
+}
+
+inline MediaItemKind media_item_kind(const std::string &content_id,
+                                     const std::string &content_type = {}) {
+  const MediaItemKind uri_kind = media_item_kind_from_token(
+    media_item_kind_token_from_uri(content_id));
+  if (uri_kind != MediaItemKind::UNKNOWN) return uri_kind;
+  // Music Assistant exposes every queue item as generic "music", including
+  // audiobooks, so only specific content types are useful as a fallback.
+  if (normalize_media_kind_token(content_type) == "music") {
+    return MediaItemKind::UNKNOWN;
+  }
+  return media_item_kind_from_token(content_type);
+}
+
+inline MediaMetadataClearDecision media_metadata_clear_decision(
+    const std::string &previous_content_id, MediaItemKind previous_kind,
+    const std::string &next_content_id, MediaItemKind next_kind) {
+  const bool item_changed =
+    !previous_content_id.empty() && !next_content_id.empty() &&
+    previous_content_id != next_content_id;
+  return {
+    item_changed,
+    item_changed,
+    item_changed && previous_kind != MediaItemKind::UNKNOWN &&
+      next_kind != MediaItemKind::UNKNOWN && previous_kind != next_kind,
+  };
+}
+
+}  // namespace espcontrol::media

--- a/components/espcontrol/media_metadata_policy.h
+++ b/components/espcontrol/media_metadata_policy.h
@@ -58,15 +58,34 @@ inline MediaItemKind media_item_kind_from_token(std::string token) {
 }
 
 inline std::string media_item_kind_token_from_uri(const std::string &content_id) {
-  const size_t scheme_end = content_id.find("://");
+  const size_t scheme_end = content_id.find(':');
   if (scheme_end == std::string::npos) return {};
   const std::string scheme = normalize_media_kind_token(
     content_id.substr(0, scheme_end));
   if (scheme == "http" || scheme == "https") return {};
-  const size_t token_start = scheme_end + 3;
-  const size_t token_end = content_id.find_first_of("/?#", token_start);
+  size_t token_start = scheme_end + 1;
+  if (content_id.compare(token_start, 2, "//") == 0) token_start += 2;
+  const size_t token_end = content_id.find_first_of(":/?#", token_start);
   if (token_start >= content_id.size() || token_end == token_start) return {};
   return content_id.substr(token_start, token_end - token_start);
+}
+
+inline uint64_t media_content_identity_fingerprint(const char *data,
+                                                   size_t length) {
+  if (data == nullptr || length == 0) return 0;
+  uint64_t hash = UINT64_C(14695981039346656037);
+  for (size_t index = 0; index < length; index++) {
+    hash ^= static_cast<uint8_t>(data[index]);
+    hash *= UINT64_C(1099511628211);
+  }
+  // Zero is reserved for a missing identity.
+  return hash == 0 ? 1 : hash;
+}
+
+inline uint64_t media_content_identity_fingerprint(
+    const std::string &content_id) {
+  return media_content_identity_fingerprint(
+    content_id.data(), content_id.size());
 }
 
 inline MediaItemKind media_item_kind(const std::string &content_id,
@@ -83,11 +102,11 @@ inline MediaItemKind media_item_kind(const std::string &content_id,
 }
 
 inline MediaMetadataClearDecision media_metadata_clear_decision(
-    const std::string &previous_content_id, MediaItemKind previous_kind,
-    const std::string &next_content_id, MediaItemKind next_kind) {
+    uint64_t previous_fingerprint, MediaItemKind previous_kind,
+    uint64_t next_fingerprint, MediaItemKind next_kind) {
   const bool item_changed =
-    !previous_content_id.empty() && !next_content_id.empty() &&
-    previous_content_id != next_content_id;
+    previous_fingerprint != 0 && next_fingerprint != 0 &&
+    previous_fingerprint != next_fingerprint;
   return {
     item_changed,
     item_changed,

--- a/components/espcontrol/media_metadata_policy.h
+++ b/components/espcontrol/media_metadata_policy.h
@@ -96,4 +96,12 @@ inline MediaMetadataClearDecision media_metadata_clear_decision(
   };
 }
 
+inline bool should_replace_media_metadata_identity(
+    const std::string &next_content_id) {
+  // Home Assistant may briefly clear media_content_id between queue items.
+  // Retain the last established identity through that gap so the next item can
+  // still be compared with the item whose metadata is currently displayed.
+  return !next_content_id.empty();
+}
+
 }  // namespace espcontrol::media

--- a/scripts/check_cover_art_contract.py
+++ b/scripts/check_cover_art_contract.py
@@ -261,6 +261,7 @@ if cover_art_subscription_order != sorted(cover_art_subscription_order):
     )
 for required in (
     "media_metadata_clear_decision(",
+    "should_replace_media_metadata_identity(next)",
     "id(cover_art_content_id).clear();",
     "id(cover_art_content_type).clear();",
     "id(cover_art_content_kind) = static_cast<uint8_t>(",
@@ -311,6 +312,7 @@ if not 0 <= content_type_subscription < content_id_subscription:
     raise SystemExit("Media content type must be subscribed before the content ID")
 for required in (
     "media_metadata_clear_decision(",
+    "should_replace_media_metadata_identity(",
     "if (decision.clear_title) state->title.clear();",
     "if (decision.clear_grouping) state->artist.clear();",
 ):

--- a/scripts/check_cover_art_contract.py
+++ b/scripts/check_cover_art_contract.py
@@ -240,6 +240,33 @@ if resubscribe_start < 0 or resubscribe_end < 0:
 resubscribe = cover_art[resubscribe_start:resubscribe_end]
 if "ha_get_" in resubscribe:
     raise SystemExit("Cover art must use live subscriptions instead of retained one-shot reads")
+cover_art_subscription_order = []
+for handler, attribute in (
+    ("handle_media_content_type", "media_content_type"),
+    ("handle_media_content_id", "media_content_id"),
+    ("handle_media_title", "media_title"),
+    ("handle_media_artist", "media_artist"),
+    ("handle_media_album", "media_album_name"),
+):
+    handler_start = resubscribe.find(handler)
+    subscription_start = resubscribe.find(
+        f'std::string("{attribute}")', handler_start
+    )
+    if handler_start < 0 or subscription_start < 0:
+        raise SystemExit(f"Cover art metadata policy subscription missing: {attribute}")
+    cover_art_subscription_order.append(subscription_start)
+if cover_art_subscription_order != sorted(cover_art_subscription_order):
+    raise SystemExit(
+        "Cover art must subscribe to content kind before title, artist, and album"
+    )
+for required in (
+    "media_metadata_clear_decision(",
+    "id(cover_art_content_id).clear();",
+    "id(cover_art_content_type).clear();",
+    "id(cover_art_content_kind) = static_cast<uint8_t>(",
+):
+    if required not in resubscribe:
+        raise SystemExit(f"Cover art metadata reset contract missing: {required}")
 proxy_404_start = cover_art.find("last_error_was_ha_media_proxy_not_found()")
 proxy_404_end = cover_art.find("- script.execute: cover_art_retry_download", proxy_404_start)
 if proxy_404_start < 0 or proxy_404_end < 0:
@@ -264,8 +291,62 @@ if metadata_start < 0 or metadata_end < 0:
 metadata = media[metadata_start:metadata_end]
 if 'state->entity_id, std::string("media_artist")' in metadata:
     raise SystemExit("Media track changes must not retain duplicate one-shot metadata reads")
-if "state->artist.clear()" in metadata:
+artist_subscription = metadata.find('std::string("media_artist")')
+if artist_subscription < 0:
+    raise SystemExit("Media artist subscription contract missing")
+if "state->artist.clear()" in metadata[:artist_subscription]:
     raise SystemExit("Media title updates must preserve an unchanged subscribed artist")
+content_start = media.find(
+    "inline void media_playback_subscribe_content(MediaPlaybackState *state) {"
+)
+content_end = media.find(
+    "inline void media_playback_subscribe_friendly_name", content_start
+)
+if content_start < 0 or content_end < 0:
+    raise SystemExit("Media content subscription contract missing")
+content = media[content_start:content_end]
+content_type_subscription = content.find('std::string("media_content_type")')
+content_id_subscription = content.find('std::string("media_content_id")')
+if not 0 <= content_type_subscription < content_id_subscription:
+    raise SystemExit("Media content type must be subscribed before the content ID")
+for required in (
+    "media_metadata_clear_decision(",
+    "if (decision.clear_title) state->title.clear();",
+    "if (decision.clear_grouping) state->artist.clear();",
+):
+    if required not in content:
+        raise SystemExit(f"Media item-change policy contract missing: {required}")
+for subscription_helper in (
+    "subscribe_media_control_state",
+    "subscribe_media_now_playing_state",
+):
+    helper_start = media.find(f"inline void {subscription_helper}")
+    if helper_start < 0:
+        raise SystemExit(f"Media subscription helper missing: {subscription_helper}")
+    helper_end = media.find("\n}", helper_start)
+    helper = media[helper_start:helper_end]
+    content_call = helper.find("media_playback_subscribe_content(state)")
+    metadata_call = helper.find("media_playback_subscribe_metadata(state)")
+    if not 0 <= content_call < metadata_call:
+        raise SystemExit(
+            f"{subscription_helper} must subscribe to content before metadata"
+        )
+
+media_driver = (
+    ROOT / "components" / "espcontrol" / "button_grid_media_driver.h"
+).read_text(encoding="utf-8")
+route_start = media_driver.find("inline void media_driver_bind_cover_art_route(")
+route_end = media_driver.find("\ninline ", route_start + 1)
+if route_start < 0 or route_end < 0:
+    raise SystemExit("Media cover-art route subscription contract missing")
+route = media_driver[route_start:route_end]
+for state_name in ("primary", "secondary"):
+    content_call = route.find(f"media_playback_subscribe_content({state_name})")
+    metadata_call = route.find(f"media_playback_subscribe_metadata({state_name})")
+    if not 0 <= content_call < metadata_call:
+        raise SystemExit(
+            f"Media cover-art {state_name} content must be subscribed before metadata"
+        )
 for required in (
     "inline bool media_cover_art_uses_screensaver_fonts(int row_span, int col_span)",
     "return row_span >= 2 && col_span >= 2;",

--- a/scripts/check_cover_art_contract.py
+++ b/scripts/check_cover_art_contract.py
@@ -261,8 +261,9 @@ if cover_art_subscription_order != sorted(cover_art_subscription_order):
     )
 for required in (
     "media_metadata_clear_decision(",
+    "media_content_identity_fingerprint(",
     "should_replace_media_metadata_identity(next)",
-    "id(cover_art_content_id).clear();",
+    "id(cover_art_content_fingerprint) = 0;",
     "id(cover_art_content_type).clear();",
     "id(cover_art_content_kind) = static_cast<uint8_t>(",
 ):
@@ -312,6 +313,7 @@ if not 0 <= content_type_subscription < content_id_subscription:
     raise SystemExit("Media content type must be subscribed before the content ID")
 for required in (
     "media_metadata_clear_decision(",
+    "media_content_identity_fingerprint(",
     "should_replace_media_metadata_identity(",
     "if (decision.clear_title) state->title.clear();",
     "if (decision.clear_grouping) state->artist.clear();",

--- a/tests/firmware/CMakeLists.txt
+++ b/tests/firmware/CMakeLists.txt
@@ -47,6 +47,12 @@ target_compile_options(media_volume_capability_test PRIVATE -Wall -Wextra -Werro
 target_include_directories(media_volume_capability_test PRIVATE ../../components/espcontrol)
 add_test(NAME media_volume_capability_test COMMAND media_volume_capability_test)
 
+add_executable(media_metadata_policy_test media_metadata_policy_test.cpp)
+target_compile_features(media_metadata_policy_test PRIVATE cxx_std_17)
+target_compile_options(media_metadata_policy_test PRIVATE -Wall -Wextra -Werror)
+target_include_directories(media_metadata_policy_test PRIVATE ../../components/espcontrol)
+add_test(NAME media_metadata_policy_test COMMAND media_metadata_policy_test)
+
 add_executable(slider_geometry_test slider_geometry_test.cpp)
 target_compile_features(slider_geometry_test PRIVATE cxx_std_17)
 target_compile_options(slider_geometry_test PRIVATE -Wall -Wextra -Werror)

--- a/tests/firmware/media_metadata_policy_test.cpp
+++ b/tests/firmware/media_metadata_policy_test.cpp
@@ -6,6 +6,7 @@ int main() {
   using espcontrol::media::MediaItemKind;
   using espcontrol::media::media_item_kind;
   using espcontrol::media::media_metadata_clear_decision;
+  using espcontrol::media::should_replace_media_metadata_identity;
 
   assert(media_item_kind("library://track/456") == MediaItemKind::TRACK);
   assert(media_item_kind("audiobookshelf://audiobook/book-id") ==
@@ -67,6 +68,21 @@ int main() {
   assert(!missing_next_item.item_changed);
   assert(!missing_next_item.clear_title);
   assert(!missing_next_item.clear_grouping);
+
+  std::string remembered_content_id = "library://track/1";
+  MediaItemKind remembered_kind = MediaItemKind::TRACK;
+  assert(!should_replace_media_metadata_identity(""));
+  if (should_replace_media_metadata_identity("")) {
+    remembered_content_id.clear();
+    remembered_kind = MediaItemKind::UNKNOWN;
+  }
+  const auto item_after_empty_gap = media_metadata_clear_decision(
+    remembered_content_id, remembered_kind,
+    "library://audiobook/2", MediaItemKind::AUDIOBOOK);
+  assert(item_after_empty_gap.item_changed);
+  assert(item_after_empty_gap.clear_title);
+  assert(item_after_empty_gap.clear_grouping);
+  assert(should_replace_media_metadata_identity("library://audiobook/2"));
 
   const auto initial_value = media_metadata_clear_decision(
     "", MediaItemKind::UNKNOWN,

--- a/tests/firmware/media_metadata_policy_test.cpp
+++ b/tests/firmware/media_metadata_policy_test.cpp
@@ -1,0 +1,79 @@
+#include <cassert>
+
+#include "media_metadata_policy.h"
+
+int main() {
+  using espcontrol::media::MediaItemKind;
+  using espcontrol::media::media_item_kind;
+  using espcontrol::media::media_metadata_clear_decision;
+
+  assert(media_item_kind("library://track/456") == MediaItemKind::TRACK);
+  assert(media_item_kind("audiobookshelf://audiobook/book-id") ==
+         MediaItemKind::AUDIOBOOK);
+  assert(media_item_kind("library://podcast_episode/42") ==
+         MediaItemKind::PODCAST);
+  assert(media_item_kind("library://radio/1") == MediaItemKind::RADIO);
+  assert(media_item_kind("library://movie/1") == MediaItemKind::VIDEO);
+  assert(media_item_kind("library://playlist/1") == MediaItemKind::COLLECTION);
+  assert(media_item_kind("https://example.test/audio", "audiobook") ==
+         MediaItemKind::AUDIOBOOK);
+  assert(media_item_kind("library://audiobook/1", "music") ==
+         MediaItemKind::AUDIOBOOK);
+  assert(media_item_kind("opaque-content-id", "music") ==
+         MediaItemKind::UNKNOWN);
+
+  const auto same_artist_track = media_metadata_clear_decision(
+    "library://track/1", MediaItemKind::TRACK,
+    "library://track/2", MediaItemKind::TRACK);
+  assert(same_artist_track.item_changed);
+  assert(same_artist_track.clear_title);
+  assert(!same_artist_track.clear_grouping);
+
+  for (MediaItemKind next : {
+         MediaItemKind::AUDIOBOOK,
+         MediaItemKind::PODCAST,
+         MediaItemKind::RADIO,
+         MediaItemKind::VIDEO,
+       }) {
+    const auto changed_kind = media_metadata_clear_decision(
+      "library://track/1", MediaItemKind::TRACK,
+      "library://item/2", next);
+    assert(changed_kind.clear_title);
+    assert(changed_kind.clear_grouping);
+  }
+
+  const auto unknown_kind = media_metadata_clear_decision(
+    "library://track/1", MediaItemKind::TRACK,
+    "opaque-content-id", MediaItemKind::UNKNOWN);
+  assert(unknown_kind.clear_title);
+  assert(!unknown_kind.clear_grouping);
+
+  const auto audiobook_to_track = media_metadata_clear_decision(
+    "library://audiobook/1", MediaItemKind::AUDIOBOOK,
+    "library://track/2", MediaItemKind::TRACK);
+  assert(audiobook_to_track.clear_title);
+  assert(audiobook_to_track.clear_grouping);
+
+  const auto unchanged_item = media_metadata_clear_decision(
+    "library://track/1", MediaItemKind::TRACK,
+    "library://track/1", MediaItemKind::TRACK);
+  assert(!unchanged_item.item_changed);
+  assert(!unchanged_item.clear_title);
+  assert(!unchanged_item.clear_grouping);
+
+  const auto missing_next_item = media_metadata_clear_decision(
+    "library://track/1", MediaItemKind::TRACK,
+    "", MediaItemKind::UNKNOWN);
+  assert(!missing_next_item.item_changed);
+  assert(!missing_next_item.clear_title);
+  assert(!missing_next_item.clear_grouping);
+
+  const auto initial_value = media_metadata_clear_decision(
+    "", MediaItemKind::UNKNOWN,
+    "library://audiobook/1", MediaItemKind::AUDIOBOOK);
+  assert(!initial_value.item_changed);
+  assert(!initial_value.clear_title);
+  assert(!initial_value.clear_grouping);
+
+  return 0;
+}

--- a/tests/firmware/media_metadata_policy_test.cpp
+++ b/tests/firmware/media_metadata_policy_test.cpp
@@ -4,6 +4,7 @@
 
 int main() {
   using espcontrol::media::MediaItemKind;
+  using espcontrol::media::media_content_identity_fingerprint;
   using espcontrol::media::media_item_kind;
   using espcontrol::media::media_metadata_clear_decision;
   using espcontrol::media::should_replace_media_metadata_identity;
@@ -16,6 +17,9 @@ int main() {
   assert(media_item_kind("library://radio/1") == MediaItemKind::RADIO);
   assert(media_item_kind("library://movie/1") == MediaItemKind::VIDEO);
   assert(media_item_kind("library://playlist/1") == MediaItemKind::COLLECTION);
+  assert(media_item_kind("spotify:track:456") == MediaItemKind::TRACK);
+  assert(media_item_kind("provider:audiobook:book-id", "music") ==
+         MediaItemKind::AUDIOBOOK);
   assert(media_item_kind("https://example.test/audio", "audiobook") ==
          MediaItemKind::AUDIOBOOK);
   assert(media_item_kind("library://audiobook/1", "music") ==
@@ -24,8 +28,10 @@ int main() {
          MediaItemKind::UNKNOWN);
 
   const auto same_artist_track = media_metadata_clear_decision(
-    "library://track/1", MediaItemKind::TRACK,
-    "library://track/2", MediaItemKind::TRACK);
+    media_content_identity_fingerprint("library://track/1"),
+    MediaItemKind::TRACK,
+    media_content_identity_fingerprint("library://track/2"),
+    MediaItemKind::TRACK);
   assert(same_artist_track.item_changed);
   assert(same_artist_track.clear_title);
   assert(!same_artist_track.clear_grouping);
@@ -37,56 +43,78 @@ int main() {
          MediaItemKind::VIDEO,
        }) {
     const auto changed_kind = media_metadata_clear_decision(
-      "library://track/1", MediaItemKind::TRACK,
-      "library://item/2", next);
+      media_content_identity_fingerprint("library://track/1"),
+      MediaItemKind::TRACK,
+      media_content_identity_fingerprint("library://item/2"), next);
     assert(changed_kind.clear_title);
     assert(changed_kind.clear_grouping);
   }
 
   const auto unknown_kind = media_metadata_clear_decision(
-    "library://track/1", MediaItemKind::TRACK,
-    "opaque-content-id", MediaItemKind::UNKNOWN);
+    media_content_identity_fingerprint("library://track/1"),
+    MediaItemKind::TRACK,
+    media_content_identity_fingerprint("opaque-content-id"),
+    MediaItemKind::UNKNOWN);
   assert(unknown_kind.clear_title);
   assert(!unknown_kind.clear_grouping);
 
   const auto audiobook_to_track = media_metadata_clear_decision(
-    "library://audiobook/1", MediaItemKind::AUDIOBOOK,
-    "library://track/2", MediaItemKind::TRACK);
+    media_content_identity_fingerprint("library://audiobook/1"),
+    MediaItemKind::AUDIOBOOK,
+    media_content_identity_fingerprint("library://track/2"),
+    MediaItemKind::TRACK);
   assert(audiobook_to_track.clear_title);
   assert(audiobook_to_track.clear_grouping);
 
   const auto unchanged_item = media_metadata_clear_decision(
-    "library://track/1", MediaItemKind::TRACK,
-    "library://track/1", MediaItemKind::TRACK);
+    media_content_identity_fingerprint("library://track/1"),
+    MediaItemKind::TRACK,
+    media_content_identity_fingerprint("library://track/1"),
+    MediaItemKind::TRACK);
   assert(!unchanged_item.item_changed);
   assert(!unchanged_item.clear_title);
   assert(!unchanged_item.clear_grouping);
 
   const auto missing_next_item = media_metadata_clear_decision(
-    "library://track/1", MediaItemKind::TRACK,
-    "", MediaItemKind::UNKNOWN);
+    media_content_identity_fingerprint("library://track/1"),
+    MediaItemKind::TRACK, 0, MediaItemKind::UNKNOWN);
   assert(!missing_next_item.item_changed);
   assert(!missing_next_item.clear_title);
   assert(!missing_next_item.clear_grouping);
 
-  std::string remembered_content_id = "library://track/1";
+  uint64_t remembered_fingerprint =
+    media_content_identity_fingerprint("library://track/1");
   MediaItemKind remembered_kind = MediaItemKind::TRACK;
   assert(!should_replace_media_metadata_identity(""));
   if (should_replace_media_metadata_identity("")) {
-    remembered_content_id.clear();
+    remembered_fingerprint = 0;
     remembered_kind = MediaItemKind::UNKNOWN;
   }
   const auto item_after_empty_gap = media_metadata_clear_decision(
-    remembered_content_id, remembered_kind,
-    "library://audiobook/2", MediaItemKind::AUDIOBOOK);
+    remembered_fingerprint, remembered_kind,
+    media_content_identity_fingerprint("library://audiobook/2"),
+    MediaItemKind::AUDIOBOOK);
   assert(item_after_empty_gap.item_changed);
   assert(item_after_empty_gap.clear_title);
   assert(item_after_empty_gap.clear_grouping);
   assert(should_replace_media_metadata_identity("library://audiobook/2"));
 
+  const std::string long_prefix(160, 'x');
+  const uint64_t long_item_one = media_content_identity_fingerprint(
+    long_prefix + "one");
+  const uint64_t long_item_two = media_content_identity_fingerprint(
+    long_prefix + "two");
+  assert(long_item_one != long_item_two);
+  const auto long_item_change = media_metadata_clear_decision(
+    long_item_one, MediaItemKind::UNKNOWN,
+    long_item_two, MediaItemKind::UNKNOWN);
+  assert(long_item_change.item_changed);
+  assert(long_item_change.clear_title);
+
   const auto initial_value = media_metadata_clear_decision(
-    "", MediaItemKind::UNKNOWN,
-    "library://audiobook/1", MediaItemKind::AUDIOBOOK);
+    0, MediaItemKind::UNKNOWN,
+    media_content_identity_fingerprint("library://audiobook/1"),
+    MediaItemKind::AUDIOBOOK);
   assert(!initial_value.item_changed);
   assert(!initial_value.clear_title);
   assert(!initial_value.clear_grouping);


### PR DESCRIPTION
## Summary

- Add a small internal policy that classifies typed media content IDs and decides when stale metadata must be cleared.
- Use `media_content_id` as the item-change signal for media cards, control modals, cover-art cards, and the full-screen cover-art screensaver.
- Preserve artist metadata between ordinary track changes, while clearing incompatible artist/album metadata when the media kind changes.

## Practical impact

Switching from music to an audiobook, podcast, radio, or video no longer leaves the previous track's artist or album on screen. Consecutive tracks, including tracks by the same artist, continue to retain valid artist metadata when Home Assistant does not resend it.

## Documentation decision

- [x] No docs needed because this does not change user-visible configuration or public APIs.

Docs notes:

- This corrects automatic metadata handling only.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.

Affected display/device, if applicable:

- All displays using media cards, media control modals, or the cover-art screensaver.

Automated checks completed:

- Firmware unit tests: 25/25 passed.
- Cover-art contract checks passed.
- Home Assistant binding checks and self-tests passed.
- Full `npm run check:fast` repository suite passed.
- ESPHome 2026.7.0 compile passed for:
  - Guition JC1060P470
  - Guition JC4880P443
  - Guition 4848S040

## Notes for testing

Please test on a physical display:

- Now-playing cards, cover-art cards, control modals, and the full-screen cover-art screensaver.
- Track by artist A → another track by artist A: artist remains visible.
- Track → audiobook: previous artist and album disappear.
- Audiobook → track: the new artist appears when supplied.
- Track → podcast, radio, and video: incompatible metadata disappears.
- Switching active media entities: metadata from the old entity is not briefly reused.
- Repeat these transitions while monitoring free heap for unexpected decline.

Automated compile/build checks do not replace this physical device test.

## PR status

- [x] Ready for device test.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.

Related to #1276.