### PR TITLE
Refresh Card Types documentation

### DIFF
--- a/docs/card-types/actions.md
+++ b/docs/card-types/actions.md
@@ -8,43 +8,16 @@ description:
 
 An Action card is a simple one-tap shortcut. It sends a selected Home Assistant action, opens an Option Select picker, or runs a registered local device action when you tap it.
 
-Use Action cards for shortcuts such as running a scene, starting a script, triggering an automation, pressing a Home Assistant button entity, changing a helper, or calling a custom action registered on the panel itself.
+Use one for shortcuts such as a scene, script, automation, Home Assistant button, helper, or a custom action registered on the panel.
 
 ## Setting Up an Action Card
 
 1. Select a card and change its type to **Action**.
 2. Set a **Label** - this is the text shown on the card.
 3. Choose an **Action**.
-4. Enter the **Entity** for the thing you want the action to use.
-5. If you choose **Set Number Helper**, enter the value.
-6. Choose an **Icon**.
-7. If you choose **Run Script**, optionally add **Fields** if the script needs inputs, and turn on **Confirmation Required** if accidental taps would be a problem.
-8. Optionally turn on **Show State** if a Home Assistant-backed Action card should show a separate Home Assistant state.
-
-## Run an Existing Home Assistant Script
-
-Use **Run Script** when you already have a Home Assistant script and want a card to run it directly. This avoids creating a separate automation just to connect the panel button to the script.
-
-For example, to run a script called `script.mettre_de_la_musique`:
-
-1. Set the card **Type** to **Action**.
-2. Set **Action** to **Run Script**.
-3. Set **Entity** to `script.mettre_de_la_musique`.
-4. Set **Label** to the text you want on the panel, such as `Music`.
-5. Choose an icon.
-
-When you tap the card, EspControl sends `script.turn_on` to Home Assistant with that script as the target entity. The label is only what appears on the panel, so it can be different from the script name.
-
-If your script defines fields, add them in **Fields**, one per line:
-
-```text
-room: kitchen
-mode: night
-```
-
-EspControl sends those values with `script.turn_on`, so Home Assistant receives them as the script's field values.
-
-For safety-sensitive scripts, turn on **Confirmation Required**. The card will open the same confirmation popup used by Switch cards before it sends `script.turn_on`. You can customise the popup message and the confirm/cancel button text.
+4. Enter the matching **Entity** (not needed for Local Action).
+5. Enter a value for **Set Number Helper**, if used, and choose an icon.
+6. For scripts, you can add fields and ask for confirmation before running it.
 
 ## Supported Actions
 
@@ -60,34 +33,7 @@ For safety-sensitive scripts, turn on **Confirmation Required**. The card will o
 | **Option Select** | `select.wled_preset` or `input_select.house_mode` | Opens option list |
 | **Local Action** | Registered local action key | Runs on the panel |
 
-## Option Select
-
-Choose **Option Select** inside the Action card when you want the panel to show and change a live `select` or `input_select` value.
-
-When you tap the card, EspControl opens the option list reported by Home Assistant. Choosing an option sends `select.select_option` for `select` entities or `input_select.select_option` for `input_select` helpers.
-
-This is useful for WLED presets, room modes, house modes, and similar helpers where you want to pick from the current list rather than hard-code one option into the card.
-
-## Local Action
-
-Choose **Local Action** inside the Action card when the action should run directly on the ESP32 instead of going through Home Assistant.
-
-Local actions are registered in your device's `on_boot` lambda using `register_local_action()`. The key must be unique per device and is used to match the card to the callback.
-
-```yaml
-esphome:
-  on_boot:
-    - priority: 700
-      then:
-        - lambda: |-
-            register_local_action(
-              "tv_off",
-              "TV Off",
-              [=]() { id(ir_blaster).transmit_nec(0x04FB, 0x08F7); }
-            );
-```
-
-When the setup page can reach the device, it shows a dropdown of registered local actions. If the device cannot be reached, enter the **Action Key** manually.
+For more about choosing from a live list, see [Option Select](/card-types/option-select). For an action that runs on the panel without Home Assistant, see [Local Action](/card-types/local-actions).
 
 ## Show State
 
@@ -103,32 +49,7 @@ Show State has three display modes:
 
 When the state entity is active, Icon mode highlights the card. Numeric mode highlights the card when the live value is greater than zero, which is useful for counters and count-based indicators. If the state entity is unavailable, the card keeps its normal appearance and clears or falls back from the live state display until Home Assistant reports a usable value again.
 
-## How It Works on the Panel
-
-When you tap an Action card:
-
-- The card briefly flashes the highlight colour.
-- The selected Home Assistant action is sent with the configured entity. Run Script cards with **Confirmation Required** ask first.
-- Local Action cards run the registered callback on the panel itself.
-- If **Show State** is off, the card does not stay highlighted.
-- If **Show State** is on, the card display follows the state entity you chose.
-
-## When to Use a Scene or Script
-
-If you want a shortcut that does several things, create a scene or script in Home Assistant first, then point the Action card at that scene or script. This keeps the panel setup simple and makes the behaviour easier to test inside Home Assistant.
-
-Use a script for locks that require a PIN or code. EspControl does not store lock codes on the panel.
-
-Use an [Action](/card-types/actions) card when the panel should directly run something that already exists in Home Assistant, or when it should run a registered local panel action. Use a [Webhook](/card-types/webhooks) card when the panel should call a URL directly without Home Assistant. Use a [Trigger](/card-types/buttons) card when you want the panel to fire a custom event that a Home Assistant automation responds to.
-
-Use the dedicated card types for richer controls:
-
-- Use [Cover](/card-types/covers) for blinds, shutters, and covers.
-- Use [Lock](/card-types/locks) for locking and unlocking doors.
-- Use [Lights](/card-types/lights) for light switching, brightness, and colour temperature.
-- Use [Media](/card-types/media) for media player playback, volume, and now-playing controls.
-- Use [Climate](/card-types/climate) for thermostat and HVAC controls.
-- Use [Vacuum](/card-types/vacuum) for robot vacuum status and cleaning controls.
+The card flashes when pressed. Home Assistant actions use the entity you selected; Local Actions run on the panel. Use the dedicated card types for richer controls such as lights, covers, media, climate, locks, and vacuums.
 
 ::: info Requires Home Assistant actions
 Home Assistant-backed Action cards send Home Assistant actions from the panel. If tapping one of those cards does nothing, check [Enable Actions](/getting-started/home-assistant-actions). Local Action mode runs on the panel and does not need Home Assistant.

