### PR TITLE
Preserve deployed OTA partition layouts

### DIFF
--- a/builds/esp32-p4-86.yaml
+++ b/builds/esp32-p4-86.yaml
@@ -7,6 +7,7 @@
 # =============================================================================
 
 substitutions:
+  partition_table: "../common/device/partitions_32mb_card_images.csv"
   cover_art_placeholder_file: "../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-p4-86"
   friendly_name: "EspControl P4 86 Panel"

--- a/builds/guition-esp32-p4-jc1060p470.yaml
+++ b/builds/guition-esp32-p4-jc1060p470.yaml
@@ -7,6 +7,7 @@
 # =============================================================================
 
 substitutions:
+  partition_table: "../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-jc1060p470"
   friendly_name: "EspControl 7inch"

--- a/builds/guition-esp32-p4-jc4880p443.yaml
+++ b/builds/guition-esp32-p4-jc4880p443.yaml
@@ -7,6 +7,7 @@
 # =============================================================================
 
 substitutions:
+  partition_table: "../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-jc4880p443"
   friendly_name: "EspControl 4inch"

--- a/builds/guition-esp32-p4-jc8012p4a1-v2.yaml
+++ b/builds/guition-esp32-p4-jc8012p4a1-v2.yaml
@@ -7,6 +7,7 @@
 # =============================================================================
 
 substitutions:
+  partition_table: "../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-jc8012p4a1-v2"
   friendly_name: "EspControl 10inch V2"

--- a/builds/guition-esp32-p4-jc8012p4a1.yaml
+++ b/builds/guition-esp32-p4-jc8012p4a1.yaml
@@ -7,6 +7,7 @@
 # =============================================================================
 
 substitutions:
+  partition_table: "../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-jc8012p4a1"
   friendly_name: "EspControl 10inch"

--- a/builds/guition-esp32-s3-4848s040.yaml
+++ b/builds/guition-esp32-s3-4848s040.yaml
@@ -7,6 +7,7 @@
 # =============================================================================
 
 substitutions:
+  partition_table: "../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-4848s040"
   friendly_name: "Guition ESP32-S3-4848S040"

--- a/common/device/partitions_16mb_card_images.csv
+++ b/common/device/partitions_16mb_card_images.csv
@@ -1,0 +1,9 @@
+# Name,       Type, SubType, Offset,    Size,      Flags
+#
+# This is the deployed layout for 16 MB EspControl panels. Keep it explicit:
+# an OTA update replaces the application image, not the partition table.
+nvs,           data, nvs,     0x9000,    0xd000,
+otadata,       data, ota,     0x16000,   0x2000,
+app0,          app,  ota_0,   0x20000,   0x6f0000,
+app1,          app,  ota_1,   0x710000,  0x6f0000,
+card_images,   data, 0x40,    0xe00000,  0x200000,

--- a/common/device/partitions_32mb_card_images.csv
+++ b/common/device/partitions_32mb_card_images.csv
@@ -1,0 +1,9 @@
+# Name,       Type, SubType, Offset,    Size,      Flags
+#
+# This is the deployed layout for the 32 MB P4-86 panel. Keep it explicit:
+# an OTA update replaces the application image, not the partition table.
+nvs,           data, nvs,     0x9000,    0xd000,
+otadata,       data, ota,     0x16000,   0x2000,
+app0,          app,  ota_0,   0x20000,   0xef0000,
+app1,          app,  ota_1,   0xf10000,  0xef0000,
+card_images,   data, 0x40,    0x1e00000, 0x200000,

--- a/devices/esp32-p4-86/dev.yaml
+++ b/devices/esp32-p4-86/dev.yaml
@@ -5,6 +5,7 @@
 # =============================================================================
 
 substitutions:
+  partition_table: "../../common/device/partitions_32mb_card_images.csv"
   cover_art_placeholder_file: "../../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-p4-86"
   friendly_name: "EspControl P4-86"

--- a/devices/esp32-p4-86/device/device.yaml
+++ b/devices/esp32-p4-86/device/device.yaml
@@ -19,6 +19,7 @@ esp32:
   variant: esp32p4
   # Waveshare documents this panel with 32MB external NOR flash.
   flash_size: 32MB
