### PR TITLE
Fix remote package partition configuration

### DIFF
--- a/builds/esp32-p4-86.yaml
+++ b/builds/esp32-p4-86.yaml
@@ -7,13 +7,15 @@
 # =============================================================================
 
 substitutions:
-  partition_table: "../common/device/partitions_32mb_card_images.csv"
   cover_art_placeholder_file: "../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-p4-86"
   friendly_name: "EspControl P4 86 Panel"
   espcontrol_component_url: "file:///config"
   mdi_font_file: "/config/common/assets/fonts/materialdesignicons-webfont-7.4.47.ttf"
   espcontrol_component_ref: "HEAD"
+
+esp32:
+  partitions: "../common/device/partitions_32mb_card_images.csv"
   voice_stt_failure_chime_file: "../devices/esp32-p4-86/device/voice_stt_failure_chime.flac"
   alarm_delay_entry_beep_file: "../devices/esp32-p4-86/device/alarm_delay_entry_beep.flac"
   alarm_delay_exit_beep_file: "../devices/esp32-p4-86/device/alarm_delay_exit_beep.flac"

--- a/builds/esp32-p4-86.yaml
+++ b/builds/esp32-p4-86.yaml
@@ -13,12 +13,12 @@ substitutions:
   espcontrol_component_url: "file:///config"
   mdi_font_file: "/config/common/assets/fonts/materialdesignicons-webfont-7.4.47.ttf"
   espcontrol_component_ref: "HEAD"
-
-esp32:
-  partitions: "../common/device/partitions_32mb_card_images.csv"
   voice_stt_failure_chime_file: "../devices/esp32-p4-86/device/voice_stt_failure_chime.flac"
   alarm_delay_entry_beep_file: "../devices/esp32-p4-86/device/alarm_delay_entry_beep.flac"
   alarm_delay_exit_beep_file: "../devices/esp32-p4-86/device/alarm_delay_exit_beep.flac"
+
+esp32:
+  partitions: "../common/device/partitions_32mb_card_images.csv"
 
 esphome:
   name_add_mac_suffix: true

--- a/builds/guition-esp32-p4-jc1060p470.yaml
+++ b/builds/guition-esp32-p4-jc1060p470.yaml
@@ -7,13 +7,15 @@
 # =============================================================================
 
 substitutions:
-  partition_table: "../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-jc1060p470"
   friendly_name: "EspControl 7inch"
   espcontrol_component_url: "file:///config"
   mdi_font_file: "/config/common/assets/fonts/materialdesignicons-webfont-7.4.47.ttf"
   espcontrol_component_ref: "HEAD"
+
+esp32:
+  partitions: "../common/device/partitions_16mb_card_images.csv"
 
 esphome:
   name_add_mac_suffix: true

--- a/builds/guition-esp32-p4-jc4880p443.yaml
+++ b/builds/guition-esp32-p4-jc4880p443.yaml
@@ -7,13 +7,15 @@
 # =============================================================================
 
 substitutions:
-  partition_table: "../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-jc4880p443"
   friendly_name: "EspControl 4inch"
   espcontrol_component_url: "file:///config"
   mdi_font_file: "/config/common/assets/fonts/materialdesignicons-webfont-7.4.47.ttf"
   espcontrol_component_ref: "HEAD"
+
+esp32:
+  partitions: "../common/device/partitions_16mb_card_images.csv"
 
 esphome:
   name_add_mac_suffix: true

--- a/builds/guition-esp32-p4-jc8012p4a1-v2.yaml
+++ b/builds/guition-esp32-p4-jc8012p4a1-v2.yaml
@@ -7,13 +7,15 @@
 # =============================================================================
 
 substitutions:
-  partition_table: "../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-jc8012p4a1-v2"
   friendly_name: "EspControl 10inch V2"
   espcontrol_component_url: "file:///config"
   mdi_font_file: "/config/common/assets/fonts/materialdesignicons-webfont-7.4.47.ttf"
   espcontrol_component_ref: "HEAD"
+
+esp32:
+  partitions: "../common/device/partitions_16mb_card_images.csv"
 
 esphome:
   name_add_mac_suffix: true

--- a/builds/guition-esp32-p4-jc8012p4a1.yaml
+++ b/builds/guition-esp32-p4-jc8012p4a1.yaml
@@ -7,13 +7,15 @@
 # =============================================================================
 
 substitutions:
-  partition_table: "../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-jc8012p4a1"
   friendly_name: "EspControl 10inch"
   espcontrol_component_url: "file:///config"
   mdi_font_file: "/config/common/assets/fonts/materialdesignicons-webfont-7.4.47.ttf"
   espcontrol_component_ref: "HEAD"
+
+esp32:
+  partitions: "../common/device/partitions_16mb_card_images.csv"
 
 esphome:
   name_add_mac_suffix: true

--- a/builds/guition-esp32-s3-4848s040.factory.yaml
+++ b/builds/guition-esp32-s3-4848s040.factory.yaml
@@ -5,7 +5,6 @@
 # =============================================================================
 
 substitutions:
-  partition_table: "../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-4848s040"
   friendly_name: "Guition ESP32-S3-4848S040"
@@ -13,6 +12,9 @@ substitutions:
   espcontrol_component_url: "file:///config"
   mdi_font_file: "/config/common/assets/fonts/materialdesignicons-webfont-7.4.47.ttf"
   espcontrol_component_ref: "HEAD"
+
+esp32:
+  partitions: "../common/device/partitions_16mb_card_images.csv"
 
 packages:
   core: !include ../devices/guition-esp32-s3-4848s040/packages.yaml

--- a/builds/guition-esp32-s3-4848s040.yaml
+++ b/builds/guition-esp32-s3-4848s040.yaml
@@ -7,13 +7,15 @@
 # =============================================================================
 
 substitutions:
-  partition_table: "../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-4848s040"
   friendly_name: "Guition ESP32-S3-4848S040"
   espcontrol_component_url: "file:///config"
   mdi_font_file: "/config/common/assets/fonts/materialdesignicons-webfont-7.4.47.ttf"
   espcontrol_component_ref: "HEAD"
+
+esp32:
+  partitions: "../common/device/partitions_16mb_card_images.csv"
 
 esphome:
   name_add_mac_suffix: true

--- a/devices/esp32-p4-86/dev.yaml
+++ b/devices/esp32-p4-86/dev.yaml
@@ -5,7 +5,6 @@
 # =============================================================================
 
 substitutions:
-  partition_table: "../../common/device/partitions_32mb_card_images.csv"
   cover_art_placeholder_file: "../../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-p4-86"
   friendly_name: "EspControl P4-86"
@@ -17,6 +16,9 @@ substitutions:
   voice_stt_failure_chime_file: "device/voice_stt_failure_chime.flac"
   alarm_delay_entry_beep_file: "device/alarm_delay_entry_beep.flac"
   alarm_delay_exit_beep_file: "device/alarm_delay_exit_beep.flac"
+
+esp32:
+  partitions: "../../common/device/partitions_32mb_card_images.csv"
 
 wifi:
   ssid: !secret wifi_ssid

--- a/devices/esp32-p4-86/device/device.yaml
+++ b/devices/esp32-p4-86/device/device.yaml
@@ -19,7 +19,6 @@ esp32:
   variant: esp32p4
   # Waveshare documents this panel with 32MB external NOR flash.
   flash_size: 32MB
-  partitions: ${partition_table}
   cpu_frequency: 360MHZ
   engineering_sample: true
   framework:

--- a/devices/esp32-p4-86/esphome.yaml
+++ b/devices/esp32-p4-86/esphome.yaml
@@ -10,7 +10,6 @@
 # Device identity
 # ---------------------------------------------------------------------------
 substitutions:
-  partition_table: "../../common/device/partitions_32mb_card_images.csv"
   name: "your-device-name"
   friendly_name: "Your Device Name"
 

--- a/devices/guition-esp32-p4-jc1060p470/dev.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/dev.yaml
@@ -5,13 +5,15 @@
 # =============================================================================
 
 substitutions:
-  partition_table: "../../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-7inch-p4"
   friendly_name: "EspControl 7inch P4"
   espcontrol_component_url: "../.."
   mdi_font_file: "../../common/assets/fonts/materialdesignicons-webfont-7.4.47.ttf"
   espcontrol_component_ref: "HEAD"
+
+esp32:
+  partitions: "../../common/device/partitions_16mb_card_images.csv"
 
 wifi:
   ssid: !secret wifi_ssid

