### PR TITLE
Fix media artwork refresh feedback

### DIFF
--- a/components/espcontrol/artwork_controller.h
+++ b/components/espcontrol/artwork_controller.h
@@ -115,8 +115,7 @@ struct SourceCandidates {
 
     // Local proxy URLs can remain unchanged while Home Assistant publishes a
     // refreshed remote URL for a new track. Prefer that fresh URL immediately.
-    if (refresh_needed && !remote_url.empty() && remote_url != current_url &&
-        selection.primary == current_url) {
+    if (refresh_needed && !remote_url.empty() && remote_url != current_url) {
       selection.fallback = selection.primary;
       selection.primary = remote_url;
       selection.preferred_refreshed_remote = true;

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -18,6 +18,7 @@
 constexpr uint32_t IMAGE_CARD_STARTUP_RETRY_MS = 45000;
 constexpr uint32_t IMAGE_CARD_RETRY_INTERVAL_MS = 2000;
 constexpr uint32_t IMAGE_CARD_API_RETRY_INTERVAL_MS = 250;
+constexpr uint32_t IMAGE_CARD_MIN_REPEAT_REFRESH_MS = 30000;
 constexpr uint32_t IMAGE_CARD_MODAL_REFRESH_DELAY_MS = 1000;
 constexpr uint32_t IMAGE_CARD_MODAL_REQUEST_DELAY_MS = 100;
 constexpr uint32_t IMAGE_CARD_MODAL_CLEANUP_DELAY_MS = 100;
@@ -2064,7 +2065,17 @@ inline void image_card_handle_picture(ImageCardCtx *ctx, esphome::StringRef pict
         ctx->media_artwork, ctx->media_artwork_retry_mask)) {
     ctx->next_picture_retry_ms = 0;
   }
+  uint32_t now = esphome::millis();
   bool source_changed = ctx->source_url != url;
+  if (!ctx->media_artwork && ctx->image_ready && !source_changed &&
+      ctx->last_download_completed_ms != 0 &&
+      (uint32_t)(now - ctx->last_download_completed_ms) <
+        IMAGE_CARD_MIN_REPEAT_REFRESH_MS) {
+    ESP_LOGD("image_card", "Skipping recent image refresh for %s",
+             ctx->entity_id.c_str());
+    image_card_log_diagnostics(ctx, "picture-recent-refresh-skipped");
+    return;
+  }
   ctx->source_url = url;
   image_card_log_diagnostics(ctx, "picture-url-ready");
   if (image_card_modal_active_for(ctx)) {
@@ -2079,7 +2090,7 @@ inline void image_card_process_media_artwork(ImageCardCtx *ctx) {
   if (!ctx || !ctx->active || !ctx->media_artwork) return;
   const bool refresh_forced = ctx->media_artwork_refresh_forced;
   const bool prefer_refreshed_remote =
-    refresh_forced || ctx->media_artwork_remote_refresh_pending;
+    ctx->media_artwork_remote_refresh_pending;
   ctx->media_artwork_refresh_forced = false;
   ctx->media_artwork_remote_refresh_pending = false;
   const espcontrol::artwork::SourceSelection selection =
@@ -2194,6 +2205,11 @@ inline void image_card_request_media_artwork(ImageCardCtx *ctx, bool force_refre
       ha_api_connected() ? IMAGE_CARD_API_RETRY_INTERVAL_MS : IMAGE_CARD_RETRY_INTERVAL_MS);
     if (!ctx->image_ready) image_card_set_loading_state(ctx, "Loading", true);
   }
+}
+
+inline void image_card_refresh_media_artwork_on_metadata_change(ImageCardCtx *ctx) {
+  if (!ctx || !ctx->active || !ctx->media_artwork) return;
+  image_card_request_media_artwork(ctx, true);
 }
 
 inline void refresh_image_cards() {

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -957,6 +957,27 @@ inline void media_playback_apply_state_to_buttons(MediaPlaybackState *state) {
   }
 }
 
+inline std::string media_playback_artwork_refresh_signature(
+    const MediaPlaybackState *state) {
+  if (!state) return {};
+  if (!state->current_content_id.empty()) {
+    return std::string("content:") + state->current_content_id;
+  }
+  if (!state->title.empty() || !state->artist.empty()) {
+    return std::string("metadata:") + state->title + "\x1f" + state->artist;
+  }
+  return state->has_state ? std::string("state:") + state->state_text : std::string();
+}
+
+inline void media_playback_refresh_stable_artwork(MediaPlaybackState *state,
+                                                  MediaNowPlayingCtx *ctx) {
+  if (!state || !ctx || !ctx->cover_art) return;
+  const std::string signature = media_playback_artwork_refresh_signature(state);
+  if (signature.empty() || signature == ctx->artwork_refresh_signature) return;
+  ctx->artwork_refresh_signature = signature;
+  image_card_refresh_media_artwork_on_metadata_change(ctx->cover_art);
+}
+
 inline void media_playback_apply_state_to_now_playing_snapshot(
     MediaPlaybackState *state, MediaNowPlayingCtx *ctx) {
   if (!state || !ctx) return;
@@ -1004,6 +1025,7 @@ inline void media_playback_apply_state_to_now_playing(MediaPlaybackState *state,
     if (active) media_playback_apply_state_to_now_playing_snapshot(active, ctx);
     return;
   }
+  media_playback_refresh_stable_artwork(state, ctx);
   media_playback_apply_state_to_now_playing_snapshot(state, ctx);
 }
 
@@ -4325,6 +4347,8 @@ inline void subscribe_media_cover_art_source_state(
   MediaPlaybackState *state = media_playback_ensure_state(entity_id);
   if (!state) return;
   media_playback_attach_now_playing(state, ctx);
+  media_playback_subscribe_content(state);
+  media_playback_subscribe_metadata(state);
   media_playback_subscribe_source(state);
 }
 

--- a/components/espcontrol/button_grid_sliders.h
+++ b/components/espcontrol/button_grid_sliders.h
@@ -8,6 +8,7 @@
 struct ImageCardCtx;
 inline void image_card_set_media_artwork_suppressed(ImageCardCtx *ctx,
                                                      bool suppressed);
+inline void image_card_refresh_media_artwork_on_metadata_change(ImageCardCtx *ctx);
 
 // ── Slider widgets ───────────────────────────────────────────────────
 
@@ -64,6 +65,7 @@ struct MediaNowPlayingCtx {
   std::string primary_entity;
   std::string secondary_entity;
   std::string active_entity;
+  std::string artwork_refresh_signature;
   std::function<void()> refresh_entity_route;
   char artist[HA_STATE_TEXT_MAX_LEN + 1] = {};
   bool source_known = false;

--- a/tests/firmware/artwork_controller_test.cpp
+++ b/tests/firmware/artwork_controller_test.cpp
@@ -87,6 +87,13 @@ int main() {
   assert(artwork_selection_needs_download(true,
                                           selected.primary == "local-stable"));
 
+  // A forced reconnect refresh keeps the current local proxy selected. The
+  // forced flag requests a new download; it must not promote an older remote
+  // fallback simply because both candidates are unchanged.
+  selected = sources.select("local-stable", false);
+  assert(selected.primary == "local-stable");
+  assert(selected.fallback == "remote-stable");
+
   // Empty responses are a real artwork update. Once both sources are empty,
   // the caller must clear/cancel the currently displayed artwork.
   assert(sources.update(false, "", RemoteUpdatePolicy::PRESERVE_LOCAL));
@@ -112,11 +119,18 @@ int main() {
   assert(!artwork_picture_response_clears_retry(true, ARTWORK_SOURCE_LOCAL));
 
   // When a stable local proxy URL still points at the previous track, a fresh
-  // remote URL wins for the refresh and the local URL remains the fallback.
-  sources.update(true, "stable-local");
-  sources.remote_url = "remote-c";
+  // remote URL wins for every changed track and the local URL remains the
+  // fallback—even when the prior refresh had already selected a remote URL.
+  sources.clear();
+  assert(sources.update(true, "stable-local"));
+  assert(sources.update(false, "remote-c", RemoteUpdatePolicy::PRESERVE_LOCAL));
   selected = sources.select("stable-local", true);
   assert(selected.primary == "remote-c");
+  assert(selected.fallback == "stable-local");
+  assert(selected.preferred_refreshed_remote);
+  assert(sources.update(false, "remote-d", RemoteUpdatePolicy::PRESERVE_LOCAL));
+  selected = sources.select("remote-c", true);
+  assert(selected.primary == "remote-d");
   assert(selected.fallback == "stable-local");
   assert(selected.preferred_refreshed_remote);
 


### PR DESCRIPTION
Addresses all four actionable review comments from #1398.

- Keeps a selected local artwork proxy during forced reconnect refreshes.
- Restores repeat throttling for non-media image cards.
- Refreshes stable artwork proxy URLs when the media item changes.
- Continues preferring a newly changed remote artwork URL on later tracks.

Checks:
- 26 firmware tests passed.
- Firmware HA binding and card-runtime checks passed.
- 10-inch V1 firmware compiled locally (no upload).