### PR TITLE
Fix 7-inch display timing

### DIFF
--- a/devices/guition-esp32-p4-jc1060p470/device/device.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/device/device.yaml
@@ -274,6 +274,9 @@ display:
       number: GPIO05
     update_interval: never
     auto_clear_enabled: false
+    # Some JC1060P470 panel revisions corrupt the image with the model's
+    # default 40-pixel pulse. The original working profile used 20 pixels.
+    hsync_pulse_width: 20
 
 # ---------------------------------------------------------------------------
 # LVGL base (display binding, must be before any page definitions)


### PR DESCRIPTION
## Summary

Fixes the corrupted/unstable image reported on the Guition JC1060P470 by using the 20-pixel horizontal sync pulse already required by the newer 10-inch panel revision.

Closes #1273.

## Validation

- `git diff --check`
- Targeted 7-inch factory firmware compile is running locally with ESPHome 2026.7.3.

## Device testing

Flash this branch to an affected 7-inch JC1060P470 panel and confirm that the normal home screen is stable, without the reported visual corruption. Physical device testing is still required.