--- a/docs/card-types/alarms.md
+++ b/docs/card-types/alarms.md
@@ -65,25 +65,7 @@ Use the PIN settings to match how you want the wall panel to behave:
 
 ## Entry and Exit Delays
 
-If Home Assistant reports an alarm arming delay or pending entry delay, the panel shows the delay state in the alarm screen with a countdown timer. A progress bar under the timer gives a quick visual indication of how much delay time is left before the alarm changes state.
-
-The delay display follows the alarm entity updates from Home Assistant, so it works whether Home Assistant sends the total delay once or keeps sending updated remaining-time values during the countdown.
-
-### Alarm Audio
-
-The **ESP32-P4 86 Panel** can also provide audible entry and exit delay feedback. This is off by default, so updating does not make an existing alarm setup start sounding unexpectedly.
-
-Open **Settings → Alarm Audio** to configure:
-
-- **Alarm Delay Audio** — enables all alarm delay sounds.
-- **TTS Announcements** — speaks the configured entry or exit message through the panel using its Home Assistant Assist voice pipeline when Voice Services are enabled. No separate Home Assistant automation is required. Beeping waits briefly for that announcement and starts after it finishes.
-- **Entry Announcement** and **Exit Announcement** — the message spoken at the start of each delay.
-- **Beep Volume** — the local warning-beep volume.
-- **Faster Beeps During Final Seconds** — changes the final countdown period; the default is 10 seconds.
-
-The exit delay uses a lower single tone, while the entry delay uses a higher double tone. The tones are generated locally and sent directly to the panel's audio mixer, avoiding a fresh media-decoder startup for every beep. Beeps repeat every second and change to every 700 ms during the final countdown. They stop when the countdown reaches zero or the alarm leaves `arming`/`pending`, including when it is disarmed, armed, triggered, or unavailable. TTS is skipped silently when Voice Services are off; local beeps continue.
-
-Firmware compile checks confirm that the speaker panel and non-speaker panels build safely, but they cannot prove sound level, tone clarity, or media restoration. After installing the test firmware on an ESP32-P4 86 Panel, physically check both alarm delays, the faster final countdown, immediate stopping after disarm, Voice Services off, and normal media playback after the alarm clears.
+When Home Assistant reports an arming or entry delay, All Controls shows a countdown and progress bar. On the **ESP32-P4 86 Panel**, optional delay sounds are available under **Settings → Alarm Audio**. They are off by default.
 
 ## How It Works on the Panel
 

--- a/docs/card-types/index.md
+++ b/docs/card-types/index.md
@@ -24,7 +24,7 @@ Use this page when you know what you want the panel to do but are not sure which
 | Call an HTTP URL directly from the panel | [Webhook](/card-types/webhooks) | URL |
 | Show a live number, readable duration, text state, or active/inactive icon | [Sensor](/card-types/sensors) | Home Assistant `sensor`, `binary_sensor`, or `text_sensor`; or a Local Sensor source |
 | Show a door or window contact sensor | [Doors & Windows](/card-types/doors-windows) | `binary_sensor` or `sensor` |
-| Show presence, motion, person, or tracker state | [Presence](/card-types/presence) | `binary_sensor`, `sensor`, `text_sensor`, `person`, or tracker helpers |
+| Show presence, motion, or occupancy state | [Presence](/card-types/presence) | `binary_sensor`, `sensor`, or `text_sensor` |
 | Drag to set light brightness or fan speed | [Slider](/card-types/sliders) | `light` or `fan` |
 | Use grouped fan controls | [Fans](/card-types/fans) | `fan` |
 | Control blinds, shutters, shades, gates, position, or tilt | [Cover](/card-types/covers) | `cover` |
@@ -63,14 +63,16 @@ Some names in the setup page group several related modes:
 |---|---|
 | **Lights** | All Controls, Switch, Brightness, Colour Temperature |
 | **Fans** | All Controls, Switch, Speed, Oscillation, Direction, Preset |
-| **Action** | Scene, Script, Automation, Button, Helper, Option Select, Local Action |
+| **Action** | Scene, Script, Automation, Button, Input Button, Toggle Helper, Set Number Helper, Option Select, Local Action |
 | **Vacuum** | Status, Start / Stop, Dock, Pause / Resume, Spot Clean, Locate, Clean Area |
 | **Lawn Mower** | Status, Start Mowing, Dock, Pause / Resume |
 | **Alarm** | All Controls, Arm Away, Arm Home, Arm Night, Arm Vacation, Disarm |
 | **Date & Time** | Clock, Date, Time & Date, World Clock |
-| **Media** | Play/Pause, Previous, Next, Volume, Track Position, Now Playing |
+| **Media** | All Controls, Speaker Group, Play/Pause, Previous, Next, Volume, Track Position, Now Playing, Cover Art, Media Content |
 | **Cover** | All Controls, Position, Tilt, Toggle, Open, Close, Stop, Set Position |
 | **Subpage** | Generic, Switch, Lights, Climate, Presence, Media, Alarm, Cover, Garage Door, Gate, Lock, Vacuum, Lawn Mower, Weather, Sensor, Camera / Image |
+
+Older configurations may also show **Weather Forecast**. It is kept for compatibility and is now set up as a **Weather** card with **Temperatures Tomorrow** selected.
 
 ## Permissions
 

--- a/docs/card-types/local-actions.md
+++ b/docs/card-types/local-actions.md
@@ -1,22 +1,16 @@
 ---
 title: Local Action Cards
 description:
-  How to trigger custom on-device callbacks directly from EspControl cards without going through Home Assistant.
+  How to trigger custom on-device callbacks directly from EspControl cards without Home Assistant.
 ---
 
 # Local Action
 
-A local action card calls a callback registered directly on the device when tapped. The action runs immediately on the ESP32 — no Home Assistant involved, no network round-trip.
+Local Action is an **Action** card mode that runs a callback on the ESP32. It works without Home Assistant, which is useful for IR, GPIO, UART, or other device-level jobs.
 
-Local action cards are useful for anything that needs to run at the device level: pulsing GPIO pins, transmitting IR codes, sending UART commands, or calling any custom ESPHome component.
+## Register the Action
 
-::: tip Works without Home Assistant
-Because the action runs on the device itself, local action cards work even when Home Assistant is offline or unreachable.
-:::
-
-## Registering Actions on the Device
-
-Local actions are registered in your device's `on_boot` lambda using `register_local_action()`. The key must be unique per device and is used to match the card to the callback.
+Add a unique key, label, and callback to the device's `on_boot` lambda:
 
 ```yaml
 esphome:
@@ -25,64 +19,17 @@ esphome:
       then:
         - lambda: |-
             register_local_action(
-              "tv_off",
-              "TV Off",
+              "tv_off", "TV Off",
               [=]() { id(ir_blaster).transmit_nec(0x04FB, 0x08F7); }
             );
 ```
 
