### PR TITLE
Fix ESP32-P4 JPEG log format warnings

### DIFF
--- a/components/artwork_image/jpeg_image.cpp
+++ b/components/artwork_image/jpeg_image.cpp
@@ -288,8 +288,9 @@ int JpegDecoder::decode_hardware_(uint8_t *buffer, size_t size) {
   }
 
   this->decoded_bytes_ = size;
-  ESP_LOGI(TAG, "ESP32-P4 hardware JPEG decoded %ux%u in %lu ms (PPA scale: %s)",
-           info.width, info.height, static_cast<unsigned long>(millis() - started_at),
+  ESP_LOGI(TAG, "ESP32-P4 hardware JPEG decoded %lux%lu in %lu ms (PPA scale: %s)",
+           static_cast<unsigned long>(info.width), static_cast<unsigned long>(info.height),
+           static_cast<unsigned long>(millis() - started_at),
            ppa_scaled ? "yes" : "no");
   return static_cast<int>(size);
 }


### PR DESCRIPTION
## Summary
- correct the ESP32-P4 JPEG decode diagnostic to use the platform’s unsigned-long format for image dimensions
- remove the two compiler format warnings seen during ESPHome 2026.7.4 builds

## Validation
- `git diff --check`
- format arguments now match their explicit `unsigned long` casts

## Device testing
- not required: this changes build-time logging only; no firmware behaviour is changed