+  partitions: ${partition_table}
   cpu_frequency: 360MHZ
   engineering_sample: true
   framework:

--- a/devices/guition-esp32-p4-jc1060p470/dev.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/dev.yaml
@@ -5,6 +5,7 @@
 # =============================================================================
 
 substitutions:
+  partition_table: "../../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-7inch-p4"
   friendly_name: "EspControl 7inch P4"

--- a/devices/guition-esp32-p4-jc1060p470/device/device.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/device/device.yaml
@@ -17,6 +17,7 @@ substitutions:
 esp32:
   variant: esp32p4
   flash_size: 16MB
+  partitions: ${partition_table}
   cpu_frequency: 360MHZ
   engineering_sample: true
   framework:

--- a/devices/guition-esp32-p4-jc4880p443/dev.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/dev.yaml
@@ -5,6 +5,7 @@
 # =============================================================================
 
 substitutions:
+  partition_table: "../../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-43inch-p4"
   friendly_name: "EspControl 4.3inch P4"

--- a/devices/guition-esp32-p4-jc4880p443/device/device.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/device/device.yaml
@@ -17,6 +17,7 @@ substitutions:
 esp32:
   variant: esp32p4
   flash_size: 16MB
+  partitions: ${partition_table}
   engineering_sample: true
   framework:
     type: esp-idf

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/dev.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/dev.yaml
@@ -5,6 +5,7 @@
 # =============================================================================
 
 substitutions:
+  partition_table: "../../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-10inch-p4-v2"
   friendly_name: "EspControl 10inch P4 V2"

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
@@ -17,6 +17,7 @@ substitutions:
 esp32:
   variant: esp32p4
   flash_size: 16MB
+  partitions: ${partition_table}
   cpu_frequency: 360MHZ
   engineering_sample: true
   framework:

--- a/devices/guition-esp32-p4-jc8012p4a1/dev.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/dev.yaml
@@ -5,6 +5,7 @@
 # =============================================================================
 
 substitutions:
+  partition_table: "../../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-10inch-p4"
   friendly_name: "EspControl 10inch P4"

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -17,6 +17,7 @@ substitutions:
 esp32:
   variant: esp32p4
   flash_size: 16MB
+  partitions: ${partition_table}
   cpu_frequency: 360MHZ
   engineering_sample: true
   framework:

--- a/devices/guition-esp32-s3-4848s040/dev.yaml
+++ b/devices/guition-esp32-s3-4848s040/dev.yaml
@@ -5,6 +5,7 @@
 # =============================================================================
 
 substitutions:
+  partition_table: "../../common/device/partitions_16mb_card_images.csv"
   cover_art_placeholder_file: "../../common/assets/cover_art_placeholder.svg"
   name: "espcontrol-4inch-s3"
   friendly_name: "EspControl 4inch S3"

--- a/devices/guition-esp32-s3-4848s040/device/device.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/device.yaml
@@ -17,6 +17,7 @@ substitutions:
 esp32:
   board: esp32-s3-devkitc-1
   flash_size: 16MB
+  partitions: ${partition_table}
   framework:
     type: esp-idf
     # stick to recommended version, currently 5.5.4, 55.03.39 with tool-esptoolpy 5.3.0. No issues

--- a/scripts/check_device_profiles.py
+++ b/scripts/check_device_profiles.py
@@ -20,6 +20,30 @@ COMPAT_FIXTURES = ROOT / "compatibility" / "fixtures" / "product_compatibility.j
 BUTTON_GRID_CARDS = ROOT / "components" / "espcontrol" / "button_grid_cards.h"
 BUTTON_GRID_WEATHER_DRIVER = ROOT / "components" / "espcontrol" / "button_grid_weather_driver.h"
 BUTTON_GRID_WEATHER_FORECAST = ROOT / "components" / "espcontrol" / "button_grid_weather_forecast.h"