-You can register as many actions as you need:
-
-```yaml
-        - lambda: |-
-            register_local_action(
-              "tv_off",      "TV Off",      [=]() { id(ir_blaster).transmit_nec(0x04FB, 0x08F7); });
-            register_local_action(
-              "tv_vol_up",   "Volume Up",   [=]() { id(ir_blaster).transmit_nec(0x04FB, 0x58A7); });
-            register_local_action(
-              "unlock_door", "Unlock Door", [=]() { id(door_relay).turn_on(); });
-```
-
-## Setting Up a Local Action
+## Add the Card
 
 1. Select a card and change its type to **Action**.
-2. In the **Action** dropdown, choose **Local Action**.
-3. The web UI queries the device for registered actions and shows a dropdown.
-4. Choose an action — the **Label** field is auto-filled from the registered label and can be edited.
-5. Choose an **Icon** (defaults to a tap gesture icon).
+2. Choose **Local Action**.
+3. Pick the registered action and choose an icon.
 
-### When the device is unreachable
+When the setup page can reach the panel, it lists registered actions. Otherwise enter the action key exactly as registered. Tapping the card flashes it briefly and runs the callback; a missing key is logged and does nothing.
 
-If the web UI can't reach the device, it shows an error banner and falls back to a manual **Action Key** text field. Enter the key exactly as it appears in your `register_local_action()` call.
-
-### When no actions are registered
-
-If the device is reachable but has no registered actions, the panel shows a message prompting you to add `register_local_action()` calls to your device config.
-
-## How It Works on the Panel
-
-When you tap a local action card:
-
-- The card flashes the highlight colour and fades back, the same visual behaviour as a Trigger card.
-- The registered callback runs immediately on the device.
-- If no action is registered for the key, a warning is logged and nothing else happens.
-
-## Action Key Tips
-
-- Keys are case-sensitive strings matched at runtime — `tv_off` and `TV_Off` are different keys.
-- If a card's key doesn't match any registered action, the device logs a warning but does not crash.
-- You can re-register an action with the same key to replace it — the latest registration wins.
-
-## Example Use Cases
-
-| Action Key | What it does |
-|---|---|
-| `tv_off` | IR blaster command to turn off a TV |
-| `unlock_door` | Pulse a GPIO relay to trigger a door latch |
-| `projector_on` | UART command to a projector or AV receiver |
-| `wake_pc` | Wake-on-LAN magic packet to a computer |
-| `night_mode` | Run an ESPHome script that sets multiple things at once |
-
-## When to Use It
-
-Use Local Action mode when the action is handled entirely by the device and does not need Home Assistant. Use [Trigger](/card-types/buttons) cards when you want Home Assistant to react to the button press, or another [Action](/card-types/actions) mode when you want to call a Home Assistant service directly.
+Use [Trigger](/card-types/buttons) when Home Assistant should react to the tap, or another [Action](/card-types/actions) mode to run a Home Assistant action.

--- a/docs/card-types/local-sensors.md
+++ b/docs/card-types/local-sensors.md
@@ -1,91 +1,22 @@
 ---
 title: Local Sensor Cards
 description:
-  How to display live sensor readings directly from the ESP32 on EspControl cards without going through Home Assistant.
+  How to display readings from ESPHome sensors on the panel itself.
 ---
 
 # Local Sensor
 
-A local sensor card displays the value of any sensor component running on the device itself. It has two modes:
+Local Sensor is a **Sensor** card source for a sensor or text sensor running on the display device. It is read-only and continues to work while Home Assistant is unavailable.
 
-- **Numeric** — shows a large number with an optional unit and label. This is the default mode.
-- **Text** — shows a chosen icon and displays the live text state where a normal card label would appear.
+## Set Up a Local Sensor
 
-Local sensor cards are read-only — tapping them does nothing.
+1. Define the sensor normally in the device's ESPHome YAML.
+2. Select a card, change its type to **Sensor**, then set **Source** to **Local Sensor**.
+3. Choose the sensor. The label and unit are filled in for you and can be changed.
+4. Choose **Numeric** for a value or **Text** for a live text state.
 
-::: tip Works without Home Assistant
-Because the value comes from the device itself, local sensor cards update and display correctly even when Home Assistant is offline or unreachable.
-:::
+The picker normally shows your own sensors. Turn on **Show internal sensors** to include diagnostics such as Wi-Fi signal strength. If the setup page cannot reach the panel, enter the ESPHome sensor `object_id` as the **Sensor Key**.
 
-## Setting Up a Local Sensor Card
+The card updates at the sensor's normal ESPHome update rate. It shows `--` until the first reading arrives.
 
