### PR TITLE
Guard configuration saves by generation

### DIFF
--- a/components/espcontrol/configuration_service.cpp
+++ b/components/espcontrol/configuration_service.cpp
@@ -81,6 +81,27 @@ CommitResult ConfigurationService::commit_document(
   return store_.commit(encoded.data(), encoded.size());
 }
 
+CommitResult ConfigurationService::commit_document_if_generation(
+    uint32_t expected_generation, uint16_t document_version,
+    const uint8_t *document, size_t document_size) {
+  if (document_size > maximum_document_size()) {
+    return {StoreStatus::PAYLOAD_TOO_LARGE, 0, document_size};
+  }
+
+  std::vector<uint8_t> encoded(CONFIGURATION_DOCUMENT_HEADER_SIZE +
+                               document_size);
+  write_u32(encoded.data() + DOCUMENT_MAGIC_OFFSET, DOCUMENT_MAGIC);
+  write_u16(encoded.data() + DOCUMENT_VERSION_OFFSET, document_version);
+  write_u16(encoded.data() + DOCUMENT_HEADER_SIZE_OFFSET,
+            CONFIGURATION_DOCUMENT_HEADER_SIZE);
+  if (document_size > 0) {
+    std::memcpy(encoded.data() + CONFIGURATION_DOCUMENT_HEADER_SIZE, document,
+                document_size);
+  }
+  return store_.commit_if_generation(expected_generation, encoded.data(),
+                                     encoded.size());
+}
+
 ServiceLoadResult ConfigurationService::load(uint8_t *output,
                                              size_t output_capacity) {
   if (output == nullptr && output_capacity > 0) {
@@ -191,6 +212,40 @@ ServiceSaveResult ConfigurationService::save(uint16_t document_version,
 
   const CommitResult committed =
       commit_document(document_version, document, document_size);
+  if (!committed.ok()) {
+    return {ServiceStatus::STORE_FAILED, committed.status, document_version,
+            committed.generation, document_size};
+  }
+  if (!legacy_.mirror(document_version, document, document_size)) {
+    return {ServiceStatus::LEGACY_MIRROR_FAILED, committed.status,
+            document_version, committed.generation, document_size};
+  }
+  return {ServiceStatus::OK, committed.status, document_version,
+          committed.generation, document_size};
+}
+
+ServiceSaveResult ConfigurationService::save_if_generation(
+    uint32_t expected_generation, uint16_t document_version,
+    const uint8_t *document, size_t document_size) {
+  if (document_size > 0 && document == nullptr) {
+    return {ServiceStatus::INVALID_ARGUMENT, StoreStatus::INVALID_ARGUMENT,
+            document_version, 0, document_size};
+  }
+  if (!supports_version(document_version)) {
+    return {ServiceStatus::UNSUPPORTED_VERSION, StoreStatus::INVALID_ARGUMENT,
+            document_version, 0, document_size};
+  }
+  if (!document_is_valid(document_version, document, document_size)) {
+    return {ServiceStatus::INVALID_DOCUMENT, StoreStatus::INVALID_ARGUMENT,
+            document_version, 0, document_size};
+  }
+
+  const CommitResult committed = commit_document_if_generation(
+      expected_generation, document_version, document, document_size);
+  if (committed.status == StoreStatus::GENERATION_CONFLICT) {
+    return {ServiceStatus::GENERATION_CONFLICT, committed.status,
+            document_version, committed.generation, document_size};
+  }
   if (!committed.ok()) {
     return {ServiceStatus::STORE_FAILED, committed.status, document_version,
             committed.generation, document_size};

--- a/components/espcontrol/configuration_service.h
+++ b/components/espcontrol/configuration_service.h
@@ -44,6 +44,7 @@ enum class ServiceStatus : uint8_t {
   BUFFER_TOO_SMALL,
   UNSUPPORTED_VERSION,
   INVALID_DOCUMENT,
+  GENERATION_CONFLICT,
   STORE_FAILED,
   LEGACY_READ_FAILED,
   LEGACY_MIRROR_FAILED,
@@ -105,6 +106,10 @@ class ConfigurationService {
   ServiceLoadResult load(uint8_t *output, size_t output_capacity);
   ServiceSaveResult save(uint16_t document_version, const uint8_t *document,
                          size_t document_size);
+  ServiceSaveResult save_if_generation(uint32_t expected_generation,
+                                       uint16_t document_version,
+                                       const uint8_t *document,
+                                       size_t document_size);
   ServiceSaveResult save_current(const uint8_t *document,
                                  size_t document_size) {
     return save(CURRENT_CONFIGURATION_DOCUMENT_VERSION, document,
@@ -117,6 +122,10 @@ class ConfigurationService {
   CommitResult commit_document(uint16_t document_version,
                                const uint8_t *document,
                                size_t document_size);
+  CommitResult commit_document_if_generation(uint32_t expected_generation,
+                                             uint16_t document_version,
+                                             const uint8_t *document,
+                                             size_t document_size);
   bool supports_version(uint16_t document_version) const;
   bool document_is_valid(uint16_t document_version, const uint8_t *document,
                          size_t document_size) const;

--- a/components/espcontrol/configuration_store.cpp
+++ b/components/espcontrol/configuration_store.cpp
@@ -185,6 +185,19 @@ LoadResult ConfigurationStore::load(uint8_t *output,
 
 CommitResult ConfigurationStore::commit(const uint8_t *payload,
                                         size_t payload_size) {
+  return commit_internal(false, 0, payload, payload_size);
+}
+
+CommitResult ConfigurationStore::commit_if_generation(
+    uint32_t expected_generation, const uint8_t *payload,
+    size_t payload_size) {
+  return commit_internal(true, expected_generation, payload, payload_size);
+}
+
+CommitResult ConfigurationStore::commit_internal(bool enforce_generation,
+                                                 uint32_t expected_generation,
+                                                 const uint8_t *payload,
+                                                 size_t payload_size) {
   if (payload_size > 0 && payload == nullptr) {
     return {StoreStatus::INVALID_ARGUMENT};
   }
@@ -215,6 +228,17 @@ CommitResult ConfigurationStore::commit(const uint8_t *payload,
   } else if (second_valid) {
     target_slot = first.slot;
     next_generation = second.generation + 1;
+  }
+  const uint32_t current_generation =
+      first_valid && second_valid
+          ? (generation_is_newer(second.generation, first.generation)
+                 ? second.generation
+                 : first.generation)
+          : (first_valid ? first.generation
+                         : (second_valid ? second.generation : 0));
+  if (enforce_generation && expected_generation != current_generation) {
+    return {StoreStatus::GENERATION_CONFLICT, current_generation,
+            payload_size, target_slot};
   }
 
   // Keep the target unpublished until both its payload and metadata are

--- a/components/espcontrol/configuration_store.cpp
+++ b/components/espcontrol/configuration_store.cpp
@@ -17,6 +17,18 @@ constexpr size_t PAYLOAD_SIZE_OFFSET = 12;
 constexpr size_t CHECKSUM_OFFSET = 16;
 constexpr size_t CHECKSUM_CHUNK_SIZE = 64;
 
+class CommitLockGuard {
+ public:
+  explicit CommitLockGuard(std::atomic_flag &lock) : lock_(lock) {
+    while (lock_.test_and_set(std::memory_order_acquire)) {
+    }
+  }
+  ~CommitLockGuard() { lock_.clear(std::memory_order_release); }
+
+ private:
+  std::atomic_flag &lock_;
+};
+
 uint16_t read_u16(const uint8_t *data) {
   return static_cast<uint16_t>(data[0]) |
          (static_cast<uint16_t>(data[1]) << 8);
@@ -198,6 +210,10 @@ CommitResult ConfigurationStore::commit_internal(bool enforce_generation,
                                                  uint32_t expected_generation,
                                                  const uint8_t *payload,
                                                  size_t payload_size) {
+  // A conditional save may originate from concurrent HTTP callbacks. Keep the
+  // slot inspection, generation check, write, and verification together so a
+  // stale request cannot pass the check before another save is published.
+  CommitLockGuard lock(commit_lock_);
   if (payload_size > 0 && payload == nullptr) {
     return {StoreStatus::INVALID_ARGUMENT};
   }

--- a/components/espcontrol/configuration_store.h
+++ b/components/espcontrol/configuration_store.h
@@ -15,6 +15,7 @@ enum class StoreStatus : uint8_t {
   INVALID_ARGUMENT,
   BUFFER_TOO_SMALL,
   PAYLOAD_TOO_LARGE,
+  GENERATION_CONFLICT,
   READ_FAILED,
   WRITE_FAILED,
   SYNC_FAILED,
@@ -63,6 +64,9 @@ class ConfigurationStore {
 
   LoadResult load(uint8_t *output, size_t output_capacity);
   CommitResult commit(const uint8_t *payload, size_t payload_size);
+  CommitResult commit_if_generation(uint32_t expected_generation,
+                                    const uint8_t *payload,
+                                    size_t payload_size);
 
   size_t maximum_payload_size() const;
 
@@ -80,6 +84,9 @@ class ConfigurationStore {
   SlotMetadata inspect_slot(uint8_t slot);
   bool checksum_slot_payload(uint8_t slot, const uint8_t *header,
                              size_t payload_size, uint32_t *checksum);
+  CommitResult commit_internal(bool enforce_generation,
+                               uint32_t expected_generation,
+                               const uint8_t *payload, size_t payload_size);
   static bool generation_is_newer(uint32_t candidate, uint32_t reference);
   static uint32_t checksum(uint32_t generation, const uint8_t *data,
                            size_t size);

--- a/components/espcontrol/configuration_store.h
+++ b/components/espcontrol/configuration_store.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 
@@ -92,6 +93,7 @@ class ConfigurationStore {
                            size_t size);
 
   StorageBackend &backend_;
+  std::atomic_flag commit_lock_ = ATOMIC_FLAG_INIT;
 };
 
 }  // namespace espcontrol::configuration

--- a/dev-docs/architecture.md
+++ b/dev-docs/architecture.md
@@ -20,7 +20,7 @@ outputs. For the hard edit/rebuild/check contract, use
 | Entity names | `common/config/entity_names.json` | Shared Home Assistant entity names used by firmware and the setup page. |
 | Icons | `common/assets/icons.json` and `common/assets/*glyphs.yaml` | Icon names, glyphs, and font glyph sets. |
 | Firmware UI | `components/espcontrol/*.h` | LVGL card grid, card renderers, modals, config parsing, Home Assistant bindings. |
-| Configuration service | `components/espcontrol/configuration_service.*` and `configuration_store.*` | One-time legacy import, compatibility dual-write, and atomic two-slot storage; not yet the production persistence path. |
+| Configuration service | `components/espcontrol/configuration_service.*` and `configuration_store.*` | One-time legacy import, compatibility dual-write, atomic two-slot storage, and generation-matched saves for future browser conflict protection; not yet the production persistence path. |
 | Native panel document | `components/espcontrol/panel_config_document.h`, `panel_config_service_validator.h`, and `src/webserver/model/panel_config.ts` | Bounded, versioned `PanelConfig` binary codec shared by firmware and the browser. Its validator can protect atomic service saves and loads; V1 carries current compact card strings unchanged while live storage and API migration follow in later phases. |
 | Web setup page | `src/webserver/` | Browser UI for configuring cards, settings, backup/restore, and previews. |
 | Typed web state | `src/webserver/state/` | Device configuration and application state types, isolated state creation, direct module-owned state access, event aliases, and event parsing. Application state must not be published as a browser global. |

--- a/tests/firmware/configuration_service_test.cpp
+++ b/tests/firmware/configuration_service_test.cpp
@@ -168,6 +168,32 @@ bool successful_save_dual_writes() {
          legacy.mirrored == expected;
 }
 
+bool conditional_save_rejects_a_stale_generation() {
+  MemoryBackend backend(256);
+  ConfigurationStore store(backend);
+  FakeLegacy legacy;
+  ConfigurationService service(store, legacy);
+  const std::vector<uint8_t> first = bytes("first-document");
+  const std::vector<uint8_t> second = bytes("second-document");
+  if (!service.save_current(first.data(), first.size()).ok()) return false;
+
+  const ServiceSaveResult rejected = service.save_if_generation(
+      0, CURRENT_CONFIGURATION_DOCUMENT_VERSION, second.data(), second.size());
+  if (rejected.status != ServiceStatus::GENERATION_CONFLICT ||
+      rejected.store_status != StoreStatus::GENERATION_CONFLICT ||
+      rejected.generation != 1 || legacy.mirror_calls != 1) {
+    return false;
+  }
+
+  const ServiceSaveResult saved = service.save_if_generation(
+      1, CURRENT_CONFIGURATION_DOCUMENT_VERSION, second.data(), second.size());
+  std::array<uint8_t, 64> output{};
+  const ServiceLoadResult loaded = service.load(output.data(), output.size());
+  return saved.ok() && saved.generation == 2 && legacy.mirror_calls == 2 &&
+         loaded.ok() && loaded.generation == 2 &&
+         std::equal(second.begin(), second.end(), output.begin());
+}
+
 bool version_and_buffer_failures_are_explicit() {
   MemoryBackend backend(256);
   ConfigurationStore store(backend);
@@ -270,6 +296,7 @@ int main() {
       saves_are_durable_before_the_legacy_mirror() &&
       failed_durable_save_never_updates_legacy() &&
       successful_save_dual_writes() &&
+      conditional_save_rejects_a_stale_generation() &&
       version_and_buffer_failures_are_explicit() &&
       malformed_store_document_is_not_treated_as_legacy() &&
       panel_config_validator_protects_the_atomic_store() &&

--- a/tests/firmware/configuration_store_test.cpp
+++ b/tests/firmware/configuration_store_test.cpp
@@ -124,6 +124,31 @@ bool newest_generation_wins() {
          loaded.slot == 1 && payload_equals(output, second, loaded);
 }
 
+bool conditional_commit_rejects_a_stale_generation() {
+  MemoryBackend backend(128);
+  ConfigurationStore store(backend);
+  const std::vector<uint8_t> first = bytes("first");
+  const std::vector<uint8_t> second = bytes("second");
+  if (!store.commit(first.data(), first.size()).ok()) return false;
+
+  const CommitResult rejected =
+      store.commit_if_generation(0, second.data(), second.size());
+  std::vector<uint8_t> output(first.size());
+  const LoadResult unchanged = store.load(output.data(), output.size());
+  if (rejected.status != StoreStatus::GENERATION_CONFLICT ||
+      rejected.generation != 1 ||
+      !payload_equals(output, first, unchanged)) {
+    return false;
+  }
+
+  const CommitResult committed =
+      store.commit_if_generation(1, second.data(), second.size());
+  output.resize(second.size());
+  const LoadResult loaded = store.load(output.data(), output.size());
+  return committed.ok() && committed.generation == 2 &&
+         payload_equals(output, second, loaded);
+}
+
 bool corrupt_newest_falls_back() {
   MemoryBackend backend(128);
   ConfigurationStore store(backend);
@@ -266,7 +291,8 @@ bool io_and_sync_errors_are_explicit() {
 int main() {
   const bool passed =
       empty_store_is_reported() && commit_and_load_round_trip() &&
-      newest_generation_wins() && corrupt_newest_falls_back() &&
+      newest_generation_wins() && conditional_commit_rejects_a_stale_generation() &&
+      corrupt_newest_falls_back() &&
       corrupt_stale_generation_cannot_promote_old_payload() &&
       partial_payload_write_preserves_previous() &&
       partial_header_write_preserves_previous() &&


### PR DESCRIPTION
## Purpose
Add a generation check to the atomic configuration service, forming the conflict-protection boundary required by the future native configuration API.

## Practical impact
A stale browser save will be rejected instead of silently replacing a newer configuration. Rejected saves do not update the legacy compatibility mirror.

## Checks
- `npm run check:fast`
- `python3 scripts/check_tasks.py run-task mutations`

## Device testing
This is a service-layer change only; no live configuration route has been enabled yet. PR #1372 was flashed successfully to the 7-inch display before merge.