### PR TITLE
Fix JC1060P470 display timing

### DIFF
--- a/devices/guition-esp32-p4-jc1060p470/device/device.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/device/device.yaml
@@ -274,6 +274,9 @@ display:
       number: GPIO05
     update_interval: never
     auto_clear_enabled: false
+    # Some JC1060P470 panel revisions corrupt the image with the model's
+    # default 40-pixel pulse. The original working profile used 20 pixels.
+    hsync_pulse_width: 20
 
 # ---------------------------------------------------------------------------
 # LVGL base (display binding, must be before any page definitions)


### PR DESCRIPTION
## Summary

- Restore the 20-pixel horizontal sync pulse used by the original working JC1060P470 profile.
- Keep every other display timing value unchanged so this remains a controlled device test.

## Practical impact

- Targets the vertical image corruption reported on some JC1060P470 panel revisions in #1273.
- Does not change the other supported display models.

## Documentation decision

- [x] No documentation change is needed because this is a device-driver compatibility correction with no new user-facing option.

## Automated testing guidance

Device testing is expected before merge because this change may affect firmware or the on-device experience.

Suggested device to test:
- Guition JC1060P470 (7 inches, Landscape)

Suggested checks:
- Confirm the device boots normally and does not restart repeatedly.
- Confirm the complete image is stable, especially the central vertical area shown in #1273.
- Confirm touch and navigation still work.
- Confirm there is no clipping, blank area, image corruption, or missing icon.

## Checks completed

- `npm run check:fast`
- `npm run check:config`
- `npm run check:device-matrix`
- `npm run check:device-profiles`
- `npm run check:firmware-release`
- ESPHome 2026.7.3 factory firmware compile: Guition JC1060P470
- ESPHome 2026.7.3 factory firmware compile: Guition JC4880P443
- ESPHome 2026.7.3 factory firmware compile: Guition 4848S040

Automated checks and firmware compiles passed. A compile is not confirmation that the timing corrects the physical panel.

## Device testing

- Flash the PR test firmware to the Guition JC1060P470.
- Fully remove and restore power after flashing.
- Verify that the full image remains stable through boot and normal use.

This PR and issue #1273 should remain open until the physical test is confirmed.

Related: #1273
