### PR TITLE
Move manual setup to Advanced docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -396,7 +396,6 @@ export default defineConfig({
           { text: 'Install', link: '/getting-started/install' },
           { text: 'C6 WiFi Recovery', link: '/getting-started/c6-recovery' },
           { text: 'Enable Actions', link: '/getting-started/home-assistant-actions' },
-          { text: 'Manual Setup', link: '/getting-started/manual-esphome-setup' },
           { text: 'Troubleshooting', link: '/getting-started/troubleshooting' },
         ],
       },
@@ -477,8 +476,9 @@ export default defineConfig({
         ],
       },
       {
-        text: 'Reference',
+        text: 'Advanced',
         items: [
+          { text: 'Manual Setup', link: '/getting-started/manual-esphome-setup' },
           { text: 'Contributing', link: '/reference/contributing' },
           { text: 'Collect USB Logs', link: '/reference/collect-usb-logs' },
           { text: 'Icon Reference', link: '/reference/icons' },


### PR DESCRIPTION
## Summary
- move Manual Setup out of the Getting Started sidebar
- place it in the renamed Advanced documentation section
- keep the existing page URL unchanged

## Practical impact
Manual ESPHome setup is now grouped with the advanced documentation, while existing direct links and bookmarks continue to work.

## Checks
- `npm run docs:build`

## Testing notes
No display firmware changes. Review the documentation sidebar on the pull request preview after it deploys.