### PR TITLE
Move Home Assistant callback ownership into core

### DIFF
--- a/components/espcontrol/espcontrol_app_core.cpp
+++ b/components/espcontrol/espcontrol_app_core.cpp
@@ -14,6 +14,7 @@ bool EspControlAppCore::configure_configuration_service(
 bool EspControlAppCore::start() {
   if (lifecycle_state_ != AppLifecycleState::CONSTRUCTED) return false;
   if (!display_lifecycle_.start()) return false;
+  set_home_assistant_callback_owner_service(&home_assistant_callback_owner_);
   lifecycle_state_ = AppLifecycleState::RUNNING;
   return true;
 }
@@ -28,6 +29,7 @@ bool EspControlAppCore::run_once() {
 bool EspControlAppCore::stop() {
   if (lifecycle_state_ != AppLifecycleState::RUNNING) return false;
   if (!display_lifecycle_.stop()) return false;
+  set_home_assistant_callback_owner_service(nullptr);
   lifecycle_state_ = AppLifecycleState::STOPPED;
   return true;
 }

--- a/components/espcontrol/espcontrol_app_core.h
+++ b/components/espcontrol/espcontrol_app_core.h
@@ -6,6 +6,7 @@
 #include "button_grid_card_runtime.h"
 #include "configuration_service.h"
 #include "display_lifecycle_service.h"
+#include "home_assistant_binding_service.h"
 
 namespace espcontrol {
 
@@ -53,6 +54,13 @@ class EspControlAppCore {
     return configuration_service_ ? &*configuration_service_ : nullptr;
   }
 
+  HomeAssistantCallbackOwnerService &home_assistant_callback_owner() {
+    return home_assistant_callback_owner_;
+  }
+  const HomeAssistantCallbackOwnerService &home_assistant_callback_owner() const {
+    return home_assistant_callback_owner_;
+  }
+
   // Compatibility facade for ESPHome YAML while display ownership migrates to
   // the explicit lifecycle service.
   DisplayModeController &display() { return display_lifecycle_.controller(); }
@@ -66,6 +74,7 @@ class EspControlAppCore {
   DisplayLifecycleService display_lifecycle_{};
   cards::CardRuntimeRegistryService card_runtime_registry_{};
   std::optional<configuration::ConfigurationService> configuration_service_;
+  HomeAssistantCallbackOwnerService home_assistant_callback_owner_{};
 };
 
 }  // namespace espcontrol

--- a/components/espcontrol/home_assistant_binding_service.h
+++ b/components/espcontrol/home_assistant_binding_service.h
@@ -4,28 +4,53 @@
 
 #include "ha_read_coordinator.h"
 
+// Tracks the current callback owner independently of the transport-specific
+// read coordinator. The application core owns the active instance; standalone
+// binding services retain a local fallback for parser and host-test use.
+class HomeAssistantCallbackOwnerService {
+ public:
+  class Scope {
+   public:
+    Scope(HomeAssistantCallbackOwnerService &service, void *owner)
+        : service_(service), previous_(service.callback_owner_) {
+      service_.callback_owner_ = owner;
+    }
+    ~Scope() { service_.callback_owner_ = previous_; }
+
+    Scope(const Scope &) = delete;
+    Scope &operator=(const Scope &) = delete;
+
+   private:
+    HomeAssistantCallbackOwnerService &service_;
+    void *previous_ = nullptr;
+  };
+
+  void *callback_owner() const { return callback_owner_; }
+  void *&callback_owner_ref() { return callback_owner_; }
+  Scope scope(void *owner) { return Scope(*this, owner); }
+
+ private:
+  void *callback_owner_ = nullptr;
+};
+
+inline HomeAssistantCallbackOwnerService *&
+home_assistant_callback_owner_service_binding() {
+  static HomeAssistantCallbackOwnerService *service = nullptr;
+  return service;
+}
+
+inline void set_home_assistant_callback_owner_service(
+    HomeAssistantCallbackOwnerService *service) {
+  home_assistant_callback_owner_service_binding() = service;
+}
+
 // Owns Home Assistant callback scope and read/subscription state. Transport and
 // heap policies keep the service host-testable and leave ESPHome as wiring.
 template<typename Transport, typename HeapProbe>
 class HomeAssistantBindingService {
  public:
   using ReadCoordinator = HaReadCoordinator<Transport, HeapProbe>;
-
-  class CallbackOwnerScope {
-   public:
-    CallbackOwnerScope(HomeAssistantBindingService &service, void *owner)
-        : service_(service), previous_(service.callback_owner_) {
-      service_.callback_owner_ = owner;
-    }
-    ~CallbackOwnerScope() { service_.callback_owner_ = previous_; }
-
-    CallbackOwnerScope(const CallbackOwnerScope &) = delete;
-    CallbackOwnerScope &operator=(const CallbackOwnerScope &) = delete;
-
-   private:
-    HomeAssistantBindingService &service_;
-    void *previous_ = nullptr;
-  };
+  using CallbackOwnerScope = HomeAssistantCallbackOwnerService::Scope;
 
   explicit HomeAssistantBindingService(
       Transport transport = Transport(), HeapProbe heap_probe = HeapProbe())
@@ -34,13 +59,21 @@ class HomeAssistantBindingService {
   ReadCoordinator &read_coordinator() { return read_coordinator_; }
   const ReadCoordinator &read_coordinator() const { return read_coordinator_; }
 
-  void *callback_owner() const { return callback_owner_; }
-  void *&callback_owner_ref() { return callback_owner_; }
+  void *callback_owner() const { return callback_owner_service().callback_owner(); }
+  void *&callback_owner_ref() { return callback_owner_service().callback_owner_ref(); }
   CallbackOwnerScope callback_owner_scope(void *owner) {
-    return CallbackOwnerScope(*this, owner);
+    return callback_owner_service().scope(owner);
   }
 
  private:
+  HomeAssistantCallbackOwnerService &callback_owner_service() const {
+    if (HomeAssistantCallbackOwnerService *service =
+            home_assistant_callback_owner_service_binding()) {
+      return *service;
+    }
+    return local_callback_owner_service_;
+  }
+
   ReadCoordinator read_coordinator_{};
-  void *callback_owner_ = nullptr;
+  mutable HomeAssistantCallbackOwnerService local_callback_owner_service_{};
 };

--- a/dev-docs/adr/0010-central-firmware-owner.md
+++ b/dev-docs/adr/0010-central-firmware-owner.md
@@ -28,7 +28,9 @@ service access. The configuration service is also core-owned; the ESPHome
 component injects its device-specific storage and legacy-text adapters before
 using it to register endpoints. Later service migrations extend this owner one
 focused pull request at a time and must not introduce generated `id(...)`
-references into compiled modules.
+references into compiled modules. Home Assistant callback ownership is likewise
+core-owned, while its transport-specific read coordinator remains an ESPHome
+wiring adapter during the compatibility migration.
 
 The application core remains independent of ESPHome so ownership and lifecycle
 are covered by executable host tests.

--- a/tests/firmware/espcontrol_app_core_test.cpp
+++ b/tests/firmware/espcontrol_app_core_test.cpp
@@ -91,12 +91,27 @@ int main() {
     return EXIT_FAILURE;
   }
 
+  int callback_owner = 0;
+  {
+    auto scope = app.home_assistant_callback_owner().scope(&callback_owner);
+    if (app.home_assistant_callback_owner().callback_owner() !=
+        &callback_owner) {
+      return EXIT_FAILURE;
+    }
+  }
+  if (app.home_assistant_callback_owner().callback_owner() != nullptr) {
+    return EXIT_FAILURE;
+  }
+
   if (!app.run_once() || !app.run_once() || app.loop_count() != 2 ||
       app.display_lifecycle().loop_count() != 2) {
     return EXIT_FAILURE;
   }
   if (!app.stop() || app.stop() || app.run_once() ||
       app.display_lifecycle().state() != DisplayLifecycleState::STOPPED) {
+    return EXIT_FAILURE;
+  }
+  if (home_assistant_callback_owner_service_binding() != nullptr) {
     return EXIT_FAILURE;
   }
   if (app.lifecycle_state() != AppLifecycleState::STOPPED) return EXIT_FAILURE;

--- a/tests/firmware/ha_read_coordinator_test.cpp
+++ b/tests/firmware/ha_read_coordinator_test.cpp
@@ -221,6 +221,21 @@ void callback_owner_scope_restores_the_previous_owner() {
   require(service.callback_owner() == nullptr, "callback scope leaked after destruction");
 }
 
+void app_owned_callback_owner_is_used_when_bound() {
+  BindingService service;
+  HomeAssistantCallbackOwnerService app_owner;
+  int owner = 0;
+  set_home_assistant_callback_owner_service(&app_owner);
+  {
+    auto scope = service.callback_owner_scope(&owner);
+    require(app_owner.callback_owner() == &owner,
+            "binding service did not use app-owned callback state");
+  }
+  set_home_assistant_callback_owner_service(nullptr);
+  require(app_owner.callback_owner() == nullptr,
+          "callback scope did not restore app-owned state");
+}
+
 }  // namespace
 
 int main() {
@@ -233,5 +248,6 @@ int main() {
   attribute_requests_preserve_attribute();
   released_owner_drops_pending_reads_even_if_its_address_is_reused();
   callback_owner_scope_restores_the_previous_owner();
+  app_owned_callback_owner_is_used_when_bound();
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Purpose

Moves the active Home Assistant callback-owner state into `EspControlAppCore`, while retaining the existing transport-specific request coordinator and helper API as a compatibility bridge.

## Practical impact

Home Assistant reads and subscriptions keep their current behaviour. Callback scopes now have an explicit app-owned lifetime and fall back safely in standalone parsing and host-test contexts.

## Checked

- All 26 firmware host tests
- Firmware parser and Home Assistant binding checks
- Documentation checks

## Physical device testing

Deferred until the complete development plan has been merged, as requested.