### PR TITLE
Bound core UI service memory

### DIFF
--- a/components/espcontrol/button_grid_modal.h
+++ b/components/espcontrol/button_grid_modal.h
@@ -85,8 +85,14 @@ inline ButtonGridModalService &control_modal_service() {
   if (auto *core = espcontrol::active_espcontrol_app_core()) {
     return core->modal_state_service<ButtonGridModalService>();
   }
+#ifdef ESP_PLATFORM
+  // Firmware UI work begins only after EspControlAppCore starts. Keeping the
+  // contract strict avoids a second permanent modal-state allocation.
+  std::abort();
+#else
   static ButtonGridModalService service;
   return service;
+#endif
 }
 
 inline ControlModalActive &control_modal_active() {

--- a/components/espcontrol/button_grid_navigation.h
+++ b/components/espcontrol/button_grid_navigation.h
@@ -41,8 +41,14 @@ inline ButtonGridNavigationService &grid_navigation_service() {
           espcontrol::active_espcontrol_app_core()) {
     return core->grid_navigation_service<ButtonGridNavigationService>();
   }
+#ifdef ESP_PLATFORM
+  // Firmware UI work begins only after EspControlAppCore starts. Keeping the
+  // contract strict avoids a second permanent navigation allocation.
+  std::abort();
+#else
   static ButtonGridNavigationService service;
   return service;
+#endif
 }
 
 // Compatibility accessors for existing grid code. New runtime ownership lives

--- a/components/espcontrol/espcontrol_app_core.cpp
+++ b/components/espcontrol/espcontrol_app_core.cpp
@@ -21,9 +21,13 @@ bool EspControlAppCore::configure_configuration_service(
 
 bool EspControlAppCore::start() {
   if (lifecycle_state_ != AppLifecycleState::CONSTRUCTED) return false;
-  if (!display_lifecycle_.start()) return false;
   active_espcontrol_app_core() = this;
   set_home_assistant_callback_owner_service(&home_assistant_callback_owner_);
+  if (!display_lifecycle_.start()) {
+    if (active_espcontrol_app_core() == this) active_espcontrol_app_core() = nullptr;
+    set_home_assistant_callback_owner_service(nullptr);
+    return false;
+  }
   lifecycle_state_ = AppLifecycleState::RUNNING;
   return true;
 }

--- a/components/espcontrol/espcontrol_app_core.h
+++ b/components/espcontrol/espcontrol_app_core.h
@@ -18,9 +18,10 @@ namespace espcontrol {
 // UI-owned service types can carry LVGL handles, so the core cannot name them
 // directly without taking on framework dependencies. This fixed-capacity slot
 // gives one such service an explicit application-owned lifetime instead.
+template<size_t Capacity>
 class FixedRuntimeServiceSlot {
  public:
-  static constexpr size_t CAPACITY = 128;
+  static constexpr size_t CAPACITY = Capacity;
 
   FixedRuntimeServiceSlot() = default;
   ~FixedRuntimeServiceSlot() { reset(); }
@@ -141,8 +142,11 @@ class EspControlAppCore {
   cards::CardRuntimeRegistryService card_runtime_registry_{};
   std::optional<configuration::ConfigurationService> configuration_service_;
   HomeAssistantCallbackOwnerService home_assistant_callback_owner_{};
-  FixedRuntimeServiceSlot grid_navigation_service_{};
-  FixedRuntimeServiceSlot modal_state_service_{};
+  // The concrete UI services assert their own sizes when they bind to these
+  // slots. Keeping each bound small avoids reserving a generic 128-byte buffer
+  // for every service in every firmware image.
+  FixedRuntimeServiceSlot<64> grid_navigation_service_{};
+  FixedRuntimeServiceSlot<64> modal_state_service_{};
 };
 
 inline EspControlAppCore *&active_espcontrol_app_core() {

--- a/dev-docs/architecture.md
+++ b/dev-docs/architecture.md
@@ -79,8 +79,9 @@ source or a committed generated input.
 `EspControlAppCore` owns the long-lived configuration, card runtime, Home
 Assistant callback, display lifecycle, grid navigation, and modal-state
 services. The navigation and modal-state slots have fixed capacity so their
-LVGL-specific types remain in the UI layer without changing the device memory
-budget.
+LVGL-specific types remain in the UI layer with a bounded, reviewable memory
+budget. Firmware UI accesses those services only after the core starts; the
+standalone host-test fallbacks are excluded from firmware images.
 
 ## Build-Time Flow
 


### PR DESCRIPTION
## Purpose

Correct the modal-state core migration so firmware does not retain duplicate fallback service allocations.

## Practical impact

Grid navigation and modal state use small bounded core slots after application startup. Their standalone fallbacks remain available only to host tests, not compiled firmware.

## Checks

- 26 firmware host tests
- Firmware parser and modal-allocation checks
- Development documentation check

## Device testing

Physical display testing is deferred until the complete reset roadmap has merged.