### PR TITLE
Register configuration endpoints before web startup

### DIFF
--- a/components/espcontrol/espcontrol_app.cpp
+++ b/components/espcontrol/espcontrol_app.cpp
@@ -159,6 +159,7 @@ void EspControlApp::register_panel_config_endpoints() {
   if (!can_bind_document_endpoints) {
     configuration::set_panel_config_read_supported(false);
     configuration::set_panel_config_write_supported(false);
+    configuration::set_panel_config_http_context_initialization_complete(true);
     return;
   }
   configuration::bind_panel_config_http_context(
@@ -172,6 +173,7 @@ void EspControlApp::register_panel_config_endpoints() {
   // loop() would briefly make concurrent requests observe a false readiness
   // flag and rewrite the shared pointers while the web task is using them.
   panel_config_http_context_bound_ = true;
+  configuration::set_panel_config_http_context_initialization_complete(true);
 }
 
 void EspControlApp::apply_boot_configuration() {

--- a/components/espcontrol/espcontrol_app.cpp
+++ b/components/espcontrol/espcontrol_app.cpp
@@ -149,7 +149,8 @@ bool EspControlApp::create_native_configuration_runtime() {
 void EspControlApp::register_panel_config_endpoints() {
   // Do not let an early reconnect cache a legacy-only capability response
   // while the deferred native configuration setup is still in progress.
-  if (!native_configuration_initialized_) return;
+  if (!native_configuration_initialized_ || panel_config_http_context_bound_)
+    return;
   configuration::ConfigurationService *const panel_config_service =
       core_.configuration_service();
   NativeConfigurationRuntime *const runtime = native_configuration_runtime_.get();
@@ -167,6 +168,10 @@ void EspControlApp::register_panel_config_endpoints() {
       web_auth_password_ == nullptr ? "" : web_auth_password_);
   configuration::set_panel_config_read_supported(true);
   configuration::set_panel_config_write_supported(true);
+  // The context transitions from not-ready to ready once. Rebinding it from
+  // loop() would briefly make concurrent requests observe a false readiness
+  // flag and rewrite the shared pointers while the web task is using them.
+  panel_config_http_context_bound_ = true;
 }
 
 void EspControlApp::apply_boot_configuration() {

--- a/components/espcontrol/espcontrol_app.cpp
+++ b/components/espcontrol/espcontrol_app.cpp
@@ -21,6 +21,7 @@
 #include "panel_config_service_validator.h"
 #include "panel_config_storage_backend.h"
 #include "panel_config_write_endpoint.h"
+#include "panel_config_http_context.h"
 #include "button_grid.h"
 
 extern "C" void espcontrol_register_web_server_handlers(
@@ -30,6 +31,8 @@ extern "C" void espcontrol_register_web_server_handlers(
   register_local_sensor_endpoint(*server);
   register_local_action_endpoint(*server);
   espcontrol::configuration::register_panel_config_capabilities_endpoint(*server);
+  espcontrol::configuration::register_panel_config_read_endpoint(*server);
+  espcontrol::configuration::register_panel_config_write_endpoint(*server);
 #else
   (void) server;
 #endif
@@ -144,12 +147,26 @@ bool EspControlApp::create_native_configuration_runtime() {
 }
 
 void EspControlApp::register_panel_config_endpoints() {
-  // ESPHome's web server is already serving requests by the time deferred
-  // configuration setup completes. Adding handlers at that point can disrupt
-  // active API clients, so use the established entity API compatibility path
-  // until native endpoint registration can happen during web-server setup.
-  configuration::set_panel_config_read_supported(false);
-  configuration::set_panel_config_write_supported(false);
+  // Do not let an early reconnect cache a legacy-only capability response
+  // while the deferred native configuration setup is still in progress.
+  if (!native_configuration_initialized_) return;
+  configuration::ConfigurationService *const panel_config_service =
+      core_.configuration_service();
+  NativeConfigurationRuntime *const runtime = native_configuration_runtime_.get();
+  const bool can_bind_document_endpoints = panel_config_service != nullptr &&
+      runtime != nullptr && runtime->document_buffer != nullptr;
+  if (!can_bind_document_endpoints) {
+    configuration::set_panel_config_read_supported(false);
+    configuration::set_panel_config_write_supported(false);
+    return;
+  }
+  configuration::bind_panel_config_http_context(
+      *panel_config_service, runtime->document_buffer,
+      PANEL_CONFIG_STORAGE_SLOT_CAPACITY,
+      web_auth_username_ == nullptr ? "" : web_auth_username_,
+      web_auth_password_ == nullptr ? "" : web_auth_password_);
+  configuration::set_panel_config_read_supported(true);
+  configuration::set_panel_config_write_supported(true);
 }
 
 void EspControlApp::apply_boot_configuration() {

--- a/components/espcontrol/espcontrol_app.cpp
+++ b/components/espcontrol/espcontrol_app.cpp
@@ -159,6 +159,7 @@ void EspControlApp::register_panel_config_endpoints() {
   if (!can_bind_document_endpoints) {
     configuration::set_panel_config_read_supported(false);
     configuration::set_panel_config_write_supported(false);
+    panel_config_http_context_bound_ = true;
     configuration::set_panel_config_http_context_initialization_complete(true);
     return;
   }

--- a/components/espcontrol/espcontrol_app.h
+++ b/components/espcontrol/espcontrol_app.h
@@ -78,6 +78,7 @@ class EspControlApp : public esphome::Component {
   std::unique_ptr<NativeConfigurationRuntime> native_configuration_runtime_;
   EspControlAppCore core_{};
   bool native_configuration_initialized_{false};
+  bool panel_config_http_context_bound_{false};
   const char *web_auth_username_{nullptr};
   const char *web_auth_password_{nullptr};
 };

--- a/components/espcontrol/panel_config_capabilities_endpoint.h
+++ b/components/espcontrol/panel_config_capabilities_endpoint.h
@@ -9,6 +9,7 @@
 #include <esp_http_server.h>
 
 #include "esphome/components/web_server_idf/web_server_idf.h"
+#include "panel_config_http_context.h"
 
 namespace espcontrol::configuration {
 
@@ -27,6 +28,13 @@ class PanelConfigCapabilitiesHandler final
   void handleRequest(
       esphome::web_server_idf::AsyncWebServerRequest *request) override {
     httpd_req_t *raw_request = *request;
+    if (!panel_config_http_context_initialization_complete()) {
+      httpd_resp_set_status(raw_request, "503 Service Unavailable");
+      httpd_resp_set_type(raw_request, "text/plain");
+      httpd_resp_send(raw_request, "Native configuration is starting",
+                      HTTPD_RESP_USE_STRLEN);
+      return;
+    }
     std::array<char, PANEL_CONFIG_CAPABILITIES_MAX_JSON_BYTES> response{};
     size_t response_size = 0;
     if (!write_panel_config_capabilities_json(response.data(), response.size(),

--- a/components/espcontrol/panel_config_http_context.h
+++ b/components/espcontrol/panel_config_http_context.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+namespace espcontrol::configuration {
+
+class ConfigurationService;
+
+struct PanelConfigHttpContext {
+  ConfigurationService *service{nullptr};
+  uint8_t *document{nullptr};
+  size_t document_capacity{0};
+  const char *username{nullptr};
+  const char *password{nullptr};
+  std::atomic<bool> ready{false};
+};
+
+inline PanelConfigHttpContext &panel_config_http_context() {
+  static PanelConfigHttpContext context;
+  return context;
+}
+
+inline void bind_panel_config_http_context(ConfigurationService &service,
+                                           uint8_t *document,
+                                           size_t document_capacity,
+                                           const char *username,
+                                           const char *password) {
+  PanelConfigHttpContext &context = panel_config_http_context();
+  context.ready.store(false, std::memory_order_release);
+  context.service = &service;
+  context.document = document;
+  context.document_capacity = document_capacity;
+  context.username = username;
+  context.password = password;
+  context.ready.store(document != nullptr && document_capacity != 0,
+                      std::memory_order_release);
+}
+
+inline bool panel_config_http_context_ready() {
+  return panel_config_http_context().ready.load(std::memory_order_acquire);
+}
+
+}  // namespace espcontrol::configuration

--- a/components/espcontrol/panel_config_http_context.h
+++ b/components/espcontrol/panel_config_http_context.h
@@ -15,6 +15,7 @@ struct PanelConfigHttpContext {
   const char *username{nullptr};
   const char *password{nullptr};
   std::atomic<bool> ready{false};
+  std::atomic<bool> initialization_complete{false};
 };
 
 inline PanelConfigHttpContext &panel_config_http_context() {
@@ -40,6 +41,19 @@ inline void bind_panel_config_http_context(ConfigurationService &service,
 
 inline bool panel_config_http_context_ready() {
   return panel_config_http_context().ready.load(std::memory_order_acquire);
+}
+
+// Capabilities must not report a permanent legacy fallback while the deferred
+// native setup is still running. Once setup completes, an unavailable context
+// intentionally advertises the normal legacy-only capability response.
+inline void set_panel_config_http_context_initialization_complete(bool complete) {
+  panel_config_http_context().initialization_complete.store(
+      complete, std::memory_order_release);
+}
+
+inline bool panel_config_http_context_initialization_complete() {
+  return panel_config_http_context().initialization_complete.load(
+      std::memory_order_acquire);
 }
 
 }  // namespace espcontrol::configuration

--- a/components/espcontrol/panel_config_read_endpoint.h
+++ b/components/espcontrol/panel_config_read_endpoint.h
@@ -12,18 +12,13 @@
 
 #include "configuration_service.h"
 #include "esphome/components/web_server_idf/web_server_idf.h"
+#include "panel_config_http_context.h"
 
 namespace espcontrol::configuration {
 
 class PanelConfigReadHandler final
     : public esphome::web_server_idf::AsyncWebHandler {
  public:
-  PanelConfigReadHandler(ConfigurationService &service, uint8_t *document,
-                         size_t document_capacity, const char *username,
-                         const char *password)
-      : service_(service), document_(document), document_capacity_(document_capacity),
-        username_(username), password_(password) {}
-
   bool canHandle(
       esphome::web_server_idf::AsyncWebServerRequest *request) const override {
     if (request->method() != HTTP_GET) return false;
@@ -35,15 +30,24 @@ class PanelConfigReadHandler final
 
   void handleRequest(
       esphome::web_server_idf::AsyncWebServerRequest *request) override {
+    PanelConfigHttpContext &context = panel_config_http_context();
+    if (!panel_config_http_context_ready()) {
+      httpd_req_t *raw_request = *request;
+      httpd_resp_set_status(raw_request, "503 Service Unavailable");
+      httpd_resp_set_type(raw_request, "text/plain");
+      httpd_resp_send(raw_request, "Native configuration is starting",
+                      HTTPD_RESP_USE_STRLEN);
+      return;
+    }
 #ifdef USE_WEBSERVER_AUTH
-    if (!request->authenticate(username_, password_)) {
+    if (!request->authenticate(context.username, context.password)) {
       request->requestAuthentication();
       return;
     }
 #endif
     httpd_req_t *raw_request = *request;
     const ServiceLoadResult loaded =
-        service_.load(document_, document_capacity_);
+        context.service->load(context.document, context.document_capacity);
     if (loaded.status == ServiceStatus::EMPTY) {
       httpd_resp_send_err(raw_request, HTTPD_404_NOT_FOUND,
                           "No native configuration is stored");
@@ -71,29 +75,16 @@ class PanelConfigReadHandler final
     httpd_resp_set_hdr(raw_request, "ETag", etag);
     httpd_resp_set_hdr(raw_request, "X-Panel-Config-Generation", generation);
     httpd_resp_set_hdr(raw_request, "X-Panel-Config-Version", version);
-    httpd_resp_send(raw_request, reinterpret_cast<const char *>(document_),
+    httpd_resp_send(raw_request, reinterpret_cast<const char *>(context.document),
                     loaded.document_size);
   }
-
- private:
-  ConfigurationService &service_;
-  uint8_t *document_;
-  size_t document_capacity_;
-  const char *username_;
-  const char *password_;
 };
 
 inline bool register_panel_config_read_endpoint(
-    ConfigurationService &service, uint8_t *document, size_t document_capacity,
-    const char *username, const char *password) {
+    esphome::web_server_idf::AsyncWebServer &server) {
   static bool registered = false;
   if (registered) return true;
-  if (document == nullptr || document_capacity == 0) return false;
-  auto *server = esphome::web_server_idf::global_async_web_server();
-  if (server == nullptr) return false;
-  server->addHandler(
-      new PanelConfigReadHandler(service, document, document_capacity, username,
-                                 password));
+  server.addHandler(new PanelConfigReadHandler());
   registered = true;
   return true;
 }
@@ -102,8 +93,7 @@ inline bool register_panel_config_read_endpoint(
 #else
 namespace espcontrol::configuration {
 class ConfigurationService;
-inline bool register_panel_config_read_endpoint(ConfigurationService &, uint8_t *,
-                                               size_t, const char *, const char *) {
+inline bool register_panel_config_read_endpoint(...) {
   return true;
 }
 }  // namespace espcontrol::configuration

--- a/components/espcontrol/panel_config_write_endpoint.h
+++ b/components/espcontrol/panel_config_write_endpoint.h
@@ -34,7 +34,15 @@ class PanelConfigWriteHandler final
                : 0;
   }
   bool canReceiveBody(esphome::web_server_idf::AsyncWebServerRequest *request) override {
-    if (!panel_config_http_context_ready()) return false;
+    if (!panel_config_http_context_ready()) {
+      // AsyncWebServer stops processing when this returns false, so reply here
+      // rather than relying on handleRequest() to report the startup state.
+      httpd_req_t *raw_request = *request;
+      send_status(raw_request, "503 Service Unavailable",
+                  "Native configuration is starting");
+      reset_upload();
+      return false;
+    }
     PanelConfigHttpContext &context = panel_config_http_context();
 #ifdef USE_WEBSERVER_AUTH
     if (!request->authenticate(context.username, context.password)) {

--- a/components/espcontrol/panel_config_write_endpoint.h
+++ b/components/espcontrol/panel_config_write_endpoint.h
@@ -13,18 +13,13 @@
 #include "esphome/components/web_server_idf/web_server_idf.h"
 #include "panel_config_document.h"
 #include "panel_config_http_etag.h"
+#include "panel_config_http_context.h"
 
 namespace espcontrol::configuration {
 
 class PanelConfigWriteHandler final
     : public esphome::web_server_idf::AsyncWebHandler {
  public:
-  PanelConfigWriteHandler(ConfigurationService &service, uint8_t *document,
-                          size_t document_capacity, const char *username,
-                          const char *password)
-      : service_(service), document_(document), document_capacity_(document_capacity),
-        username_(username), password_(password) {}
-
   bool canHandle(
       esphome::web_server_idf::AsyncWebServerRequest *request) const override {
     if (request->method() != HTTP_PUT) return false;
@@ -33,10 +28,16 @@ class PanelConfigWriteHandler final
     const esphome::StringRef url = request->url_to(url_buffer);
     return std::strcmp(url.c_str(), "/api/v1/config") == 0;
   }
-  size_t maximumBodySize() const override { return document_capacity_; }
+  size_t maximumBodySize() const override {
+    return panel_config_http_context_ready()
+               ? panel_config_http_context().document_capacity
+               : 0;
+  }
   bool canReceiveBody(esphome::web_server_idf::AsyncWebServerRequest *request) override {
+    if (!panel_config_http_context_ready()) return false;
+    PanelConfigHttpContext &context = panel_config_http_context();
 #ifdef USE_WEBSERVER_AUTH
-    if (!request->authenticate(username_, password_)) {
+    if (!request->authenticate(context.username, context.password)) {
       request->requestAuthentication();
       return false;
     }
@@ -46,24 +47,34 @@ class PanelConfigWriteHandler final
 
   void handleBody(esphome::web_server_idf::AsyncWebServerRequest *, uint8_t *data,
                   size_t len, size_t index, size_t total) override {
+    PanelConfigHttpContext &context = panel_config_http_context();
     if (index == 0) {
       received_size_ = 0;
       expected_size_ = total;
-      body_valid_ = total > 0 && total <= document_capacity_;
+      body_valid_ = panel_config_http_context_ready() && total > 0 &&
+                    total <= context.document_capacity;
     }
     if (!body_valid_ || data == nullptr || index != received_size_ ||
-        len > document_capacity_ - received_size_) {
+        len > context.document_capacity - received_size_) {
       body_valid_ = false;
       return;
     }
-    std::memcpy(document_ + received_size_, data, len);
+    std::memcpy(context.document + received_size_, data, len);
     received_size_ += len;
   }
 
   void handleRequest(
       esphome::web_server_idf::AsyncWebServerRequest *request) override {
+    PanelConfigHttpContext &context = panel_config_http_context();
+    if (!panel_config_http_context_ready()) {
+      httpd_req_t *raw_request = *request;
+      send_status(raw_request, "503 Service Unavailable",
+                  "Native configuration is starting");
+      reset_upload();
+      return;
+    }
 #ifdef USE_WEBSERVER_AUTH
-    if (!request->authenticate(username_, password_)) {
+    if (!request->authenticate(context.username, context.password)) {
       request->requestAuthentication();
       reset_upload();
       return;
@@ -95,8 +106,9 @@ class PanelConfigWriteHandler final
       return;
     }
 
-    const ServiceSaveResult saved = service_.save_if_generation(
-        expected_generation, PANEL_CONFIG_DOCUMENT_VERSION, document_, received_size_);
+    const ServiceSaveResult saved = context.service->save_if_generation(
+        expected_generation, PANEL_CONFIG_DOCUMENT_VERSION, context.document,
+        received_size_);
     reset_upload();
     if (saved.status == ServiceStatus::GENERATION_CONFLICT) {
       set_generation_headers(raw_request, saved.generation);
@@ -152,27 +164,16 @@ class PanelConfigWriteHandler final
     httpd_resp_set_hdr(request, "X-Panel-Config-Version", "1");
   }
 
-  ConfigurationService &service_;
-  uint8_t *document_;
-  size_t document_capacity_;
-  const char *username_;
-  const char *password_;
   size_t received_size_{0};
   size_t expected_size_{0};
   bool body_valid_{false};
 };
 
 inline bool register_panel_config_write_endpoint(
-    ConfigurationService &service, uint8_t *document, size_t document_capacity,
-    const char *username, const char *password) {
+    esphome::web_server_idf::AsyncWebServer &server) {
   static bool registered = false;
   if (registered) return true;
-  if (document == nullptr || document_capacity == 0) return false;
-  auto *server = esphome::web_server_idf::global_async_web_server();
-  if (server == nullptr) return false;
-  server->addHandler(new PanelConfigWriteHandler(service, document,
-                                                  document_capacity, username,
-                                                  password));
+  server.addHandler(new PanelConfigWriteHandler());
   registered = true;
   return true;
 }
@@ -181,8 +182,7 @@ inline bool register_panel_config_write_endpoint(
 #else
 namespace espcontrol::configuration {
 class ConfigurationService;
-inline bool register_panel_config_write_endpoint(ConfigurationService &, uint8_t *,
-                                                size_t, const char *, const char *) {
+inline bool register_panel_config_write_endpoint(...) {
   return true;
 }
 }  // namespace espcontrol::configuration

--- a/components/web_server_idf/web_server_idf.cpp
+++ b/components/web_server_idf/web_server_idf.cpp
@@ -231,8 +231,9 @@ void AsyncWebServer::begin() {
   config.close_fn = AsyncWebServer::safe_close_with_shutdown;
   if (httpd_start(&this->server_, &config) == ESP_OK) {
     global_async_web_server() = this;
-    // Register static EspControl routes before the generic dispatcher starts
-    // accepting requests. Adding handlers later can disrupt API clients.
+    // Let an external component add its static handlers before the generic
+    // dispatcher is exposed to browsers or API clients. Handlers added later
+    // can disrupt concurrent network activity on ESP32-P4 panels.
     if (espcontrol_register_web_server_handlers != nullptr) {
       espcontrol_register_web_server_handlers(this);
     }

--- a/tests/firmware/panel_config_capabilities_test.cpp
+++ b/tests/firmware/panel_config_capabilities_test.cpp
@@ -3,6 +3,7 @@
 #include <array>
 
 #include "panel_config_capabilities.h"
+#include "panel_config_http_context.h"
 
 int main() {
   using namespace espcontrol::configuration;
@@ -33,5 +34,15 @@ int main() {
                                            &capabilities_size) &&
       std::strstr(capabilities.data(), "\"read\":true") != nullptr &&
       std::strstr(capabilities.data(), "\"write\":true") != nullptr;
-  return passed && read_capability_is_advertised ? EXIT_SUCCESS : EXIT_FAILURE;
+  set_panel_config_http_context_initialization_complete(false);
+  const bool startup_capability_is_retryable =
+      !panel_config_http_context_initialization_complete();
+  set_panel_config_http_context_initialization_complete(true);
+  const bool completed_initialization_is_observable =
+      panel_config_http_context_initialization_complete();
+  return passed && read_capability_is_advertised &&
+                 startup_capability_is_retryable &&
+                 completed_initialization_is_observable
+             ? EXIT_SUCCESS
+             : EXIT_FAILURE;
 }

--- a/tests/web/native_panel_config.test.ts
+++ b/tests/web/native_panel_config.test.ts
@@ -113,13 +113,13 @@ export async function runNativePanelConfigTests(migrationFixture?: MigrationFixt
     if (path === "/api/v1/capabilities") {
       return nativeInitializationComplete
         ? response(200)
-        : { ...response(404), json: async () => ({}) };
+        : { ...response(503), json: async () => ({}) };
     }
     if (request?.method === "PUT") return response(204);
     return response(200, document, "\"8\"");
   });
   equal(await reconnectingClient.discover(), false,
-    "an editor reconnecting during initialization sees native config as temporarily unavailable");
+    "an editor reconnecting during initialization treats the retryable 503 as temporary");
   equal(reconnectingClient.retryable(), true,
     "a missing capabilities endpoint is retried after deferred initialization");
   nativeInitializationComplete = true;


### PR DESCRIPTION
## Purpose

Registers ESPControl web handlers while the web server is being created, then binds the native configuration handlers only after the delayed configuration service is ready. This removes the late handler registration that can reset Home Assistant API connections and stop cover-art URLs from resolving.

## Practical impact

- Home Assistant remains connected while browser configuration endpoints are available.
- Native `PanelConfig` API stays enabled after its normal startup delay.
- Local sensor and action endpoints are also installed during web-server startup.

## Checked

- `python3 scripts/check_firmware_parser.py`
- Firmware host suite: 26/26 passing.
- 10-inch V1 firmware compile: passed (ESPHome 2026.7.4; 26% app partition free).

## Device to test

10-inch V1 (`guition-esp32-p4-jc8012p4a1`): verify the Home Assistant connection stays online, a cover-art card loads its image, and the browser can save and reload a card. Physical flashing is deferred until the end of the refactor as agreed.