### PR TITLE
Add control modal state service

### DIFF
--- a/components/espcontrol/button_grid_modal.h
+++ b/components/espcontrol/button_grid_modal.h
@@ -4,6 +4,8 @@
 
 // Shared control modal helpers.
 
+#include "control_modal_service.h"
+
 constexpr lv_coord_t CONTROL_MODAL_REFERENCE_SIDE_PX = DISPLAY_MODAL_REFERENCE_SIDE_PX;
 constexpr lv_coord_t CONTROL_MODAL_ARC_STROKE_REF_PX = DISPLAY_MODAL_ARC_STROKE_REF_PX;
 constexpr lv_coord_t CONTROL_MODAL_BACK_BUTTON_REF_PX = DISPLAY_MODAL_BACK_BUTTON_REF_PX;
@@ -12,31 +14,6 @@ constexpr lv_coord_t CONTROL_MODAL_INSET_REF_PX = DISPLAY_MODAL_INSET_REF_PX;
 constexpr lv_coord_t CONTROL_MODAL_CONTROLS_GAP_REF_PX = DISPLAY_MODAL_CONTROLS_GAP_REF_PX;
 constexpr lv_coord_t CONTROL_MODAL_CONTROLS_DOWN_REF_PX = DISPLAY_MODAL_CONTROLS_DOWN_REF_PX;
 constexpr lv_coord_t CONTROL_MODAL_TITLE_GAP_REF_PX = DISPLAY_MODAL_TITLE_GAP_REF_PX;
