### PR TITLE
Fix app core header visibility

### DIFF
--- a/components/espcontrol/button_grid_ha.h
+++ b/components/espcontrol/button_grid_ha.h
@@ -7,6 +7,7 @@
 
 #include "ha_read_coordinator.h"
 #include "home_assistant_binding_service.h"
+#include "espcontrol_app_core.h"
 
 #ifdef ESP_PLATFORM
 #include "esp_heap_caps.h"


### PR DESCRIPTION
## Purpose
Fix P4 firmware compilation after the app-core Home Assistant binding migration.

## Practical impact
The compatibility header now explicitly includes the core declaration before calling its accessor, so ESPHome sees the required type in its normal include order.

## Checked
- 26 firmware host tests
- Firmware parser checks
- CI full supported-device compilation requested

## Device testing
- Deferred until the final merged roadmap verification, as requested.