-No firmware changes are needed. Define your sensors in your ESPHome YAML as normal — EspControl discovers them automatically.
-
-1. Select a card and change its type to **Sensor**.
-2. Change **Source** from **Home Assistant** to **Local Sensor**.
-3. Open the **Local Sensor** dropdown — the device is queried for its available sensors.
-4. Select the sensor you want to display. The **Label** and **Unit** fields auto-fill from the sensor's name and unit of measurement. You can edit them freely.
-5. Choose **Numeric** or **Text** mode. This is set automatically based on the sensor type but can be changed.
-
-For **Numeric** mode:
-
-1. Edit **Label** if you want different text under the value.
-2. Edit **Unit** to change the unit label shown next to the value.
-3. Set **Unit Precision** if you want one or two decimal places.
-
-For **Text** mode:
-
-1. Choose an **Icon**. This icon is always shown and does not change based on the sensor value.
-2. The live state is shown where a Switch card label would normally appear.
-
-### Internal Sensors
-
-By default the dropdown shows only your own sensors. Check **Show internal sensors** to also see diagnostic sensors such as WiFi signal strength, uptime, and temperature calibration values.
-
-### Device Unreachable
-
-If the web UI cannot reach the device while you are configuring a card, a manual **Sensor Key** text field appears as a fallback. Enter the ESPHome `object_id` of the sensor (the lowercase, underscore-separated form of its name).
-
-## How It Works on the Panel
-
-- The device subscribes directly to the sensor's value updates — the display refreshes automatically whenever the sensor reports a new reading.
-- The refresh rate is controlled by the sensor's own `update_interval` in your ESPHome YAML.
-- Before the first value is received (for example, immediately after boot), the card shows `--`.
-- Numeric mode uses the fixed **tertiary** background colour, so it remains visually distinct from Switch and Trigger cards.
-- Text mode uses the same tertiary colour while keeping the normal Switch-style icon and label layout.
-
-## Example Sensors
-
-| Sensor | Mode | Unit | What it shows |
-|---|---|---|---|
-| DHT22 temperature | Numeric | `°C` | Ambient temperature |
-| DHT22 humidity | Numeric | `%` | Relative humidity |
-| SCD40 CO₂ | Numeric | `ppm` | CO₂ concentration |
-| BH1750 illuminance | Numeric | `lx` | Light level |
-| Template text sensor | Text | | `Open`, `Closed`, or `Ajar` |
-
-## Advanced: Pushing Values Manually
-
-For values that are not ESPHome sensor entities — computed results, aggregations, or readings you do not want to expose as entities — you can push updates directly using `send_local_sensor_update()` in an `on_value:` lambda. The sensor key must match the value entered in the **Sensor Key** field (manual fallback mode).
-
-```yaml
-sensor:
-  - platform: adc
-    pin: GPIO34
-    on_value:
-      then:
-        - lambda: send_local_sensor_update("raw_voltage", x);
-
-text_sensor:
-  - platform: template
-    lambda: |-
-      if (id(door_contact).state) return {"Open"};
-      return {"Closed"};
-    on_value:
-      then:
-        - lambda: send_local_sensor_update("door_state", x.c_str());
-```
-
-## When to Use It
-
-Use the **Local Sensor** source when the sensor is part of the device's ESPHome config and you want to display its value without relying on Home Assistant. Use the default **Home Assistant** source when the data is already in Home Assistant and you want to pull it from there.
+For values already in Home Assistant, keep the standard [Sensor](/card-types/sensors) source instead.

--- a/docs/card-types/media.md
+++ b/docs/card-types/media.md
@@ -1,356 +1,47 @@
 ---
 title: Media Cards
 description:
-  How to use media cards on your EspControl panel to control Home Assistant media player entities.
+  How to use media cards on your EspControl panel to control Home Assistant media players.
 ---
 
 # Media
 
-A Media card controls a Home Assistant `media_player` entity. It can work as a simple playback button, a volume control, a track position control, a now-playing display, or a cover-art tile.
+A Media card controls a Home Assistant `media_player`. Choose a small one-job card, or use **All Controls** for the main playback screen.
 
 ![Wide media card showing now-playing title and artist](/images/card-media.png)
 
-## Setting Up a Media Card
+## Set Up a Media Card
 
 1. Select a card and change its type to **Media**.
-2. Choose the media **Type**:
-   - **All Controls**
-   - **Speaker Group**
-   - **Play/Pause Button**
-   - **Previous Button**
-   - **Next Button**
-   - **Volume Button**
-   - **Track Position**
-   - **Now Playing**
-   - **Cover Art**
-   - **Media Content**
-3. Enter the media player entity, for example `media_player.living_room`.
-4. Set a label or icon if the selected type shows those fields.
+2. Choose a **Type** and enter the player entity, such as `media_player.living_room`.
+3. Set a label or icon where the chosen type offers one.
 
-If Home Assistant reports the media player as unavailable, the card keeps its normal appearance. A card set to show the live state can still say **Unavailable**, and controls will work again when Home Assistant can accept actions for the player.
+| Type | Best for |
+|---|---|
+| **All Controls** | Playback, volume, progress, and any supported power or speaker controls in one popup. |
+| **Play/Pause**, **Previous**, **Next** | A simple playback shortcut. |
+| **Volume** | Opening a volume control. **Maximum Volume** can cap the level. |
+| **Track Position** | Seeing and, where supported, seeking through the current item. |
+| **Now Playing** | Showing title and artist, with optional progress or play/pause. |
+| **Cover Art** | Showing current artwork; tapping it opens All Controls. |
+| **Speaker Group** | Opening the speaker-group screen directly. |
+| **Media Content** | Playing a saved playlist, source, URL, or other media content. |
 
-## Playback Buttons
+## What to Expect
 
-**Play/Pause Button**, **Previous Button**, and **Next Button** send the matching Home Assistant media player action when tapped.
-
-For Play/Pause, you can choose whether the card shows its fixed label or the live state, such as **Playing** or **Paused**.
-
-## Volume Button
-
-The Volume Button shows the current volume percentage. Tapping it opens a volume control popup on the panel, where you can adjust the volume without leaving the current page.
-
-For media players that support setting an exact volume, the popup dial is draggable. Some integrations, including Android TV Remote, only support volume-up and volume-down commands. For those players, the dial remains a live volume indicator and the **−** and **+** buttons adjust the volume one device-defined step at a time.
-
-Set **Maximum Volume** to cap the panel control below 100%. The popup dial rescales to that maximum, so a 40% cap makes 40% the end of the arc.
-
-For step-only players, the maximum is best-effort because the device decides the size of each volume step. EspControl disables further volume-up commands once Home Assistant reports that the configured maximum has been reached.
-
-The card watches the media player's `volume_level` attribute, so it also updates when volume changes elsewhere.
-
-## Track Position
-
-Track Position shows playback progress and elapsed time.
-
-- Drag the progress bar to seek within the current track.
-- The card uses Home Assistant's `media_duration`, `media_position`, and `media_position_updated_at` attributes when they are available.
-- You can show a fixed label or the live playback state.
-
-Seeking depends on the media player integration. Some players expose progress but do not support seeking.
-
-## Now Playing
-
-Now Playing shows the media title and artist from Home Assistant. For TV or Line-in sources that do not provide artist data, the artist line shows **Source** instead of reusing the previous track's artist.
-
-You can choose optional controls:
-
-- **None** shows only the current title and artist.
-- **Track Position** adds a progress background and lets you seek.
-- **Play/Pause** makes the card tappable so it toggles playback.
-
-Now Playing works best on wider or larger cards because it has more room for track text.
+- Playback buttons send the matching Home Assistant media action.
+- Volume and track position follow changes made elsewhere in Home Assistant. Some players show progress but do not support seeking; some only support volume up and down rather than an exact level.
+- All Controls hides tabs that the selected player does not support. Its speaker tab appears only when compatible speakers are available.
+- For **Media Content**, choose the speaker, then provide the content ID or URI. You can also set the player source or input when the integration uses one.
 
 ## Cover Art
 
