### PR TITLE
Expose native panel configuration reads

### DIFF
--- a/common/addon/web_server_auth.yaml
+++ b/common/addon/web_server_auth.yaml
@@ -14,3 +14,7 @@ web_server:
     type: digest
     username: ${espcontrol_web_username}
     password: ${espcontrol_web_password}
+
+espcontrol:
+  web_auth_username: ${espcontrol_web_username}
+  web_auth_password: ${espcontrol_web_password}

--- a/components/espcontrol/__init__.py
+++ b/components/espcontrol/__init__.py
@@ -21,6 +21,8 @@ CONF_BUTTON_ORDER = "button_order"
 CONF_BUTTONS = "buttons"
 CONF_CONFIG = "config"
 CONF_SUBPAGE_CHUNKS = "subpage_chunks"
+CONF_WEB_AUTH_USERNAME = "web_auth_username"
+CONF_WEB_AUTH_PASSWORD = "web_auth_password"
 
 espcontrol_ns = cg.global_ns.namespace("espcontrol")
 EspControlApp = espcontrol_ns.class_("EspControlApp", cg.Component)
@@ -49,6 +51,8 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(CONF_ID): cv.declare_id(EspControlApp),
         cv.Optional(CONF_ACTION_RESPONSES, default=True): cv.boolean,
         cv.Optional(CONF_PANEL_CONFIG): PANEL_CONFIG_SCHEMA,
+        cv.Optional(CONF_WEB_AUTH_USERNAME, default=""): cv.string_strict,
+        cv.Optional(CONF_WEB_AUTH_PASSWORD, default=""): cv.sensitive(cv.string_strict),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -56,6 +60,8 @@ CONFIG_SCHEMA = cv.Schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
+    cg.add(var.set_web_auth_credentials(
+        config[CONF_WEB_AUTH_USERNAME], config[CONF_WEB_AUTH_PASSWORD]))
 
     panel_config = config.get(CONF_PANEL_CONFIG)
     if panel_config is not None:

