### PR TITLE
Preserve alarm countdown during TTS

### DIFF
--- a/devices/esp32-p4-86/device/voice_assistant.yaml
+++ b/devices/esp32-p4-86/device/voice_assistant.yaml
@@ -855,17 +855,21 @@ script:
   - id: restore_voice_home_ui
     mode: restart
     then:
-      - script.stop: cover_art_delay_timer
-      - script.stop: show_cover_art_view
-      - script.stop: cover_art_show_track_overlay
-      - script.execute: screensaver_wake
-      - script.wait: screensaver_wake
-      - script.execute: hide_cover_art_view
-      - script.wait: hide_cover_art_view
-      - lambda: |-
-          navigation_return_home(id(main_page)->obj);
-      - delay: 50ms
-      - script.execute: clock_bar_apply
+      - if:
+          condition:
+            lambda: return !id(alarm_delay_audio_session_active);
+          then:
+            - script.stop: cover_art_delay_timer
+            - script.stop: show_cover_art_view
+            - script.stop: cover_art_show_track_overlay
+            - script.execute: screensaver_wake
+            - script.wait: screensaver_wake
+            - script.execute: hide_cover_art_view
+            - script.wait: hide_cover_art_view
+            - lambda: |-
+                navigation_return_home(id(main_page)->obj);
+            - delay: 50ms
+            - script.execute: clock_bar_apply
 
   - id: release_voice_after_response
     mode: restart


### PR DESCRIPTION
## Summary

- Keep the alarm entry/exit countdown screen visible while its TTS announcement plays.
- Preserve the existing return-to-home behaviour for normal voice assistant responses.

## Root cause

Alarm delay announcements use the voice assistant TTS callbacks. Those callbacks run the normal `restore_voice_home_ui` routine, which navigates back to the main card grid even while the alarm countdown has an active critical display takeover.

The home UI restore now waits while the existing alarm-delay audio session flag is active, allowing the countdown takeover to remain in control until the alarm delay ends.

Relates to #1242.

## Automated checks

- `npm run check:firmware-ha-bindings`
- `npm run test:firmware` — all 26 tests passed
- ESPHome 2026.7.0 configuration validation for `builds/esp32-p4-86.factory.yaml`
- Full ESPHome 2026.7.0 factory firmware compile for ESP32-P4 86 — passed; factory and OTA images produced

## Physical device testing

Not performed yet. On an ESP32-P4 86 Panel:

1. Enable Voice Services, Alarm Delay Audio, and Alarm Delay TTS.
2. Arm an alarm with an exit delay.
3. Confirm the countdown screen stays visible while the TTS announcement plays.
4. Confirm local beeps begin after TTS and the countdown continues updating.
5. Disarm or let the delay complete, and confirm the normal UI returns correctly.