### PR TITLE
Keep Home Assistant connected while configuring web endpoints

### DIFF
--- a/common/device/core_infra.yaml
+++ b/common/device/core_infra.yaml
@@ -18,7 +18,6 @@ api:
   homeassistant_services: true
   on_client_connected:
     - lambda: |-
-        register_local_sensor_endpoint();
         ESP_LOGI("api", "API client connected: %s", client_info.c_str());
         bool is_home_assistant = client_info.find("Home Assistant") != std::string::npos;
         if (is_home_assistant && ha_api_connected()) {
@@ -32,7 +31,6 @@ api:
             ha_flush_deferred_state_requests();
           }
         }
-        register_local_action_endpoint();
     - delay: 2s
     - lambda: |-
         if (ha_api_connected()) refresh_image_cards();
@@ -73,7 +71,6 @@ api:
         weather_forecast_cancel_pending_requests();
         cover_stop_cancel_pending_request();
         todo_cancel_pending_request("api disconnected");
-
 interval:
   - interval: 5s
     then:

--- a/components/espcontrol/button_grid_local_controls.h
+++ b/components/espcontrol/button_grid_local_controls.h
@@ -189,17 +189,22 @@ class LocalActionHandler : public esphome::web_server_idf::AsyncWebHandler {
   }
 };
 
