### PR TITLE
Add card runtime registry service

### DIFF
--- a/components/espcontrol/button_grid_card_runtime.h
+++ b/components/espcontrol/button_grid_card_runtime.h
@@ -70,28 +70,48 @@ inline Family family_for_runtime_type(espcontrol::card_runtime::CardTypeId type)
   }
 }
 
+// Generated metadata selects a handwritten driver here; it never carries card
+// behavior. The singleton is the registry-service boundary for legacy helpers.
+class CardRuntimeRegistryService {
+ public:
+  Context context_for(const std::string &type, const std::string &mode,
+                      Surface surface = Surface::MAIN_GRID) const {
+    using namespace espcontrol::card_runtime;
+    Context context;
+    context.runtime = card_runtime_spec(card_type_id(type));
+    context.runtime.driver = resolve_card_driver(context.runtime.type, mode);
+    context.family = family_for_runtime_type(context.runtime.type);
+    context.surface = surface;
+    context.known = context.runtime.type != CardTypeId::UNKNOWN;
+    context.allow_in_subpage = has_capability(context.runtime, CAPABILITY_SUBPAGE);
+    // Todo was removed from the configurator but old saved cards remain
+    // supported through one explicit compatibility driver.
+    if (!context.known && type == "todo") {
+      context.family = Family::TODO;
+      context.known = true;
+      context.allow_in_subpage = true;
+      context.runtime.capabilities = static_cast<uint16_t>(
+          CAPABILITY_SUBSCRIPTIONS | CAPABILITY_ACTIONS | CAPABILITY_MODAL |
+          CAPABILITY_RUNTIME_ALLOCATION | CAPABILITY_SUBPAGE);
+      context.legacy_dispatch = true;
+    }
+    return context;
+  }
+
+  Registration registration_for(const std::string &type) const {
+    const Context context = context_for(type, "");
+    return registration(context.family, context.known, context.allow_in_subpage);
+  }
+};
+
+inline const CardRuntimeRegistryService &card_runtime_registry_service() {
+  static const CardRuntimeRegistryService service;
+  return service;
+}
+
 inline Context context_for(const std::string &type, const std::string &mode,
                            Surface surface = Surface::MAIN_GRID) {
-  using namespace espcontrol::card_runtime;
-  Context context;
-  context.runtime = card_runtime_spec(card_type_id(type));
-  context.runtime.driver = resolve_card_driver(context.runtime.type, mode);
-  context.family = family_for_runtime_type(context.runtime.type);
-  context.surface = surface;
-  context.known = context.runtime.type != CardTypeId::UNKNOWN;
-  context.allow_in_subpage = has_capability(context.runtime, CAPABILITY_SUBPAGE);
-  // Todo was removed from the configurator but old saved cards remain
-  // supported through one explicit compatibility driver.
-  if (!context.known && type == "todo") {
-    context.family = Family::TODO;
-    context.known = true;
-    context.allow_in_subpage = true;
-    context.runtime.capabilities = static_cast<uint16_t>(
-        CAPABILITY_SUBSCRIPTIONS | CAPABILITY_ACTIONS | CAPABILITY_MODAL |
-        CAPABILITY_RUNTIME_ALLOCATION | CAPABILITY_SUBPAGE);
-    context.legacy_dispatch = true;
-  }
-  return context;
+  return card_runtime_registry_service().context_for(type, mode, surface);
 }
 
 }  // namespace espcontrol::cards
@@ -112,9 +132,7 @@ inline espcontrol::cards::Context card_runtime_context(
 }
 
 inline espcontrol::cards::Registration card_runtime_registration(const std::string &type) {
-  const auto context = card_runtime_context(type);
-  return espcontrol::cards::registration(
-      context.family, context.known, context.allow_in_subpage);
+  return espcontrol::cards::card_runtime_registry_service().registration_for(type);
 }
 
 inline espcontrol::cards::Family card_runtime_family(const std::string &type) {

--- a/scripts/generate_card_runtime_coverage.js
+++ b/scripts/generate_card_runtime_coverage.js
@@ -99,7 +99,7 @@ function firmwareRegistrations() {
       registrations.set(type, family);
     }
   }
-  const registryStart = source.indexOf("class CardRuntimeRegistryService", end);
+  const registryStart = source.indexOf("class CardRuntimeRegistryService", start);
   const legacyStart = registryStart >= 0 ? registryStart : end;
   const legacyBody = source.slice(legacyStart, source.indexOf("return context;", legacyStart));
   for (const match of legacyBody.matchAll(/type == "([^"]+)"\)[\s\S]*?context\.family = Family::([A-Z_]+);/g)) {

--- a/scripts/generate_card_runtime_coverage.js
+++ b/scripts/generate_card_runtime_coverage.js
@@ -99,7 +99,9 @@ function firmwareRegistrations() {
       registrations.set(type, family);
     }
   }
-  const legacyBody = source.slice(end, source.indexOf("return context;", end));
+  const registryStart = source.indexOf("class CardRuntimeRegistryService", end);
+  const legacyStart = registryStart >= 0 ? registryStart : end;
+  const legacyBody = source.slice(legacyStart, source.indexOf("return context;", legacyStart));
   for (const match of legacyBody.matchAll(/type == "([^"]+)"\)[\s\S]*?context\.family = Family::([A-Z_]+);/g)) {
     registrations.set(match[1], match[2]);
   }

--- a/tests/firmware/button_grid_foundations_test.cpp
+++ b/tests/firmware/button_grid_foundations_test.cpp
@@ -9,6 +9,12 @@ int main() {
   static_assert(MAX_GRID_SLOTS == ESPCONTROL_MAX_GRID_SLOTS);
   static_assert(MAX_SUBPAGE_ITEMS == MAX_GRID_SLOTS * MAX_GRID_SLOTS);
 
+  const auto &registry_service = espcontrol::cards::card_runtime_registry_service();
+  const auto service_media = registry_service.context_for("media", "");
+  if (!service_media.known || service_media.family != espcontrol::cards::Family::MEDIA) {
+    return EXIT_FAILURE;
+  }
+
   if (string_ref_limited(esphome::StringRef("calendar"), 4) != "cale") return EXIT_FAILURE;
   if (string_ref_limited(esphome::StringRef("clock"), 32) != "clock") return EXIT_FAILURE;
   if (decode_html_entities("Earth, Wind &amp; Fire") != "Earth, Wind & Fire") {


### PR DESCRIPTION
## Purpose
Make generated card metadata selection an explicit registry service while keeping the existing card-runtime helper functions as compatibility adapters.

## Practical impact
Generated metadata continues to select handwritten drivers; card behaviour remains in handwritten driver code. Existing YAML and card helpers retain their current interface.

## Checked
- `button_grid_foundations_test`: passed
- `git diff --check`

## Device testing
- 10-inch P4 V1 is reachable at `192.168.6.103`. Direct OTA build/upload remains blocked before compilation by the desktop sandbox process-permission restriction; no device firmware was changed.