### PR TITLE
Add configuration compatibility lifecycle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,11 @@ jobs:
           bash scripts/prune_actions_cache.sh "${NPM_CACHE}" "${ESPCONTROL_NPM_CACHE_MAX_MB}" --strategy reset
 
       - name: Run release preflight
-        run: npm run check:release-preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          npm run check:release-preflight
+          python3 scripts/check_release_contract.py --github-repository "${GITHUB_REPOSITORY}"
 
   device-matrix:
     name: Prepare Device Matrix

--- a/components/espcontrol/configuration_release_policy.h
+++ b/components/espcontrol/configuration_release_policy.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "configuration_service.h"
+
+namespace espcontrol::configuration {
+
+// Generated release policy source is product/release_contract.json. Keep this
+// value in lock-step with that declaration; check_release_contract.py protects
+// the relationship before a release is published.
+constexpr LegacyConfigurationMode PANEL_CONFIG_LEGACY_MODE =
+    LegacyConfigurationMode::DUAL_WRITE;
+
+}  // namespace espcontrol::configuration

--- a/components/espcontrol/configuration_release_policy.h
+++ b/components/espcontrol/configuration_release_policy.h
@@ -4,9 +4,9 @@
 
 namespace espcontrol::configuration {
 
-// Generated release policy source is product/release_contract.json. Keep this
-// value in lock-step with that declaration; check_release_contract.py protects
-// the relationship before a release is published.
+// The authoritative release policy source is product/release_contract.json.
+// Keep this value in lock-step with that declaration; check_release_contract.py
+// protects the relationship before a release is published.
 constexpr LegacyConfigurationMode PANEL_CONFIG_LEGACY_MODE =
     LegacyConfigurationMode::DUAL_WRITE;
 

--- a/components/espcontrol/configuration_service.cpp
+++ b/components/espcontrol/configuration_service.cpp
@@ -295,7 +295,8 @@ ServiceSaveResult ConfigurationService::save(uint16_t document_version,
     return {ServiceStatus::STORE_FAILED, committed.status, document_version,
             committed.generation, document_size};
   }
-  const bool mirrored = legacy_.mirror(document_version, document, document_size);
+  const bool mirrored = !legacy_writes_enabled() ||
+                        legacy_.mirror(document_version, document, document_size);
   const bool applied = runtime_ == nullptr ||
                        runtime_->apply(document_version, document, document_size);
   if (!applied) {
@@ -336,7 +337,8 @@ ServiceSaveResult ConfigurationService::save_if_generation(
     return {ServiceStatus::STORE_FAILED, committed.status, document_version,
             committed.generation, document_size};
   }
-  const bool mirrored = legacy_.mirror(document_version, document, document_size);
+  const bool mirrored = !legacy_writes_enabled() ||
+                        legacy_.mirror(document_version, document, document_size);
   const bool applied = runtime_ == nullptr ||
                        runtime_->apply(document_version, document, document_size);
   if (!applied) {

--- a/components/espcontrol/configuration_service.h
+++ b/components/espcontrol/configuration_service.h
@@ -11,6 +11,14 @@ namespace espcontrol::configuration {
 constexpr uint16_t CURRENT_CONFIGURATION_DOCUMENT_VERSION = 1;
 constexpr size_t CONFIGURATION_DOCUMENT_HEADER_SIZE = 8;
 
+// Release-controlled compatibility phases. The read/import-only phase is used
+// after the two dual-write releases: older panels can still be upgraded, but
+// native saves no longer overwrite their legacy text entities.
+enum class LegacyConfigurationMode : uint8_t {
+  DUAL_WRITE,
+  READ_IMPORT_ONLY,
+};
+
 enum class LegacyStatus : uint8_t {
   OK,
   EMPTY,
@@ -116,9 +124,11 @@ class ConfigurationService {
   ConfigurationService(ConfigurationStore &store,
                        LegacyConfigurationAdapter &legacy,
       const ConfigurationDocumentValidator *validator = nullptr,
-      uint8_t *scratch_buffer = nullptr, size_t scratch_capacity = 0)
+      uint8_t *scratch_buffer = nullptr, size_t scratch_capacity = 0,
+      LegacyConfigurationMode legacy_mode = LegacyConfigurationMode::DUAL_WRITE)
       : store_(store), legacy_(legacy), validator_(validator),
-        scratch_buffer_(scratch_buffer), scratch_capacity_(scratch_capacity) {}
+        scratch_buffer_(scratch_buffer), scratch_capacity_(scratch_capacity),
+        legacy_mode_(legacy_mode) {}
 
   ServiceLoadResult load(uint8_t *output, size_t output_capacity);
   // During compatibility releases the text entities remain authoritative.
@@ -139,6 +149,9 @@ class ConfigurationService {
   }
 
   size_t maximum_document_size() const;
+  bool legacy_writes_enabled() const {
+    return legacy_mode_ == LegacyConfigurationMode::DUAL_WRITE;
+  }
   void set_scratch_buffer(uint8_t *scratch_buffer, size_t scratch_capacity) {
     scratch_buffer_ = scratch_buffer;
     scratch_capacity_ = scratch_capacity;
@@ -167,6 +180,7 @@ class ConfigurationService {
   uint8_t *scratch_buffer_{nullptr};
   size_t scratch_capacity_{0};
   ConfigurationRuntimeAdapter *runtime_{nullptr};
+  LegacyConfigurationMode legacy_mode_{LegacyConfigurationMode::DUAL_WRITE};
 };
 
 }  // namespace espcontrol::configuration

--- a/components/espcontrol/espcontrol_app.cpp
+++ b/components/espcontrol/espcontrol_app.cpp
@@ -9,6 +9,7 @@
 #include "esphome/core/log.h"
 
 #include "panel_config_capabilities_endpoint.h"
+#include "configuration_release_policy.h"
 #include "panel_config_read_endpoint.h"
 #include "panel_config_write_endpoint.h"
 
@@ -82,7 +83,8 @@ void EspControlApp::setup() {
     ESP_LOGE(TAG, "Application core failed to start");
   }
   if (!core_.configure_configuration_service(
-          panel_config_store_, legacy_config_, &panel_config_validator_)) {
+          panel_config_store_, legacy_config_, &panel_config_validator_,
+          configuration::PANEL_CONFIG_LEGACY_MODE)) {
     ESP_LOGE(TAG, "Native configuration service is already configured");
     register_panel_config_endpoints();
     return;
@@ -128,21 +130,25 @@ void EspControlApp::setup() {
       ESP_LOGE(TAG, "Native configuration load failed (%u)",
                static_cast<unsigned>(loaded.status));
     }
-    const configuration::ServiceLoadResult refreshed =
-        panel_config_service->refresh_legacy_shadow(
-            panel_config_document_buffer_, PANEL_CONFIG_STORAGE_SLOT_CAPACITY);
-    if (refreshed.status == configuration::ServiceStatus::SYNCED_LEGACY) {
-      ESP_LOGI(TAG, "Refreshed native configuration shadow to generation %" PRIu32,
-               refreshed.generation);
-    } else if (!refreshed.ok() &&
-               refreshed.status != configuration::ServiceStatus::EMPTY) {
-      ESP_LOGE(TAG, "Native configuration refresh failed (%u)",
-               static_cast<unsigned>(refreshed.status));
+    configuration::ServiceLoadResult live_document = loaded;
+    if (panel_config_service->legacy_writes_enabled()) {
+      const configuration::ServiceLoadResult refreshed =
+          panel_config_service->refresh_legacy_shadow(
+              panel_config_document_buffer_, PANEL_CONFIG_STORAGE_SLOT_CAPACITY);
+      if (refreshed.status == configuration::ServiceStatus::SYNCED_LEGACY) {
+        ESP_LOGI(TAG, "Refreshed native configuration shadow to generation %" PRIu32,
+                 refreshed.generation);
+      } else if (!refreshed.ok() &&
+                 refreshed.status != configuration::ServiceStatus::EMPTY) {
+        ESP_LOGE(TAG, "Native configuration refresh failed (%u)",
+                 static_cast<unsigned>(refreshed.status));
+      }
+      if (refreshed.ok()) live_document = refreshed;
     }
-    if (refreshed.ok() &&
-        !legacy_config_.apply(refreshed.document_version,
+    if (live_document.ok() &&
+        !legacy_config_.apply(live_document.document_version,
                               panel_config_document_buffer_,
-                              refreshed.document_size)) {
+                              live_document.document_size)) {
       ESP_LOGE(TAG, "Native configuration could not update the live grid");
     }
   }

--- a/components/espcontrol/espcontrol_app_core.cpp
+++ b/components/espcontrol/espcontrol_app_core.cpp
@@ -13,9 +13,11 @@ EspControlAppCore::~EspControlAppCore() {
 bool EspControlAppCore::configure_configuration_service(
     configuration::ConfigurationStore &store,
     configuration::LegacyConfigurationAdapter &legacy,
-    const configuration::ConfigurationDocumentValidator *validator) {
+    const configuration::ConfigurationDocumentValidator *validator,
+    configuration::LegacyConfigurationMode legacy_mode) {
   if (configuration_service_) return false;
-  configuration_service_.emplace(store, legacy, validator);
+  configuration_service_.emplace(store, legacy, validator, nullptr, 0,
+                                 legacy_mode);
   return true;
 }
 

--- a/components/espcontrol/espcontrol_app_core.h
+++ b/components/espcontrol/espcontrol_app_core.h
@@ -98,7 +98,9 @@ class EspControlAppCore {
   bool configure_configuration_service(
       configuration::ConfigurationStore &store,
       configuration::LegacyConfigurationAdapter &legacy,
-      const configuration::ConfigurationDocumentValidator *validator = nullptr);
+      const configuration::ConfigurationDocumentValidator *validator = nullptr,
+      configuration::LegacyConfigurationMode legacy_mode =
+          configuration::LegacyConfigurationMode::DUAL_WRITE);
   bool has_configuration_service() const {
     return configuration_service_.has_value();
   }

--- a/dev-docs/compatibility-contract.md
+++ b/dev-docs/compatibility-contract.md
@@ -33,7 +33,10 @@ explicit migration path, compatibility fixture, release note, and rollback plan.
 
 `product/release_contract.json` declares the PanelConfig compatibility phase,
 and `configuration_release_policy.h` is the checked firmware projection of that
-choice. Keep `dual-write` for two stable releases. For the following stable
+choice. Keep `dual-write` for two stable releases. The release preflight reads
+the immutable `release-manifest.json` assets from published stable releases and
+rejects a move to `read-import-only` until two consecutive releases with the
+same PanelConfig document version prove that window. For the following stable
 release, change both declarations to `read-import-only`: new native saves stop
 mirroring legacy text entities, while an older panel's text configuration can
 still be imported once. Retire legacy reads only after that read/import-only

--- a/dev-docs/compatibility-contract.md
+++ b/dev-docs/compatibility-contract.md
@@ -29,6 +29,16 @@ explicit migration path, compatibility fixture, release note, and rollback plan.
 - Do not require users to resave cards after updating unless the release notes
   clearly call out the migration.
 
+### PanelConfig release lifecycle
+
+`product/release_contract.json` declares the PanelConfig compatibility phase,
+and `configuration_release_policy.h` is the checked firmware projection of that
+choice. Keep `dual-write` for two stable releases. For the following stable
+release, change both declarations to `read-import-only`: new native saves stop
+mirroring legacy text entities, while an older panel's text configuration can
+still be imported once. Retire legacy reads only after that read/import-only
+release has shipped and its upgrade coverage has been confirmed.
+
 ## Required Migration Shape
 
 Every compatibility-affecting change needs:

--- a/product/release_contract.json
+++ b/product/release_contract.json
@@ -2,5 +2,10 @@
   "schemaVersion": 1,
   "productModelVersion": 2,
   "panelConfigDocumentVersion": 1,
-  "webAssetVersion": 1
+  "webAssetVersion": 1,
+  "panelConfigCompatibility": {
+    "phase": "dual-write",
+    "dualWriteStableReleases": 2,
+    "readImportOnlyStableReleases": 1
+  }
 }

--- a/scripts/check_firmware_release.py
+++ b/scripts/check_firmware_release.py
@@ -168,6 +168,8 @@ def test_release_workflow_uses_current_ota_output() -> None:
     assert "scripts/firmware_release.py publish-draft" in workflow
     assert "--source-revision" in workflow
     assert "scripts/firmware_release.py verify-recovery" in workflow
+    assert "scripts/check_release_contract.py --github-repository" in workflow
+    assert "GH_TOKEN: ${{ github.token }}" in workflow
     assert str(prepare_c6_firmware.C6_RELATIVE_PATH) in workflow
     assert "path: dist/firmware/" in workflow, "publishable firmware must use the dist boundary"
 

--- a/scripts/check_release_contract.py
+++ b/scripts/check_release_contract.py
@@ -81,6 +81,7 @@ def verify() -> None:
 def self_test() -> None:
     verify()
     original = PRODUCT_MODEL.read_text(encoding="utf-8")
+    original_policy = COMPATIBILITY_POLICY.read_text(encoding="utf-8")
     try:
         product_model = json.loads(original)
         product_model["modelVersion"] = int(product_model["modelVersion"]) + 1
@@ -93,6 +94,22 @@ def self_test() -> None:
             raise AssertionError("mismatched Product Model version was accepted")
     finally:
         PRODUCT_MODEL.write_text(original, encoding="utf-8")
+    try:
+        COMPATIBILITY_POLICY.write_text(
+            original_policy.replace(
+                "LegacyConfigurationMode::DUAL_WRITE",
+                "LegacyConfigurationMode::READ_IMPORT_ONLY",
+            ),
+            encoding="utf-8",
+        )
+        try:
+            verify()
+        except AssertionError as error:
+            assert "firmware PanelConfig compatibility policy" in str(error)
+        else:
+            raise AssertionError("mismatched PanelConfig compatibility policy was accepted")
+    finally:
+        COMPATIBILITY_POLICY.write_text(original_policy, encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/scripts/check_release_contract.py
+++ b/scripts/check_release_contract.py
@@ -15,6 +15,7 @@ DEVICE_MANIFEST = ROOT / "devices" / "manifest.json"
 WEB_MANIFEST = ROOT / "docs" / "public" / "webserver" / "web-assets.json"
 DOCUMENT_HEADER = ROOT / "components" / "espcontrol" / "panel_config_document.h"
 CAPABILITIES_HEADER = ROOT / "components" / "espcontrol" / "panel_config_capabilities.h"
+COMPATIBILITY_POLICY = ROOT / "components" / "espcontrol" / "configuration_release_policy.h"
 
 
 def read_json(path: Path) -> dict:
@@ -56,6 +57,24 @@ def verify() -> None:
     )
     assert bundle.get("deviceProfiles") == device_slugs, (
         "web-asset device profiles disagree with generated device manifest"
+    )
+    compatibility = contract.get("panelConfigCompatibility")
+    assert isinstance(compatibility, dict), "release contract lacks PanelConfig compatibility policy"
+    assert compatibility.get("phase") in {"dual-write", "read-import-only"}, (
+        "PanelConfig compatibility phase is invalid"
+    )
+    assert compatibility.get("dualWriteStableReleases") == 2, (
+        "PanelConfig compatibility policy must retain two dual-write stable releases"
+    )
+    assert compatibility.get("readImportOnlyStableReleases") == 1, (
+        "PanelConfig compatibility policy must retain one read/import-only stable release"
+    )
+    expected_mode = {
+        "dual-write": "LegacyConfigurationMode::DUAL_WRITE",
+        "read-import-only": "LegacyConfigurationMode::READ_IMPORT_ONLY",
+    }[compatibility["phase"]]
+    assert expected_mode in COMPATIBILITY_POLICY.read_text(encoding="utf-8"), (
+        "firmware PanelConfig compatibility policy disagrees with release contract"
     )
 
 

--- a/scripts/check_release_contract.py
+++ b/scripts/check_release_contract.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import json
+import os
 import re
+from urllib.request import Request, urlopen
 from pathlib import Path
 
 
@@ -29,7 +31,86 @@ def constant(path: Path, name: str) -> int:
     return int(match.group(1))
 
 
-def verify() -> None:
+def compatibility_policy(contract: dict) -> dict:
+    compatibility = contract.get("panelConfigCompatibility")
+    assert isinstance(compatibility, dict), "release contract lacks PanelConfig compatibility policy"
+    assert compatibility.get("phase") in {"dual-write", "read-import-only"}, (
+        "PanelConfig compatibility phase is invalid"
+    )
+    assert compatibility.get("dualWriteStableReleases") == 2, (
+        "PanelConfig compatibility policy must retain two dual-write stable releases"
+    )
+    assert compatibility.get("readImportOnlyStableReleases") == 1, (
+        "PanelConfig compatibility policy must retain one read/import-only stable release"
+    )
+    return compatibility
+
+
+def validate_release_history(contract: dict, releases: list[dict]) -> None:
+    """Require published manifests before advancing past the dual-write window."""
+    policy = compatibility_policy(contract)
+    if policy["phase"] == "dual-write":
+        return
+
+    matching = [
+        release
+        for release in releases
+        if release["manifest"].get("releaseContract", {}).get("panelConfigDocumentVersion")
+        == contract["panelConfigDocumentVersion"]
+    ]
+    assert matching, "no published release manifests match this PanelConfig document version"
+    phases = [
+        release["manifest"]["releaseContract"].get("panelConfigCompatibility", {}).get("phase")
+        for release in matching
+    ]
+    if phases[0] == "read-import-only":
+        phases = phases[1:]
+    required = policy["dualWriteStableReleases"]
+    assert phases[:required] == ["dual-write"] * required, (
+        f"read-import-only requires {required} consecutive published dual-write releases "
+        "with the current PanelConfig document version"
+    )
+
+
+def github_release_history(repository: str) -> list[dict]:
+    """Read immutable release manifests, newest first, from GitHub releases."""
+    assert re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository), (
+        "GitHub repository must be OWNER/NAME"
+    )
+    headers = {"Accept": "application/vnd.github+json"}
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    def fetch_json(url: str) -> object:
+        request = Request(url, headers=headers)
+        with urlopen(request, timeout=20) as response:  # nosec B310: URLs are checked below.
+            return json.loads(response.read().decode("utf-8"))
+
+    releases = fetch_json(f"https://api.github.com/repos/{repository}/releases?per_page=100")
+    assert isinstance(releases, list), "GitHub releases response was not a list"
+    history = []
+    for release in releases:
+        if release.get("draft") or release.get("prerelease"):
+            continue
+        asset = next((item for item in release.get("assets", []) if item.get("name") == "release-manifest.json"), None)
+        if asset is None:
+            continue
+        url = asset.get("browser_download_url")
+        assert isinstance(url, str) and url.startswith("https://"), "release manifest asset URL is invalid"
+        manifest = fetch_json(url)
+        assert isinstance(manifest, dict), "release manifest asset was not a JSON object"
+        assert manifest.get("releaseVersion") == release.get("tag_name"), (
+            f"published release manifest does not match tag {release.get('tag_name')}"
+        )
+        assert isinstance(manifest.get("releaseContract"), dict), (
+            f"published release {release.get('tag_name')} lacks its release contract"
+        )
+        history.append({"tagName": release["tag_name"], "manifest": manifest})
+    return history
+
+
+def verify() -> dict:
     contract = read_json(CONTRACT)
     assert contract["schemaVersion"] == 1, "release contract schema version must be 1"
     product_model = read_json(PRODUCT_MODEL)
@@ -58,17 +139,7 @@ def verify() -> None:
     assert bundle.get("deviceProfiles") == device_slugs, (
         "web-asset device profiles disagree with generated device manifest"
     )
-    compatibility = contract.get("panelConfigCompatibility")
-    assert isinstance(compatibility, dict), "release contract lacks PanelConfig compatibility policy"
-    assert compatibility.get("phase") in {"dual-write", "read-import-only"}, (
-        "PanelConfig compatibility phase is invalid"
-    )
-    assert compatibility.get("dualWriteStableReleases") == 2, (
-        "PanelConfig compatibility policy must retain two dual-write stable releases"
-    )
-    assert compatibility.get("readImportOnlyStableReleases") == 1, (
-        "PanelConfig compatibility policy must retain one read/import-only stable release"
-    )
+    compatibility = compatibility_policy(contract)
     expected_mode = {
         "dual-write": "LegacyConfigurationMode::DUAL_WRITE",
         "read-import-only": "LegacyConfigurationMode::READ_IMPORT_ONLY",
@@ -76,10 +147,36 @@ def verify() -> None:
     assert expected_mode in COMPATIBILITY_POLICY.read_text(encoding="utf-8"), (
         "firmware PanelConfig compatibility policy disagrees with release contract"
     )
+    return contract
 
 
 def self_test() -> None:
     verify()
+    contract = read_json(CONTRACT)
+    read_import_contract = json.loads(json.dumps(contract))
+    read_import_contract["panelConfigCompatibility"]["phase"] = "read-import-only"
+
+    def published(phase: str) -> dict:
+        manifest_contract = json.loads(json.dumps(contract))
+        manifest_contract["panelConfigCompatibility"]["phase"] = phase
+        return {"manifest": {"releaseContract": manifest_contract}}
+
+    validate_release_history(read_import_contract, [published("dual-write"), published("dual-write")])
+    try:
+        validate_release_history(read_import_contract, [published("dual-write")])
+    except AssertionError as error:
+        assert "2 consecutive published dual-write" in str(error)
+    else:
+        raise AssertionError("read/import-only accepted a single published dual-write release")
+    try:
+        validate_release_history(
+            read_import_contract,
+            [published("dual-write"), published("read-import-only"), published("dual-write")],
+        )
+    except AssertionError as error:
+        assert "2 consecutive published dual-write" in str(error)
+    else:
+        raise AssertionError("read/import-only accepted non-consecutive dual-write releases")
     original = PRODUCT_MODEL.read_text(encoding="utf-8")
     original_policy = COMPATIBILITY_POLICY.read_text(encoding="utf-8")
     try:
@@ -117,10 +214,17 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--self-test", action="store_true")
+    parser.add_argument(
+        "--github-repository",
+        metavar="OWNER/NAME",
+        help="verify the published immutable release manifests before advancing compatibility phase",
+    )
     args = parser.parse_args()
     if args.self_test:
         self_test()
         print("Release contract self-test passed.")
     else:
-        verify()
+        contract = verify()
+        if args.github_repository:
+            validate_release_history(contract, github_release_history(args.github_repository))
         print("Release contract checks passed.")

--- a/tests/firmware/configuration_service_test.cpp
+++ b/tests/firmware/configuration_service_test.cpp
@@ -240,6 +240,42 @@ bool runtime_is_updated_even_if_the_legacy_mirror_fails() {
          runtime.applied == expected;
 }
 
+bool read_import_only_preserves_upgrade_import_without_legacy_writes() {
+  MemoryBackend backend(256);
+  ConfigurationStore store(backend);
+  FakeLegacy legacy;
+  FakeRuntime runtime;
+  ConfigurationService service(
+      store, legacy, nullptr, nullptr, 0,
+      LegacyConfigurationMode::READ_IMPORT_ONLY);
+  service.set_runtime_adapter(&runtime);
+  const std::vector<uint8_t> expected = bytes("native-only-save");
+  if (!service.save_current(expected.data(), expected.size()).ok() ||
+      service.legacy_writes_enabled() || legacy.mirror_calls != 0 ||
+      runtime.apply_calls != 1 || runtime.applied != expected) {
+    return false;
+  }
+  legacy.value = bytes("older-legacy-value");
+  std::array<uint8_t, 64> output{};
+  const ServiceLoadResult native = service.load(output.data(), output.size());
+  if (!native.ok() || native.document_size != expected.size() ||
+      !std::equal(expected.begin(), expected.end(), output.begin())) {
+    return false;
+  }
+
+  MemoryBackend upgrade_backend(256);
+  ConfigurationStore upgrade_store(upgrade_backend);
+  FakeLegacy upgrade_legacy;
+  upgrade_legacy.value = bytes("upgrade-legacy-value");
+  ConfigurationService upgrade_service(
+      upgrade_store, upgrade_legacy, nullptr, nullptr, 0,
+      LegacyConfigurationMode::READ_IMPORT_ONLY);
+  output.fill(0);
+  const ServiceLoadResult imported =
+      upgrade_service.load(output.data(), output.size());
+  return imported.imported_legacy() && upgrade_legacy.mirror_calls == 0;
+}
+
 bool conditional_save_rejects_a_stale_generation() {
   MemoryBackend backend(256);
   ConfigurationStore store(backend);
@@ -371,6 +407,7 @@ int main() {
       successful_save_dual_writes() &&
       successful_save_updates_the_native_runtime() &&
       runtime_is_updated_even_if_the_legacy_mirror_fails() &&
+      read_import_only_preserves_upgrade_import_without_legacy_writes() &&
       conditional_save_rejects_a_stale_generation() &&
       version_and_buffer_failures_are_explicit() &&
       malformed_store_document_is_not_treated_as_legacy() &&


### PR DESCRIPTION
## Purpose
Make the PanelConfig rollout phase explicit and release-checked.

## Practical impact
Current firmware remains dual-write. The next declared read/import-only phase stops new legacy text mirrors while preserving one-time legacy imports for panels upgrading from older firmware.

## Checked
- 26 firmware host tests
- Firmware parser checks
- Release-contract self-test and validation
- Developer documentation consistency

## Device testing
- The current main revision was successfully compiled and flashed to the 10-inch V1; this PR needs normal CI review before any additional device flash.