### PR TITLE
Move card registry under app core

### DIFF
--- a/components/espcontrol/button_grid_card_runtime.h
+++ b/components/espcontrol/button_grid_card_runtime.h
@@ -71,7 +71,7 @@ inline Family family_for_runtime_type(espcontrol::card_runtime::CardTypeId type)
 }
 
 // Generated metadata selects a handwritten driver here; it never carries card
-// behavior. The singleton is the registry-service boundary for legacy helpers.
+// behavior.
 class CardRuntimeRegistryService {
  public:
   Context context_for(const std::string &type, const std::string &mode,
@@ -104,7 +104,25 @@ class CardRuntimeRegistryService {
   }
 };
 
+// The application core binds its owned registry during setup. Existing card
+// helpers continue to use this accessor while callers migrate to the explicit
+// core service. The local fallback keeps standalone parsing and host tests
+// independent of ESPHome application setup.
+inline const CardRuntimeRegistryService *&card_runtime_registry_binding() {
+  static const CardRuntimeRegistryService *service = nullptr;
+  return service;
+}
+
+inline void set_card_runtime_registry_service(
+    const CardRuntimeRegistryService *service) {
+  card_runtime_registry_binding() = service;
+}
+
 inline const CardRuntimeRegistryService &card_runtime_registry_service() {
+  if (const CardRuntimeRegistryService *service =
+          card_runtime_registry_binding()) {
+    return *service;
+  }
   static const CardRuntimeRegistryService service;
   return service;
 }

--- a/components/espcontrol/espcontrol_app.cpp
+++ b/components/espcontrol/espcontrol_app.cpp
@@ -56,7 +56,11 @@ void EspControlApp::set_panel_config_button(
 }
 
 void EspControlApp::setup() {
-  core_.start();
+  if (core_.start()) {
+    cards::set_card_runtime_registry_service(&core_.card_runtime_registry());
+  } else {
+    ESP_LOGE(TAG, "Application core failed to start");
+  }
   if (!legacy_config_.configured()) {
     ESP_LOGW(TAG, "Native configuration sources are not configured");
   } else if (!panel_config_blobs_.begin()) {
@@ -125,6 +129,9 @@ void EspControlApp::setup() {
 
 void EspControlApp::loop() { core_.run_once(); }
 
-void EspControlApp::on_shutdown() { core_.stop(); }
+void EspControlApp::on_shutdown() {
+  cards::set_card_runtime_registry_service(nullptr);
+  core_.stop();
+}
 
 }  // namespace espcontrol

--- a/components/espcontrol/espcontrol_app_core.h
+++ b/components/espcontrol/espcontrol_app_core.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 
+#include "button_grid_card_runtime.h"
 #include "display_lifecycle_service.h"
 
 namespace espcontrol {
@@ -27,6 +28,13 @@ class EspControlAppCore {
   DisplayLifecycleService &display_lifecycle() { return display_lifecycle_; }
   const DisplayLifecycleService &display_lifecycle() const { return display_lifecycle_; }
 
+  cards::CardRuntimeRegistryService &card_runtime_registry() {
+    return card_runtime_registry_;
+  }
+  const cards::CardRuntimeRegistryService &card_runtime_registry() const {
+    return card_runtime_registry_;
+  }
+
   // Compatibility facade for ESPHome YAML while display ownership migrates to
   // the explicit lifecycle service.
   DisplayModeController &display() { return display_lifecycle_.controller(); }
@@ -38,6 +46,7 @@ class EspControlAppCore {
   AppLifecycleState lifecycle_state_{AppLifecycleState::CONSTRUCTED};
   uint32_t loop_count_{0};
   DisplayLifecycleService display_lifecycle_{};
+  cards::CardRuntimeRegistryService card_runtime_registry_{};
 };
 
 }  // namespace espcontrol

--- a/dev-docs/adr/0010-central-firmware-owner.md
+++ b/dev-docs/adr/0010-central-firmware-owner.md
@@ -20,11 +20,13 @@ firmware services. ESPHome calls the application boundary for setup, loop, and
 shutdown. Device YAML keeps the stable `espcontrol_app` ID and acts as a wiring
 and compatibility layer rather than owning service state.
 
-The first migrated service is `DisplayModeController`. Existing display
-behaviour and method names are unchanged; YAML reaches the controller through
-`id(espcontrol_app).display()`. Later service migrations extend this owner one
-focused pull request at a time and must not introduce generated `id(...)`
-references into compiled modules.
+`DisplayModeController` and the card-runtime registry are migrated services.
+Existing display behaviour and method names are unchanged; YAML reaches the
+controller through `id(espcontrol_app).display()`. Existing card helpers use a
+compatibility binding to the core-owned registry while they migrate to explicit
+service access. Later service migrations extend this owner one focused pull
+request at a time and must not introduce generated `id(...)` references into
+compiled modules.
 
 The application core remains independent of ESPHome so ownership and lifecycle
 are covered by executable host tests.

--- a/tests/firmware/button_grid_foundations_test.cpp
+++ b/tests/firmware/button_grid_foundations_test.cpp
@@ -15,6 +15,16 @@ int main() {
     return EXIT_FAILURE;
   }
 
+  espcontrol::cards::CardRuntimeRegistryService explicit_registry;
+  espcontrol::cards::set_card_runtime_registry_service(&explicit_registry);
+  if (&espcontrol::cards::card_runtime_registry_service() != &explicit_registry) {
+    return EXIT_FAILURE;
+  }
+  espcontrol::cards::set_card_runtime_registry_service(nullptr);
+  if (&espcontrol::cards::card_runtime_registry_service() == &explicit_registry) {
+    return EXIT_FAILURE;
+  }
+
   if (string_ref_limited(esphome::StringRef("calendar"), 4) != "cale") return EXIT_FAILURE;
   if (string_ref_limited(esphome::StringRef("clock"), 32) != "clock") return EXIT_FAILURE;
   if (decode_html_entities("Earth, Wind &amp; Fire") != "Earth, Wind & Fire") {

--- a/tests/firmware/espcontrol_app_core_test.cpp
+++ b/tests/firmware/espcontrol_app_core_test.cpp
@@ -27,6 +27,11 @@ int main() {
     return EXIT_FAILURE;
   }
 
+  const auto media = app.card_runtime_registry().context_for("media", "");
+  if (!media.known || media.family != espcontrol::cards::Family::MEDIA) {
+    return EXIT_FAILURE;
+  }
+
   if (!app.run_once() || !app.run_once() || app.loop_count() != 2 ||
       app.display_lifecycle().loop_count() != 2) {
     return EXIT_FAILURE;


### PR DESCRIPTION
## Purpose

Moves the card-runtime registry from a hidden process-wide singleton to `EspControlAppCore`, keeping the existing helper calls as a temporary compatibility bridge.

## Practical impact

Card selection remains unchanged on existing panels, while its lifetime is now explicit and shared with the firmware application owner.

## Checked

- All 26 firmware host tests
- Firmware parser and card-runtime checks
- Documentation checks

## Device test

- 10-inch P4 V1 (`192.168.6.103`) will be compiled and flashed before merge.

## Notes

The compatibility binding falls back safely for standalone parsers and host tests, and is cleared at firmware shutdown.