### PR TITLE
Fix large climate card numbers

### DIFF
--- a/components/espcontrol/button_grid_climate_control_driver.h
+++ b/components/espcontrol/button_grid_climate_control_driver.h
@@ -28,8 +28,16 @@ inline bool climate_control_driver_attach_interaction(
 }
 
 inline bool climate_control_driver_refresh_layout(
-    BtnSlot &, const ParsedCfg &, const Context &context) {
-  return climate_control_driver_matches(context);
+    BtnSlot &slot, const ParsedCfg &config, const Context &context,
+    const DisplayProfile &display, int row_span, int col_span) {
+  if (!climate_control_driver_matches(context)) return false;
+  if (card_large_numbers_active_for_layout(config, row_span, col_span) &&
+      display_large_sensor_font(display)) {
+    apply_large_sensor_number_style(
+      slot, display_large_sensor_font(display),
+      display_large_sensor_unit_offset_percent(display));
+  }
+  return true;
 }
 
 inline bool climate_control_driver_cleanup(

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -545,7 +545,8 @@ inline void setup_card_visual(BtnSlot &s, const ParsedCfg &p,
   if (espcontrol::cards::climate_control_driver_setup_visual(
         s, p, context, display)) {
     espcontrol::cards::climate_control_driver_attach_interaction(s, p, context);
-    espcontrol::cards::climate_control_driver_refresh_layout(s, p, context);
+    espcontrol::cards::climate_control_driver_refresh_layout(
+      s, p, context, display, row_span, col_span);
     return;
   }
   if (espcontrol::cards::alarm_driver_setup_visual(s, p, context)) {


### PR DESCRIPTION
## Summary

Makes the existing **Large Temperature Numbers** setting apply to Climate and All Controls cards.

The climate-card driver reset each value to the normal font but did not run the shared large-number layout styling. The driver now applies that styling when the existing large-number rule is active, including for cards displayed in subpages.

Addresses #1341.

## Validation

- Firmware CMake test suite: 19/19 passed, including saved-configuration parsing.
- ESPHome factory compile: blocked before C++ compilation by a pre-existing clean-`main` configuration error in `common/device/screen_cover_art.yaml` (`image.platform` is rejected by ESPHome 2026.6.2). All six factory targets include that shared file.

## Device testing needed

On a JC8012P4A1, test Climate and All Controls cards using Actual and Target display modes:
- enable and disable Large Temperature Numbers on a 1×1 card;
- check a large card and a climate card inside a subpage;
- confirm Icon display remains unchanged.