### PR TITLE
Persist 10-inch native configuration safely

### DIFF
--- a/components/espcontrol/__init__.py
+++ b/components/espcontrol/__init__.py
@@ -22,6 +22,7 @@ CONF_BUTTON_ON_COLOR = "button_on_color"
 CONF_BUTTONS = "buttons"
 CONF_CONFIG = "config"
 CONF_SUBPAGE_CHUNKS = "subpage_chunks"
+CONF_STORAGE = "storage"
 CONF_WEB_AUTH_USERNAME = "web_auth_username"
 CONF_WEB_AUTH_PASSWORD = "web_auth_password"
 
@@ -45,6 +46,9 @@ PANEL_CONFIG_SCHEMA = cv.Schema(
         cv.Required(CONF_BUTTONS): cv.All(
             cv.ensure_list(PANEL_CONFIG_BUTTON_SCHEMA), cv.Length(min=1, max=32)
         ),
+        cv.Optional(CONF_STORAGE, default="nvs"): cv.one_of(
+            "nvs", "card_images", lower=True
+        ),
     }
 )
 
@@ -67,6 +71,8 @@ async def to_code(config):
 
     panel_config = config.get(CONF_PANEL_CONFIG)
     if panel_config is not None:
+        if panel_config[CONF_STORAGE] == "card_images":
+            cg.add(var.set_panel_config_card_images_storage(True))
         cg.add(var.set_panel_config_device_profile(panel_config[CONF_DEVICE_PROFILE]))
         button_order = await cg.get_variable(panel_config[CONF_BUTTON_ORDER])
         cg.add(var.set_panel_config_button_order(button_order))

