### PR TITLE
Fix ESPHome 2026.7.3 compile warnings

### DIFF
--- a/common/addon/time.yaml
+++ b/common/addon/time.yaml
@@ -479,7 +479,7 @@ script:
                                             id(homeassistant_time).now());
           bool use_12h = id(clock_format_12h);
           if (now.is_valid()) {
-            static char date_buf[11];
+            static char date_buf[16];
             snprintf(date_buf, sizeof(date_buf), "%04d-%02d-%02d",
                      now.year, now.month, now.day_of_month);
             id(screen_date_sensor).publish_state(date_buf);

--- a/components/espcontrol/backlight.h
+++ b/components/espcontrol/backlight.h
@@ -47,8 +47,8 @@ inline void backlight_close_modals_for_display_takeover() {
 struct SunCalcResult {
   int rise_h, rise_m, set_h, set_m;
   bool valid;
-  char sunrise_str[16];
-  char sunset_str[16];
+  char sunrise_str[32];
+  char sunset_str[32];
 };
 
 inline SunCalcResult recalc_sunrise_sunset(

--- a/components/espcontrol/button_grid_actions.h
+++ b/components/espcontrol/button_grid_actions.h
@@ -529,7 +529,7 @@ inline void send_slider_action(const std::string &entity_id, int value, bool cov
       cover_tilt ? "cover.set_cover_tilt_position" : "cover.set_cover_position",
       false, 2)) return;
     ha_action_add_entity(req, entity_id);
-    char buf[8];
+    char buf[12];
     snprintf(buf, sizeof(buf), "%d", value);
     ha_action_add_data(req, cover_tilt ? "tilt_position" : "position", buf);
   } else if (is_fan_entity(entity_id)) {
@@ -539,7 +539,7 @@ inline void send_slider_action(const std::string &entity_id, int value, bool cov
     } else {
       if (!ha_action_begin(req, "fan.turn_on", false, 2)) return;
       ha_action_add_entity(req, entity_id);
-      char buf[8];
+      char buf[12];
       snprintf(buf, sizeof(buf), "%d", value);
       ha_action_add_data(req, "percentage", buf);
     }
@@ -549,7 +549,7 @@ inline void send_slider_action(const std::string &entity_id, int value, bool cov
   } else {
     if (!ha_action_begin(req, "light.turn_on", false, 2)) return;
     ha_action_add_entity(req, entity_id);
-    char buf[8];
+    char buf[12];
     snprintf(buf, sizeof(buf), "%d", value);
     ha_action_add_data(req, "brightness_pct", buf);
   }

--- a/components/espcontrol/button_grid_fan.h
+++ b/components/espcontrol/button_grid_fan.h
@@ -505,7 +505,7 @@ inline void send_fan_step_action(FanCardCtx *ctx, bool increase) {
   if (!ctx) return;
   const char *service = increase ? "fan.increase_speed" : "fan.decrease_speed";
   if (ctx->percentage_step_known && ctx->percentage_step > 0) {
-    char buf[8];
+    char buf[12];
     snprintf(buf, sizeof(buf), "%d", ctx->percentage_step);
     send_fan_action(ctx->entity_id, service, "percentage_step", buf);
   } else {


### PR DESCRIPTION
## Summary

- Update the repository ESPHome pin from 2026.7.0 to 2026.7.3.
- Increase formatting buffers used for slider/fan values, sunrise/sunset text, and the diagnostic date.
- Remove the nine EspControl truncation warnings shown while compiling installs.

## Practical impact

- ESPHome installs no longer fill the output with EspControl buffer truncation warnings.
- The expected ESP32-P4 experimental-feature notice remains because it comes from ESPHome.
- No display behaviour is intended to change.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- This is an internal compiler-safety cleanup and build-version pin update.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.
- [ ] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- Shared firmware code; warning originally reproduced on the Guition JC8012P4A1.

## Notes for testing

- ESPHome 2026.7.3 factory compiles passed for JC8012P4A1, JC1060P470, JC4880P443, and 4848S040.
- `python3 scripts/check_firmware_release.py` passed.
- Please install this branch on a JC8012P4A1 and confirm the firmware uploads and boots normally.
- ESPHome still prints its expected experimental ESP32-P4 notice. Clean builds may also show separate upstream artwork decoder format warnings.

## PR status

- [ ] Checks running or waiting.
- [ ] Needs automated fix.
- [x] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.