-Cover Art shows the current artwork reported by the selected media player. Choose a square card size: **1x1**, **2x2**, or **3x3**. EspControl crops the image to fill the tile without stretching it.
-
-If the main player is a soundbar or speaker that reports an external `TV`, `Line-in`, or `HDMI` source, you can set **External Source Media Entity** to the connected player, such as an Apple TV. While that external source is active, the card takes its artwork, track details, progress, and controls from the connected player. If the connected player is unavailable or has no current media, the card hides cached artwork and shows the main player's source instead. It switches back to the main player automatically for normal playback.
-
-Enable **Show Track Details** to place the current title and artist over the artwork. EspControl adds an artwork-derived dark tint so the text remains readable. If artwork is unavailable, the title and artist remain visible on the card's normal background. The setting is off by default, so existing Cover Art cards remain image-only.
-
-Tapping Cover Art always opens the full **All Controls** popup.
-
-Cover Art uses one of the display's shared image download slots. If all slots are already used by image or cover-art cards, remove one before adding another. Artwork availability and update speed depend on the media player integration and the `entity_picture` information it supplies to Home Assistant.
-
-## All Controls
-
-All Controls opens playback controls and volume in a popup. The parent card uses the play/pause icon, and can show either its fixed label or the current media player state. Its top-left area can show either the icon or the current volume number.
-
-When the main player reports Home Assistant's grouping capability and speaker discovery returns at least one valid player, All Controls includes a fourth **Speakers** tab. By default, EspControl reads the compatible-speaker inventory from `sensor.speaker_group`. If that sensor is missing or empty, the tab stays hidden instead of showing an unusable list.
-
-When Home Assistant reports that the media player supports both power-on and power-off actions, the popup also includes a Power tab. Media players without both capabilities do not show the tab.
+Cover Art is available in square **1×1**, **2×2**, and **3×3** card sizes. It uses one of the panel's shared image slots. ESP32-P4 screens have six slots shared between Camera and Cover Art cards across all pages. If the card shows **Too many**, remove one of those image cards.
 
 ## Speaker Groups
 