-inline void register_local_action_endpoint() {
+inline void register_local_action_endpoint(
+    esphome::web_server_idf::AsyncWebServer &server) {
   static bool registered = false;
   if (registered) return;
+  server.addHandler(new LocalActionHandler());
+  registered = true;
+  ESP_LOGI("espcontrol", "Local action endpoint registered");
+}
+
+inline void register_local_action_endpoint() {
   auto *server = esphome::web_server_idf::global_async_web_server();
-  if (!server) {
+  if (server == nullptr) {
     ESP_LOGW("espcontrol", "register_local_action_endpoint: server not ready");
     return;
   }
-  server->addHandler(new LocalActionHandler());
-  registered = true;
-  ESP_LOGI("espcontrol", "Local action endpoint registered");
+  register_local_action_endpoint(*server);
 }
 
 class LocalSensorHandler : public esphome::web_server_idf::AsyncWebHandler {
@@ -255,17 +260,22 @@ class LocalSensorHandler : public esphome::web_server_idf::AsyncWebHandler {
   }
 };
 
-inline void register_local_sensor_endpoint() {
+inline void register_local_sensor_endpoint(
+    esphome::web_server_idf::AsyncWebServer &server) {
   static bool registered = false;
   if (registered) return;
+  server.addHandler(new LocalSensorHandler());
+  registered = true;
+  ESP_LOGI("sensors", "Local sensor endpoint registered");
+}
+
+inline void register_local_sensor_endpoint() {
   auto *server = esphome::web_server_idf::global_async_web_server();
-  if (!server) {
+  if (server == nullptr) {
     ESP_LOGW("sensors", "register_local_sensor_endpoint: server not ready");
     return;
   }
-  server->addHandler(new LocalSensorHandler());
-  registered = true;
-  ESP_LOGI("sensors", "Local sensor endpoint registered");
+  register_local_sensor_endpoint(*server);
 }
 #endif  // USE_WEBSERVER
 

--- a/components/espcontrol/espcontrol_app.cpp
+++ b/components/espcontrol/espcontrol_app.cpp
@@ -21,6 +21,19 @@
 #include "panel_config_service_validator.h"
 #include "panel_config_storage_backend.h"
 #include "panel_config_write_endpoint.h"
+#include "button_grid.h"
+
+extern "C" void espcontrol_register_web_server_handlers(
+    esphome::web_server_idf::AsyncWebServer *server) {
+#ifdef USE_WEBSERVER
+  if (server == nullptr) return;
+  register_local_sensor_endpoint(*server);
+  register_local_action_endpoint(*server);
+  espcontrol::configuration::register_panel_config_capabilities_endpoint(*server);
+#else
+  (void) server;
+#endif
+}
 
 namespace espcontrol {
 

--- a/components/espcontrol/espcontrol_app.cpp
+++ b/components/espcontrol/espcontrol_app.cpp
@@ -131,29 +131,12 @@ bool EspControlApp::create_native_configuration_runtime() {
 }
 
 void EspControlApp::register_panel_config_endpoints() {
-  // Do not let an early reconnect cache a legacy-only capability response
-  // while the deferred native configuration setup is still in progress.
-  if (!native_configuration_initialized_) return;
-  configuration::ConfigurationService *const panel_config_service =
-      core_.configuration_service();
-  NativeConfigurationRuntime *const runtime = native_configuration_runtime_.get();
-  const bool can_register_document_endpoints = panel_config_service != nullptr &&
-      runtime != nullptr && runtime->document_buffer != nullptr;
-  const bool read_endpoint_registered = can_register_document_endpoints &&
-      configuration::register_panel_config_read_endpoint(
-          *panel_config_service, runtime->document_buffer,
-          PANEL_CONFIG_STORAGE_SLOT_CAPACITY,
-          web_auth_username_ == nullptr ? "" : web_auth_username_,
-          web_auth_password_ == nullptr ? "" : web_auth_password_);
-  const bool write_endpoint_registered = can_register_document_endpoints &&
-      configuration::register_panel_config_write_endpoint(
-          *panel_config_service, runtime->document_buffer,
-          PANEL_CONFIG_STORAGE_SLOT_CAPACITY,
-          web_auth_username_ == nullptr ? "" : web_auth_username_,
-          web_auth_password_ == nullptr ? "" : web_auth_password_);
-  configuration::set_panel_config_read_supported(read_endpoint_registered);
-  configuration::set_panel_config_write_supported(write_endpoint_registered);
-  configuration::register_panel_config_capabilities_endpoint();
+  // ESPHome's web server is already serving requests by the time deferred
+  // configuration setup completes. Adding handlers at that point can disrupt
+  // active API clients, so use the established entity API compatibility path
+  // until native endpoint registration can happen during web-server setup.
+  configuration::set_panel_config_read_supported(false);
+  configuration::set_panel_config_write_supported(false);
 }
 
 void EspControlApp::apply_boot_configuration() {

--- a/components/espcontrol/panel_config_capabilities_endpoint.h
+++ b/components/espcontrol/panel_config_capabilities_endpoint.h
@@ -42,21 +42,25 @@ class PanelConfigCapabilitiesHandler final
   }
 };
 
-inline bool register_panel_config_capabilities_endpoint() {
+inline bool register_panel_config_capabilities_endpoint(
+    esphome::web_server_idf::AsyncWebServer &server) {
   static bool registered = false;
   if (registered) return true;
-  auto *server = esphome::web_server_idf::global_async_web_server();
-  if (server == nullptr) return false;
-  server->addHandler(new PanelConfigCapabilitiesHandler());
+  server.addHandler(new PanelConfigCapabilitiesHandler());
   registered = true;
   return true;
+}
+
+inline bool register_panel_config_capabilities_endpoint() {
+  auto *server = esphome::web_server_idf::global_async_web_server();
+  return server != nullptr && register_panel_config_capabilities_endpoint(*server);
 }
 
 }  // namespace espcontrol::configuration
 #else
 namespace espcontrol::configuration {
 
-inline bool register_panel_config_capabilities_endpoint() { return true; }
+inline bool register_panel_config_capabilities_endpoint(...) { return true; }
 
 }  // namespace espcontrol::configuration
 #endif

--- a/components/web_server_idf/web_server_idf.cpp
+++ b/components/web_server_idf/web_server_idf.cpp
@@ -47,6 +47,9 @@ namespace esphome::web_server_idf {
 
 static const char *const TAG = "web_server_idf";
 
+extern "C" void espcontrol_register_web_server_handlers(
+    AsyncWebServer *server) __attribute__((weak));
+
 // Global instance to avoid guard variable (saves 8 bytes)
 // This is initialized at program startup before any threads
 namespace {
@@ -228,6 +231,11 @@ void AsyncWebServer::begin() {
   config.close_fn = AsyncWebServer::safe_close_with_shutdown;
   if (httpd_start(&this->server_, &config) == ESP_OK) {
     global_async_web_server() = this;
+    // Register static EspControl routes before the generic dispatcher starts
+    // accepting requests. Adding handlers later can disrupt API clients.
+    if (espcontrol_register_web_server_handlers != nullptr) {
+      espcontrol_register_web_server_handlers(this);
+    }
     const httpd_uri_t handler_get = {
         .uri = "",
         .method = HTTP_GET,


### PR DESCRIPTION
## Purpose
Restore Home Assistant API connectivity and cover art by preventing late web-server handler registration from interrupting active API clients.

## Practical impact
- Keeps native PanelConfig storage and existing saved cards unchanged.
- Uses the established entity API browser path while the native configuration HTTP endpoints are reworked for safe startup registration.
- Stops browser helper endpoints from being created during the API handshake.

## Checked
- Firmware parser checks passed.
- 10-inch V1 compiled successfully with ESPHome 2026.7.4 (26% app-partition free).
- The 10-inch V1 accepted the test firmware over OTA and completed an ESPHome API handshake when late endpoint registration was absent.

## Device testing
The 10-inch V1 (guition-esp32-p4-jc8012p4a1) was used for this investigation. Its artwork base URL was confirmed after the API handshake. Please verify that an active media card displays its cover art after the device reconnects to Home Assistant.