+LEGACY_OTA_PARTITION_LAYOUTS = {
+    "esp32-p4-86": "partitions_32mb_card_images.csv",
+    "guition-esp32-p4-jc1060p470": "partitions_16mb_card_images.csv",
+    "guition-esp32-p4-jc4880p443": "partitions_16mb_card_images.csv",
+    "guition-esp32-p4-jc8012p4a1": "partitions_16mb_card_images.csv",
+    "guition-esp32-p4-jc8012p4a1-v2": "partitions_16mb_card_images.csv",
+    "guition-esp32-s3-4848s040": "partitions_16mb_card_images.csv",
+}
+LEGACY_OTA_PARTITION_ROWS = {
+    "partitions_16mb_card_images.csv": (
+        "nvs,           data, nvs,     0x9000,    0xd000,",
+        "otadata,       data, ota,     0x16000,   0x2000,",
+        "app0,          app,  ota_0,   0x20000,   0x6f0000,",
+        "app1,          app,  ota_1,   0x710000,  0x6f0000,",
+        "card_images,   data, 0x40,    0xe00000,  0x200000,",
+    ),
+    "partitions_32mb_card_images.csv": (
+        "nvs,           data, nvs,     0x9000,    0xd000,",
+        "otadata,       data, ota,     0x16000,   0x2000,",
+        "app0,          app,  ota_0,   0x20000,   0xef0000,",
+        "app1,          app,  ota_1,   0xf10000,  0xef0000,",
+        "card_images,   data, 0x40,    0x1e00000, 0x200000,",
+    ),
+}
 REQUIRED_SETUP_ICON_GLYPHS = {
     r'"\U000F012C"': "mdi-check",
     r'"\U000F0996"': "mdi-progress-clock",
@@ -202,6 +226,27 @@ def test_upgrades_do_not_reset_saved_panel_config() -> None:
         assert not re.search(r"id\((?:button|subpage)_\d+_config(?:_ext(?:_\d+)?)?\)\.publish_state\(\"\"\)", text), (
             f"{rel}: must not clear saved button or subpage config"
         )
+
+
+def test_ota_preserves_deployed_partition_layouts() -> None:
+    for slug, table_name in LEGACY_OTA_PARTITION_LAYOUTS.items():
+        device = (ROOT / "devices" / slug / "device" / "device.yaml").read_text(encoding="utf-8")
+        dev = (ROOT / "devices" / slug / "dev.yaml").read_text(encoding="utf-8")
+        build = (ROOT / "builds" / f"{slug}.yaml").read_text(encoding="utf-8")
+        assert "partitions: ${partition_table}" in device, (
+            f"{slug}: OTA builds must select the deployed partition table per entry point"
+        )
+        assert f'partition_table: "../../common/device/{table_name}"' in dev, (
+            f"{slug}: local development builds must retain the deployed {table_name} flash layout"
+        )
+        assert f'partition_table: "../common/device/{table_name}"' in build, (
+            f"{slug}: copied firmware builds must retain the deployed {table_name} flash layout"
+        )
+
+    for table_name, rows in LEGACY_OTA_PARTITION_ROWS.items():
+        table = (ROOT / "common" / "device" / table_name).read_text(encoding="utf-8")
+        for row in rows:
+            assert row in table, f"{table_name}: missing deployed partition row {row}"
 
 
 def test_local_voice_generation_uses_capability() -> None:
@@ -676,6 +721,7 @@ def main() -> int:
     test_zero_image_capacity_disables_all_image_card_pickers(profiles)
     test_constrained_s3_supports_one_cover_art_card(profiles)
     test_generated_yaml(profiles)
+    test_ota_preserves_deployed_partition_layouts()
     test_upgrades_do_not_reset_saved_panel_config()
     test_local_voice_generation_uses_capability()
     test_square_s3_reapplies_clock_bar_after_screen_changes()


### PR DESCRIPTION
## Purpose

Keep firmware builds aligned with the partition tables already installed on P4 and affected 16 MB panels, so OTA updates target the same application slots and retain card-image storage.

## Practical impact

The 10-inch V1 build now uses the deployed 6.9 MB OTA slots rather than the newer default layout. The same explicit layout is used for all affected device and release build entry points.

## Checks

- `python3 scripts/check_device_profiles.py`
- 10-inch V1 ESPHome build: 5,274,040 bytes / 7,274,496-byte deployed app slot (72.5%)
- Physical OTA verification pending: the reference 10-inch is temporarily offline after the prior rollback cycle.

## Device testing

Test on: Guition 10-inch V1 (`guition-esp32-p4-jc8012p4a1`). Confirm OTA upload, restart, web UI, Home Assistant reconnect, and card persistence.