--- a/components/espcontrol/espcontrol_app.cpp
+++ b/components/espcontrol/espcontrol_app.cpp
@@ -97,7 +97,8 @@ void EspControlApp::setup() {
     const bool read_endpoint_registered =
         configuration::register_panel_config_read_endpoint(
             panel_config_service_, panel_config_document_buffer_,
-            PANEL_CONFIG_STORAGE_SLOT_CAPACITY);
+            PANEL_CONFIG_STORAGE_SLOT_CAPACITY, web_auth_username_.c_str(),
+            web_auth_password_.c_str());
     configuration::set_panel_config_read_supported(read_endpoint_registered);
     if (!read_endpoint_registered) {
       ESP_LOGW(TAG, "Native configuration read endpoint is unavailable");

--- a/components/espcontrol/espcontrol_app.cpp
+++ b/components/espcontrol/espcontrol_app.cpp
@@ -9,6 +9,7 @@
 #include "esphome/core/log.h"
 
 #include "panel_config_capabilities_endpoint.h"
+#include "panel_config_read_endpoint.h"
 
 namespace espcontrol {
 
@@ -92,6 +93,14 @@ void EspControlApp::setup() {
                refreshed.status != configuration::ServiceStatus::EMPTY) {
       ESP_LOGE(TAG, "Native configuration refresh failed (%u)",
                static_cast<unsigned>(refreshed.status));
+    }
+    const bool read_endpoint_registered =
+        configuration::register_panel_config_read_endpoint(
+            panel_config_service_, panel_config_document_buffer_,
+            PANEL_CONFIG_STORAGE_SLOT_CAPACITY);
+    configuration::set_panel_config_read_supported(read_endpoint_registered);
+    if (!read_endpoint_registered) {
+      ESP_LOGW(TAG, "Native configuration read endpoint is unavailable");
     }
   }
   configuration::register_panel_config_capabilities_endpoint();

--- a/components/espcontrol/espcontrol_app.h
+++ b/components/espcontrol/espcontrol_app.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <string>
 
 #include "esphome/components/text/text.h"
 #include "esphome/core/component.h"
@@ -44,6 +45,10 @@ class EspControlApp : public esphome::Component {
       esphome::text::Text *subpage_2, esphome::text::Text *subpage_3,
       esphome::text::Text *subpage_4, esphome::text::Text *subpage_5,
       esphome::text::Text *subpage_6, esphome::text::Text *subpage_7);
+  void set_web_auth_credentials(const char *username, const char *password) {
+    web_auth_username_ = username == nullptr ? "" : username;
+    web_auth_password_ = password == nullptr ? "" : password;
+  }
 
  private:
   struct LegacyButtonTextSources {
@@ -64,6 +69,8 @@ class EspControlApp : public esphome::Component {
       panel_config_store_, legacy_config_, &panel_config_validator_};
   uint8_t *panel_config_memory_{nullptr};
   uint8_t *panel_config_document_buffer_{nullptr};
+  std::string web_auth_username_;
+  std::string web_auth_password_;
   configuration::EspHomeLegacyTextValue button_order_text_{};
   std::array<LegacyButtonTextSources, configuration::PANEL_CONFIG_MAX_SLOT_COUNT>
       legacy_button_texts_{};

--- a/components/espcontrol/panel_config_capabilities.h
+++ b/components/espcontrol/panel_config_capabilities.h
@@ -10,6 +10,15 @@ constexpr uint16_t PANEL_CONFIG_API_VERSION = 1;
 constexpr uint16_t PANEL_CONFIG_WEB_ASSET_VERSION = 1;
 constexpr size_t PANEL_CONFIG_CAPABILITIES_MAX_JSON_BYTES = 160;
 
+inline bool &panel_config_read_supported() {
+  static bool supported = false;
+  return supported;
+}
+
+inline void set_panel_config_read_supported(bool supported) {
+  panel_config_read_supported() = supported;
+}
+
 // The discovery response is deliberately static for the first native
 // configuration release. The future immutable web-bundle manifest will
 // replace the legacy delivery marker while preserving these version fields.
@@ -21,10 +30,11 @@ inline bool write_panel_config_capabilities_json(char *output,
   const int written = std::snprintf(
       output, output_capacity,
       "{\"api\":{\"version\":%u},\"configuration\":{\"document_versions\":[%u],"
-      "\"read\":false,\"write\":false},\"web_assets\":{\"versions\":[%u],"
+      "\"read\":%s,\"write\":false},\"web_assets\":{\"versions\":[%u],"
       "\"delivery\":\"legacy\"}}",
       static_cast<unsigned>(PANEL_CONFIG_API_VERSION),
       static_cast<unsigned>(PANEL_CONFIG_DOCUMENT_VERSION),
+      panel_config_read_supported() ? "true" : "false",
       static_cast<unsigned>(PANEL_CONFIG_WEB_ASSET_VERSION));
   if (written < 0 || static_cast<size_t>(written) >= output_capacity)
     return false;

--- a/components/espcontrol/panel_config_read_endpoint.h
+++ b/components/espcontrol/panel_config_read_endpoint.h
@@ -19,8 +19,10 @@ class PanelConfigReadHandler final
     : public esphome::web_server_idf::AsyncWebHandler {
  public:
   PanelConfigReadHandler(ConfigurationService &service, uint8_t *document,
-                         size_t document_capacity)
-      : service_(service), document_(document), document_capacity_(document_capacity) {}
+                         size_t document_capacity, const char *username,
+                         const char *password)
+      : service_(service), document_(document), document_capacity_(document_capacity),
+        username_(username), password_(password) {}
 
   bool canHandle(
       esphome::web_server_idf::AsyncWebServerRequest *request) const override {
@@ -33,6 +35,12 @@ class PanelConfigReadHandler final
 
   void handleRequest(
       esphome::web_server_idf::AsyncWebServerRequest *request) override {
+#ifdef USE_WEBSERVER_AUTH
+    if (!request->authenticate(username_, password_)) {
+      request->requestAuthentication();
+      return;
+    }
+#endif
     httpd_req_t *raw_request = *request;
     const ServiceLoadResult loaded =
         service_.load(document_, document_capacity_);
@@ -48,8 +56,11 @@ class PanelConfigReadHandler final
     }
 
     char generation[16]{};
+    char etag[20]{};
     char version[8]{};
     std::snprintf(generation, sizeof(generation), "%lu",
+                  static_cast<unsigned long>(loaded.generation));
+    std::snprintf(etag, sizeof(etag), "\"%lu\"",
                   static_cast<unsigned long>(loaded.generation));
     std::snprintf(version, sizeof(version), "%u",
                   static_cast<unsigned>(loaded.document_version));
@@ -57,7 +68,7 @@ class PanelConfigReadHandler final
     httpd_resp_set_type(raw_request,
                         "application/vnd.espcontrol.panel-config");
     httpd_resp_set_hdr(raw_request, "Cache-Control", "no-store");
-    httpd_resp_set_hdr(raw_request, "ETag", generation);
+    httpd_resp_set_hdr(raw_request, "ETag", etag);
     httpd_resp_set_hdr(raw_request, "X-Panel-Config-Generation", generation);
     httpd_resp_set_hdr(raw_request, "X-Panel-Config-Version", version);
     httpd_resp_send(raw_request, reinterpret_cast<const char *>(document_),
@@ -68,17 +79,21 @@ class PanelConfigReadHandler final
   ConfigurationService &service_;
   uint8_t *document_;
   size_t document_capacity_;
+  const char *username_;
+  const char *password_;
 };
 
 inline bool register_panel_config_read_endpoint(
-    ConfigurationService &service, uint8_t *document, size_t document_capacity) {
+    ConfigurationService &service, uint8_t *document, size_t document_capacity,
+    const char *username, const char *password) {
   static bool registered = false;
   if (registered) return true;
   if (document == nullptr || document_capacity == 0) return false;
   auto *server = esphome::web_server_idf::global_async_web_server();
   if (server == nullptr) return false;
   server->addHandler(
-      new PanelConfigReadHandler(service, document, document_capacity));
+      new PanelConfigReadHandler(service, document, document_capacity, username,
+                                 password));
   registered = true;
   return true;
 }
@@ -88,7 +103,7 @@ inline bool register_panel_config_read_endpoint(
 namespace espcontrol::configuration {
 class ConfigurationService;
 inline bool register_panel_config_read_endpoint(ConfigurationService &, uint8_t *,
-                                               size_t) {
+                                               size_t, const char *, const char *) {
   return true;
 }
 }  // namespace espcontrol::configuration

--- a/components/espcontrol/panel_config_read_endpoint.h
+++ b/components/espcontrol/panel_config_read_endpoint.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#ifdef USE_WEBSERVER
+#include <array>
+#include <cstdio>
+#include <cstring>
+
+#include <esp_http_server.h>
+
+#include "configuration_service.h"
+#include "esphome/components/web_server_idf/web_server_idf.h"
+
+namespace espcontrol::configuration {
+
+class PanelConfigReadHandler final
+    : public esphome::web_server_idf::AsyncWebHandler {
+ public:
+  PanelConfigReadHandler(ConfigurationService &service, uint8_t *document,
+                         size_t document_capacity)
+      : service_(service), document_(document), document_capacity_(document_capacity) {}
+
+  bool canHandle(
+      esphome::web_server_idf::AsyncWebServerRequest *request) const override {
+    if (request->method() != HTTP_GET) return false;
+    char url_buffer[
+        esphome::web_server_idf::AsyncWebServerRequest::URL_BUF_SIZE];
+    const esphome::StringRef url = request->url_to(url_buffer);
+    return std::strcmp(url.c_str(), "/api/v1/config") == 0;
+  }
+
+  void handleRequest(
+      esphome::web_server_idf::AsyncWebServerRequest *request) override {
+    httpd_req_t *raw_request = *request;
+    const ServiceLoadResult loaded =
+        service_.load(document_, document_capacity_);
+    if (loaded.status == ServiceStatus::EMPTY) {
+      httpd_resp_send_err(raw_request, HTTPD_404_NOT_FOUND,
+                          "No native configuration is stored");
+      return;
+    }
+    if (!loaded.ok()) {
+      httpd_resp_send_err(raw_request, HTTPD_500_INTERNAL_SERVER_ERROR,
+                          "Native configuration is unavailable");
+      return;
+    }
+
+    char generation[16]{};
+    char version[8]{};
+    std::snprintf(generation, sizeof(generation), "%lu",
+                  static_cast<unsigned long>(loaded.generation));
+    std::snprintf(version, sizeof(version), "%u",
+                  static_cast<unsigned>(loaded.document_version));
+    httpd_resp_set_status(raw_request, "200 OK");
+    httpd_resp_set_type(raw_request,
+                        "application/vnd.espcontrol.panel-config");
+    httpd_resp_set_hdr(raw_request, "Cache-Control", "no-store");
+    httpd_resp_set_hdr(raw_request, "ETag", generation);
+    httpd_resp_set_hdr(raw_request, "X-Panel-Config-Generation", generation);
+    httpd_resp_set_hdr(raw_request, "X-Panel-Config-Version", version);
+    httpd_resp_send(raw_request, reinterpret_cast<const char *>(document_),
+                    loaded.document_size);
+  }
+
+ private:
+  ConfigurationService &service_;
+  uint8_t *document_;
+  size_t document_capacity_;
+};
+
+inline bool register_panel_config_read_endpoint(
+    ConfigurationService &service, uint8_t *document, size_t document_capacity) {
+  static bool registered = false;
+  if (registered) return true;
+  if (document == nullptr || document_capacity == 0) return false;
+  auto *server = esphome::web_server_idf::global_async_web_server();
+  if (server == nullptr) return false;
+  server->addHandler(
+      new PanelConfigReadHandler(service, document, document_capacity));
+  registered = true;
+  return true;
+}
+
+}  // namespace espcontrol::configuration
+#else
+namespace espcontrol::configuration {
+class ConfigurationService;
+inline bool register_panel_config_read_endpoint(ConfigurationService &, uint8_t *,
+                                               size_t) {
+  return true;
+}
+}  // namespace espcontrol::configuration
+#endif

--- a/tests/firmware/panel_config_capabilities_test.cpp
+++ b/tests/firmware/panel_config_capabilities_test.cpp
@@ -22,5 +22,11 @@ int main() {
                       !write_panel_config_capabilities_json(nullptr,
                                                             capabilities.size(),
                                                             &capabilities_size);
-  return passed ? EXIT_SUCCESS : EXIT_FAILURE;
+  set_panel_config_read_supported(true);
+  const bool read_capability_is_advertised =
+      write_panel_config_capabilities_json(capabilities.data(),
+                                           capabilities.size(),
+                                           &capabilities_size) &&
+      std::strstr(capabilities.data(), "\"read\":true") != nullptr;
+  return passed && read_capability_is_advertised ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
## Purpose
Add the first native read path: GET /api/v1/config returns the validated binary PanelConfig, with generation and document-version response headers. Capabilities advertise read support only when the endpoint is available.

## Checked
- python3 scripts/check_tasks.py run-task firmware-tests

## Device test
- Flash the 7-inch P4 and confirm /api/v1/capabilities advertises native reads and /api/v1/config returns a binary document with generation headers.