-Speaker Group opens the speaker panel directly, without the playback, progress, and single-player volume tabs. It lets you join and unjoin compatible speakers and control the volume of speakers that are currently grouped.
-
-### Before You Start
-
-Speaker grouping needs at least two speakers from a platform that supports Home Assistant's `media_player.join` and `media_player.unjoin` actions. Common compatible platforms include Sonos, Google Cast, HEOS, Yamaha MusicCast, LinkPlay, Bluesound, and Bang & Olufsen. Music Assistant may also work, depending on the player provider.
-
-First, try joining the same speakers in Home Assistant. Home Assistant can reject a request to join speakers from different platforms, such as a Sonos speaker and a Google Cast speaker.
-
-The panel must also be allowed to run `media_player.join`, `media_player.unjoin`, and `media_player.volume_set`; see [Enable Actions](/getting-started/home-assistant-actions).
-
-### Create the Speaker Discovery Sensor
-
-EspControl needs a Home Assistant template sensor that supplies the list of speakers, their names, availability, and current volumes. Add one of the templates below to `configuration.yaml`, then restart Home Assistant so it can load the new template.
-
-#### Standard Integrations
-
-Use this for Sonos, Google Cast, HEOS, Yamaha MusicCast, LinkPlay, Bluesound, Bang & Olufsen, and similar integrations. Replace both instances of `sonos` with the integration name for your speakers. For example, Google Cast uses `cast` and HEOS uses `heos`.
-
-```yaml
-template:
-  - sensor:
-      - name: "Speaker Group"
-        unique_id: speaker_group
-        state: >
-          {%- set s = integration_entities("sonos") | select("match", "media_player") | list -%}
-          {{ s | count }}
-        attributes:
-          data: >
-            {%- set s = integration_entities("sonos") | select("match", "media_player") | list -%}
-            {%- set ns = namespace(items=[]) -%}
-            {%- for entity_id in s -%}
-              {%- set available = states(entity_id) not in ["unknown", "unavailable"] -%}
-              {%- set ns.items = ns.items + [[entity_id, state_attr(entity_id, "friendly_name") or entity_id, state_attr(entity_id, "volume_level"), available]] -%}
-            {%- endfor -%}
-            v2|{{ ns.items | to_json }}
-```
-
-#### Music Assistant 2.8 and Later
-
-Music Assistant 2.8 combines players that support multiple protocols into one entity. Use this template to list its media players. Only include players that can be grouped together; remove providers or entities that your Music Assistant setup cannot join.
-
-```yaml
-template:
-  - sensor:
-      - name: "Speaker Group"
-        unique_id: speaker_group
-        state: >
-          {%- set s = integration_entities("music_assistant") | select("match", "media_player") | list -%}
-          {{ s | count }}
-        attributes:
-          data: >
-            {%- set s = integration_entities("music_assistant") | select("match", "media_player") | list -%}
-            {%- set ns = namespace(items=[]) -%}
-            {%- for entity_id in s -%}
-              {%- set available = states(entity_id) not in ["unknown", "unavailable"] -%}
-              {%- set ns.items = ns.items + [[entity_id, state_attr(entity_id, "friendly_name") or entity_id, state_attr(entity_id, "volume_level"), available]] -%}
-            {%- endfor -%}
-            v2|{{ ns.items | to_json }}
-```
-
-#### Music Assistant 2.7 and Earlier
-
-Older Music Assistant versions can expose group and sync-group entities as well as individual speakers. This version excludes those virtual group entities so the panel shows only physical players.
-
-```yaml
-template:
-  - sensor:
-      - name: "Speaker Group"
-        unique_id: speaker_group
-        state: >
-          {%- set s = integration_entities("music_assistant")
-              | select("match", "media_player")
-              | reject("is_state_attr", "mass_player_type", "group")
-              | reject("is_state_attr", "mass_player_type", "sync_group")
-              | list -%}
-          {{ s | count }}
-        attributes:
-          data: >
-            {%- set s = integration_entities("music_assistant")
-                | select("match", "media_player")
-                | reject("is_state_attr", "mass_player_type", "group")
-                | reject("is_state_attr", "mass_player_type", "sync_group")
-                | list -%}
-            {%- set ns = namespace(items=[]) -%}
-            {%- for entity_id in s -%}
-              {%- set available = states(entity_id) not in ["unknown", "unavailable"] -%}
-              {%- set ns.items = ns.items + [[entity_id, state_attr(entity_id, "friendly_name") or entity_id, state_attr(entity_id, "volume_level"), available]] -%}
-            {%- endfor -%}
-            v2|{{ ns.items | to_json }}
-```
-
-### Verify the Sensor
-
-After Home Assistant restarts, open **Developer Tools** > **States** and search for `sensor.speaker_group`. Its state should be the number of speakers found, and its `data` attribute should list the speaker names. If it is missing, check the YAML indentation. If its state is `0`, check that the integration name matches Home Assistant and that it has `media_player` entities.
-
-The versioned JSON format above is recommended because speaker names can safely contain commas and it reports availability explicitly. The earlier comma-separated ESPHome Media Player format remains supported for existing installations.
-
-### Add the Card in EspControl
-
-1. Select a card and change its type to **Media**.
-2. Choose **Speaker Group** as the media type.
-3. Enter the main speaker entity, for example `media_player.living_room`.
-4. Leave **Speaker Discovery Entity** empty to use `sensor.speaker_group`, or enter a different discovery sensor if you created one.
-5. Save the card.
-
-You can also use **All Controls**. When the selected player supports grouping and the discovery sensor has speakers, its popup includes a **Speakers** tab.
-
-The main speaker is always selected. Selecting another speaker sends `media_player.join` with the complete selected group; clearing one sends `media_player.unjoin` to that speaker. A row shows a pending state while Home Assistant handles the request. If an integration rejects an incompatible request, the selection is restored and the panel shows an error.
-
-The optional **Speaker Discovery Entity** card setting can point to another compatible discovery sensor. A Home Assistant media-player Group helper can provide a manually maintained list for joining and removing speakers, but it exposes only entity IDs. Group and per-speaker volume controls therefore require the discovery sensor format above, which also supplies each member's volume.
-
-### Group and Individual Volume
-
-Individual volume controls appear only for speakers in a multi-speaker group. While grouped, the main Volume tab shows **Group** and its arc represents the arithmetic mean of the available members' current levels. Moving it applies the same difference to each speaker instead of making every speaker equally loud.
-
-For example, `10%`, `25%`, and `40%` has a group level of `25%`. Moving Group Volume to `35%` sends `20%`, `35%`, and `50%`. Each result is limited to `0%` and the card's **Maximum Volume** setting. Group Volume remains disabled until every available member has reported a volume, which avoids losing the existing balance.
-
-### Troubleshooting and Device Testing
-
-- If the **Speakers** tab does not appear, check that `sensor.speaker_group` exists and its `data` attribute is not empty.
-- If a speaker does not appear, make sure it is a `media_player` from the integration named in the template and is not unavailable.
-- If adding a speaker fails, try the same join in Home Assistant first. The speakers may not be compatible, or the integration may not support grouping.
-- If the panel can show speakers but cannot change them, check the panel's Home Assistant action permissions.
-- If volume controls are missing, join at least one other speaker and check that each group member reports a `volume_level` value.
-- Change membership and volume in Home Assistant and confirm the panel updates.
-- Reconnect or restart a speaker and confirm its state returns without reopening the card.
-
-## Media Content
-
-Media Content is a shortcut for anything Home Assistant can play with the `media_player.play_media` action. It is not tied to Spotify, Music Assistant, Plex, Jellyfin, Sonos, or any other specific music system.
-
-Use it for playlists, radio stations, albums, saved favorites, channels, podcasts, or other playable media items.
-
-Enter:
-
-- **Speaker Entity** - the Home Assistant `media_player` that should play the media, for example `media_player.living_room`.
-- **Source** - choose the source preset, such as **Spotify**, **Apple Music**, **YouTube Music**, **Plex**, **Jellyfin**, **Home Assistant Media Source**, or **Custom / full URI**.
-- **Media Type** - choose the type Home Assistant expects, such as `playlist`, `music`, `album`, `track`, or `channel`. Use **Custom** if your integration needs a different value.
-- **ID** - enter only the playlist, station, album, track, or favorite ID when using a source preset. Use **Custom / full URI** if your integration needs the full media content ID exactly as Home Assistant shows it.
-- **Label** - the name shown on the button, for example `Morning Playlist`.
-- **Icon** - the icon shown on the button.
-
-EspControl sends the media content type as `playlist` automatically. The important part is that the media content ID works in Home Assistant first.
-
-When Home Assistant reports the currently playing `media_content_id`, the Playlist Button highlights only while that configured playlist or media item is playing. Some integrations do not report this value reliably; in that case EspControl can start the playlist, but it may not be able to confirm that the specific playlist is active.
-
-### Find the Media Content ID
-
-The easiest way is to test the media item in Home Assistant first, then copy the working values into EspControl.
-
-1. In Home Assistant, open **Media** from the sidebar.
-2. Browse to the playlist, station, album, or favorite you want to play.
-3. Play it once from Home Assistant to confirm the speaker and media source work.
-4. Open **Developer Tools**.
-5. Open the **Actions** tab.
-6. Choose the action **Media player: Play media**.
-7. Select the same speaker entity you want EspControl to use.
-8. Enter the media content ID you want to test and use `playlist` as the media content type.
-9. Press **Perform action**.
-10. If the speaker starts the right media, copy those same values into EspControl.
-
-The YAML view in Home Assistant will look similar to this:
-
-```yaml
-action: media_player.play_media
-target:
-  entity_id: media_player.living_room
-data:
-  media_content_id: "spotify:playlist:1LG2Lnt9EDQS1DqoE8E2uO"
-  media_content_type: "playlist"
-```
-
-In EspControl, that becomes:
-
-| Home Assistant value | EspControl field |
-| --- | --- |
-| `entity_id: media_player.living_room` | **Speaker Entity** |
-| `media_content_id: "spotify:playlist:1LG2Lnt9EDQS1DqoE8E2uO"` | **Source:** Spotify, **Media Type:** Playlist, **ID:** `1LG2Lnt9EDQS1DqoE8E2uO` |
-| `media_content_type: "playlist"` | **Media Type:** Playlist |
-
-If the value does not match one of the source presets, choose **Custom / full URI** and paste the full `media_content_id` into **ID**.
-
-### If You Do Not Know the ID Format
-
-Different Home Assistant integrations use different ID formats. There is no single format that works for every music system.
-
-Common examples look like this:
-
-| System or source | Source | ID | Media Type |
-| --- | --- | --- | --- |
-| Spotify playlist | Spotify | `1LG2Lnt9EDQS1DqoE8E2uO` | `playlist` |
-| Spotify track | Spotify | `0KIhLAkHfL9fvgn0yy1qsU` | `music` or `track` |
-| Home Assistant media source | Home Assistant Media Source | `media_source/local/Morning.mp3` | `music` |
-| Integration favorite | Custom / full URI | `favorite_id_or_uri` | often `music`, `playlist`, or `favorite` |
-
-These examples are starting points only. The value that matters is the one your Home Assistant integration accepts when you test `media_player.play_media`.
-
-### Using a Shared Playlist URL
-
-Many music services give you a web sharing URL. EspControl usually needs the media ID or URI, not the full website URL.
-
-For example, this Spotify playlist URL:
-
-```text
-https://open.spotify.com/playlist/1LG2Lnt9EDQS1DqoE8E2uO?si=1Jho2boIRDGE4PQ9Q0COXA
-```
-
-contains this playlist ID:
-
-```text
-1LG2Lnt9EDQS1DqoE8E2uO
-```
-
-For Spotify, the Home Assistant media content ID is commonly:
-
-```text
-spotify:playlist:1LG2Lnt9EDQS1DqoE8E2uO
-```
-
-In EspControl, choose **Spotify**, choose **Playlist**, and paste only this ID into **ID**:
-
-```text
-1LG2Lnt9EDQS1DqoE8E2uO
-```
-
-The same idea applies to other services: copy the playlist, album, station, or favorite ID from the shared URL, then turn it into the URI format your Home Assistant integration expects.
-
-Examples:
-
-| Shared link or ID | Source | Media Type | ID |
-| --- | --- | --- | --- |
-| `https://open.spotify.com/playlist/1LG2Lnt9EDQS1DqoE8E2uO?si=...` | Spotify | Playlist | `1LG2Lnt9EDQS1DqoE8E2uO` |
-| `https://open.spotify.com/track/0KIhLAkHfL9fvgn0yy1qsU?si=...` | Spotify | Track | `0KIhLAkHfL9fvgn0yy1qsU` |
-
-Always test the result in Home Assistant first:
-
-```yaml
-action: media_player.play_media
-target:
-  entity_id: media_player.living_room
-data:
-  media_content_id: "spotify:playlist:1LG2Lnt9EDQS1DqoE8E2uO"
-  media_content_type: "playlist"
-```
-
-If the Home Assistant test starts the right playlist, use the same `media_content_id` in EspControl.
-
-### Troubleshooting
-
-If tapping the Media Content button does not start playback:
-
-- Make sure the button has an **ID**. EspControl requires this before saving.
-- Test the same values with `media_player.play_media` in Home Assistant.
-- Check that the selected **Speaker Entity** can play that source from Home Assistant.
-- Try a different **Media Type**. Some integrations use `playlist`, while others use `music`, `album`, `track`, `channel`, or a custom value.
-- If your integration gives you a full sharing URL, convert it to the ID or URI format that Home Assistant expects.
-- If the preset source builds the wrong value for your integration, choose **Custom / full URI** and paste the exact `media_content_id` that works in Home Assistant.
-- If the button starts the playlist but does not stay highlighted, check whether the media player entity reports a matching `media_content_id` while playing.
-- If the speaker needs repeat or shuffle, create a Home Assistant script that sets those options and starts playback, then trigger that script from an EspControl Action card.
+For speaker groups, first confirm the speakers can join in Home Assistant. EspControl uses the compatible-player list supplied by the configured discovery entity; by default this is `sensor.speaker_group`. The group screen stays hidden when no usable speakers are reported.
 
 ::: info Requires Home Assistant actions
