### PR TITLE
Add improv_serial section for wifi provisioning via usb/serial connection

### DIFF
--- a/common/addon/connectivity.yaml
+++ b/common/addon/connectivity.yaml
@@ -68,6 +68,8 @@ wifi:
         then:
           - script.execute: wifi_reconnect_flow
 
+improv_serial:
+
 api:
   on_client_connected:
     - script.execute: ha_restore_after_api


### PR DESCRIPTION
**TL;DR:** Add ESPHome's `improv_serial` component so users can enter Wi-Fi credentials directly in the browser over USB right after flashing, instead of having to join the panel's temporary AP and go through the captive portal. Complements the existing captive-portal flow (still needed for re-provisioning a mounted panel) and requires minimal changes — just an `improv_serial:` config block.

## Why add `improv_serial`?

Right now, first-time Wi-Fi setup requires: flash firmware → disconnect → find and join the panel's temporary AP → open the captive portal → enter Wi-Fi credentials → reconnect to the home network. That's a lot of steps for users who may not be familiar with captive portals or temporary AP networks.

ESPHome's `improv_serial` component implements the open [Improv](https://www.improv-wifi.com/) standard, letting Wi-Fi credentials be entered over the same USB serial connection used for flashing. Browser-based flashers built on ESP Web Tools detect this automatically and show a credential form right in the same tab — no AP hunting, no captive portal, no network switching.

**Benefits:**
- Shortens onboarding to: flash → enter Wi-Fi in the browser → done.
- Removes the most confusing step for less technical users.
- Useful for panels that'll be wall-mounted or hard to reach later — full setup can happen at the desk, before installation.
- Doesn't replace the existing captive portal, which is still needed for re-provisioning a mounted, non-USB-connected panel (e.g. after a factory reset).
- Low implementation cost: just an `improv_serial:` config block (requires the serial `logger`, which is already configured on supported boards) plus an optional `next_url` to redirect straight to the panel's own setup page after provisioning — no new UI needed, since flashers already support Improv detection.