### PR TITLE
Refresh climate font when cards resize

### DIFF
--- a/components/espcontrol/button_grid_climate_control_driver.h
+++ b/components/espcontrol/button_grid_climate_control_driver.h
@@ -36,6 +36,8 @@ inline bool climate_control_driver_refresh_layout(
     apply_large_sensor_number_style(
       slot, display_large_sensor_font(display),
       display_large_sensor_unit_offset_percent(display));
+  } else {
+    apply_standard_sensor_number_style(slot, display);
   }
   return true;
 }

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -220,6 +220,13 @@ inline void apply_large_sensor_number_style(const BtnSlot &s, const lv_font_t *l
   }
 }
 
+inline void apply_standard_sensor_number_style(const BtnSlot &s, const DisplayProfile &display) {
+  if (s.sensor_lbl && display_sensor_font(display)) {
+    lv_obj_set_style_text_font(s.sensor_lbl, display_sensor_font(display), LV_PART_MAIN);
+  }
+  if (s.unit_lbl) lv_obj_set_style_translate_y(s.unit_lbl, 0, LV_PART_MAIN);
+}
+
 inline bool large_number_square_card_layout(int row_span, int col_span) {
   return card_span_is_large(row_span, col_span);
 }
@@ -501,10 +508,7 @@ inline void setup_card_visual(BtnSlot &s, const ParsedCfg &p,
   apply_button_colors(s.btn, palette.has_on, palette.on_val,
     palette.has_off, palette.off_val);
   apply_button_on_pattern(s.btn, p.options, palette.has_on, palette.on_val);
-  if (s.sensor_lbl && display_sensor_font(display)) {
-    lv_obj_set_style_text_font(s.sensor_lbl, display_sensor_font(display), LV_PART_MAIN);
-  }
-  if (s.unit_lbl) lv_obj_set_style_translate_y(s.unit_lbl, 0, LV_PART_MAIN);
+  apply_standard_sensor_number_style(s, display);
   if (s.unit_lbl) lv_obj_clear_flag(s.unit_lbl, LV_OBJ_FLAG_HIDDEN);
   if (s.text_lbl) lv_obj_clear_flag(s.text_lbl, LV_OBJ_FLAG_HIDDEN);
   if (s.icon_lbl) lv_obj_align(s.icon_lbl, LV_ALIGN_TOP_LEFT, 0, 0);
@@ -854,6 +858,9 @@ inline void refresh_card_layout(BtnSlot &s, const ParsedCfg &p,
 
   if (espcontrol::cards::numeric_selectable_driver_refresh_layout(
         s, p, context)) return;
+
+  if (espcontrol::cards::climate_control_driver_refresh_layout(
+        s, p, context, display, row_span, col_span)) return;
 
   if (espcontrol::cards::image_driver_refresh_layout(
         s, p, context)) {


### PR DESCRIPTION
## Summary

Refreshes climate-card temperature styling immediately after a dashboard card is resized. The value and unit now grow when the card becomes eligible for large numbers, and return to their normal styling when it becomes ineligible.

Addresses #1341.

## Validation

- `python3 scripts/check_tasks.py run-task firmware-tests` — passed (19/19), including saved-configuration parsing.
- The 10-inch P4 factory compile reaches the existing clean-main ESPHome 2026.6.2 incompatibility in `common/device/screen_cover_art.yaml` (`image.platform: file`) before it compiles firmware. This PR does not change that unrelated baseline issue.

## Device testing

On the 10-inch P4, resize a Climate or All Controls card without restarting the display. Confirm the temperature font and unit alignment update immediately when changing between 1×1 and a larger size, including large-numbers enabled, disabled, Actual, Target, and icon-only modes.