### PR TITLE
Move grid navigation into app core

### DIFF
--- a/components/espcontrol/button_grid_navigation.h
+++ b/components/espcontrol/button_grid_navigation.h
@@ -3,6 +3,7 @@
 // Internal implementation detail for button_grid.h. Include button_grid.h from device YAML.
 
 #include "grid_navigation_service.h"
+#include "espcontrol_app_core.h"
 
 // ── Home Assistant-driven home-screen navigation ─────────────────────
 
@@ -36,6 +37,10 @@ using ButtonGridNavigationService =
     GridNavigationService<NavigationHomeTargetEntry, NavigationSubpageEntry>;
 
 inline ButtonGridNavigationService &grid_navigation_service() {
+  if (espcontrol::EspControlAppCore *core =
+          espcontrol::active_espcontrol_app_core()) {
+    return core->grid_navigation_service<ButtonGridNavigationService>();
+  }
   static ButtonGridNavigationService service;
   return service;
 }

--- a/components/espcontrol/espcontrol_app_core.cpp
+++ b/components/espcontrol/espcontrol_app_core.cpp
@@ -2,6 +2,14 @@
 
 namespace espcontrol {
 
+EspControlAppCore::~EspControlAppCore() {
+  if (active_espcontrol_app_core() == this) active_espcontrol_app_core() = nullptr;
+  if (home_assistant_callback_owner_service_binding() ==
+      &home_assistant_callback_owner_) {
+    set_home_assistant_callback_owner_service(nullptr);
+  }
+}
+
 bool EspControlAppCore::configure_configuration_service(
     configuration::ConfigurationStore &store,
     configuration::LegacyConfigurationAdapter &legacy,
@@ -14,6 +22,7 @@ bool EspControlAppCore::configure_configuration_service(
 bool EspControlAppCore::start() {
   if (lifecycle_state_ != AppLifecycleState::CONSTRUCTED) return false;
   if (!display_lifecycle_.start()) return false;
+  active_espcontrol_app_core() = this;
   set_home_assistant_callback_owner_service(&home_assistant_callback_owner_);
   lifecycle_state_ = AppLifecycleState::RUNNING;
   return true;
@@ -29,6 +38,8 @@ bool EspControlAppCore::run_once() {
 bool EspControlAppCore::stop() {
   if (lifecycle_state_ != AppLifecycleState::RUNNING) return false;
   if (!display_lifecycle_.stop()) return false;
+  grid_navigation_service_.reset();
+  if (active_espcontrol_app_core() == this) active_espcontrol_app_core() = nullptr;
   set_home_assistant_callback_owner_service(nullptr);
   lifecycle_state_ = AppLifecycleState::STOPPED;
   return true;

--- a/components/espcontrol/espcontrol_app_core.h
+++ b/components/espcontrol/espcontrol_app_core.h
@@ -1,7 +1,12 @@
 #pragma once
 
+#include <array>
+#include <cstddef>
 #include <cstdint>
+#include <cstdlib>
+#include <new>
 #include <optional>
+#include <type_traits>
 
 #include "button_grid_card_runtime.h"
 #include "configuration_service.h"
@@ -9,6 +14,53 @@
 #include "home_assistant_binding_service.h"
 
 namespace espcontrol {
+
+// UI-owned service types can carry LVGL handles, so the core cannot name them
+// directly without taking on framework dependencies. This fixed-capacity slot
+// gives one such service an explicit application-owned lifetime instead.
+class FixedRuntimeServiceSlot {
+ public:
+  static constexpr size_t CAPACITY = 128;
+
+  FixedRuntimeServiceSlot() = default;
+  ~FixedRuntimeServiceSlot() { reset(); }
+  FixedRuntimeServiceSlot(const FixedRuntimeServiceSlot &) = delete;
+  FixedRuntimeServiceSlot &operator=(const FixedRuntimeServiceSlot &) = delete;
+
+  template<typename Service>
+  Service &get_or_create() {
+    static_assert(sizeof(Service) <= CAPACITY,
+                  "runtime service exceeds the fixed core slot capacity");
+    static_assert(alignof(Service) <= alignof(std::max_align_t),
+                  "runtime service alignment exceeds the fixed core slot");
+    const void *type = service_type<Service>();
+    if (type_ == nullptr) {
+      new (storage_.data()) Service();
+      type_ = type;
+      destroy_ = [](void *storage) { static_cast<Service *>(storage)->~Service(); };
+    } else if (type_ != type) {
+      std::abort();
+    }
+    return *static_cast<Service *>(static_cast<void *>(storage_.data()));
+  }
+
+  void reset() {
+    if (destroy_ != nullptr) destroy_(storage_.data());
+    type_ = nullptr;
+    destroy_ = nullptr;
+  }
+
+ private:
+  template<typename Service>
+  static const void *service_type() {
+    static const int marker = 0;
+    return &marker;
+  }
+
+  alignas(std::max_align_t) std::array<uint8_t, CAPACITY> storage_{};
+  const void *type_{nullptr};
+  void (*destroy_)(void *){nullptr};
+};
 
 enum class AppLifecycleState : uint8_t {
   CONSTRUCTED,
@@ -21,6 +73,8 @@ enum class AppLifecycleState : uint8_t {
 // executable in host tests.
 class EspControlAppCore {
  public:
+  ~EspControlAppCore();
+
   bool start();
   bool run_once();
   bool stop();
@@ -61,6 +115,11 @@ class EspControlAppCore {
     return home_assistant_callback_owner_;
   }
 
+  template<typename NavigationService>
+  NavigationService &grid_navigation_service() {
+    return grid_navigation_service_.get_or_create<NavigationService>();
+  }
+
   // Compatibility facade for ESPHome YAML while display ownership migrates to
   // the explicit lifecycle service.
   DisplayModeController &display() { return display_lifecycle_.controller(); }
@@ -75,6 +134,12 @@ class EspControlAppCore {
   cards::CardRuntimeRegistryService card_runtime_registry_{};
   std::optional<configuration::ConfigurationService> configuration_service_;
   HomeAssistantCallbackOwnerService home_assistant_callback_owner_{};
+  FixedRuntimeServiceSlot grid_navigation_service_{};
 };
+
+inline EspControlAppCore *&active_espcontrol_app_core() {
+  static EspControlAppCore *core = nullptr;
+  return core;
+}
 
 }  // namespace espcontrol

--- a/dev-docs/adr/0010-central-firmware-owner.md
+++ b/dev-docs/adr/0010-central-firmware-owner.md
@@ -30,7 +30,9 @@ using it to register endpoints. Later service migrations extend this owner one
 focused pull request at a time and must not introduce generated `id(...)`
 references into compiled modules. Home Assistant callback ownership is likewise
 core-owned, while its transport-specific read coordinator remains an ESPHome
-wiring adapter during the compatibility migration.
+wiring adapter during the compatibility migration. Grid navigation is stored in
+a fixed-capacity core-owned slot because its entries carry LVGL handles; the UI
+continues to define those entries while the core defines their lifetime.
 
 The application core remains independent of ESPHome so ownership and lifecycle
 are covered by executable host tests.

--- a/tests/firmware/CMakeLists.txt
+++ b/tests/firmware/CMakeLists.txt
@@ -17,7 +17,12 @@ target_include_directories(button_grid_foundations_test PRIVATE
 )
 add_test(NAME button_grid_foundations_test COMMAND button_grid_foundations_test)
 
-add_executable(grid_navigation_service_test grid_navigation_service_test.cpp)
+add_executable(grid_navigation_service_test
+  grid_navigation_service_test.cpp
+  ../../components/espcontrol/espcontrol_app_core.cpp
+  ../../components/espcontrol/configuration_service.cpp
+  ../../components/espcontrol/configuration_store.cpp
+)
 target_compile_features(grid_navigation_service_test PRIVATE cxx_std_17)
 target_compile_options(grid_navigation_service_test PRIVATE -Wall -Wextra -Werror)
 target_include_directories(grid_navigation_service_test PRIVATE ../../components/espcontrol)

--- a/tests/firmware/espcontrol_app_core_test.cpp
+++ b/tests/firmware/espcontrol_app_core_test.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "espcontrol_app_core.h"
+#include "grid_navigation_service.h"
 
 using espcontrol::AppLifecycleState;
 using espcontrol::DisplayLifecycleState;
@@ -47,6 +48,16 @@ class EmptyLegacy final
   }
   bool mirror(uint16_t, const uint8_t *, size_t) override { return true; }
 };
+
+struct HomeTarget {
+  int slot = 0;
+};
+
+struct Subpage {
+  int slot = 0;
+};
+
+using NavigationService = GridNavigationService<HomeTarget, Subpage>;
 
 }  // namespace
 
@@ -100,6 +111,13 @@ int main() {
     }
   }
   if (app.home_assistant_callback_owner().callback_owner() != nullptr) {
+    return EXIT_FAILURE;
+  }
+
+  NavigationService &navigation = app.grid_navigation_service<NavigationService>();
+  navigation.home_targets().push_back({1});
+  navigation.subpages().push_back({2});
+  if (navigation.home_target_count() != 1 || navigation.subpage_count() != 1) {
     return EXIT_FAILURE;
   }
 

--- a/tests/firmware/grid_navigation_service_test.cpp
+++ b/tests/firmware/grid_navigation_service_test.cpp
@@ -1,5 +1,6 @@
 #include <cassert>
 
+#include "espcontrol_app_core.h"
 #include "grid_navigation_service.h"
 
 namespace {
@@ -31,5 +32,13 @@ int main() {
 
   navigation.clear_subpages();
   assert(navigation.subpage_count() == 0);
+
+  espcontrol::EspControlAppCore app;
+  assert(app.start());
+  auto &core_navigation = app.grid_navigation_service<
+      GridNavigationService<HomeTarget, Subpage>>();
+  core_navigation.home_targets().push_back({3});
+  assert(core_navigation.home_target_count() == 1);
+  assert(app.stop());
   return 0;
 }


### PR DESCRIPTION
## Purpose

Moves the button-grid navigation registry into an explicit, fixed-capacity service slot owned by `EspControlAppCore`.

## Practical impact

Existing navigation helpers and UI entry types are unchanged. They use the core-owned registry after application startup and retain a standalone fallback for parser and host-test use.

## Checked

- All 26 firmware host tests
- Firmware parser checks
- Documentation checks

## Physical device testing

Deferred until the complete development plan has been merged, as requested.

## Notes

The slot itself has fixed storage; the UI remains the sole owner of LVGL-specific entry types.