-
-enum class ControlModalKind {
-  NONE,
-  MEDIA_VOLUME,
-  CLIMATE,
-  SWITCH_CONFIRMATION,
-  OPTION_SELECT,
-  FAN_PRESET,
-  FAN_CONTROL,
-  NETWORK_STATUS,
-  ALARM_PIN,
-  ALARM_CONTROL,
-  IMAGE_CARD,
-  TODO_LIST,
-  COVER_CONTROL,
-  LIGHT_CONTROL,
-  MEDIA_CONTROL,
-};
-
-using ControlModalCloseCallback = void (*)();
-
-enum class ControlModalDismissPolicy {
-  DISMISS,
-  PRESERVE_DURING_DISPLAY_TAKEOVER,
-};
 
 enum class ControlModalPresentation {
   ARC_CONTROL,
@@ -99,27 +76,25 @@ inline ControlModalDefinition control_modal_definition(ControlModalKind kind) {
   return {};
 }
 
-struct ControlModalActive {
-  ControlModalKind kind = ControlModalKind::NONE;
-  lv_obj_t *overlay = nullptr;
-  ControlModalCloseCallback close_callback = nullptr;
-  ControlModalDismissPolicy dismiss_policy = ControlModalDismissPolicy::DISMISS;
-  uint32_t close_guard_until_ms = 0;
-  bool closing = false;
-};
+using ControlModalActive = ControlModalActiveState<lv_obj_t>;
+using ControlModalNestedActive = ControlModalNestedActiveState<lv_obj_t>;
+using ButtonGridModalService = ControlModalStateService<lv_obj_t>;
+
+inline ButtonGridModalService &control_modal_service() {
+  static ButtonGridModalService service;
+  return service;
+}
 
 inline ControlModalActive &control_modal_active() {
-  static ControlModalActive active;
-  return active;
+  return control_modal_service().active();
 }
 
 inline void control_modal_reset_active() {
-  control_modal_active() = ControlModalActive();
+  control_modal_service().reset_active();
 }
 
 inline void control_modal_clear_active(ControlModalKind kind) {
-  ControlModalActive &active = control_modal_active();
-  if (active.kind == kind) control_modal_reset_active();
+  control_modal_service().clear_active(kind);
 }
 
 inline void control_modal_delete_overlay(ControlModalKind kind, lv_obj_t *&overlay) {
@@ -132,13 +107,7 @@ inline void control_modal_delete_overlay(ControlModalKind kind, lv_obj_t *&overl
 inline void control_modal_set_active(ControlModalKind kind, lv_obj_t *overlay,
                                      ControlModalCloseCallback close_callback,
                                      ControlModalDismissPolicy dismiss_policy) {
-  ControlModalActive &active = control_modal_active();
-  active.kind = kind;
-  active.overlay = overlay;
-  active.close_callback = close_callback;
-  active.dismiss_policy = dismiss_policy;
-  active.close_guard_until_ms = 0;
-  active.closing = false;
+  control_modal_service().set_active(kind, overlay, close_callback, dismiss_policy);
 }
 
 inline bool control_modal_close_guard_active(const ControlModalActive &active) {
@@ -147,19 +116,16 @@ inline bool control_modal_close_guard_active(const ControlModalActive &active) {
 }
 
 inline void control_modal_block_close_for(uint32_t delay_ms) {
-  ControlModalActive &active = control_modal_active();
-  if (active.kind == ControlModalKind::NONE || delay_ms == 0) return;
-  active.close_guard_until_ms = lv_tick_get() + delay_ms;
+  control_modal_service().block_close_for(lv_tick_get(), delay_ms);
 }
 
 inline void control_modal_close_active_internal(bool honor_close_guard) {
-  ControlModalActive &active = control_modal_active();
-  if (active.kind == ControlModalKind::NONE || active.closing) return;
-  if (honor_close_guard && control_modal_close_guard_active(active)) return;
-
-  ControlModalKind closing_kind = active.kind;
-  void (*close_callback)() = active.close_callback;
-  active.closing = true;
+  ControlModalKind closing_kind = ControlModalKind::NONE;
+  ControlModalCloseCallback close_callback = nullptr;
+  if (!control_modal_service().begin_active_close(
+          lv_tick_get(), honor_close_guard, &closing_kind, &close_callback)) {
+    return;
+  }
   if (close_callback) close_callback();
   if (control_modal_active().kind == closing_kind) control_modal_reset_active();
 }
@@ -267,28 +233,20 @@ struct ControlModalNestedShell {
   lv_obj_t *panel = nullptr;
 };
 
-struct ControlModalNestedActive {
-  lv_obj_t *overlay = nullptr;
-  ControlModalCloseCallback close_callback = nullptr;
-  bool closing = false;
-};
-
 struct ControlModalToastShell {
   lv_obj_t *box = nullptr;
 };
 
 inline ControlModalNestedActive &control_modal_nested_active() {
-  static ControlModalNestedActive active;
-  return active;
+  return control_modal_service().nested_active();
 }
 
 inline void control_modal_reset_nested_menu() {
-  control_modal_nested_active() = ControlModalNestedActive();
+  control_modal_service().reset_nested_menu();
 }
 
 inline void control_modal_clear_nested_menu(lv_obj_t *overlay) {
-  ControlModalNestedActive &active = control_modal_nested_active();
-  if (active.overlay == overlay) control_modal_reset_nested_menu();
+  control_modal_service().clear_nested_menu(overlay);
 }
 
 inline void control_modal_delete_nested_overlay(lv_obj_t *&overlay) {
@@ -299,12 +257,11 @@ inline void control_modal_delete_nested_overlay(lv_obj_t *&overlay) {
 }
 
 inline void control_modal_close_nested_menu() {
-  ControlModalNestedActive &active = control_modal_nested_active();
-  if (!active.overlay || active.closing) return;
-
-  lv_obj_t *closing_overlay = active.overlay;
-  ControlModalCloseCallback close_callback = active.close_callback;
-  active.closing = true;
+  lv_obj_t *closing_overlay = nullptr;
+  ControlModalCloseCallback close_callback = nullptr;
+  if (!control_modal_service().begin_nested_close(&closing_overlay, &close_callback)) {
+    return;
+  }
   if (close_callback) close_callback();
   else if (closing_overlay) lv_obj_del(closing_overlay);
   if (control_modal_nested_active().overlay == closing_overlay) control_modal_reset_nested_menu();

--- a/components/espcontrol/control_modal_service.h
+++ b/components/espcontrol/control_modal_service.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <cstdint>
+
+enum class ControlModalKind {
+  NONE,
+  MEDIA_VOLUME,
+  CLIMATE,
+  SWITCH_CONFIRMATION,
+  OPTION_SELECT,
+  FAN_PRESET,
+  FAN_CONTROL,
+  NETWORK_STATUS,
+  ALARM_PIN,
+  ALARM_CONTROL,
+  IMAGE_CARD,
+  TODO_LIST,
+  COVER_CONTROL,
+  LIGHT_CONTROL,
+  MEDIA_CONTROL,
+};
+
+using ControlModalCloseCallback = void (*)();
+
+enum class ControlModalDismissPolicy {
+  DISMISS,
+  PRESERVE_DURING_DISPLAY_TAKEOVER,
+};
+
+template <typename Overlay>
+struct ControlModalActiveState {
+  ControlModalKind kind = ControlModalKind::NONE;
+  Overlay *overlay = nullptr;
+  ControlModalCloseCallback close_callback = nullptr;
+  ControlModalDismissPolicy dismiss_policy = ControlModalDismissPolicy::DISMISS;
+  uint32_t close_guard_until_ms = 0;
+  bool closing = false;
+};
+
+template <typename Overlay>
+struct ControlModalNestedActiveState {
+  Overlay *overlay = nullptr;
+  ControlModalCloseCallback close_callback = nullptr;
+  bool closing = false;
+};
+
+// Owns modal lifecycle state separately from the LVGL widgets. The caller
+// creates and deletes widgets, while this service makes opening, close guards,
+// and re-entrant callbacks predictable and testable on the host.
+template <typename Overlay>
+class ControlModalStateService {
+ public:
+  using Active = ControlModalActiveState<Overlay>;
+  using NestedActive = ControlModalNestedActiveState<Overlay>;
+
+  Active &active() { return active_; }
+  const Active &active() const { return active_; }
+  NestedActive &nested_active() { return nested_active_; }
+  const NestedActive &nested_active() const { return nested_active_; }
+
+  void reset_active() { active_ = Active{}; }
+  void clear_active(ControlModalKind kind) {
+    if (active_.kind == kind) reset_active();
+  }
+
+  void set_active(ControlModalKind kind, Overlay *overlay,
+                  ControlModalCloseCallback close_callback,
+                  ControlModalDismissPolicy dismiss_policy) {
+    active_.kind = kind;
+    active_.overlay = overlay;
+    active_.close_callback = close_callback;
+    active_.dismiss_policy = dismiss_policy;
+    active_.close_guard_until_ms = 0;
+    active_.closing = false;
+  }
+
+  bool close_guard_active(uint32_t now_ms) const {
+    return active_.close_guard_until_ms != 0 &&
+           static_cast<int32_t>(now_ms - active_.close_guard_until_ms) < 0;
+  }
+
+  void block_close_for(uint32_t now_ms, uint32_t delay_ms) {
+    if (active_.kind == ControlModalKind::NONE || delay_ms == 0) return;
+    active_.close_guard_until_ms = now_ms + delay_ms;
+  }
+
+  bool begin_active_close(uint32_t now_ms, bool honor_close_guard,
+                          ControlModalKind *closing_kind,
+                          ControlModalCloseCallback *close_callback) {
+    if (active_.kind == ControlModalKind::NONE || active_.closing ||
+        (honor_close_guard && close_guard_active(now_ms))) {
+      return false;
+    }
+    active_.closing = true;
+    if (closing_kind != nullptr) *closing_kind = active_.kind;
+    if (close_callback != nullptr) *close_callback = active_.close_callback;
+    return true;
+  }
+
+  void reset_nested_menu() { nested_active_ = NestedActive{}; }
+  void clear_nested_menu(Overlay *overlay) {
+    if (nested_active_.overlay == overlay) reset_nested_menu();
+  }
+
+  bool begin_nested_close(Overlay **closing_overlay,
+                          ControlModalCloseCallback *close_callback) {
+    if (nested_active_.overlay == nullptr || nested_active_.closing) return false;
+    nested_active_.closing = true;
+    if (closing_overlay != nullptr) *closing_overlay = nested_active_.overlay;
+    if (close_callback != nullptr) *close_callback = nested_active_.close_callback;
+    return true;
+  }
+
+ private:
+  Active active_{};
+  NestedActive nested_active_{};
+};

--- a/scripts/check_firmware_modals.py
+++ b/scripts/check_firmware_modals.py
@@ -79,6 +79,7 @@ def firmware_modal_sleep_takeover_errors(root: Path) -> list[str]:
     firmware_dir = root / "components" / "espcontrol"
     backlight_header_path = firmware_dir / "backlight.h"
     modal_path = firmware_dir / "button_grid_modal.h"
+    modal_service_path = firmware_dir / "control_modal_service.h"
     navigation_path = firmware_dir / "button_grid_navigation.h"
     grid_path = firmware_dir / "button_grid_grid.h"
     image_path = firmware_dir / "button_grid_image.h"
@@ -102,17 +103,24 @@ def firmware_modal_sleep_takeover_errors(root: Path) -> list[str]:
         errors.append("components/espcontrol/button_grid_modal.h: provide shared modal lifecycle helpers")
     else:
         text = modal_path.read_text(encoding="utf-8")
+        modal_state_text = (
+            modal_service_path.read_text(encoding="utf-8")
+            if modal_service_path.exists()
+            else text
+        )
         if (
-            "enum class ControlModalDismissPolicy" not in text
+            "enum class ControlModalDismissPolicy" not in modal_state_text
             or "control_modal_force_close_active" not in text
             or "control_modal_close_active_internal(false)" not in text
             or "control_modal_close_for_display_takeover" not in text
-            or "PRESERVE_DURING_DISPLAY_TAKEOVER" not in text
+            or "PRESERVE_DURING_DISPLAY_TAKEOVER" not in modal_state_text
         ):
             errors.append(
                 "components/espcontrol/button_grid_modal.h: centralize modal dismissal policy for display takeover"
             )
-        kind_enum = re.search(r"enum class ControlModalKind\s*\{(?P<body>.*?)\};", text, re.S)
+        kind_enum = re.search(
+            r"enum class ControlModalKind\s*\{(?P<body>.*?)\};", modal_state_text, re.S
+        )
         definition = re.search(
             r"inline\s+ControlModalDefinition\s+control_modal_definition\s*\([^)]*\)\s*\{(?P<body>.*?)\n\}",
             text,

--- a/tests/firmware/CMakeLists.txt
+++ b/tests/firmware/CMakeLists.txt
@@ -23,6 +23,12 @@ target_compile_options(grid_navigation_service_test PRIVATE -Wall -Wextra -Werro
 target_include_directories(grid_navigation_service_test PRIVATE ../../components/espcontrol)
 add_test(NAME grid_navigation_service_test COMMAND grid_navigation_service_test)
 
+add_executable(control_modal_service_test control_modal_service_test.cpp)
+target_compile_features(control_modal_service_test PRIVATE cxx_std_17)
+target_compile_options(control_modal_service_test PRIVATE -Wall -Wextra -Werror)
+target_include_directories(control_modal_service_test PRIVATE ../../components/espcontrol)
+add_test(NAME control_modal_service_test COMMAND control_modal_service_test)
+
 add_executable(alarm_delay_audio_test alarm_delay_audio_test.cpp)
 target_compile_features(alarm_delay_audio_test PRIVATE cxx_std_17)
 target_compile_options(alarm_delay_audio_test PRIVATE -Wall -Wextra -Werror)

--- a/tests/firmware/control_modal_service_test.cpp
+++ b/tests/firmware/control_modal_service_test.cpp
@@ -1,0 +1,50 @@
+#include <cassert>
+
+#include "control_modal_service.h"
+
+namespace {
+
+struct Overlay {};
+
+int close_calls = 0;
+
+void close_modal() { ++close_calls; }
+
+}  // namespace
+
+int main() {
+  ControlModalStateService<Overlay> modal;
+  Overlay overlay;
+  Overlay nested_overlay;
+
+  modal.set_active(ControlModalKind::IMAGE_CARD, &overlay, close_modal,
+                   ControlModalDismissPolicy::DISMISS);
+  assert(modal.active().overlay == &overlay);
+  assert(modal.active().kind == ControlModalKind::IMAGE_CARD);
+
+  modal.block_close_for(100, 50);
+  assert(modal.close_guard_active(149));
+  assert(!modal.close_guard_active(150));
+
+  ControlModalKind closing_kind = ControlModalKind::NONE;
+  ControlModalCloseCallback close_callback = nullptr;
+  assert(!modal.begin_active_close(149, true, &closing_kind, &close_callback));
+  assert(modal.begin_active_close(149, false, &closing_kind, &close_callback));
+  assert(closing_kind == ControlModalKind::IMAGE_CARD);
+  assert(close_callback == close_modal);
+  close_callback();
+  assert(close_calls == 1);
+  assert(!modal.begin_active_close(150, false, nullptr, nullptr));
+
+  modal.reset_active();
+  modal.nested_active().overlay = &nested_overlay;
+  modal.nested_active().close_callback = close_modal;
+  Overlay *closing_overlay = nullptr;
+  close_callback = nullptr;
+  assert(modal.begin_nested_close(&closing_overlay, &close_callback));
+  assert(closing_overlay == &nested_overlay);
+  assert(close_callback == close_modal);
+  modal.clear_nested_menu(&nested_overlay);
+  assert(modal.nested_active().overlay == nullptr);
+  return 0;
+}


### PR DESCRIPTION
## Purpose
Move the shared control-modal lifecycle state into an explicit service without changing card-specific modal layouts or interactions.

## Practical impact
The existing modal helpers remain compatibility adapters. The new service owns active-modal and nested-menu state, close guards, and re-entrant-close protection.

## Checks
- `cmake -S tests/firmware -B /private/tmp/espcontrol-modal-service-build`
- `cmake --build /private/tmp/espcontrol-modal-service-build -j 4`
- `ctest --test-dir /private/tmp/espcontrol-modal-service-build --output-on-failure` (26 passed)

## Device testing
Target device: 10-inch V1. OTA upload remains unavailable in this environment because macOS blocks the ESP-IDF build tool process-inspection call before compilation. No device flash is claimed for this PR.