### PR TITLE
Apply native config to live panel runtime

### DIFF
--- a/components/espcontrol/configuration_service.cpp
+++ b/components/espcontrol/configuration_service.cpp
@@ -295,7 +295,14 @@ ServiceSaveResult ConfigurationService::save(uint16_t document_version,
     return {ServiceStatus::STORE_FAILED, committed.status, document_version,
             committed.generation, document_size};
   }
-  if (!legacy_.mirror(document_version, document, document_size)) {
+  const bool mirrored = legacy_.mirror(document_version, document, document_size);
+  const bool applied = runtime_ == nullptr ||
+                       runtime_->apply(document_version, document, document_size);
+  if (!applied) {
+    return {ServiceStatus::RUNTIME_APPLY_FAILED, committed.status,
+            document_version, committed.generation, document_size};
+  }
+  if (!mirrored) {
     return {ServiceStatus::LEGACY_MIRROR_FAILED, committed.status,
             document_version, committed.generation, document_size};
   }
@@ -329,7 +336,14 @@ ServiceSaveResult ConfigurationService::save_if_generation(
     return {ServiceStatus::STORE_FAILED, committed.status, document_version,
             committed.generation, document_size};
   }
-  if (!legacy_.mirror(document_version, document, document_size)) {
+  const bool mirrored = legacy_.mirror(document_version, document, document_size);
+  const bool applied = runtime_ == nullptr ||
+                       runtime_->apply(document_version, document, document_size);
+  if (!applied) {
+    return {ServiceStatus::RUNTIME_APPLY_FAILED, committed.status,
+            document_version, committed.generation, document_size};
+  }
+  if (!mirrored) {
     return {ServiceStatus::LEGACY_MIRROR_FAILED, committed.status,
             document_version, committed.generation, document_size};
   }

--- a/components/espcontrol/configuration_service.h
+++ b/components/espcontrol/configuration_service.h
@@ -37,6 +37,17 @@ class LegacyConfigurationAdapter {
                       size_t document_size) = 0;
 };
 
+// Applies a validated native document to the currently running panel. This is
+// deliberately separate from the legacy mirror: a panel can update its live
+// grid without writing the legacy preference-backed entities.
+class ConfigurationRuntimeAdapter {
+ public:
+  virtual ~ConfigurationRuntimeAdapter() = default;
+
+  virtual bool apply(uint16_t document_version, const uint8_t *document,
+                     size_t document_size) = 0;
+};
+
 enum class ServiceStatus : uint8_t {
   OK,
   IMPORTED_LEGACY,
@@ -50,6 +61,7 @@ enum class ServiceStatus : uint8_t {
   STORE_FAILED,
   LEGACY_READ_FAILED,
   LEGACY_MIRROR_FAILED,
+  RUNTIME_APPLY_FAILED,
 };
 
 struct ServiceLoadResult {
@@ -78,7 +90,8 @@ struct ServiceSaveResult {
   bool ok() const { return status == ServiceStatus::OK; }
   bool durable() const {
     return status == ServiceStatus::OK ||
-           status == ServiceStatus::LEGACY_MIRROR_FAILED;
+           status == ServiceStatus::LEGACY_MIRROR_FAILED ||
+           status == ServiceStatus::RUNTIME_APPLY_FAILED;
   }
 };
 
@@ -130,6 +143,9 @@ class ConfigurationService {
     scratch_buffer_ = scratch_buffer;
     scratch_capacity_ = scratch_capacity;
   }
+  void set_runtime_adapter(ConfigurationRuntimeAdapter *runtime) {
+    runtime_ = runtime;
+  }
 
  private:
   CommitResult commit_document(uint16_t document_version,
@@ -150,6 +166,7 @@ class ConfigurationService {
   const ConfigurationDocumentValidator *validator_{nullptr};
   uint8_t *scratch_buffer_{nullptr};
   size_t scratch_capacity_{0};
+  ConfigurationRuntimeAdapter *runtime_{nullptr};
 };
 
 }  // namespace espcontrol::configuration

--- a/components/espcontrol/espcontrol_app.cpp
+++ b/components/espcontrol/espcontrol_app.cpp
@@ -94,6 +94,7 @@ void EspControlApp::setup() {
     register_panel_config_endpoints();
     return;
   }
+  panel_config_service->set_runtime_adapter(&legacy_config_);
   if (!legacy_config_.configured()) {
     ESP_LOGW(TAG, "Native configuration sources are not configured");
   } else if (!panel_config_blobs_.begin()) {
@@ -137,6 +138,12 @@ void EspControlApp::setup() {
                refreshed.status != configuration::ServiceStatus::EMPTY) {
       ESP_LOGE(TAG, "Native configuration refresh failed (%u)",
                static_cast<unsigned>(refreshed.status));
+    }
+    if (refreshed.ok() &&
+        !legacy_config_.apply(refreshed.document_version,
+                              panel_config_document_buffer_,
+                              refreshed.document_size)) {
+      ESP_LOGE(TAG, "Native configuration could not update the live grid");
     }
   }
   register_panel_config_endpoints();

--- a/components/espcontrol/panel_config_esphome_text.h
+++ b/components/espcontrol/panel_config_esphome_text.h
@@ -23,6 +23,12 @@ class EspHomeLegacyTextValue final : public LegacyTextValue {
     return true;
   }
 
+  bool publish_value(const char *value, size_t value_size) override {
+    if (text_ == nullptr || (value == nullptr && value_size > 0)) return false;
+    text_->publish_state(std::string(value == nullptr ? "" : value, value_size));
+    return true;
+  }
+
  private:
   esphome::text::Text *text_{nullptr};
   std::string empty_;

--- a/components/espcontrol/panel_config_legacy_adapter.cpp
+++ b/components/espcontrol/panel_config_legacy_adapter.cpp
@@ -112,24 +112,44 @@ bool PanelConfigLegacyAdapter::mirror(uint16_t document_version,
                                       const uint8_t *document,
                                       size_t document_size) {
   return document_version == PANEL_CONFIG_DOCUMENT_VERSION && configured() &&
-         mirror_document(document, document_size);
+         apply_document(document, document_size, true);
 }
 
-bool PanelConfigLegacyAdapter::mirror_document(const uint8_t *document,
-                                               size_t document_size) {
+bool PanelConfigLegacyAdapter::apply(uint16_t document_version,
+                                     const uint8_t *document,
+                                     size_t document_size) {
+  return document_version == PANEL_CONFIG_DOCUMENT_VERSION && configured() &&
+         apply_document(document, document_size, false);
+}
+
+bool PanelConfigLegacyAdapter::write_value(LegacyTextValue *target,
+                                           const char *value,
+                                           size_t value_size,
+                                           bool persist_legacy) {
+  if (target == nullptr) return false;
+  return persist_legacy ? target->set_value(value, value_size)
+                        : target->publish_value(value, value_size);
+}
+
+bool PanelConfigLegacyAdapter::apply_document(const uint8_t *document,
+                                              size_t document_size,
+                                              bool persist_legacy) {
   PanelConfigReader reader(document, document_size);
   if (reader.begin() != PanelConfigStatus::OK) return false;
 
   // Clear known values first. Missing records intentionally mean that the
-  // corresponding old entity is empty in the native document.
-  if (!button_order_->set_value("", 0)) return false;
-  if (button_on_color_ != nullptr && !button_on_color_->set_value("", 0))
+  // corresponding compatibility entity is empty in the native document.
+  if (!write_value(button_order_, "", 0, persist_legacy)) return false;
+  if (button_on_color_ != nullptr &&
+      !write_value(button_on_color_, "", 0, persist_legacy))
     return false;
   for (ButtonSources &sources : buttons_) {
-    if (sources.button != nullptr && !sources.button->set_value("", 0))
+    if (sources.button != nullptr &&
+        !write_value(sources.button, "", 0, persist_legacy))
       return false;
     for (LegacyTextValue *chunk : sources.subpage_chunks) {
-      if (chunk != nullptr && !chunk->set_value("", 0)) return false;
+      if (chunk != nullptr && !write_value(chunk, "", 0, persist_legacy))
+        return false;
     }
   }
 
@@ -145,8 +165,9 @@ bool PanelConfigLegacyAdapter::mirror_document(const uint8_t *document,
     } else if (record.type == PanelConfigRecordType::BUTTON) {
       ButtonSources &sources = buttons_[record.slot - 1];
       if (sources.button == nullptr ||
-          !sources.button->set_value(reinterpret_cast<const char *>(record.value),
-                                     record.value_size)) {
+          !write_value(sources.button,
+                       reinterpret_cast<const char *>(record.value),
+                       record.value_size, persist_legacy)) {
         return false;
       }
     } else if (record.type == PanelConfigRecordType::SUBPAGE) {
@@ -155,8 +176,9 @@ bool PanelConfigLegacyAdapter::mirror_document(const uint8_t *document,
       for (LegacyTextValue *chunk : sources.subpage_chunks) {
         if (chunk == nullptr) continue;
         const size_t chunk_size = std::min<size_t>(255, record.value_size - offset);
-        if (!chunk->set_value(reinterpret_cast<const char *>(record.value + offset),
-                              chunk_size)) {
+        if (!write_value(chunk,
+                         reinterpret_cast<const char *>(record.value + offset),
+                         chunk_size, persist_legacy)) {
           return false;
         }
         offset += chunk_size;
@@ -165,16 +187,18 @@ bool PanelConfigLegacyAdapter::mirror_document(const uint8_t *document,
     } else if (record.type == PanelConfigRecordType::SETTING &&
                record.key_size == sizeof(BUTTON_ORDER_KEY) - 1 &&
                std::memcmp(record.key, BUTTON_ORDER_KEY, record.key_size) == 0) {
-      if (!button_order_->set_value(reinterpret_cast<const char *>(record.value),
-                                    record.value_size)) {
+      if (!write_value(button_order_,
+                       reinterpret_cast<const char *>(record.value),
+                       record.value_size, persist_legacy)) {
         return false;
       }
     } else if (record.type == PanelConfigRecordType::SETTING &&
                record.key_size == sizeof(BUTTON_ON_COLOR_KEY) - 1 &&
                std::memcmp(record.key, BUTTON_ON_COLOR_KEY, record.key_size) == 0) {
       if (button_on_color_ != nullptr &&
-          !button_on_color_->set_value(
-              reinterpret_cast<const char *>(record.value), record.value_size)) {
+          !write_value(button_on_color_,
+                       reinterpret_cast<const char *>(record.value),
+                       record.value_size, persist_legacy)) {
         return false;
       }
     }

--- a/components/espcontrol/panel_config_legacy_adapter.h
+++ b/components/espcontrol/panel_config_legacy_adapter.h
@@ -17,10 +17,16 @@ class LegacyTextValue {
   virtual ~LegacyTextValue() = default;
 
   virtual const std::string &value() const = 0;
+  // Changes the preference-backed compatibility entity for firmware that is
+  // later downgraded to a legacy release.
   virtual bool set_value(const char *value, size_t value_size) = 0;
+  // Updates only the live ESPHome state. This triggers the existing grid
+  // refresh wiring without overwriting the compatibility preference store.
+  virtual bool publish_value(const char *value, size_t value_size) = 0;
 };
 
-class PanelConfigLegacyAdapter final : public LegacyConfigurationAdapter {
+class PanelConfigLegacyAdapter final : public LegacyConfigurationAdapter,
+                                       public ConfigurationRuntimeAdapter {
  public:
   static constexpr size_t MAX_SUBPAGE_CHUNKS = 8;
 
@@ -39,6 +45,8 @@ class PanelConfigLegacyAdapter final : public LegacyConfigurationAdapter {
   LegacyLoadResult load(uint8_t *output, size_t output_capacity) override;
   bool mirror(uint16_t document_version, const uint8_t *document,
               size_t document_size) override;
+  bool apply(uint16_t document_version, const uint8_t *document,
+             size_t document_size) override;
 
  private:
   struct ButtonSources {
@@ -48,7 +56,10 @@ class PanelConfigLegacyAdapter final : public LegacyConfigurationAdapter {
 
   bool write_document(uint8_t *output, size_t output_capacity,
                       size_t *document_size) const;
-  bool mirror_document(const uint8_t *document, size_t document_size);
+  bool apply_document(const uint8_t *document, size_t document_size,
+                      bool persist_legacy);
+  static bool write_value(LegacyTextValue *target, const char *value,
+                          size_t value_size, bool persist_legacy);
 
   std::string device_profile_;
   LegacyTextValue *button_order_{nullptr};

--- a/tests/firmware/configuration_service_test.cpp
+++ b/tests/firmware/configuration_service_test.cpp
@@ -79,6 +79,22 @@ class FakeLegacy final : public LegacyConfigurationAdapter {
   bool mirror_failed{false};
 };
 
+class FakeRuntime final : public ConfigurationRuntimeAdapter {
+ public:
+  bool apply(uint16_t document_version, const uint8_t *document,
+             size_t document_size) override {
+    ++apply_calls;
+    applied_version = document_version;
+    applied.assign(document, document + document_size);
+    return !apply_failed;
+  }
+
+  std::vector<uint8_t> applied;
+  uint16_t applied_version{0};
+  size_t apply_calls{0};
+  bool apply_failed{false};
+};
+
 std::vector<uint8_t> bytes(const char *value) {
   return std::vector<uint8_t>(value, value + std::strlen(value));
 }
@@ -191,6 +207,37 @@ bool successful_save_dual_writes() {
   return saved.ok() && saved.generation == 1 && legacy.mirror_calls == 1 &&
          legacy.mirrored_version == CURRENT_CONFIGURATION_DOCUMENT_VERSION &&
          legacy.mirrored == expected;
+}
+
+bool successful_save_updates_the_native_runtime() {
+  MemoryBackend backend(256);
+  ConfigurationStore store(backend);
+  FakeLegacy legacy;
+  FakeRuntime runtime;
+  ConfigurationService service(store, legacy);
+  service.set_runtime_adapter(&runtime);
+  const std::vector<uint8_t> expected = bytes("live-native-document");
+  const ServiceSaveResult saved =
+      service.save_current(expected.data(), expected.size());
+  return saved.ok() && runtime.apply_calls == 1 &&
+         runtime.applied_version == CURRENT_CONFIGURATION_DOCUMENT_VERSION &&
+         runtime.applied == expected;
+}
+
+bool runtime_is_updated_even_if_the_legacy_mirror_fails() {
+  MemoryBackend backend(256);
+  ConfigurationStore store(backend);
+  FakeLegacy legacy;
+  legacy.mirror_failed = true;
+  FakeRuntime runtime;
+  ConfigurationService service(store, legacy);
+  service.set_runtime_adapter(&runtime);
+  const std::vector<uint8_t> expected = bytes("durable-native-document");
+  const ServiceSaveResult saved =
+      service.save_current(expected.data(), expected.size());
+  return saved.status == ServiceStatus::LEGACY_MIRROR_FAILED &&
+         saved.durable() && runtime.apply_calls == 1 &&
+         runtime.applied == expected;
 }
 
 bool conditional_save_rejects_a_stale_generation() {
@@ -322,6 +369,8 @@ int main() {
       failed_legacy_mirror_keeps_the_native_save_durable() &&
       failed_durable_save_never_updates_legacy() &&
       successful_save_dual_writes() &&
+      successful_save_updates_the_native_runtime() &&
+      runtime_is_updated_even_if_the_legacy_mirror_fails() &&
       conditional_save_rejects_a_stale_generation() &&
       version_and_buffer_failures_are_explicit() &&
       malformed_store_document_is_not_treated_as_legacy() &&

--- a/tests/firmware/panel_config_legacy_adapter_test.cpp
+++ b/tests/firmware/panel_config_legacy_adapter_test.cpp
@@ -24,8 +24,18 @@ class FakeText final : public LegacyTextValue {
   bool set_value(const char *value, size_t value_size) override {
     if (value == nullptr && value_size > 0) return false;
     state_.assign(value, value_size);
+    ++persistent_writes;
     return true;
   }
+  bool publish_value(const char *value, size_t value_size) override {
+    if (value == nullptr && value_size > 0) return false;
+    state_.assign(value, value_size);
+    ++runtime_publishes;
+    return true;
+  }
+
+  size_t persistent_writes{0};
+  size_t runtime_publishes{0};
 
  private:
   std::string state_;
@@ -125,11 +135,42 @@ bool native_document_mirrors_back_to_legacy_entities_for_downgrade() {
          on_color.value() == "0088FF";
 }
 
+bool native_document_updates_live_grid_without_writing_legacy_preferences() {
+  FakeText order("old-order");
+  FakeText button("old-button");
+  std::array<LegacyTextValue *, PanelConfigLegacyAdapter::MAX_SUBPAGE_CHUNKS>
+      chunks{};
+  PanelConfigLegacyAdapter adapter;
+  adapter.set_device_profile("profile");
+  adapter.set_button_order(&order);
+  adapter.set_button(1, &button, chunks);
+
+  std::array<uint8_t, 256> document{};
+  PanelConfigWriter writer(document.data(), document.size());
+  size_t document_size = 0;
+  if (writer.begin() != PanelConfigStatus::OK ||
+      writer.append_device_profile(reinterpret_cast<const uint8_t *>("profile"),
+                                   7) != PanelConfigStatus::OK ||
+      writer.append_button(1, reinterpret_cast<const uint8_t *>("new-button"),
+                           10) != PanelConfigStatus::OK ||
+      writer.append_setting(reinterpret_cast<const uint8_t *>("button_order"),
+                            12, reinterpret_cast<const uint8_t *>("1"), 1) !=
+          PanelConfigStatus::OK ||
+      writer.finish(&document_size) != PanelConfigStatus::OK) {
+    return false;
+  }
+  return adapter.apply(1, document.data(), document_size) &&
+         button.value() == "new-button" && order.value() == "1" &&
+         button.persistent_writes == 0 && order.persistent_writes == 0 &&
+         button.runtime_publishes == 2 && order.runtime_publishes == 2;
+}
+
 }  // namespace
 
 int main() {
   return imports_legacy_button_subpage_and_order() &&
-                 native_document_mirrors_back_to_legacy_entities_for_downgrade()
+                 native_document_mirrors_back_to_legacy_entities_for_downgrade() &&
+                 native_document_updates_live_grid_without_writing_legacy_preferences()
              ? 0
              : 1;
 }


### PR DESCRIPTION
## Purpose

Make the live grid use the durable native PanelConfig without writing the legacy preference entities. The existing legacy mirror remains enabled for the compatibility releases.

## Practical impact

Native configuration saves now update the active screen even if a legacy mirror later fails. At boot, the native document is republished through the existing grid-refresh wiring without persisting compatibility values.

## Checks

- 26 firmware host tests passed
- Modified C++ sources compiled for the 10-inch V1 configuration
- Full ESP-IDF image build is deferred to CI; the local initial framework build was still compiling unrelated libraries

## Device testing

No device flashed in this PR. Per current plan, physical testing is deferred until the reset work is merged.