### PR TITLE
Move modal state into app core

### DIFF
--- a/components/espcontrol/button_grid_modal.h
+++ b/components/espcontrol/button_grid_modal.h
@@ -5,6 +5,7 @@
 // Shared control modal helpers.
 
 #include "control_modal_service.h"
+#include "espcontrol_app_core.h"
 
 constexpr lv_coord_t CONTROL_MODAL_REFERENCE_SIDE_PX = DISPLAY_MODAL_REFERENCE_SIDE_PX;
 constexpr lv_coord_t CONTROL_MODAL_ARC_STROKE_REF_PX = DISPLAY_MODAL_ARC_STROKE_REF_PX;
@@ -81,6 +82,9 @@ using ControlModalNestedActive = ControlModalNestedActiveState<lv_obj_t>;
 using ButtonGridModalService = ControlModalStateService<lv_obj_t>;
 
 inline ButtonGridModalService &control_modal_service() {
+  if (auto *core = espcontrol::active_espcontrol_app_core()) {
+    return core->modal_state_service<ButtonGridModalService>();
+  }
   static ButtonGridModalService service;
   return service;
 }

--- a/components/espcontrol/espcontrol_app_core.cpp
+++ b/components/espcontrol/espcontrol_app_core.cpp
@@ -38,6 +38,7 @@ bool EspControlAppCore::run_once() {
 bool EspControlAppCore::stop() {
   if (lifecycle_state_ != AppLifecycleState::RUNNING) return false;
   if (!display_lifecycle_.stop()) return false;
+  modal_state_service_.reset();
   grid_navigation_service_.reset();
   if (active_espcontrol_app_core() == this) active_espcontrol_app_core() = nullptr;
   set_home_assistant_callback_owner_service(nullptr);

--- a/components/espcontrol/espcontrol_app_core.h
+++ b/components/espcontrol/espcontrol_app_core.h
@@ -120,6 +120,13 @@ class EspControlAppCore {
     return grid_navigation_service_.get_or_create<NavigationService>();
   }
 
+  // Modal widgets stay in the LVGL-facing UI layer, while their lifecycle
+  // state receives the same application-owned lifetime as navigation.
+  template<typename ModalService>
+  ModalService &modal_state_service() {
+    return modal_state_service_.get_or_create<ModalService>();
+  }
+
   // Compatibility facade for ESPHome YAML while display ownership migrates to
   // the explicit lifecycle service.
   DisplayModeController &display() { return display_lifecycle_.controller(); }
@@ -135,6 +142,7 @@ class EspControlAppCore {
   std::optional<configuration::ConfigurationService> configuration_service_;
   HomeAssistantCallbackOwnerService home_assistant_callback_owner_{};
   FixedRuntimeServiceSlot grid_navigation_service_{};
+  FixedRuntimeServiceSlot modal_state_service_{};
 };
 
 inline EspControlAppCore *&active_espcontrol_app_core() {

--- a/dev-docs/architecture.md
+++ b/dev-docs/architecture.md
@@ -76,6 +76,12 @@ source or a committed generated input.
 6. Firmware parses the saved compact config string and updates the on-device
    cards.
 
+`EspControlAppCore` owns the long-lived configuration, card runtime, Home
+Assistant callback, display lifecycle, grid navigation, and modal-state
+services. The navigation and modal-state slots have fixed capacity so their
+LVGL-specific types remain in the UI layer without changing the device memory
+budget.
+
 ## Build-Time Flow
 
 ```text

--- a/tests/firmware/CMakeLists.txt
+++ b/tests/firmware/CMakeLists.txt
@@ -28,7 +28,12 @@ target_compile_options(grid_navigation_service_test PRIVATE -Wall -Wextra -Werro
 target_include_directories(grid_navigation_service_test PRIVATE ../../components/espcontrol)
 add_test(NAME grid_navigation_service_test COMMAND grid_navigation_service_test)
 
-add_executable(control_modal_service_test control_modal_service_test.cpp)
+add_executable(control_modal_service_test
+  control_modal_service_test.cpp
+  ../../components/espcontrol/espcontrol_app_core.cpp
+  ../../components/espcontrol/configuration_service.cpp
+  ../../components/espcontrol/configuration_store.cpp
+)
 target_compile_features(control_modal_service_test PRIVATE cxx_std_17)
 target_compile_options(control_modal_service_test PRIVATE -Wall -Wextra -Werror)
 target_include_directories(control_modal_service_test PRIVATE ../../components/espcontrol)

--- a/tests/firmware/control_modal_service_test.cpp
+++ b/tests/firmware/control_modal_service_test.cpp
@@ -1,6 +1,7 @@
 #include <cassert>
 
 #include "control_modal_service.h"
+#include "espcontrol_app_core.h"
 
 namespace {
 
@@ -46,5 +47,14 @@ int main() {
   assert(close_callback == close_modal);
   modal.clear_nested_menu(&nested_overlay);
   assert(modal.nested_active().overlay == nullptr);
+
+  espcontrol::EspControlAppCore app;
+  assert(app.start());
+  auto &core_modal = app.modal_state_service<ControlModalStateService<Overlay>>();
+  core_modal.set_active(ControlModalKind::TODO_LIST, &overlay, nullptr,
+                        ControlModalDismissPolicy::DISMISS);
+  assert(core_modal.active().kind == ControlModalKind::TODO_LIST);
+  assert(app.stop());
+
   return 0;
 }

--- a/tests/firmware/espcontrol_app_core_test.cpp
+++ b/tests/firmware/espcontrol_app_core_test.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "espcontrol_app_core.h"
+#include "control_modal_service.h"
 #include "grid_navigation_service.h"
 
 using espcontrol::AppLifecycleState;
@@ -58,6 +59,12 @@ struct Subpage {
 };
 
 using NavigationService = GridNavigationService<HomeTarget, Subpage>;
+
+struct ModalOverlay {
+  int slot = 0;
+};
+
+using ModalService = ControlModalStateService<ModalOverlay>;
 
 }  // namespace
 
@@ -120,6 +127,12 @@ int main() {
   if (navigation.home_target_count() != 1 || navigation.subpage_count() != 1) {
     return EXIT_FAILURE;
   }
+
+  ModalOverlay overlay;
+  ModalService &modal = app.modal_state_service<ModalService>();
+  modal.set_active(ControlModalKind::TODO_LIST, &overlay, nullptr,
+                   ControlModalDismissPolicy::DISMISS);
+  if (modal.active().overlay != &overlay) return EXIT_FAILURE;
 
   if (!app.run_once() || !app.run_once() || app.loop_count() != 2 ||
       app.display_lifecycle().loop_count() != 2) {


### PR DESCRIPTION
## Purpose

Give modal lifecycle state an explicit application-owned lifetime while keeping LVGL-specific widget code in the UI layer.

## Practical impact

Modal state now starts and stops with `EspControlAppCore`, matching the configuration, card registry, Home Assistant callback, display, and navigation services. Existing modal helpers continue to work as a compatibility facade.

## Checks

- 26 firmware host tests
- Firmware parser and modal-allocation checks
- Development documentation check

## Device testing

Physical display testing is intentionally deferred until the complete reset roadmap has merged, at which point the full integrated build will be tested.