-Media cards send Home Assistant actions from the panel. If tapping a card does nothing, check [Enable Actions](/getting-started/home-assistant-actions).
+Media cards send Home Assistant actions. If a control does not respond, check [Enable Actions](/getting-started/home-assistant-actions).
 :::

--- a/docs/card-types/presence.md
+++ b/docs/card-types/presence.md
@@ -1,12 +1,12 @@
 ---
 title: Presence Cards
 description:
-  How to show person, room, motion, or presence sensors on your EspControl panel.
+  How to show room, motion, or occupancy sensors on your EspControl panel.
 ---
 
 # Presence
 
-A Presence card is a read-only card for showing whether someone or something is detected. It is useful for room presence sensors, motion sensors, people, device trackers, or template sensors that represent occupancy.
+A Presence card is a read-only card for showing whether someone or something is detected. It is useful for room presence sensors, motion sensors, and template sensors that represent occupancy.
 
 ## Setting Up a Presence Card
 
@@ -28,6 +28,5 @@ A Presence card is a read-only card for showing whether someone or something is 
 | Entity | What it shows |
 |---|---|
 | `binary_sensor.living_room_presence` | Room presence from a mmWave or motion sensor |
-| `person.jane` | Whether a person is home |
-| `device_tracker.phone` | Whether a tracked device is home |
-| `input_boolean.guest_mode` | A manual helper that marks a room or mode as occupied |
+| `sensor.office_occupancy` | Occupancy reported by a room sensor |
+| `text_sensor.guest_room_status` | A text-based occupancy status |

--- a/docs/card-types/sensors.md
+++ b/docs/card-types/sensors.md
@@ -1,85 +1,40 @@
 ---
 title: Sensor Cards
 description:
-  How to display live numeric readings, durations, text states, or icon states from Home Assistant or local device sensors on your EspControl panel.
+  How to display live readings, durations, text, or icon states from Home Assistant on EspControl.
 ---
 
 # Sensor
 
-A sensor card displays live sensor data. By default it uses Home Assistant entities, and it can also use local sensors running directly on the display device.
-
-It has four Home Assistant types:
-
-- **Numeric** — shows a large number with an optional unit and label. This is the default mode.
-- **Time** — turns a numeric duration into compact text such as `36m`, `1h 30m`, or `1d 4h`.
-- **Text** — shows a chosen icon and displays the live text state where a normal card label would appear.
-- **Icon** — shows an icon and can change to an on icon when the sensor is active.
-
-Sensor cards are read-only — tapping them does nothing.
+A Sensor card is read-only. It displays a Home Assistant `sensor`, `binary_sensor`, or `text_sensor`; it can also use a [Local Sensor](/card-types/local-sensors) from the panel itself.
 
 ![Sensor card showing 0 kph wind speed](/images/card-sensor.png)
 
-## Setting Up a Sensor Card
+## Set Up a Sensor Card
 
 1. Select a card and change its type to **Sensor**.
-2. Leave **Source** set to **Home Assistant**. This is the default.
-3. Choose **Numeric**, **Time**, **Text**, or **Icon** from the **Type** dropdown. Numeric is selected by default.
-4. Enter a **Sensor Entity** — the Home Assistant entity ID of the sensor you want to display.
+2. Leave **Source** as **Home Assistant**, choose the display type, and enter the sensor entity.
+3. Set a label, unit, and icon as needed.
 
