### PR TITLE
Add display lifecycle service boundary

### DIFF
--- a/components/espcontrol/display_lifecycle_service.h
+++ b/components/espcontrol/display_lifecycle_service.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <cstdint>
+
+#include "display_mode_controller.h"
+
+namespace espcontrol {
+
+enum class DisplayLifecycleState : uint8_t {
+  CONSTRUCTED,
+  RUNNING,
+  STOPPED,
+};
+
+// Owns display-mode state independently of the ESPHome component lifecycle.
+// The controller accessor remains available while YAML wiring migrates through
+// this service boundary.
+class DisplayLifecycleService {
+ public:
+  bool start() {
+    if (state_ != DisplayLifecycleState::CONSTRUCTED) return false;
+    state_ = DisplayLifecycleState::RUNNING;
+    return true;
+  }
+
+  bool run_once() {
+    if (state_ != DisplayLifecycleState::RUNNING) return false;
+    ++loop_count_;
+    return true;
+  }
+
+  bool stop() {
+    if (state_ != DisplayLifecycleState::RUNNING) return false;
+    state_ = DisplayLifecycleState::STOPPED;
+    return true;
+  }
+
+  DisplayLifecycleState state() const { return state_; }
+  uint32_t loop_count() const { return loop_count_; }
+  DisplayModeController &controller() { return controller_; }
+  const DisplayModeController &controller() const { return controller_; }
+
+ private:
+  DisplayLifecycleState state_{DisplayLifecycleState::CONSTRUCTED};
+  uint32_t loop_count_{0};
+  DisplayModeController controller_{};
+};
+
+}  // namespace espcontrol

--- a/components/espcontrol/espcontrol_app_core.cpp
+++ b/components/espcontrol/espcontrol_app_core.cpp
@@ -4,18 +4,21 @@ namespace espcontrol {
 
 bool EspControlAppCore::start() {
   if (lifecycle_state_ != AppLifecycleState::CONSTRUCTED) return false;
+  if (!display_lifecycle_.start()) return false;
   lifecycle_state_ = AppLifecycleState::RUNNING;
   return true;
 }
 
 bool EspControlAppCore::run_once() {
   if (lifecycle_state_ != AppLifecycleState::RUNNING) return false;
+  if (!display_lifecycle_.run_once()) return false;
   ++loop_count_;
   return true;
 }
 
 bool EspControlAppCore::stop() {
   if (lifecycle_state_ != AppLifecycleState::RUNNING) return false;
+  if (!display_lifecycle_.stop()) return false;
   lifecycle_state_ = AppLifecycleState::STOPPED;
   return true;
 }

--- a/components/espcontrol/espcontrol_app_core.h
+++ b/components/espcontrol/espcontrol_app_core.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-#include "display_mode_controller.h"
+#include "display_lifecycle_service.h"
 
 namespace espcontrol {
 
@@ -24,13 +24,20 @@ class EspControlAppCore {
   AppLifecycleState lifecycle_state() const { return lifecycle_state_; }
   uint32_t loop_count() const { return loop_count_; }
 
-  DisplayModeController &display() { return display_; }
-  const DisplayModeController &display() const { return display_; }
+  DisplayLifecycleService &display_lifecycle() { return display_lifecycle_; }
+  const DisplayLifecycleService &display_lifecycle() const { return display_lifecycle_; }
+
+  // Compatibility facade for ESPHome YAML while display ownership migrates to
+  // the explicit lifecycle service.
+  DisplayModeController &display() { return display_lifecycle_.controller(); }
+  const DisplayModeController &display() const {
+    return display_lifecycle_.controller();
+  }
 
  private:
   AppLifecycleState lifecycle_state_{AppLifecycleState::CONSTRUCTED};
   uint32_t loop_count_{0};
-  DisplayModeController display_{};
+  DisplayLifecycleService display_lifecycle_{};
 };
 
 }  // namespace espcontrol

--- a/tests/firmware/espcontrol_app_core_test.cpp
+++ b/tests/firmware/espcontrol_app_core_test.cpp
@@ -3,6 +3,7 @@
 #include "espcontrol_app_core.h"
 
 using espcontrol::AppLifecycleState;
+using espcontrol::DisplayLifecycleState;
 using espcontrol::DisplayMode;
 using espcontrol::DisplayRequestSource;
 using espcontrol::EspControlAppCore;
@@ -13,6 +14,9 @@ int main() {
   if (app.run_once() || app.stop()) return EXIT_FAILURE;
   if (!app.start() || app.start()) return EXIT_FAILURE;
   if (app.lifecycle_state() != AppLifecycleState::RUNNING) return EXIT_FAILURE;
+  if (app.display_lifecycle().state() != DisplayLifecycleState::RUNNING) {
+    return EXIT_FAILURE;
+  }
 
   auto &display = app.display();
   if (!display.request(DisplayRequestSource::MANUAL_SLEEP,
@@ -23,10 +27,14 @@ int main() {
     return EXIT_FAILURE;
   }
 
-  if (!app.run_once() || !app.run_once() || app.loop_count() != 2) {
+  if (!app.run_once() || !app.run_once() || app.loop_count() != 2 ||
+      app.display_lifecycle().loop_count() != 2) {
     return EXIT_FAILURE;
   }
-  if (!app.stop() || app.stop() || app.run_once()) return EXIT_FAILURE;
+  if (!app.stop() || app.stop() || app.run_once() ||
+      app.display_lifecycle().state() != DisplayLifecycleState::STOPPED) {
+    return EXIT_FAILURE;
+  }
   if (app.lifecycle_state() != AppLifecycleState::STOPPED) return EXIT_FAILURE;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Purpose
Establish the display lifecycle as an explicit service owned by `EspControlAppCore`, while retaining the existing `display()` interface as a compatibility facade for ESPHome YAML.

## Practical impact
Display transitions keep their existing behaviour. Startup, loop, and shutdown now drive the service directly, with lifecycle and loop-count coverage in host tests.

## Checked
- Firmware host build and all 24 CTest checks: passed
- 7-inch P4 factory ESPHome compile: running (fresh toolchain setup and C++ compilation)
- `git diff --check`

## Device testing
- Target: 10-inch P4 V1 (`192.168.6.103`), reachable over OTA.
- The desktop sandbox terminates the direct ESPHome upload while it refreshes the local component checkout, before compilation/upload; no device firmware was changed.