### PR TITLE
Fix P4 startup service crashes

### DIFF
--- a/components/espcontrol/button_grid_climate.h
+++ b/components/espcontrol/button_grid_climate.h
@@ -2390,8 +2390,10 @@ inline void climate_control_open_modal(ClimateControlCtx *ctx) {
   lv_obj_set_style_pad_all(ui.target_row, 0, LV_PART_MAIN);
   lv_obj_set_style_pad_column(ui.target_row, 4, LV_PART_MAIN);
   lv_obj_set_layout(ui.target_row, LV_LAYOUT_FLEX);
-  lv_obj_set_style_flex_flow(ui.target_row, LV_FLEX_FLOW_ROW, LV_PART_MAIN);
-  lv_obj_set_style_flex_cross_place(ui.target_row, LV_FLEX_ALIGN_END, LV_PART_MAIN);
+  // The default flex flow is a horizontal row.  Explicitly writing these
+  // local styles can allocate from LVGL's constrained internal heap and has
+  // caused an unrecoverable allocation abort on the ESP32-P4 during startup.
+  // Keep the defaults here so the climate modal remains usable under pressure.
   lv_obj_clear_flag(ui.target_row, LV_OBJ_FLAG_CLICKABLE);
   lv_obj_clear_flag(ui.target_row, LV_OBJ_FLAG_SCROLLABLE);
 

--- a/components/espcontrol/button_grid_climate.h
+++ b/components/espcontrol/button_grid_climate.h
@@ -2226,11 +2226,39 @@ inline void delete_climate_control_context(ClimateControlCtx *ctx) {
   delete ctx;
 }
 
+// The climate panel is one of the largest transient LVGL views.  ESPHome's
+// LVGL allocator uses PSRAM first, so creating it while an artwork refresh has
+// consumed or fragmented that heap can make a later widget allocation return
+// null and abort the entire firmware.  Leave enough room for the panel and
+// keep the device online; the user can open the card once memory is available.
+constexpr size_t CLIMATE_MODAL_LVGL_MIN_FREE_BYTES = 256 * 1024;
+constexpr size_t CLIMATE_MODAL_LVGL_MIN_LARGEST_BLOCK_BYTES = 96 * 1024;
+
+inline bool climate_control_modal_memory_available() {
+#ifdef ESP_PLATFORM
+  lv_mem_monitor_t memory{};
+  lv_mem_monitor(&memory);
+  if (memory.free_size < CLIMATE_MODAL_LVGL_MIN_FREE_BYTES ||
+      memory.free_biggest_size < CLIMATE_MODAL_LVGL_MIN_LARGEST_BLOCK_BYTES) {
+    ESP_LOGW("climate_control",
+             "Deferring climate panel: LVGL heap free=%u largest=%u",
+             static_cast<unsigned>(memory.free_size),
+             static_cast<unsigned>(memory.free_biggest_size));
+    return false;
+  }
+#endif
+  return true;
+}
+
 inline void climate_control_open_modal(ClimateControlCtx *ctx) {
-  if (!ctx || !ctx->available) return;
+  if (!ctx || !ctx->available || !climate_control_modal_memory_available()) return;
   ControlModalShell shell = control_modal_open_shell(
     ControlModalKind::CLIMATE, ctx->btn, ctx->width_compensation_percent,
     ctx->icon_font, climate_control_hide_modal);
+  if (!shell.overlay || !shell.panel || !shell.close_btn) {
+    ESP_LOGW("climate_control", "Unable to create climate panel shell");
+    return;
+  }
   ClimateControlModalUi &ui = climate_control_modal_ui();
   ui.active = ctx;
   ui.overlay = shell.overlay;

--- a/components/espcontrol/button_grid_climate.h
+++ b/components/espcontrol/button_grid_climate.h
@@ -2237,7 +2237,10 @@ constexpr uint32_t CLIMATE_MODAL_STARTUP_GUARD_MS = 15000;
 
 inline bool climate_control_modal_memory_available() {
 #ifdef ESP_PLATFORM
-  if (esphome::millis() < CLIMATE_MODAL_STARTUP_GUARD_MS) {
+  static uint32_t first_climate_modal_attempt_ms = 0;
+  const uint32_t now = esphome::millis();
+  if (first_climate_modal_attempt_ms == 0) first_climate_modal_attempt_ms = now;
+  if (now - first_climate_modal_attempt_ms < CLIMATE_MODAL_STARTUP_GUARD_MS) {
     ESP_LOGW("climate_control", "Deferring climate panel until startup is complete");
     return false;
   }

--- a/components/espcontrol/button_grid_climate.h
+++ b/components/espcontrol/button_grid_climate.h
@@ -2259,14 +2259,13 @@ inline bool climate_control_modal_memory_available() {
 }
 
 inline void climate_control_open_modal(ClimateControlCtx *ctx) {
-#if defined(CONFIG_IDF_TARGET_ESP32P4)
+  (void) ctx;
   // The P4 firmware can start with its LVGL allocator exhausted after artwork
   // initialisation.  Opening this large modal then aborts the whole firmware,
   // taking down Home Assistant and the web server with it.  Keep the main
   // controls available while the compact P4 climate view is rebuilt.
   ESP_LOGW("climate_control", "Climate details are temporarily unavailable on this display");
   return;
-#endif
   if (!ctx || !ctx->available || !climate_control_modal_memory_available()) return;
   ControlModalShell shell = control_modal_open_shell(
     ControlModalKind::CLIMATE, ctx->btn, ctx->width_compensation_percent,

--- a/components/espcontrol/button_grid_climate.h
+++ b/components/espcontrol/button_grid_climate.h
@@ -2259,6 +2259,14 @@ inline bool climate_control_modal_memory_available() {
 }
 
 inline void climate_control_open_modal(ClimateControlCtx *ctx) {
+#if defined(CONFIG_IDF_TARGET_ESP32P4)
+  // The P4 firmware can start with its LVGL allocator exhausted after artwork
+  // initialisation.  Opening this large modal then aborts the whole firmware,
+  // taking down Home Assistant and the web server with it.  Keep the main
+  // controls available while the compact P4 climate view is rebuilt.
+  ESP_LOGW("climate_control", "Climate details are temporarily unavailable on this display");
+  return;
+#endif
   if (!ctx || !ctx->available || !climate_control_modal_memory_available()) return;
   ControlModalShell shell = control_modal_open_shell(
     ControlModalKind::CLIMATE, ctx->btn, ctx->width_compensation_percent,

--- a/components/espcontrol/button_grid_climate.h
+++ b/components/espcontrol/button_grid_climate.h
@@ -2233,9 +2233,14 @@ inline void delete_climate_control_context(ClimateControlCtx *ctx) {
 // keep the device online; the user can open the card once memory is available.
 constexpr size_t CLIMATE_MODAL_LVGL_MIN_FREE_BYTES = 256 * 1024;
 constexpr size_t CLIMATE_MODAL_LVGL_MIN_LARGEST_BLOCK_BYTES = 96 * 1024;
+constexpr uint32_t CLIMATE_MODAL_STARTUP_GUARD_MS = 15000;
 
 inline bool climate_control_modal_memory_available() {
 #ifdef ESP_PLATFORM
+  if (esphome::millis() < CLIMATE_MODAL_STARTUP_GUARD_MS) {
+    ESP_LOGW("climate_control", "Deferring climate panel until startup is complete");
+    return false;
+  }
   lv_mem_monitor_t memory{};
   lv_mem_monitor(&memory);
   if (memory.free_size < CLIMATE_MODAL_LVGL_MIN_FREE_BYTES ||

--- a/components/espcontrol/button_grid_climate.h
+++ b/components/espcontrol/button_grid_climate.h
@@ -2226,54 +2226,11 @@ inline void delete_climate_control_context(ClimateControlCtx *ctx) {
   delete ctx;
 }
 
-// The climate panel is one of the largest transient LVGL views.  ESPHome's
-// LVGL allocator uses PSRAM first, so creating it while an artwork refresh has
-// consumed or fragmented that heap can make a later widget allocation return
-// null and abort the entire firmware.  Leave enough room for the panel and
-// keep the device online; the user can open the card once memory is available.
-constexpr size_t CLIMATE_MODAL_LVGL_MIN_FREE_BYTES = 256 * 1024;
-constexpr size_t CLIMATE_MODAL_LVGL_MIN_LARGEST_BLOCK_BYTES = 96 * 1024;
-constexpr uint32_t CLIMATE_MODAL_STARTUP_GUARD_MS = 15000;
-
-inline bool climate_control_modal_memory_available() {
-#ifdef ESP_PLATFORM
-  static uint32_t first_climate_modal_attempt_ms = 0;
-  const uint32_t now = esphome::millis();
-  if (first_climate_modal_attempt_ms == 0) first_climate_modal_attempt_ms = now;
-  if (now - first_climate_modal_attempt_ms < CLIMATE_MODAL_STARTUP_GUARD_MS) {
-    ESP_LOGW("climate_control", "Deferring climate panel until startup is complete");
-    return false;
-  }
-  lv_mem_monitor_t memory{};
-  lv_mem_monitor(&memory);
-  if (memory.free_size < CLIMATE_MODAL_LVGL_MIN_FREE_BYTES ||
-      memory.free_biggest_size < CLIMATE_MODAL_LVGL_MIN_LARGEST_BLOCK_BYTES) {
-    ESP_LOGW("climate_control",
-             "Deferring climate panel: LVGL heap free=%u largest=%u",
-             static_cast<unsigned>(memory.free_size),
-             static_cast<unsigned>(memory.free_biggest_size));
-    return false;
-  }
-#endif
-  return true;
-}
-
 inline void climate_control_open_modal(ClimateControlCtx *ctx) {
-  (void) ctx;
-  // The P4 firmware can start with its LVGL allocator exhausted after artwork
-  // initialisation.  Opening this large modal then aborts the whole firmware,
-  // taking down Home Assistant and the web server with it.  Keep the main
-  // controls available while the compact P4 climate view is rebuilt.
-  ESP_LOGW("climate_control", "Climate details are temporarily unavailable on this display");
-  return;
-  if (!ctx || !ctx->available || !climate_control_modal_memory_available()) return;
+  if (!ctx || !ctx->available) return;
   ControlModalShell shell = control_modal_open_shell(
     ControlModalKind::CLIMATE, ctx->btn, ctx->width_compensation_percent,
     ctx->icon_font, climate_control_hide_modal);
-  if (!shell.overlay || !shell.panel || !shell.close_btn) {
-    ESP_LOGW("climate_control", "Unable to create climate panel shell");
-    return;
-  }
   ClimateControlModalUi &ui = climate_control_modal_ui();
   ui.active = ctx;
   ui.overlay = shell.overlay;
@@ -2397,10 +2354,8 @@ inline void climate_control_open_modal(ClimateControlCtx *ctx) {
   lv_obj_set_style_pad_all(ui.target_row, 0, LV_PART_MAIN);
   lv_obj_set_style_pad_column(ui.target_row, 4, LV_PART_MAIN);
   lv_obj_set_layout(ui.target_row, LV_LAYOUT_FLEX);
-  // The default flex flow is a horizontal row.  Explicitly writing these
-  // local styles can allocate from LVGL's constrained internal heap and has
-  // caused an unrecoverable allocation abort on the ESP32-P4 during startup.
-  // Keep the defaults here so the climate modal remains usable under pressure.
+  lv_obj_set_style_flex_flow(ui.target_row, LV_FLEX_FLOW_ROW, LV_PART_MAIN);
+  lv_obj_set_style_flex_cross_place(ui.target_row, LV_FLEX_ALIGN_END, LV_PART_MAIN);
   lv_obj_clear_flag(ui.target_row, LV_OBJ_FLAG_CLICKABLE);
   lv_obj_clear_flag(ui.target_row, LV_OBJ_FLAG_SCROLLABLE);
 

--- a/components/espcontrol/button_grid_ha.h
+++ b/components/espcontrol/button_grid_ha.h
@@ -97,14 +97,26 @@ using EspHomeHaReadCoordinator = HaReadCoordinator<EspHomeHaReadTransport, EspHo
 using EspHomeHaBindingService =
     HomeAssistantBindingService<EspHomeHaReadTransport, EspHomeHaHeapProbe>;
 
-inline EspHomeHaBindingService &ha_binding_service() {
-  if (auto *core = espcontrol::active_espcontrol_app_core()) {
-    return core->home_assistant_binding_service<EspHomeHaBindingService>();
-  }
-  // ESPHome can reset subscriptions while the application core is starting.
-  // Keep that transition harmless rather than aborting the entire firmware.
+inline EspHomeHaBindingService &pre_core_ha_binding_service() {
   static EspHomeHaBindingService service;
   return service;
+}
+
+inline bool &pre_core_ha_binding_service_is_active() {
+  static bool active = false;
+  return active;
+}
+
+inline EspHomeHaBindingService &ha_binding_service() {
+  if (auto *core = espcontrol::active_espcontrol_app_core(); core != nullptr &&
+      !pre_core_ha_binding_service_is_active()) {
+    return core->home_assistant_binding_service<EspHomeHaBindingService>();
+  }
+  // ESPHome can reset subscriptions before the application core starts. Once
+  // that happens, preserve this service for the firmware lifetime so callback
+  // ownership and deferred subscriptions never switch to a different object.
+  pre_core_ha_binding_service_is_active() = true;
+  return pre_core_ha_binding_service();
 }
 
 inline EspHomeHaReadCoordinator &ha_read_coordinator() {

--- a/components/espcontrol/button_grid_ha.h
+++ b/components/espcontrol/button_grid_ha.h
@@ -101,14 +101,10 @@ inline EspHomeHaBindingService &ha_binding_service() {
   if (auto *core = espcontrol::active_espcontrol_app_core()) {
     return core->home_assistant_binding_service<EspHomeHaBindingService>();
   }
-#ifdef ESP_PLATFORM
-  // Firmware UI work begins only after EspControlAppCore starts. Keeping the
-  // contract strict avoids a second permanent binding-service allocation.
-  std::abort();
-#else
+  // ESPHome can reset subscriptions while the application core is starting.
+  // Keep that transition harmless rather than aborting the entire firmware.
   static EspHomeHaBindingService service;
   return service;
-#endif
 }
 
 inline EspHomeHaReadCoordinator &ha_read_coordinator() {

--- a/components/espcontrol/button_grid_modal.h
+++ b/components/espcontrol/button_grid_modal.h
@@ -85,14 +85,11 @@ inline ButtonGridModalService &control_modal_service() {
   if (auto *core = espcontrol::active_espcontrol_app_core()) {
     return core->modal_state_service<ButtonGridModalService>();
   }
-#ifdef ESP_PLATFORM
-  // Firmware UI work begins only after EspControlAppCore starts. Keeping the
-  // contract strict avoids a second permanent modal-state allocation.
-  std::abort();
-#else
+  // A component can request modal cleanup while ESPHome is still bringing the
+  // application core online.  Treat that transition as an empty modal state;
+  // aborting here turns a harmless startup callback into a boot loop.
   static ButtonGridModalService service;
   return service;
-#endif
 }
 
 inline ControlModalActive &control_modal_active() {

--- a/components/espcontrol/button_grid_navigation.h
+++ b/components/espcontrol/button_grid_navigation.h
@@ -41,14 +41,11 @@ inline ButtonGridNavigationService &grid_navigation_service() {
           espcontrol::active_espcontrol_app_core()) {
     return core->grid_navigation_service<ButtonGridNavigationService>();
   }
-#ifdef ESP_PLATFORM
-  // Firmware UI work begins only after EspControlAppCore starts. Keeping the
-  // contract strict avoids a second permanent navigation allocation.
-  std::abort();
-#else
+  // ESPHome may dispatch navigation cleanup while the core is still being
+  // registered during startup. Preserve that state until core ownership is
+  // available instead of turning the callback into a reboot.
   static ButtonGridNavigationService service;
   return service;
-#endif
 }
 
 // Compatibility accessors for existing grid code. New runtime ownership lives

--- a/components/espcontrol/espcontrol_app.cpp
+++ b/components/espcontrol/espcontrol_app.cpp
@@ -105,6 +105,11 @@ bool EspControlApp::create_native_configuration_runtime() {
   runtime->legacy_config.set_button_on_color(&runtime->button_on_color);
   for (size_t index = 0; index < panel_config_button_texts_.size(); ++index) {
     const PanelConfigTextSources &sources = panel_config_button_texts_[index];
+    // Device profiles only provide text entities for their real panel slots.
+    // Do not register placeholder wrappers for the remaining fixed-capacity
+    // entries: a restored document would correctly try to clear them, but the
+    // wrappers have no ESPHome text object to update.
+    if (sources.button == nullptr) continue;
     NativeConfigurationRuntime::LegacyButtonTextSources &legacy_sources =
         runtime->buttons[index];
     legacy_sources.button.bind(sources.button);

--- a/components/espcontrol/espcontrol_app.cpp
+++ b/components/espcontrol/espcontrol_app.cpp
@@ -1,6 +1,8 @@
 #include "espcontrol_app.h"
 
+#include <array>
 #include <cinttypes>
+#include <new>
 
 #ifdef USE_ESP32
 #include <esp_heap_caps.h>
@@ -10,50 +12,113 @@
 
 #include "panel_config_capabilities_endpoint.h"
 #include "configuration_release_policy.h"
+#include "configuration_service.h"
+#include "configuration_store.h"
 #include "panel_config_read_endpoint.h"
+#include "panel_config_espidf_storage.h"
+#include "panel_config_esphome_text.h"
+#include "panel_config_legacy_adapter.h"
+#include "panel_config_service_validator.h"
+#include "panel_config_storage_backend.h"
 #include "panel_config_write_endpoint.h"
 
 namespace espcontrol {
 
 static const char *const TAG = "espcontrol.config";
 
+class EspControlApp::NativeConfigurationRuntime {
+ public:
+  struct LegacyButtonTextSources {
+    configuration::EspHomeLegacyTextValue button;
+    std::array<configuration::EspHomeLegacyTextValue,
+               configuration::PanelConfigLegacyAdapter::MAX_SUBPAGE_CHUNKS>
+        subpages{};
+  };
+
+  NativeConfigurationRuntime()
+      : backend(blobs), store(backend) {}
+
+  configuration::PanelConfigLegacyAdapter legacy_config{};
+  configuration::PanelConfigDocumentValidator validator{};
+  configuration::EspIdfPanelConfigBlobStorage blobs{};
+  configuration::BufferedBlobStorageBackend<PANEL_CONFIG_STORAGE_SLOT_CAPACITY>
+      backend;
+  configuration::ConfigurationStore store;
+  uint8_t *memory{nullptr};
+  uint8_t *document_buffer{nullptr};
+  uint8_t *boot_buffer{nullptr};
+  bool boot_configuration_pending{false};
+  configuration::EspHomeLegacyTextValue button_order{};
+  configuration::EspHomeLegacyTextValue button_on_color{};
+  std::array<LegacyButtonTextSources, configuration::PANEL_CONFIG_MAX_SLOT_COUNT>
+      buttons{};
+};
+
+EspControlApp::EspControlApp() = default;
+
+EspControlApp::~EspControlApp() = default;
+
 void EspControlApp::set_panel_config_device_profile(const char *device_profile) {
-  legacy_config_.set_device_profile(device_profile);
+  panel_config_device_profile_ = device_profile;
 }
 
 void EspControlApp::set_panel_config_button_order(
     esphome::text::Text *button_order) {
-  button_order_text_.bind(button_order);
-  legacy_config_.set_button_order(&button_order_text_);
+  panel_config_button_order_ = button_order;
 }
 
 void EspControlApp::set_panel_config_button_on_color(
     esphome::text::Text *button_on_color) {
-  button_on_color_text_.bind(button_on_color);
-  legacy_config_.set_button_on_color(&button_on_color_text_);
+  panel_config_button_on_color_ = button_on_color;
 }
 
 void EspControlApp::set_panel_config_button(
     uint8_t slot, esphome::text::Text *button,
     esphome::text::Text *subpage_0, esphome::text::Text *subpage_1,
-    esphome::text::Text *subpage_2, esphome::text::Text *subpage_3,
-    esphome::text::Text *subpage_4, esphome::text::Text *subpage_5,
-    esphome::text::Text *subpage_6, esphome::text::Text *subpage_7) {
-  if (slot == 0 || slot > legacy_button_texts_.size()) return;
-  LegacyButtonTextSources &sources = legacy_button_texts_[slot - 1];
-  sources.button.bind(button);
-  const std::array<esphome::text::Text *,
-                   configuration::PanelConfigLegacyAdapter::MAX_SUBPAGE_CHUNKS>
-      subpages{{subpage_0, subpage_1, subpage_2, subpage_3, subpage_4,
-                subpage_5, subpage_6, subpage_7}};
-  std::array<configuration::LegacyTextValue *,
-             configuration::PanelConfigLegacyAdapter::MAX_SUBPAGE_CHUNKS>
-      legacy_subpages{};
-  for (size_t index = 0; index < subpages.size(); ++index) {
-    sources.subpages[index].bind(subpages[index]);
-    legacy_subpages[index] = &sources.subpages[index];
+      esphome::text::Text *subpage_2, esphome::text::Text *subpage_3,
+      esphome::text::Text *subpage_4, esphome::text::Text *subpage_5,
+      esphome::text::Text *subpage_6, esphome::text::Text *subpage_7) {
+  if (slot == 0 || slot > panel_config_button_texts_.size()) return;
+  panel_config_button_texts_[slot - 1] = {
+      button, {subpage_0, subpage_1, subpage_2, subpage_3, subpage_4,
+               subpage_5, subpage_6, subpage_7}};
+}
+
+bool EspControlApp::native_configuration_requested() const {
+  return panel_config_device_profile_ != nullptr &&
+         panel_config_button_order_ != nullptr;
+}
+
+bool EspControlApp::create_native_configuration_runtime() {
+  if (native_configuration_runtime_ != nullptr) return true;
+  NativeConfigurationRuntime *runtime =
+      new (std::nothrow) NativeConfigurationRuntime();
+  if (runtime == nullptr) {
+    ESP_LOGE(TAG, "Native configuration runtime memory is unavailable");
+    return false;
   }
-  legacy_config_.set_button(slot, &sources.button, legacy_subpages);
+  native_configuration_runtime_.reset(runtime);
+  runtime->legacy_config.set_device_profile(panel_config_device_profile_);
+  runtime->button_order.bind(panel_config_button_order_);
+  runtime->legacy_config.set_button_order(&runtime->button_order);
+  runtime->button_on_color.bind(panel_config_button_on_color_);
+  runtime->legacy_config.set_button_on_color(&runtime->button_on_color);
+  for (size_t index = 0; index < panel_config_button_texts_.size(); ++index) {
+    const PanelConfigTextSources &sources = panel_config_button_texts_[index];
+    NativeConfigurationRuntime::LegacyButtonTextSources &legacy_sources =
+        runtime->buttons[index];
+    legacy_sources.button.bind(sources.button);
+    std::array<configuration::LegacyTextValue *,
+               configuration::PanelConfigLegacyAdapter::MAX_SUBPAGE_CHUNKS>
+        legacy_subpages{};
+    for (size_t subpage = 0; subpage < sources.subpages.size(); ++subpage) {
+      legacy_sources.subpages[subpage].bind(sources.subpages[subpage]);
+      legacy_subpages[subpage] = &legacy_sources.subpages[subpage];
+    }
+    runtime->legacy_config.set_button(static_cast<uint8_t>(index + 1),
+                                      &legacy_sources.button, legacy_subpages);
+  }
+  return true;
 }
 
 void EspControlApp::register_panel_config_endpoints() {
@@ -62,28 +127,33 @@ void EspControlApp::register_panel_config_endpoints() {
   if (!native_configuration_initialized_) return;
   configuration::ConfigurationService *const panel_config_service =
       core_.configuration_service();
-  const bool can_register_document_endpoints =
-      panel_config_service != nullptr && panel_config_document_buffer_ != nullptr;
+  NativeConfigurationRuntime *const runtime = native_configuration_runtime_.get();
+  const bool can_register_document_endpoints = panel_config_service != nullptr &&
+      runtime != nullptr && runtime->document_buffer != nullptr;
   const bool read_endpoint_registered = can_register_document_endpoints &&
       configuration::register_panel_config_read_endpoint(
-          *panel_config_service, panel_config_document_buffer_,
-          PANEL_CONFIG_STORAGE_SLOT_CAPACITY, web_auth_username_.c_str(),
-          web_auth_password_.c_str());
+          *panel_config_service, runtime->document_buffer,
+          PANEL_CONFIG_STORAGE_SLOT_CAPACITY,
+          web_auth_username_ == nullptr ? "" : web_auth_username_,
+          web_auth_password_ == nullptr ? "" : web_auth_password_);
   const bool write_endpoint_registered = can_register_document_endpoints &&
       configuration::register_panel_config_write_endpoint(
-          *panel_config_service, panel_config_document_buffer_,
-          PANEL_CONFIG_STORAGE_SLOT_CAPACITY, web_auth_username_.c_str(),
-          web_auth_password_.c_str());
+          *panel_config_service, runtime->document_buffer,
+          PANEL_CONFIG_STORAGE_SLOT_CAPACITY,
+          web_auth_username_ == nullptr ? "" : web_auth_username_,
+          web_auth_password_ == nullptr ? "" : web_auth_password_);
   configuration::set_panel_config_read_supported(read_endpoint_registered);
   configuration::set_panel_config_write_supported(write_endpoint_registered);
   configuration::register_panel_config_capabilities_endpoint();
 }
 
 void EspControlApp::apply_boot_configuration() {
-  if (!boot_configuration_pending_ || boot_configuration_buffer_ == nullptr)
+  NativeConfigurationRuntime *const runtime = native_configuration_runtime_.get();
+  if (runtime == nullptr || !runtime->boot_configuration_pending ||
+      runtime->boot_buffer == nullptr)
     return;
 
-  boot_configuration_pending_ = false;
+  runtime->boot_configuration_pending = false;
   configuration::ConfigurationService *const panel_config_service =
       core_.configuration_service();
   if (panel_config_service == nullptr) return;
@@ -95,7 +165,7 @@ void EspControlApp::apply_boot_configuration() {
   // nor the running grid can be reverted by an older startup document.
   const configuration::ServiceLoadResult loaded =
       panel_config_service->load_and_apply_runtime(
-          boot_configuration_buffer_, PANEL_CONFIG_STORAGE_SLOT_CAPACITY);
+          runtime->boot_buffer, PANEL_CONFIG_STORAGE_SLOT_CAPACITY);
   if (!loaded.ok()) {
     ESP_LOGE(TAG, "Native configuration could not reload for the live grid (%u)",
              static_cast<unsigned>(loaded.status));
@@ -117,8 +187,20 @@ void EspControlApp::setup() {
 }
 
 void EspControlApp::initialize_native_configuration() {
+  if (!native_configuration_requested()) {
+    ESP_LOGD(TAG, "Native configuration is not requested for this device");
+    native_configuration_initialized_ = true;
+    register_panel_config_endpoints();
+    return;
+  }
+  if (!create_native_configuration_runtime()) {
+    native_configuration_initialized_ = true;
+    register_panel_config_endpoints();
+    return;
+  }
+  NativeConfigurationRuntime &runtime = *native_configuration_runtime_;
   if (!core_.configure_configuration_service(
-          panel_config_store_, legacy_config_, &panel_config_validator_,
+          runtime.store, runtime.legacy_config, &runtime.validator,
           configuration::PANEL_CONFIG_LEGACY_MODE)) {
     ESP_LOGE(TAG, "Native configuration service is already configured");
     native_configuration_initialized_ = true;
@@ -133,10 +215,10 @@ void EspControlApp::initialize_native_configuration() {
     register_panel_config_endpoints();
     return;
   }
-  panel_config_service->set_runtime_adapter(&legacy_config_);
-  if (!legacy_config_.configured()) {
+  panel_config_service->set_runtime_adapter(&runtime.legacy_config);
+  if (!runtime.legacy_config.configured()) {
     ESP_LOGW(TAG, "Native configuration sources are not configured");
-  } else if (!panel_config_blobs_.begin()) {
+  } else if (!runtime.blobs.begin()) {
     ESP_LOGE(TAG, "Native configuration storage is unavailable");
   } else {
 #ifdef USE_ESP32
@@ -144,12 +226,12 @@ void EspControlApp::initialize_native_configuration() {
     // delayed boot-application buffers must not overlap each other.
     constexpr size_t panel_config_memory_size =
         PANEL_CONFIG_STORAGE_SLOT_CAPACITY * 5;
-    panel_config_memory_ = static_cast<uint8_t *>(
+    runtime.memory = static_cast<uint8_t *>(
         heap_caps_malloc(panel_config_memory_size,
                          MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
 #endif
-    if (panel_config_memory_ == nullptr ||
-        !panel_config_backend_.begin(panel_config_memory_,
+    if (runtime.memory == nullptr ||
+        !runtime.backend.begin(runtime.memory,
                                      PANEL_CONFIG_STORAGE_SLOT_CAPACITY * 2)) {
       ESP_LOGE(TAG, "Native configuration memory is unavailable");
       native_configuration_initialized_ = true;
@@ -157,14 +239,13 @@ void EspControlApp::initialize_native_configuration() {
       return;
     }
     panel_config_service->set_scratch_buffer(
-        panel_config_memory_ + PANEL_CONFIG_STORAGE_SLOT_CAPACITY * 2,
+        runtime.memory + PANEL_CONFIG_STORAGE_SLOT_CAPACITY * 2,
         PANEL_CONFIG_STORAGE_SLOT_CAPACITY);
-    panel_config_document_buffer_ =
-        panel_config_memory_ + PANEL_CONFIG_STORAGE_SLOT_CAPACITY * 3;
-    boot_configuration_buffer_ =
-        panel_config_memory_ + PANEL_CONFIG_STORAGE_SLOT_CAPACITY * 4;
+    runtime.document_buffer =
+        runtime.memory + PANEL_CONFIG_STORAGE_SLOT_CAPACITY * 3;
+    runtime.boot_buffer = runtime.memory + PANEL_CONFIG_STORAGE_SLOT_CAPACITY * 4;
     const configuration::ServiceLoadResult loaded = panel_config_service->load(
-        panel_config_document_buffer_, PANEL_CONFIG_STORAGE_SLOT_CAPACITY);
+        runtime.document_buffer, PANEL_CONFIG_STORAGE_SLOT_CAPACITY);
     if (loaded.status == configuration::ServiceStatus::IMPORTED_LEGACY) {
       ESP_LOGI(TAG, "Imported legacy panel configuration into generation %" PRIu32,
                loaded.generation);
@@ -176,7 +257,7 @@ void EspControlApp::initialize_native_configuration() {
     if (panel_config_service->legacy_writes_enabled()) {
       const configuration::ServiceLoadResult refreshed =
           panel_config_service->refresh_legacy_shadow(
-              panel_config_document_buffer_, PANEL_CONFIG_STORAGE_SLOT_CAPACITY);
+              runtime.document_buffer, PANEL_CONFIG_STORAGE_SLOT_CAPACITY);
       if (refreshed.status == configuration::ServiceStatus::SYNCED_LEGACY) {
         ESP_LOGI(TAG, "Refreshed native configuration shadow to generation %" PRIu32,
                  refreshed.generation);
@@ -194,7 +275,7 @@ void EspControlApp::initialize_native_configuration() {
       // while this component's WiFi-priority setup callback is still running.
       // Browser PUT requests still apply immediately through the runtime
       // adapter; this deferral is strictly for startup restoration.
-      boot_configuration_pending_ = true;
+      runtime.boot_configuration_pending = true;
       this->set_timeout(1000, [this]() { this->apply_boot_configuration(); });
     }
   }

--- a/components/espcontrol/espcontrol_app.h
+++ b/components/espcontrol/espcontrol_app.h
@@ -3,20 +3,12 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
-#include <string>
+#include <memory>
 
 #include "esphome/components/text/text.h"
 #include "esphome/core/component.h"
 
 #include "espcontrol_app_core.h"
-#include "configuration_service.h"
-#include "configuration_store.h"
-#include "panel_config_espidf_storage.h"
-#include "panel_config_esphome_text.h"
-#include "panel_config_legacy_adapter.h"
-#include "panel_config_service_validator.h"
-#include "panel_config_storage_backend.h"
-
 namespace espcontrol {
 
 // The single ESPHome component boundary for EspControl-owned firmware state.
@@ -25,6 +17,9 @@ namespace espcontrol {
 class EspControlApp : public esphome::Component {
  public:
   static constexpr size_t PANEL_CONFIG_STORAGE_SLOT_CAPACITY = 40 * 1024;
+
+  EspControlApp();
+  ~EspControlApp();
 
   void setup() override;
   void loop() override;
@@ -49,40 +44,36 @@ class EspControlApp : public esphome::Component {
       esphome::text::Text *subpage_4, esphome::text::Text *subpage_5,
       esphome::text::Text *subpage_6, esphome::text::Text *subpage_7);
   void set_web_auth_credentials(const char *username, const char *password) {
-    web_auth_username_ = username == nullptr ? "" : username;
-    web_auth_password_ = password == nullptr ? "" : password;
+    web_auth_username_ = username;
+    web_auth_password_ = password;
   }
 
  private:
+  class NativeConfigurationRuntime;
+
   void register_panel_config_endpoints();
   void initialize_native_configuration();
   void apply_boot_configuration();
+  bool native_configuration_requested() const;
+  bool create_native_configuration_runtime();
 
-  struct LegacyButtonTextSources {
-    configuration::EspHomeLegacyTextValue button;
-    std::array<configuration::EspHomeLegacyTextValue,
-               configuration::PanelConfigLegacyAdapter::MAX_SUBPAGE_CHUNKS>
-        subpages{};
+  struct PanelConfigTextSources {
+    esphome::text::Text *button{nullptr};
+    std::array<esphome::text::Text *, 8> subpages{};
   };
 
-  configuration::PanelConfigLegacyAdapter legacy_config_{};
-  configuration::PanelConfigDocumentValidator panel_config_validator_{};
-  configuration::EspIdfPanelConfigBlobStorage panel_config_blobs_{};
-  configuration::BufferedBlobStorageBackend<PANEL_CONFIG_STORAGE_SLOT_CAPACITY>
-      panel_config_backend_{panel_config_blobs_};
-  configuration::ConfigurationStore panel_config_store_{panel_config_backend_};
+  const char *panel_config_device_profile_{nullptr};
+  esphome::text::Text *panel_config_button_order_{nullptr};
+  esphome::text::Text *panel_config_button_on_color_{nullptr};
+  std::array<PanelConfigTextSources, 32> panel_config_button_texts_{};
+  // This owns every non-trivial configuration object. Keeping it separate
+  // leaves the ESPHome-created application object safe to construct before
+  // the framework's allocators and component setup are ready.
+  std::unique_ptr<NativeConfigurationRuntime> native_configuration_runtime_;
   EspControlAppCore core_{};
-  uint8_t *panel_config_memory_{nullptr};
-  uint8_t *panel_config_document_buffer_{nullptr};
-  uint8_t *boot_configuration_buffer_{nullptr};
   bool native_configuration_initialized_{false};
-  bool boot_configuration_pending_{false};
-  std::string web_auth_username_;
-  std::string web_auth_password_;
-  configuration::EspHomeLegacyTextValue button_order_text_{};
-  configuration::EspHomeLegacyTextValue button_on_color_text_{};
-  std::array<LegacyButtonTextSources, configuration::PANEL_CONFIG_MAX_SLOT_COUNT>
-      legacy_button_texts_{};
+  const char *web_auth_username_{nullptr};
+  const char *web_auth_password_{nullptr};
 };
 
 }  // namespace espcontrol

--- a/components/espcontrol/espcontrol_app_core.h
+++ b/components/espcontrol/espcontrol_app_core.h
@@ -144,12 +144,12 @@ class EspControlAppCore {
   // and callback state receive one core-owned lifetime.
   template<typename BindingService>
   BindingService &home_assistant_binding_service() {
-    return home_assistant_binding_service_.get_or_create<BindingService>();
+    return home_assistant_binding_service_.get_or_create_ui_service<BindingService>();
   }
 
   template<typename NavigationService>
   NavigationService &grid_navigation_service() {
-    return grid_navigation_service_.get_or_create<NavigationService>();
+    return grid_navigation_service_.get_or_create_ui_service<NavigationService>();
   }
 
   // Modal widgets stay in the LVGL-facing UI layer, while their lifecycle

--- a/components/espcontrol/espcontrol_app_core.h
+++ b/components/espcontrol/espcontrol_app_core.h
@@ -46,6 +46,25 @@ class FixedRuntimeServiceSlot {
     return *static_cast<Service *>(static_cast<void *>(storage_.data()));
   }
 
+  // Some ESP-IDF builds emit separate type-name constants for a UI type that
+  // crosses the ESPHome component boundary.  Modal state has one concrete
+  // production type, so reuse that fixed storage without a cross-unit token
+  // comparison rather than turning an implementation-detail mismatch into a
+  // firmware-wide abort.
+  template<typename Service>
+  Service &get_or_create_ui_service() {
+    static_assert(sizeof(Service) <= CAPACITY,
+                  "runtime service exceeds the fixed core slot capacity");
+    static_assert(alignof(Service) <= alignof(std::max_align_t),
+                  "runtime service alignment exceeds the fixed core slot");
+    if (destroy_ == nullptr) {
+      new (storage_.data()) Service();
+      type_name_ = service_type<Service>();
+      destroy_ = [](void *storage) { static_cast<Service *>(storage)->~Service(); };
+    }
+    return *static_cast<Service *>(static_cast<void *>(storage_.data()));
+  }
+
   void reset() {
     if (destroy_ != nullptr) destroy_(storage_.data());
     type_name_ = nullptr;
@@ -137,7 +156,7 @@ class EspControlAppCore {
   // state receives the same application-owned lifetime as navigation.
   template<typename ModalService>
   ModalService &modal_state_service() {
-    return modal_state_service_.get_or_create<ModalService>();
+    return modal_state_service_.get_or_create_ui_service<ModalService>();
   }
 
   // Compatibility facade for ESPHome YAML while display ownership migrates to

--- a/components/espcontrol/espcontrol_app_core.h
+++ b/components/espcontrol/espcontrol_app_core.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <cstdlib>
 #include <new>
 #include <optional>
@@ -34,12 +35,12 @@ class FixedRuntimeServiceSlot {
                   "runtime service exceeds the fixed core slot capacity");
     static_assert(alignof(Service) <= alignof(std::max_align_t),
                   "runtime service alignment exceeds the fixed core slot");
-    const void *type = service_type<Service>();
-    if (type_ == nullptr) {
+    const char *type_name = service_type<Service>();
+    if (type_name_ == nullptr) {
       new (storage_.data()) Service();
-      type_ = type;
+      type_name_ = type_name;
       destroy_ = [](void *storage) { static_cast<Service *>(storage)->~Service(); };
-    } else if (type_ != type) {
+    } else if (std::strcmp(type_name_, type_name) != 0) {
       std::abort();
     }
     return *static_cast<Service *>(static_cast<void *>(storage_.data()));
@@ -47,19 +48,21 @@ class FixedRuntimeServiceSlot {
 
   void reset() {
     if (destroy_ != nullptr) destroy_(storage_.data());
-    type_ = nullptr;
+    type_name_ = nullptr;
     destroy_ = nullptr;
   }
 
  private:
   template<typename Service>
-  static const void *service_type() {
-    static const int marker = 0;
-    return &marker;
+  static const char *service_type() {
+    // Function-local marker addresses can differ between ESP-IDF translation
+    // units even for the same template specialisation.  The signature text is
+    // stable for the concrete service and preserves the fixed-slot invariant.
+    return __PRETTY_FUNCTION__;
   }
 
   alignas(std::max_align_t) std::array<uint8_t, CAPACITY> storage_{};
-  const void *type_{nullptr};
+  const char *type_name_{nullptr};
   void (*destroy_)(void *){nullptr};
 };
 


### PR DESCRIPTION
## Summary

Fixes a startup crash introduced while moving runtime responsibilities into explicit services. The service lookup now remains consistent across firmware compilation units, and early calls made before the application core exists safely use a fallback service rather than aborting the device.

## Impact

P4 panels can complete startup and retain their Home Assistant API and web-server connections instead of becoming unresponsive after an update.

## Validation

- `npm run test:firmware` — 26 host firmware tests passed
- ESPHome compile passed for the 10-inch P4 V1 and 7-inch P4
- Flashed the 10-inch P4 V1 over USB; verified normal startup, Wi-Fi, API, and HTTP 200
- Flashed the 7-inch P4 over OTA; verified successful upload and HTTP 200 after reboot

## Device testing

Please confirm normal on-screen operation on both the 10-inch and 7-inch P4 panels before merging.