-To display a sensor that runs directly on the device, change **Source** to **Local Sensor**. See [Local Sensor](/card-types/local-sensors) for the local setup details.
+| Type | What it shows |
+|---|---|
+| **Numeric** | A live number, optional unit, and label. **Large Sensor Numbers** is available on Large cards. |
+| **Time** | A compact duration such as `36m` or `1h 30m`. Leave **Incoming Value Unit** on Auto unless the entity does not report a usable unit. |
+| **Text** | The live state beside a chosen icon. Advanced settings can replace up to two raw states with friendlier text. |
+| **Icon** | A normal and optional active icon for a status-style sensor. |
 
-For **Icon** mode:
+Choose **Lit When Active** when an active status should use the on colour. It is not available for Time cards. Numeric cards treat values above zero as active; Text and Icon cards follow recognised Home Assistant active states.
 
-1. Choose an **Icon** for the normal state.
-2. Choose an **On Icon** if you want a different icon when the sensor is active.
-3. Set a **Label** if you want custom text. If left blank, the entity name from Home Assistant is used.
+## Useful Details
 
-For **Numeric** mode:
+- A Time card needs a value in days, hours, minutes, seconds, milliseconds, or microseconds. You can select the unit manually when Auto cannot identify it.
+- Unknown, unavailable, or invalid values are left blank rather than guessed.
+- Changes made in Home Assistant update the panel automatically.
+- To show a device-local sensor, change **Source** to **Local Sensor** and follow the [Local Sensor](/card-types/local-sensors) setup.
 
-1. Set a **Unit** — the unit label shown next to the value, for example `°C`, `%`, `W`, or `kWh`.
-2. Set a **Label** if you want custom text under the value. If left blank, the entity name from Home Assistant is used.
-3. Set **Unit Precision** if you want one or two decimal places.
-4. On a **Large** card, turn on **Large Sensor Numbers** if you want the top sensor readout scaled much larger.
-
-For **Time** mode:
-
-1. Set a **Label** if you want custom text under the duration. If left blank, the entity name from Home Assistant is used.
-2. Leave **Incoming Value Unit** set to **Auto** when the entity has a supported Home Assistant unit of measurement. Auto recognises days (`d`), hours (`h`), minutes (`min`), seconds (`s`), milliseconds (`ms`), and microseconds (`µs`).
-3. If the entity has no unit, or its unit is not supported, choose **Seconds**, **Minutes**, **Hours**, or **Days** manually. A manual choice overrides the Home Assistant unit.
-
-Time values are rounded down to whole seconds so a remaining-runtime reading is never overstated. Single-column cards show the largest non-zero part so the value fits without changing the font: `90` seconds becomes `1m` and `28` hours becomes `1d`. Cards that are at least two columns wide show up to two parts, such as `1m 30s` or `1d 4h`. Zero becomes `0s`. Unavailable, unknown, malformed, infinite, and negative values leave the duration blank.
-
-::: info Time mode limitations
-Time is available only for the **Home Assistant** source. It does not currently support **Large Sensor Numbers**, and its fixed `d`, `h`, `m`, and `s` abbreviations are not translated.
-:::
-
-For **Text** mode:
-
-1. Choose an **Icon**. This icon is always shown and does not change based on the sensor value.
-2. The live state from Home Assistant is shown where a Switch card label would normally appear.
-3. Open **Advanced** if you want to replace raw Home Assistant states with friendlier labels. For example, you can show `Please empty` when the sensor reports `high`, and `Full` when another sensor state reports `low`.
-
-For **Numeric**, **Text**, or **Icon** mode, turn on **Lit When Active** if you want the card background to use the active/on colour while Home Assistant reports an active state. This is useful for status sensors such as a washing machine running or a door being open. The option is not shown in Time mode.
-
-## How It Works on the Panel
-
-- Icon mode treats active Home Assistant states such as `on`, `true`, `home`, `playing`, `open`, or `unlocked` as active and uses the on icon when configured.
-- When **Lit When Active** is enabled, Text and Icon cards use the active/on background colour for those active states. Numeric cards treat any positive value as active. All three return to the Sensor card colour when the state is inactive, zero, unknown, or unavailable.
-- Numeric mode displays the current value in large text, with the unit beside it and the label underneath.
-- Time mode listens for both the value and its Home Assistant unit when **Incoming Value Unit** is Auto. A change to either one updates the card. Missing or unsupported unit metadata leaves the value blank rather than guessing.
-- Numeric mode normally uses the fixed **tertiary** background colour, so it remains visually distinct from Switch and Trigger cards.
-- Text mode normally uses the same tertiary colour as Numeric mode, while keeping the normal Switch-style icon and label layout.
-- Text mode capitalises each word in the Home Assistant text and preserves line breaks. Advanced status translation is applied before the text is shown. Very long values are limited to roughly 256 characters so the panel stays responsive.
-
-## Example Sensors
-
-| Entity | Mode | Unit | What it shows |
-|---|---|---|---|
-| `sensor.living_room_temperature` | Numeric | `°C` | Indoor temperature |
-| `sensor.solar_power` | Numeric | `W` | Current solar generation |
-| `sensor.humidity` | Numeric | `%` | Relative humidity |
-| `sensor.ups_battery_runtime` | Time | Auto | `36m` for a value of `0.6` hours |
-| `sensor.timer_remaining` | Time | Seconds | `1m 30s` for a value of `90` |
-| `binary_sensor.laundry_running` | Icon |  | Laundry running or idle |
-| `text_sensor.washing_machine_status` | Text |  | `Running`, `Rinsing`, or `Finished` |
-| `sensor.fan_level` | Text |  | `low`, `medium`, or `high` |
+| Example entity | Suggested type |
+|---|---|
+| `sensor.living_room_temperature` | Numeric |
+| `sensor.ups_battery_runtime` | Time |
+| `binary_sensor.laundry_running` | Icon |
+| `text_sensor.washing_machine_status` | Text |


### PR DESCRIPTION
## Summary

- Completed the Card Types chooser with the current Media modes and the Weather Forecast compatibility note.
- Corrected Presence guidance to match the supported entity types.
- Shortened the Action, Alarm, Media, Sensor, Local Action, and Local Sensor pages into quick setup references.

## Documentation decision

- [x] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [ ] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Updated the Card Types overview and quick-reference pages to match the current card layouts and controls.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [ ] Device testing is required before merge.
- [x] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- Not applicable.

## Notes for testing

- Documentation-only change; no device behavior or firmware has changed.

## PR status

- [ ] Checks running or waiting.
- [ ] Needs automated fix.
- [ ] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [x] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.