### PR TITLE
Add grid navigation service boundary

### DIFF
--- a/components/espcontrol/button_grid_navigation.h
+++ b/components/espcontrol/button_grid_navigation.h
@@ -2,6 +2,8 @@
 
 // Internal implementation detail for button_grid.h. Include button_grid.h from device YAML.
 
+#include "grid_navigation_service.h"
+
 // ── Home Assistant-driven home-screen navigation ─────────────────────
 
 struct NavigationHomeTargetEntry {
@@ -30,14 +32,22 @@ struct NavigationSubpageEntry {
 
 inline void navigation_release_subpage_runtime(NavigationSubpageEntry &entry);
 
+using ButtonGridNavigationService =
+    GridNavigationService<NavigationHomeTargetEntry, NavigationSubpageEntry>;
+
+inline ButtonGridNavigationService &grid_navigation_service() {
+  static ButtonGridNavigationService service;
+  return service;
+}
+
+// Compatibility accessors for existing grid code. New runtime ownership lives
+// in GridNavigationService so it can be migrated independently of the UI.
 inline std::vector<NavigationHomeTargetEntry> &navigation_home_targets() {
-  static std::vector<NavigationHomeTargetEntry> entries;
-  return entries;
+  return grid_navigation_service().home_targets();
 }
 
 inline std::vector<NavigationSubpageEntry> &navigation_subpages() {
-  static std::vector<NavigationSubpageEntry> entries;
-  return entries;
+  return grid_navigation_service().subpages();
 }
 
 inline std::string navigation_trim(const std::string &value) {
@@ -85,7 +95,7 @@ inline bool navigation_return_home(lv_obj_t *main_page_obj) {
 }
 
 inline void navigation_clear_home_targets() {
-  navigation_home_targets().clear();
+  grid_navigation_service().clear_home_targets();
 }
 
 inline void navigation_clear_subpages() {
@@ -95,7 +105,7 @@ inline void navigation_clear_subpages() {
       lv_obj_del(entry.screen);
     }
   }
-  navigation_subpages().clear();
+  grid_navigation_service().clear_subpages();
   clock_bar_clear_button_grid_pages();
 }
 

--- a/components/espcontrol/grid_navigation_service.h
+++ b/components/espcontrol/grid_navigation_service.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+// Owns the runtime navigation registries for one button-grid instance.  The
+// entries remain defined by the UI layer so this service stays independent of
+// LVGL and can be exercised on the host.
+template <typename HomeTarget, typename Subpage>
+class GridNavigationService {
+ public:
+  std::vector<HomeTarget> &home_targets() { return home_targets_; }
+  const std::vector<HomeTarget> &home_targets() const { return home_targets_; }
+
+  std::vector<Subpage> &subpages() { return subpages_; }
+  const std::vector<Subpage> &subpages() const { return subpages_; }
+
+  size_t home_target_count() const { return home_targets_.size(); }
+  size_t subpage_count() const { return subpages_.size(); }
+
+  void clear_home_targets() { home_targets_.clear(); }
+  void clear_subpages() { subpages_.clear(); }
+
+ private:
+  std::vector<HomeTarget> home_targets_;
+  std::vector<Subpage> subpages_;
+};

--- a/tests/firmware/CMakeLists.txt
+++ b/tests/firmware/CMakeLists.txt
@@ -17,6 +17,12 @@ target_include_directories(button_grid_foundations_test PRIVATE
 )
 add_test(NAME button_grid_foundations_test COMMAND button_grid_foundations_test)
 
+add_executable(grid_navigation_service_test grid_navigation_service_test.cpp)
+target_compile_features(grid_navigation_service_test PRIVATE cxx_std_17)
+target_compile_options(grid_navigation_service_test PRIVATE -Wall -Wextra -Werror)
+target_include_directories(grid_navigation_service_test PRIVATE ../../components/espcontrol)
+add_test(NAME grid_navigation_service_test COMMAND grid_navigation_service_test)
+
 add_executable(alarm_delay_audio_test alarm_delay_audio_test.cpp)
 target_compile_features(alarm_delay_audio_test PRIVATE cxx_std_17)
 target_compile_options(alarm_delay_audio_test PRIVATE -Wall -Wextra -Werror)

--- a/tests/firmware/grid_navigation_service_test.cpp
+++ b/tests/firmware/grid_navigation_service_test.cpp
@@ -1,0 +1,35 @@
+#include <cassert>
+
+#include "grid_navigation_service.h"
+
+namespace {
+
+struct HomeTarget {
+  int slot = 0;
+};
+
+struct Subpage {
+  int slot = 0;
+};
+
+}  // namespace
+
+int main() {
+  GridNavigationService<HomeTarget, Subpage> navigation;
+
+  navigation.home_targets().push_back({1});
+  navigation.subpages().push_back({2});
+
+  assert(navigation.home_target_count() == 1);
+  assert(navigation.subpage_count() == 1);
+  assert(navigation.home_targets().front().slot == 1);
+  assert(navigation.subpages().front().slot == 2);
+
+  navigation.clear_home_targets();
+  assert(navigation.home_target_count() == 0);
+  assert(navigation.subpage_count() == 1);
+
+  navigation.clear_subpages();
+  assert(navigation.subpage_count() == 0);
+  return 0;
+}


### PR DESCRIPTION
## Purpose
Move the button-grid navigation registries behind an explicit service without changing the existing navigation behaviour.

## Practical impact
Existing navigation helpers remain compatibility adapters, while future grid/navigation work has a clear runtime owner.

## Checks
- `cmake -S tests/firmware -B /private/tmp/espcontrol-grid-navigation-build`
- `cmake --build /private/tmp/espcontrol-grid-navigation-build -j 4`
- `ctest --test-dir /private/tmp/espcontrol-grid-navigation-build --output-on-failure` (25 passed)

## Device testing
Target device: 10-inch V1. The display is reachable, but this environment cannot start the ESP-IDF build needed for OTA upload because macOS blocks the build tool process inspection call. No device flash is claimed for this PR.