### PR TITLE
Add Home Assistant binding service boundary

### DIFF
--- a/components/espcontrol/button_grid_ha.h
+++ b/components/espcontrol/button_grid_ha.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "ha_read_coordinator.h"
+#include "home_assistant_binding_service.h"
 
 #ifdef ESP_PLATFORM
 #include "esp_heap_caps.h"
@@ -92,23 +93,28 @@ struct EspHomeHaHeapProbe {
 };
 
 using EspHomeHaReadCoordinator = HaReadCoordinator<EspHomeHaReadTransport, EspHomeHaHeapProbe>;
+using EspHomeHaBindingService =
+    HomeAssistantBindingService<EspHomeHaReadTransport, EspHomeHaHeapProbe>;
+
+inline EspHomeHaBindingService &ha_binding_service() {
+  static EspHomeHaBindingService service;
+  return service;
+}
 
 inline EspHomeHaReadCoordinator &ha_read_coordinator() {
-  static EspHomeHaReadCoordinator coordinator;
-  return coordinator;
+  return ha_binding_service().read_coordinator();
 }
 
 inline void *&ha_callback_owner() {
-  static void *owner = nullptr;
-  return owner;
+  return ha_binding_service().callback_owner_ref();
 }
 
 class HaCallbackOwnerScope {
  public:
-  explicit HaCallbackOwnerScope(void *owner) : previous_(ha_callback_owner()) { ha_callback_owner() = owner; }
-  ~HaCallbackOwnerScope() { ha_callback_owner() = previous_; }
+  explicit HaCallbackOwnerScope(void *owner)
+      : scope_(ha_binding_service().callback_owner_scope(owner)) {}
  private:
-  void *previous_ = nullptr;
+  EspHomeHaBindingService::CallbackOwnerScope scope_;
 };
 
 inline void ha_release_callbacks_for_owner(void *owner) { ha_read_coordinator().release_owner(owner); }

--- a/components/espcontrol/home_assistant_binding_service.h
+++ b/components/espcontrol/home_assistant_binding_service.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <utility>
+
+#include "ha_read_coordinator.h"
+
+// Owns Home Assistant callback scope and read/subscription state. Transport and
+// heap policies keep the service host-testable and leave ESPHome as wiring.
+template<typename Transport, typename HeapProbe>
+class HomeAssistantBindingService {
+ public:
+  using ReadCoordinator = HaReadCoordinator<Transport, HeapProbe>;
+
+  class CallbackOwnerScope {
+   public:
+    CallbackOwnerScope(HomeAssistantBindingService &service, void *owner)
+        : service_(service), previous_(service.callback_owner_) {
+      service_.callback_owner_ = owner;
+    }
+    ~CallbackOwnerScope() { service_.callback_owner_ = previous_; }
+
+    CallbackOwnerScope(const CallbackOwnerScope &) = delete;
+    CallbackOwnerScope &operator=(const CallbackOwnerScope &) = delete;
+
+   private:
+    HomeAssistantBindingService &service_;
+    void *previous_ = nullptr;
+  };
+
+  explicit HomeAssistantBindingService(
+      Transport transport = Transport(), HeapProbe heap_probe = HeapProbe())
+      : read_coordinator_(std::move(transport), std::move(heap_probe)) {}
+
+  ReadCoordinator &read_coordinator() { return read_coordinator_; }
+  const ReadCoordinator &read_coordinator() const { return read_coordinator_; }
+
+  void *callback_owner() const { return callback_owner_; }
+  void *&callback_owner_ref() { return callback_owner_; }
+  CallbackOwnerScope callback_owner_scope(void *owner) {
+    return CallbackOwnerScope(*this, owner);
+  }
+
+ private:
+  ReadCoordinator read_coordinator_{};
+  void *callback_owner_ = nullptr;
+};

--- a/tests/firmware/ha_read_coordinator_test.cpp
+++ b/tests/firmware/ha_read_coordinator_test.cpp
@@ -1,4 +1,5 @@
 #include "ha_read_coordinator.h"
+#include "home_assistant_binding_service.h"
 
 #include <cstdlib>
 #include <functional>
@@ -58,6 +59,7 @@ struct FakeHeapProbe {
 };
 
 using Coordinator = HaReadCoordinator<FakeTransport, FakeHeapProbe>;
+using BindingService = HomeAssistantBindingService<FakeTransport, FakeHeapProbe>;
 
 [[noreturn]] void fail(const char *message) {
   (void) message;
@@ -202,6 +204,23 @@ void released_owner_drops_pending_reads_even_if_its_address_is_reused() {
           "released owner delivered a callback after its address was reused");
 }
 
+void callback_owner_scope_restores_the_previous_owner() {
+  BindingService service;
+  int first = 0;
+  int second = 0;
+  require(service.callback_owner() == nullptr, "new binding service has no callback owner");
+  {
+    auto first_scope = service.callback_owner_scope(&first);
+    require(service.callback_owner() == &first, "first callback scope was not applied");
+    {
+      auto second_scope = service.callback_owner_scope(&second);
+      require(service.callback_owner() == &second, "nested callback scope was not applied");
+    }
+    require(service.callback_owner() == &first, "nested callback scope was not restored");
+  }
+  require(service.callback_owner() == nullptr, "callback scope leaked after destruction");
+}
+
 }  // namespace
 
 int main() {
@@ -213,5 +232,6 @@ int main() {
   stale_generations_do_not_deliver();
   attribute_requests_preserve_attribute();
   released_owner_drops_pending_reads_even_if_its_address_is_reused();
+  callback_owner_scope_restores_the_previous_owner();
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Purpose
Move Home Assistant read/subscription state and callback-owner scope into a typed, host-testable service while retaining the existing YAML-facing helper functions as adapters.

## Practical impact
Existing cards keep their Home Assistant binding behaviour. Callback ownership is now explicit and nested scopes are tested.

## Checked
- `ha_read_coordinator_test`: passed
- `git diff --check`

## Device testing
- 10-inch P4 V1 is reachable at `192.168.6.103`.
- Direct ESPHome OTA build/upload is blocked before compilation by the desktop sandbox denying the ESP-IDF dependency tool access to process information; no device firmware was changed.