### PR TITLE
Fix ESPHome 2026.7.4 build notices

### DIFF
--- a/components/artwork_image/bmp_image.cpp
+++ b/components/artwork_image/bmp_image.cpp
@@ -3,6 +3,8 @@
 
 #ifdef USE_ARTWORK_IMAGE_BMP_SUPPORT
 
+#include <inttypes.h>
+
 #include "esphome/components/display/display.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
@@ -39,7 +41,8 @@ int HOT BmpDecoder::decode(uint8_t *buffer, size_t size) {
     this->compression_method_ = encode_uint32(buffer[33], buffer[32], buffer[31], buffer[30]);
 
     if (this->width_ <= 0 || this->height_ <= 0) {
-      ESP_LOGE(TAG, "Unsupported BMP orientation or dimensions: %dx%d", this->width_, this->height_);
+      ESP_LOGE(TAG, "Unsupported BMP orientation or dimensions: %" PRId32 "x%" PRId32,
+               this->width_, this->height_);
       return DECODE_ERROR_UNSUPPORTED_FORMAT;
     }
     if (this->bits_per_pixel_ == 24) {

--- a/components/artwork_image/jpeg_image.cpp
+++ b/components/artwork_image/jpeg_image.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <climits>
+#include <inttypes.h>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -288,7 +289,7 @@ int JpegDecoder::decode_hardware_(uint8_t *buffer, size_t size) {
   }
 
   this->decoded_bytes_ = size;
-  ESP_LOGI(TAG, "ESP32-P4 hardware JPEG decoded %ux%u in %lu ms (PPA scale: %s)",
+  ESP_LOGI(TAG, "ESP32-P4 hardware JPEG decoded %" PRIu32 "x%" PRIu32 " in %lu ms (PPA scale: %s)",
            info.width, info.height, static_cast<unsigned long>(millis() - started_at),
            ppa_scaled ? "yes" : "no");
   return static_cast<int>(size);

--- a/components/artwork_image/p4_jpeg_backend.cpp
+++ b/components/artwork_image/p4_jpeg_backend.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
+#include <inttypes.h>
 
 #include "driver/jpeg_decode.h"
 #include "driver/ppa.h"
@@ -96,7 +97,8 @@ static bool scale_cover(const uint8_t *source, uint32_t stride_pixels, uint32_t 
   uint32_t scale_x_steps = p4::exact_scale_steps(crop_width, target_width);
   uint32_t scale_y_steps = p4::exact_scale_steps(crop_height, target_height);
   if (scale_x_steps == 0 || scale_y_steps == 0) {
-    ESP_LOGD(TAG, "PPA cannot exactly scale %ux%u to %ux%u; using CPU scaling",
+    ESP_LOGD(TAG, "PPA cannot exactly scale %" PRIu32 "x%" PRIu32 " to %" PRIu32 "x%" PRIu32
+                  "; using CPU scaling",
              crop_width, crop_height, target_width, target_height);
     return false;
   }
@@ -184,7 +186,8 @@ bool try_decode_p4_jpeg(const uint8_t *data, size_t size, int target_width, int 
   frame.height = scaled ? target_height : info.height;
   frame.stride_bytes = static_cast<size_t>(scaled ? target_width : padded_width) * 2;
   frame.ppa_scaled = scaled;
-  ESP_LOGI(TAG, "Hardware JPEG decoded %ux%u in %lu ms (PPA scale: %s)", info.width, info.height,
+  ESP_LOGI(TAG, "Hardware JPEG decoded %" PRIu32 "x%" PRIu32 " in %lu ms (PPA scale: %s)",
+           info.width, info.height,
            static_cast<unsigned long>(millis() - started_at), scaled ? "yes" : "no");
   return true;
 }

--- a/devices/esp32-p4-86/device/device.yaml
+++ b/devices/esp32-p4-86/device/device.yaml
@@ -36,7 +36,6 @@ esp32:
       disable_vfs_support_dir: false
     sdkconfig_options:
       CONFIG_SDMMC_HOST_DEFAULT: "y"
-      CONFIG_COMPILER_OPTIMIZATION_PERF: "y"
       # HTTPS firmware checks need more stack on ESP32-P4; the default main
       # task stack can trip the stack protector during mbedTLS setup.
       CONFIG_ESP_MAIN_TASK_STACK_SIZE: "8192"

--- a/devices/guition-esp32-p4-jc1060p470/device/device.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/device/device.yaml
@@ -34,7 +34,6 @@ esp32:
       disable_vfs_support_dir: false
     sdkconfig_options:
       CONFIG_SDMMC_HOST_DEFAULT: "y"
-      CONFIG_COMPILER_OPTIMIZATION_PERF: "y"
       # HTTPS firmware checks need more stack on ESP32-P4; the default main
       # task stack can trip the stack protector during mbedTLS setup.
       CONFIG_ESP_MAIN_TASK_STACK_SIZE: "8192"

--- a/devices/guition-esp32-p4-jc4880p443/device/device.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/device/device.yaml
@@ -29,7 +29,6 @@ esp32:
       enable_idf_experimental_features: yes
       execute_from_psram: true
     sdkconfig_options:
-      CONFIG_COMPILER_OPTIMIZATION_PERF: "y"
       # HTTPS firmware checks need more stack on ESP32-P4; the default main
       # task stack can trip the stack protector during mbedTLS setup.
       CONFIG_ESP_MAIN_TASK_STACK_SIZE: "8192"

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
@@ -34,7 +34,6 @@ esp32:
       disable_vfs_support_dir: false
     sdkconfig_options:
       CONFIG_SDMMC_HOST_DEFAULT: "y"
-      CONFIG_COMPILER_OPTIMIZATION_PERF: "y"
       # HTTPS firmware checks need more stack on ESP32-P4; the default main
       # task stack can trip the stack protector during mbedTLS setup.
       CONFIG_ESP_MAIN_TASK_STACK_SIZE: "8192"

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -34,7 +34,6 @@ esp32:
       disable_vfs_support_dir: false
     sdkconfig_options:
       CONFIG_SDMMC_HOST_DEFAULT: "y"
-      CONFIG_COMPILER_OPTIMIZATION_PERF: "y"
       # HTTPS firmware checks need more stack on ESP32-P4; the default main
       # task stack can trip the stack protector during mbedTLS setup.
       CONFIG_ESP_MAIN_TASK_STACK_SIZE: "8192"


### PR DESCRIPTION
## Summary

- fix ESP32-P4 BMP and JPEG logging format warnings
- remove conflicting compiler optimisation overrides from P4 device configurations

## Root cause

ESP-IDF on ESP32-P4 treats 32-bit dimensions as `long`, while the log messages used `int`/unsigned-int specifiers. ESPHome 2026.7.4 also supplies its own optimisation setting, which conflicted with the project override.

## Validation

- ESPHome 2026.7.4 factory builds passed:
  - guition-esp32-p4-jc1060p470
  - guition-esp32-p4-jc4880p443
  - guition-esp32-s3-4848s040
  - guition-esp32-p4-jc8012p4a1

## Device testing

No physical device test performed; this change only affects compile-time logging and redundant build configuration.

_Updated after resolving the branch against the latest main._