--- a/components/espcontrol/espcontrol_app.cpp
+++ b/components/espcontrol/espcontrol_app.cpp
@@ -232,7 +232,10 @@ void EspControlApp::initialize_native_configuration() {
   panel_config_service->set_runtime_adapter(&runtime.legacy_config);
   if (!runtime.legacy_config.configured()) {
     ESP_LOGW(TAG, "Native configuration sources are not configured");
-  } else if (!runtime.blobs.begin()) {
+  } else if (panel_config_card_images_storage_
+                 ? !runtime.blobs.begin_card_images_partition(
+                       PANEL_CONFIG_STORAGE_SLOT_CAPACITY)
+                 : !runtime.blobs.begin()) {
     ESP_LOGE(TAG, "Native configuration storage is unavailable");
   } else {
     ESP_LOGI(TAG, "Allocating native configuration buffers");

--- a/components/espcontrol/espcontrol_app.h
+++ b/components/espcontrol/espcontrol_app.h
@@ -45,6 +45,9 @@ class EspControlApp : public esphome::Component {
       esphome::text::Text *subpage_2, esphome::text::Text *subpage_3,
       esphome::text::Text *subpage_4, esphome::text::Text *subpage_5,
       esphome::text::Text *subpage_6, esphome::text::Text *subpage_7);
+  void set_panel_config_card_images_storage(bool enabled) {
+    panel_config_card_images_storage_ = enabled;
+  }
   void set_web_auth_credentials(const char *username, const char *password) {
     web_auth_username_ = username;
     web_auth_password_ = password;
@@ -68,6 +71,7 @@ class EspControlApp : public esphome::Component {
   esphome::text::Text *panel_config_button_order_{nullptr};
   esphome::text::Text *panel_config_button_on_color_{nullptr};
   std::array<PanelConfigTextSources, 32> panel_config_button_texts_{};
+  bool panel_config_card_images_storage_{false};
   // This owns every non-trivial configuration object. Keeping it separate
   // leaves the ESPHome-created application object safe to construct before
   // the framework's allocators and component setup are ready.

--- a/components/espcontrol/panel_config_espidf_storage.cpp
+++ b/components/espcontrol/panel_config_espidf_storage.cpp
@@ -1,10 +1,12 @@
 #include "panel_config_espidf_storage.h"
 
+#include <algorithm>
 #include <cstring>
 
 #ifdef USE_ESP32
 #include <esp_err.h>
 #include <nvs.h>
+#include <esp_partition.h>
 #endif
 
 namespace espcontrol::configuration {
@@ -25,6 +27,111 @@ bool EspIdfPanelConfigBlobStorage::begin() {
 #endif
 }
 
+bool EspIdfPanelConfigBlobStorage::begin_card_images_partition(
+    size_t slot_capacity) {
+#ifdef USE_ESP32
+  if (ready_ || slot_capacity == 0) return false;
+  const esp_partition_t *const partition = esp_partition_find_first(
+      ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_ANY,
+      CARD_IMAGES_PARTITION_LABEL);
+  if (partition == nullptr) return false;
+
+  partition_slot_capacity_ = slot_capacity;
+  if (partition_slot_stride() > partition->size / 2) {
+    partition_slot_capacity_ = 0;
+    return false;
+  }
+  partition_ = partition;
+  partition_backed_ = true;
+  ready_ = true;
+  return true;
+#else
+  (void) slot_capacity;
+  return false;
+#endif
+}
+
+#ifdef USE_ESP32
+size_t EspIdfPanelConfigBlobStorage::partition_slot_stride() const {
+  const size_t unaligned = PARTITION_SLOT_HEADER_SIZE + partition_slot_capacity_;
+  return ((unaligned + FLASH_ERASE_SIZE - 1) / FLASH_ERASE_SIZE) *
+         FLASH_ERASE_SIZE;
+}
+
+size_t EspIdfPanelConfigBlobStorage::partition_slot_offset(uint8_t slot) const {
+  return static_cast<size_t>(slot) * partition_slot_stride();
+}
+
+bool EspIdfPanelConfigBlobStorage::erase_partition_slot(uint8_t slot) {
+  return partition_ != nullptr && slot < 2 &&
+         esp_partition_erase_range(partition_, partition_slot_offset(slot),
+                                   partition_slot_stride()) == ESP_OK;
+}
+
+bool EspIdfPanelConfigBlobStorage::load_partition_blob(uint8_t slot,
+                                                        uint8_t *output,
+                                                        size_t capacity) {
+  if (partition_ == nullptr || slot >= 2 || output == nullptr ||
+      capacity != partition_slot_capacity_)
+    return false;
+  uint32_t marker = 0;
+  const size_t offset = partition_slot_offset(slot);
+  if (esp_partition_read(partition_, offset, &marker, sizeof(marker)) != ESP_OK)
+    return false;
+  if (marker != PARTITION_COMMIT_MARKER) return false;
+  return esp_partition_read(partition_, offset + PARTITION_SLOT_HEADER_SIZE,
+                            output, capacity) == ESP_OK;
+}
+
+bool EspIdfPanelConfigBlobStorage::save_partition_blob(uint8_t slot,
+                                                        const uint8_t *data,
+                                                        size_t size) {
+  if (partition_ == nullptr || slot >= 2 ||
+      (size > 0 && data == nullptr) || size > partition_slot_capacity_)
+    return false;
+
+  const size_t offset = partition_slot_offset(slot);
+  const bool unpublished = size == sizeof(uint32_t) && data != nullptr &&
+                           data[0] == 0 && data[1] == 0 && data[2] == 0 &&
+                           data[3] == 0;
+  if (unpublished) return erase_partition_slot(slot);
+  if (size < sizeof(uint32_t) || data == nullptr) return false;
+
+  // ConfigurationStore persists payload, metadata and its own magic marker
+  // through separate sync boundaries.  Keep our slot unpublished until the
+  // final marker is written: a power loss at any earlier point is therefore
+  // ignored and the other atomic slot remains authoritative.
+  const bool store_magic_is_clear =
+      data[0] == 0 && data[1] == 0 && data[2] == 0 && data[3] == 0;
+  if (store_magic_is_clear) {
+    const bool metadata_is_erased = size >= PARTITION_SLOT_HEADER_SIZE &&
+        std::all_of(data + sizeof(uint32_t),
+                    data + PARTITION_SLOT_HEADER_SIZE,
+                    [](uint8_t value) { return value == 0xFF; });
+    const size_t payload_offset = PARTITION_SLOT_HEADER_SIZE;
+    if (metadata_is_erased) {
+      if (size <= payload_offset) return true;
+      return esp_partition_write(partition_,
+                                 offset + PARTITION_SLOT_HEADER_SIZE +
+                                     payload_offset,
+                                 data + payload_offset,
+                                 size - payload_offset) == ESP_OK;
+    }
+    return esp_partition_write(partition_,
+                               offset + PARTITION_SLOT_HEADER_SIZE +
+                                   sizeof(uint32_t),
+                               data + sizeof(uint32_t),
+                               size - sizeof(uint32_t)) == ESP_OK;
+  }
+
+  if (esp_partition_write(partition_, offset + PARTITION_SLOT_HEADER_SIZE,
+                          data, size) != ESP_OK)
+    return false;
+  return esp_partition_write(partition_, offset, &PARTITION_COMMIT_MARKER,
+                             sizeof(PARTITION_COMMIT_MARKER)) == ESP_OK;
+}
+#endif
+
 BlobLoadResult EspIdfPanelConfigBlobStorage::load_blob(uint8_t slot,
                                                         uint8_t *output,
                                                         size_t capacity) {
@@ -32,6 +139,12 @@ BlobLoadResult EspIdfPanelConfigBlobStorage::load_blob(uint8_t slot,
   const char *key = slot_key(slot);
   if (!ready_ || key == nullptr || (capacity > 0 && output == nullptr))
     return {BlobLoadStatus::FAILED};
+  if (partition_backed_) {
+    if (capacity != partition_slot_capacity_) return {BlobLoadStatus::FAILED};
+    return load_partition_blob(slot, output, capacity)
+               ? BlobLoadResult{BlobLoadStatus::OK, capacity}
+               : BlobLoadResult{BlobLoadStatus::MISSING};
+  }
   size_t stored_size = 0;
   esp_err_t result = nvs_get_blob(handle_, key, nullptr, &stored_size);
   if (result == ESP_ERR_NVS_NOT_FOUND) return {BlobLoadStatus::MISSING};
@@ -53,6 +166,8 @@ bool EspIdfPanelConfigBlobStorage::save_blob(uint8_t slot, const uint8_t *data,
                                               size_t size) {
 #ifdef USE_ESP32
   const char *key = slot_key(slot);
+  if (partition_backed_)
+    return ready_ && save_partition_blob(slot, data, size);
   return ready_ && key != nullptr && (size == 0 || data != nullptr) &&
          nvs_set_blob(handle_, key, data, size) == ESP_OK;
 #else
@@ -65,6 +180,7 @@ bool EspIdfPanelConfigBlobStorage::save_blob(uint8_t slot, const uint8_t *data,
 
 bool EspIdfPanelConfigBlobStorage::sync() {
 #ifdef USE_ESP32
+  if (partition_backed_) return ready_;
   return ready_ && nvs_commit(handle_) == ESP_OK;
 #else
   return false;

--- a/components/espcontrol/panel_config_espidf_storage.h
+++ b/components/espcontrol/panel_config_espidf_storage.h
@@ -7,6 +7,7 @@
 
 #ifdef USE_ESP32
 #include <nvs.h>
+#include <esp_partition.h>
 #endif
 
 namespace espcontrol::configuration {
@@ -16,7 +17,11 @@ namespace espcontrol::configuration {
 // a partition-table migration during the compatibility releases.
 class EspIdfPanelConfigBlobStorage final : public BlobStorage {
  public:
+  // Existing profiles keep their compact NVS backing. Profiles with a large
+  // fixed-capacity document can opt into the reserved beginning of the
+  // already-deployed card_images partition without changing its layout.
   bool begin();
+  bool begin_card_images_partition(size_t slot_capacity);
   BlobLoadResult load_blob(uint8_t slot, uint8_t *output,
                            size_t capacity) override;
   bool save_blob(uint8_t slot, const uint8_t *data, size_t size) override;
@@ -26,7 +31,21 @@ class EspIdfPanelConfigBlobStorage final : public BlobStorage {
   static const char *slot_key(uint8_t slot);
 
 #ifdef USE_ESP32
+  static constexpr const char *CARD_IMAGES_PARTITION_LABEL = "card_images";
+  static constexpr size_t FLASH_ERASE_SIZE = 4096;
+  static constexpr size_t PARTITION_SLOT_HEADER_SIZE = 16;
+  static constexpr uint32_t PARTITION_COMMIT_MARKER = 0x50434647;
+
+  size_t partition_slot_stride() const;
+  size_t partition_slot_offset(uint8_t slot) const;
+  bool load_partition_blob(uint8_t slot, uint8_t *output, size_t capacity);
+  bool save_partition_blob(uint8_t slot, const uint8_t *data, size_t size);
+  bool erase_partition_slot(uint8_t slot);
+
   nvs_handle_t handle_{0};
+  const esp_partition_t *partition_{nullptr};
+  size_t partition_slot_capacity_{0};
+  bool partition_backed_{false};
 #endif
   bool ready_{false};
 };

--- a/components/espcontrol/panel_config_storage_backend.h
+++ b/components/espcontrol/panel_config_storage_backend.h
@@ -83,6 +83,12 @@ class BufferedBlobStorageBackend final : public StorageBackend {
     if (offset == 0 && size == sizeof(uint32_t) &&
         std::all_of(data, data + size,
                     [](uint8_t value) { return value == 0; })) {
+      // A full-blob binding may need to rewrite an erased flash slot during
+      // the following sync boundaries.  Do not retain stale header bytes in
+      // the in-memory image after ConfigurationStore withdraws publication.
+      // Besides keeping compact NVS writes compact, this makes the next
+      // payload and metadata writes safe for a raw-flash implementation.
+      std::memset(slots_[slot], 0xFF, SlotCapacity);
       stored_sizes_[slot] = 0;
     }
     if (size > 0) std::memcpy(slots_[slot] + offset, data, size);

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -69,6 +69,45 @@ external_components:
 
 espcontrol:
   id: espcontrol_app
+  # This profile uses the existing card-images partition for the two native
+  # configuration slots. Its NVS partition is intentionally kept for the
+  # restored legacy text entities, and the deployed OTA layout is unchanged.
+  panel_config:
+    device_profile: ${device_slug}
+    storage: card_images
+    button_order: button_order
+    button_on_color: button_on_color
+    buttons:
+      - config: button_1_config
+        subpage_chunks: [subpage_1_config, subpage_1_config_ext, subpage_1_config_ext_2, subpage_1_config_ext_3, subpage_1_config_ext_4, subpage_1_config_ext_5, subpage_1_config_ext_6, subpage_1_config_ext_7]
+      - config: button_2_config
+        subpage_chunks: [subpage_2_config, subpage_2_config_ext, subpage_2_config_ext_2, subpage_2_config_ext_3, subpage_2_config_ext_4, subpage_2_config_ext_5, subpage_2_config_ext_6, subpage_2_config_ext_7]
+      - config: button_3_config
+        subpage_chunks: [subpage_3_config, subpage_3_config_ext, subpage_3_config_ext_2, subpage_3_config_ext_3, subpage_3_config_ext_4, subpage_3_config_ext_5, subpage_3_config_ext_6, subpage_3_config_ext_7]
+      - config: button_4_config
+        subpage_chunks: [subpage_4_config, subpage_4_config_ext, subpage_4_config_ext_2, subpage_4_config_ext_3, subpage_4_config_ext_4, subpage_4_config_ext_5, subpage_4_config_ext_6, subpage_4_config_ext_7]
+      - config: button_5_config
+        subpage_chunks: [subpage_5_config, subpage_5_config_ext, subpage_5_config_ext_2, subpage_5_config_ext_3, subpage_5_config_ext_4, subpage_5_config_ext_5, subpage_5_config_ext_6, subpage_5_config_ext_7]
+      - config: button_6_config
+        subpage_chunks: [subpage_6_config, subpage_6_config_ext, subpage_6_config_ext_2, subpage_6_config_ext_3, subpage_6_config_ext_4, subpage_6_config_ext_5, subpage_6_config_ext_6, subpage_6_config_ext_7]
+      - config: button_7_config
+        subpage_chunks: [subpage_7_config, subpage_7_config_ext, subpage_7_config_ext_2, subpage_7_config_ext_3, subpage_7_config_ext_4, subpage_7_config_ext_5, subpage_7_config_ext_6, subpage_7_config_ext_7]
+      - config: button_8_config
+        subpage_chunks: [subpage_8_config, subpage_8_config_ext, subpage_8_config_ext_2, subpage_8_config_ext_3, subpage_8_config_ext_4, subpage_8_config_ext_5, subpage_8_config_ext_6, subpage_8_config_ext_7]
+      - config: button_9_config
+        subpage_chunks: [subpage_9_config, subpage_9_config_ext, subpage_9_config_ext_2, subpage_9_config_ext_3, subpage_9_config_ext_4, subpage_9_config_ext_5, subpage_9_config_ext_6, subpage_9_config_ext_7]
+      - config: button_10_config
+        subpage_chunks: [subpage_10_config, subpage_10_config_ext, subpage_10_config_ext_2, subpage_10_config_ext_3, subpage_10_config_ext_4, subpage_10_config_ext_5, subpage_10_config_ext_6, subpage_10_config_ext_7]
+      - config: button_11_config
+        subpage_chunks: [subpage_11_config, subpage_11_config_ext, subpage_11_config_ext_2, subpage_11_config_ext_3, subpage_11_config_ext_4, subpage_11_config_ext_5, subpage_11_config_ext_6, subpage_11_config_ext_7]
+      - config: button_12_config
+        subpage_chunks: [subpage_12_config, subpage_12_config_ext, subpage_12_config_ext_2, subpage_12_config_ext_3, subpage_12_config_ext_4, subpage_12_config_ext_5, subpage_12_config_ext_6, subpage_12_config_ext_7]
+      - config: button_13_config
+        subpage_chunks: [subpage_13_config, subpage_13_config_ext, subpage_13_config_ext_2, subpage_13_config_ext_3, subpage_13_config_ext_4, subpage_13_config_ext_5, subpage_13_config_ext_6, subpage_13_config_ext_7]
+      - config: button_14_config
+        subpage_chunks: [subpage_14_config, subpage_14_config_ext, subpage_14_config_ext_2, subpage_14_config_ext_3, subpage_14_config_ext_4, subpage_14_config_ext_5, subpage_14_config_ext_6, subpage_14_config_ext_7]
+      - config: button_15_config
+        subpage_chunks: [subpage_15_config, subpage_15_config_ext, subpage_15_config_ext_2, subpage_15_config_ext_3, subpage_15_config_ext_4, subpage_15_config_ext_5, subpage_15_config_ext_6, subpage_15_config_ext_7]
 # ---------------------------------------------------------------------------
 # ESPHome core (device name from substitutions)
 # ---------------------------------------------------------------------------

--- a/tests/firmware/panel_config_storage_backend_test.cpp
+++ b/tests/firmware/panel_config_storage_backend_test.cpp
@@ -125,13 +125,31 @@ bool failed_sync_keeps_the_pending_slot_for_retry() {
   return backend.sync() && blobs.save_calls() == 2 && blobs.sync_calls() == 2;
 }
 
+bool withdrawing_a_slot_discards_stale_header_bytes() {
+  FakeBlobStorage blobs;
+  BufferedBlobStorageBackend<kSlotCapacity> backend(blobs);
+  std::array<uint8_t, kSlotCapacity * 2> memory{};
+  if (!backend.begin(memory.data(), memory.size())) return false;
+  const std::array<uint8_t, 4> stale{{1, 2, 3, 4}};
+  const std::array<uint8_t, 4> withdrawn{};
+  if (!backend.write(0, 4, stale.data(), stale.size()) || !backend.sync() ||
+      !backend.write(0, 0, withdrawn.data(), withdrawn.size()) ||
+      !backend.sync() || blobs.stored_size(0) != withdrawn.size()) {
+    return false;
+  }
+  std::array<uint8_t, stale.size()> retained{};
+  return backend.read(0, 4, retained.data(), retained.size()) &&
+         retained == std::array<uint8_t, stale.size()>{{0xFF, 0xFF, 0xFF, 0xFF}};
+}
+
 }  // namespace
 
 int main() {
   return missing_slots_behave_like_an_empty_store() &&
                  commits_are_buffered_until_the_store_sync_boundary() &&
                  persisted_blobs_are_compact_but_remain_readable() &&
-                 failed_sync_keeps_the_pending_slot_for_retry()
+                 failed_sync_keeps_the_pending_slot_for_retry() &&
+                 withdrawing_a_slot_discards_stale_header_bytes()
              ? 0
              : 1;
 }


### PR DESCRIPTION
## Purpose

Enable the 10-inch V1 native `PanelConfig` path without changing its deployed OTA partition table. The two atomic configuration slots use a reserved 88 KiB region at the start of the existing `card_images` partition; NVS remains available for restored legacy entities.

## Practical impact

- The 10-inch V1 advertises and uses the native configuration API.
- A cancelled or interrupted save leaves the last fully committed configuration available.
- The existing 16 MB partition layout is unchanged, so this remains suitable for OTA updates.

## Checked

- Full firmware host suite: 26/26 passing.
- Generated outputs and device-profile checks passing.
- Full ESPHome / ESP-IDF build for `guition-esp32-p4-jc8012p4a1` passing (5.1 MB, within the deployed OTA slot).

## Device testing

When the 10-inch V1 is back online: create/edit/save a card, restart the panel, confirm the change remains, then repeat after interrupting a save.

Affected display: 10-inch V1 (`guition-esp32-p4-jc8012p4a1`).