### PR TITLE
Prevent 7-inch development firmware OTA rollback

### DIFF
--- a/devices/guition-esp32-p4-jc1060p470/dev.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/dev.yaml
@@ -17,8 +17,9 @@ wifi:
   password: !secret wifi_password
 
 web_server:
-  js_url: ""
-  js_include: "../../docs/public/webserver/www.js"
+  # Keep the full editor out of the ESP32-P4 executable. Embedding the current
+  # bundle makes the 7-inch OTA trial image reset before it can start Wi-Fi.
+  js_url: "https://cdn.jsdelivr.net/gh/jtenniswood/espcontrol@742365f04/docs/public/webserver/www.js?device=${device_slug}"
 
 packages:
   espcontrol: !include packages.yaml


### PR DESCRIPTION
## Purpose

Keep the current web editor out of the 7-inch ESP32-P4 development firmware image. The embedded editor made the OTA trial image reset before Wi-Fi started, so the bootloader restored the older firmware and the new Landscape (4x3) option never appeared.

The development build now loads the exact current-main editor bundle from jsDelivr. The URL is pinned to commit `742365f04`, which contains the 4x3 card support.

## Practical impact

The 7-inch development firmware boots successfully after OTA and exposes the Landscape (4x3) size through the hosted editor. The release configuration already uses a hosted editor and is unchanged.

<!-- espcontrol-pr-testing-guidance -->
## Automated testing guidance

Device testing is expected before merge because this change may affect firmware or the on-device experience.

Suggested devices to test:
- Guition JC1060P470 (7 inches, Landscape)

Suggested checks:
- Confirm the device boots normally and does not restart repeatedly.
- Confirm the affected screen, card, or setting appears correctly.
- Confirm touch/navigation still works where the changed area is interactive.
- Confirm there is no obvious text overlap, clipping, blank screen, or missing icon.

Suggested PR status: Ready for device test once automated checks pass.

Changed files considered:
- `devices/guition-esp32-p4-jc1060p470/dev.yaml`

## Checks completed

Automated:
- ESPHome configuration validation passed.
- Full 7-inch firmware compile passed.
- `npm run check:local-esphome` passed.
- `npm run check:device-matrix` passed.
- `npm run check:config` passed.
- `git diff --check` passed.

Physical device:
- OTA upload to the 7-inch panel at `192.168.6.102` succeeded.
- The panel reported the new compile time (`2026-08-04 14:17:13 +0100`).
- It passed the 60-second boot safety check without rollback.
- The configured editor bundle was verified to contain `Landscape (4x3)`.
- Network check passed with 3/3 ping replies.

Physical interaction with the new size option still needs user confirmation before merge.