### PR TITLE
Advertise manifest web asset delivery

### DIFF
--- a/components/espcontrol/panel_config_capabilities.h
+++ b/components/espcontrol/panel_config_capabilities.h
@@ -9,6 +9,7 @@ namespace espcontrol::configuration {
 constexpr uint16_t PANEL_CONFIG_API_VERSION = 1;
 constexpr uint16_t PANEL_CONFIG_WEB_ASSET_VERSION = 1;
 constexpr size_t PANEL_CONFIG_CAPABILITIES_MAX_JSON_BYTES = 160;
+constexpr const char *PANEL_CONFIG_WEB_ASSET_DELIVERY = "manifest";
 
 inline bool &panel_config_read_supported() {
   static bool supported = false;
@@ -28,9 +29,8 @@ inline void set_panel_config_write_supported(bool supported) {
   panel_config_write_supported() = supported;
 }
 
-// The discovery response is deliberately static for the first native
-// configuration release. The future immutable web-bundle manifest will
-// replace the legacy delivery marker while preserving these version fields.
+// The delivery marker lets the hosted bridge distinguish firmware that
+// understands the versioned web-asset manifest from earlier installations.
 inline bool write_panel_config_capabilities_json(char *output,
                                                  size_t output_capacity,
                                                  size_t *output_size) {
@@ -40,12 +40,13 @@ inline bool write_panel_config_capabilities_json(char *output,
       output, output_capacity,
       "{\"api\":{\"version\":%u},\"configuration\":{\"document_versions\":[%u],"
       "\"read\":%s,\"write\":%s},\"web_assets\":{\"versions\":[%u],"
-      "\"delivery\":\"legacy\"}}",
+      "\"delivery\":\"%s\"}}",
       static_cast<unsigned>(PANEL_CONFIG_API_VERSION),
       static_cast<unsigned>(PANEL_CONFIG_DOCUMENT_VERSION),
       panel_config_read_supported() ? "true" : "false",
       panel_config_write_supported() ? "true" : "false",
-      static_cast<unsigned>(PANEL_CONFIG_WEB_ASSET_VERSION));
+      static_cast<unsigned>(PANEL_CONFIG_WEB_ASSET_VERSION),
+      PANEL_CONFIG_WEB_ASSET_DELIVERY);
   if (written < 0 || static_cast<size_t>(written) >= output_capacity)
     return false;
   *output_size = static_cast<size_t>(written);

--- a/tests/firmware/panel_config_capabilities_test.cpp
+++ b/tests/firmware/panel_config_capabilities_test.cpp
@@ -10,6 +10,7 @@ int main() {
   size_t capabilities_size = 0;
   const bool passed = PANEL_CONFIG_API_VERSION == 1 &&
                       PANEL_CONFIG_WEB_ASSET_VERSION == 1 &&
+                      std::strcmp(PANEL_CONFIG_WEB_ASSET_DELIVERY, "manifest") == 0 &&
                       write_panel_config_capabilities_json(
                           capabilities.data(), capabilities.size(),
                           &capabilities_size) &&
@@ -19,6 +20,8 @@ int main() {
                       std::strstr(capabilities.data(), "\"read\":false") != nullptr &&
                       std::strstr(capabilities.data(), "\"write\":false") != nullptr &&
                       std::strstr(capabilities.data(), "\"web_assets\"") != nullptr &&
+                      std::strstr(capabilities.data(), "\"delivery\":\"manifest\"") !=
+                          nullptr &&
                       !write_panel_config_capabilities_json(nullptr,
                                                             capabilities.size(),
                                                             &capabilities_size);


### PR DESCRIPTION
## Purpose

Mark firmware capabilities as using the versioned web-asset manifest rather than the transitional legacy delivery path.

## Practical impact

- The browser can identify firmware that understands the manifest-based web delivery contract.
- The existing configuration API and supported web-asset version remain unchanged.
- A firmware host test now protects the advertised marker.

## Checks

- Focused `panel_config_capabilities_test` host build: passed
- `python3 scripts/check_firmware_parser.py`: passed
- 10-inch V1 factory ESPHome compile: running (first-run toolchain setup and full build)

## Device testing

Target: 10-inch V1 (`guition-esp32-p4-jc8012p4a1`). This is a capability-only firmware change; no OTA flash has been attempted while the compile is in progress.