--- a/devices/guition-esp32-p4-jc1060p470/device/device.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/device/device.yaml
@@ -17,7 +17,6 @@ substitutions:
 esp32:
   variant: esp32p4
   flash_size: 16MB
-  partitions: ${partition_table}
   cpu_frequency: 360MHZ
   engineering_sample: true
   framework:

--- a/devices/guition-esp32-p4-jc1060p470/esphome.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/esphome.yaml
@@ -10,7 +10,6 @@
 # Device identity
 # ---------------------------------------------------------------------------
 substitutions:
-  partition_table: "../../common/device/partitions_16mb_card_images.csv"
   name: "your-device-name"
   friendly_name: "Your Device Name"
   # Set this to "ethernet" for the built-in wired Ethernet port.

--- a/devices/guition-esp32-p4-jc4880p443/dev.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/dev.yaml
@@ -5,13 +5,15 @@
 # =============================================================================
 
 substitutions:
-  partition_table: "../../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-43inch-p4"
   friendly_name: "EspControl 4.3inch P4"
   espcontrol_component_url: "../.."
   mdi_font_file: "../../common/assets/fonts/materialdesignicons-webfont-7.4.47.ttf"
   espcontrol_component_ref: "HEAD"
+
+esp32:
+  partitions: "../../common/device/partitions_16mb_card_images.csv"
 
 wifi:
   ssid: !secret wifi_ssid

--- a/devices/guition-esp32-p4-jc4880p443/device/device.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/device/device.yaml
@@ -17,7 +17,6 @@ substitutions:
 esp32:
   variant: esp32p4
   flash_size: 16MB
-  partitions: ${partition_table}
   engineering_sample: true
   framework:
     type: esp-idf

--- a/devices/guition-esp32-p4-jc4880p443/esphome.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/esphome.yaml
@@ -10,7 +10,6 @@
 # Device identity
 # ---------------------------------------------------------------------------
 substitutions:
-  partition_table: "../../common/device/partitions_16mb_card_images.csv"
   name: "your-device-name"
   friendly_name: "Your Device Name"
 

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/dev.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/dev.yaml
@@ -5,13 +5,15 @@
 # =============================================================================
 
 substitutions:
-  partition_table: "../../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-10inch-p4-v2"
   friendly_name: "EspControl 10inch P4 V2"
   espcontrol_component_url: "../.."
   mdi_font_file: "../../common/assets/fonts/materialdesignicons-webfont-7.4.47.ttf"
   espcontrol_component_ref: "HEAD"
+
+esp32:
+  partitions: "../../common/device/partitions_16mb_card_images.csv"
 
 wifi:
   ssid: !secret wifi_ssid

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
@@ -17,7 +17,6 @@ substitutions:
 esp32:
   variant: esp32p4
   flash_size: 16MB
-  partitions: ${partition_table}
   cpu_frequency: 360MHZ
   engineering_sample: true
   framework:

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/esphome.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/esphome.yaml
@@ -10,7 +10,6 @@
 # Device identity
 # ---------------------------------------------------------------------------
 substitutions:
-  partition_table: "../../common/device/partitions_16mb_card_images.csv"
   name: "your-device-name"
   friendly_name: "Your Device Name"
 

--- a/devices/guition-esp32-p4-jc8012p4a1/dev.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/dev.yaml
@@ -5,13 +5,15 @@
 # =============================================================================
 
 substitutions:
-  partition_table: "../../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-10inch-p4"
   friendly_name: "EspControl 10inch P4"
   espcontrol_component_url: "../.."
   mdi_font_file: "../../common/assets/fonts/materialdesignicons-webfont-7.4.47.ttf"
   espcontrol_component_ref: "HEAD"
+
+esp32:
+  partitions: "../../common/device/partitions_16mb_card_images.csv"
 
 wifi:
   ssid: !secret wifi_ssid

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -17,7 +17,6 @@ substitutions:
 esp32:
   variant: esp32p4
   flash_size: 16MB
-  partitions: ${partition_table}
   cpu_frequency: 360MHZ
   engineering_sample: true
   framework:

--- a/devices/guition-esp32-p4-jc8012p4a1/esphome.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/esphome.yaml
@@ -10,7 +10,6 @@
 # Device identity
 # ---------------------------------------------------------------------------
 substitutions:
-  partition_table: "../../common/device/partitions_16mb_card_images.csv"
   name: "your-device-name"
   friendly_name: "Your Device Name"
 

--- a/devices/guition-esp32-s3-4848s040/dev.yaml
+++ b/devices/guition-esp32-s3-4848s040/dev.yaml
@@ -5,13 +5,15 @@
 # =============================================================================
 
 substitutions:
-  partition_table: "../../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-4inch-s3"
   friendly_name: "EspControl 4inch S3"
   espcontrol_component_url: "../.."
   mdi_font_file: "../../common/assets/fonts/materialdesignicons-webfont-7.4.47.ttf"
   espcontrol_component_ref: "HEAD"
+
+esp32:
+  partitions: "../../common/device/partitions_16mb_card_images.csv"
 
 wifi:
   ssid: !secret wifi_ssid

--- a/devices/guition-esp32-s3-4848s040/device/device.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/device.yaml
@@ -17,7 +17,6 @@ substitutions:
 esp32:
   board: esp32-s3-devkitc-1
   flash_size: 16MB
-  partitions: ${partition_table}
   framework:
     type: esp-idf
     # stick to recommended version, currently 5.5.4, 55.03.39 with tool-esptoolpy 5.3.0. No issues

--- a/devices/guition-esp32-s3-4848s040/esphome.yaml
+++ b/devices/guition-esp32-s3-4848s040/esphome.yaml
@@ -10,7 +10,6 @@
 # Device identity
 # ---------------------------------------------------------------------------
 substitutions:
-  partition_table: "../../common/device/partitions_16mb_card_images.csv"
   name: "your-device-name"
   friendly_name: "Your Device Name"
 

--- a/scripts/check_device_profiles.py
+++ b/scripts/check_device_profiles.py
@@ -223,20 +223,20 @@ def test_ota_preserves_deployed_partition_layouts() -> None:
         public_config = public_config_path.read_text(encoding="utf-8")
         build = build_path.read_text(encoding="utf-8")
         factory = factory_path.read_text(encoding="utf-8")
-        assert "partitions: ${partition_table}" in device, (
-            f"{slug}: OTA builds must select the deployed partition table per entry point"
+        assert "partitions:" not in device, (
+            f"{slug}: device package must not require a local partition table from remote installs"
         )
-        assert f'partition_table: "../../common/device/{table_name}"' in dev, (
+        assert f'partitions: "../../common/device/{table_name}"' in dev, (
             f"{slug}: local development builds must retain the deployed {table_name} flash layout"
         )
-        assert f'partition_table: "../../common/device/{table_name}"' in public_config, (
-            f"{slug}: published configuration must retain the deployed {table_name} flash layout"
+        assert "partition_table:" not in public_config, (
+            f"{slug}: published remote configuration must not reference a local partition table"
         )
-        assert f'partition_table: "../common/device/{table_name}"' in build, (
+        assert f'partitions: "../common/device/{table_name}"' in build, (
             f"{slug}: copied firmware builds must retain the deployed {table_name} flash layout"
         )
         assert (
-            f'partition_table: "../common/device/{table_name}"' in factory
+            f'partitions: "../common/device/{table_name}"' in factory
             or f"!include {slug}.yaml" in factory
         ), f"{slug}: factory builds must retain the deployed {table_name} flash layout"
 


### PR DESCRIPTION
## Summary

Fixes ESPHome Dashboard configurations that compile a remote EspControl package from /config.

## Root cause

The previous partition-table substitution referred to a repository-relative CSV. In a Dashboard install the configuration file is stored at /config, while the repository is held in the ESPHome package cache, so the substitution was either missing in older copied configurations or resolved to a file that did not exist.

## Changes

- Keep explicit deployed partition maps in local development, CI, and factory build entry points.
- Remove the partition-table requirement from remote package device definitions and public starter configurations.
- Add checks that protect both the remote-install path and the release partition layouts.

## Validation

- `python3 scripts/check_device_profiles.py`
- ESPHome 2026.7.4 factory compile: `guition-esp32-p4-jc1060p470` (passed; 5.03 MB image, 31% app-slot free).

## Device test

In ESPHome Dashboard, compile the 7-inch P4 configuration again. The undefined `partition_table` warning and `/config/${partition_table}` file error should no longer appear.