### PR TITLE
Move media card into Product Model

### DIFF
--- a/product/README.md
+++ b/product/README.md
@@ -30,9 +30,11 @@ Edit these files when changing product behavior or supported hardware:
 in `product/v2/`. The selected pilot overlays below prove the per-card and
 per-device composition path without changing the generated output.
 
-## Product Model v2 Pilot
+## Product Model v2 Pilots
 
 - `v2/cards/sensor.json` is the authoritative Sensor card definition.
+- `v2/cards/media.json` is the authoritative Media card definition, including
+  the cover-art configuration used by media-player cards.
 - `v2/devices/guition-esp32-p4-jc8012p4a1.json` is the authoritative 10-inch
   V1 device entry; shared hardware profiles remain in `product/v2/device_catalog.json`.
 

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor card and 10-inch V1 device pilot authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor and media card pilots plus the 10-inch V1 device pilot authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -45,7 +45,8 @@
   },
   "pilots": {
     "cards": {
-      "sensor": "product/v2/cards/sensor.json"
+      "sensor": "product/v2/cards/sensor.json",
+      "media": "product/v2/cards/media.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json"

--- a/product/v2/cards/media.json
+++ b/product/v2/cards/media.json
@@ -1,0 +1,322 @@
+{
+  "label": "Media",
+  "allowInSubpage": true,
+  "domains": [
+    "media_player"
+  ],
+  "options": [
+    {
+      "name": "media_mode",
+      "label": "Type",
+      "kind": "choice",
+      "values": [
+        "control_modal",
+        "speaker_group",
+        "play_pause",
+        "previous",
+        "next",
+        "volume",
+        "position",
+        "now_playing",
+        "cover_art",
+        "playlist"
+      ],
+      "defaultValue": "play_pause",
+      "storageField": "sensor",
+      "omitDefault": false,
+      "aliases": {
+        "controls": "play_pause"
+      }
+    },
+    {
+      "name": "media_display",
+      "label": "Type",
+      "kind": "choice",
+      "values": [
+        "",
+        "state"
+      ],
+      "defaultValue": "",
+      "storageField": "precision",
+      "omitDefault": true,
+      "applicability": [
+        {
+          "source": "field",
+          "name": "sensor",
+          "operator": "in",
+          "value": [
+            "play_pause",
+            "position"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "media_now_playing_controls",
+      "label": "Controls",
+      "kind": "choice",
+      "values": [
+        "",
+        "progress",
+        "play_pause"
+      ],
+      "defaultValue": "",
+      "storageField": "precision",
+      "omitDefault": true,
+      "applicability": [
+        {
+          "source": "field",
+          "name": "sensor",
+          "operator": "equals",
+          "value": "now_playing"
+        }
+      ]
+    },
+    {
+      "name": "cover_art_details",
+      "label": "Show Track Details",
+      "kind": "flag",
+      "omitDefault": true,
+      "applicability": [
+        {
+          "source": "field",
+          "name": "sensor",
+          "operator": "equals",
+          "value": "cover_art"
+        }
+      ]
+    },
+    {
+      "name": "cover_art_secondary_entity",
+      "label": "External Source Media Entity",
+      "kind": "text",
+      "omitDefault": true,
+      "applicability": [
+        {
+          "source": "field",
+          "name": "sensor",
+          "operator": "equals",
+          "value": "cover_art"
+        }
+      ]
+    },
+    {
+      "name": "volume_max",
+      "label": "Maximum Volume",
+      "kind": "number",
+      "min": 1,
+      "max": 100,
+      "step": 1,
+      "defaultValue": "100",
+      "omitDefault": true,
+      "applicability": [
+        {
+          "source": "field",
+          "name": "sensor",
+          "operator": "in",
+          "value": [
+            "control_modal",
+            "speaker_group",
+            "volume"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "speaker_group_entity",
+      "label": "Speaker Discovery Entity",
+      "kind": "text",
+      "omitDefault": true,
+      "applicability": [
+        {
+          "source": "field",
+          "name": "sensor",
+          "operator": "in",
+          "value": [
+            "control_modal",
+            "speaker_group"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "label_display",
+      "label": "Label Display",
+      "kind": "choice",
+      "values": [
+        "label",
+        "status"
+      ],
+      "defaultValue": "status",
+      "omitDefault": true,
+      "applicability": [
+        {
+          "source": "field",
+          "name": "sensor",
+          "operator": "equals",
+          "value": "control_modal"
+        }
+      ]
+    },
+    {
+      "name": "number_display",
+      "label": "Top Left Display",
+      "kind": "choice",
+      "values": [
+        "icon",
+        "volume"
+      ],
+      "defaultValue": "icon",
+      "omitDefault": true,
+      "applicability": [
+        {
+          "source": "field",
+          "name": "sensor",
+          "operator": "equals",
+          "value": "control_modal"
+        }
+      ]
+    },
+    {
+      "name": "playlist_content_id",
+      "label": "Media Content ID / URI",
+      "kind": "text",
+      "omitDefault": true,
+      "applicability": [
+        {
+          "source": "field",
+          "name": "sensor",
+          "operator": "equals",
+          "value": "playlist"
+        }
+      ]
+    },
+    {
+      "name": "playlist_content_type",
+      "label": "Media Content Type",
+      "kind": "text",
+      "defaultValue": "playlist",
+      "hidden": true,
+      "docsHidden": true,
+      "omitDefault": true,
+      "applicability": [
+        {
+          "source": "field",
+          "name": "sensor",
+          "operator": "equals",
+          "value": "playlist"
+        }
+      ]
+    },
+    {
+      "name": "playlist_player_source",
+      "label": "Player Source / Input",
+      "kind": "text",
+      "omitDefault": true,
+      "applicability": [
+        {
+          "source": "field",
+          "name": "sensor",
+          "operator": "equals",
+          "value": "playlist"
+        }
+      ]
+    },
+    {
+      "name": "large_numbers",
+      "label": "Large Media Numbers",
+      "kind": "flag",
+      "omitDefault": true,
+      "applicability": [
+        {
+          "source": "field",
+          "name": "sensor",
+          "operator": "in",
+          "value": [
+            "volume",
+            "position"
+          ]
+        }
+      ]
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": {
+        "policy": "keep"
+      },
+      "label": {
+        "policy": "hook",
+        "hook": "normalize_media_fields"
+      },
+      "icon": {
+        "policy": "hook",
+        "hook": "normalize_media_fields"
+      },
+      "icon_on": {
+        "policy": "keep"
+      },
+      "sensor": {
+        "policy": "hook",
+        "hook": "normalize_media_fields"
+      },
+      "unit": {
+        "policy": "keep"
+      },
+      "type": {
+        "policy": "default",
+        "value": "media"
+      },
+      "precision": {
+        "policy": "hook",
+        "hook": "normalize_media_fields"
+      },
+      "options": {
+        "policy": "hook",
+        "hook": "normalize_media_options"
+      }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": [
+      "label_display",
+      "number_display",
+      "cover_art_details",
+      "cover_art_secondary_entity",
+      "speaker_group_entity",
+      "volume_max",
+      "playlist_content_id",
+      "playlist_content_type",
+      "playlist_player_source",
+      "large_numbers"
+    ],
+    "optionHook": "normalize_media_options"
+  },
+  "behavior": {
+    "media": {
+      "defaultMode": "play_pause",
+      "legacyModes": {
+        "controls": "play_pause"
+      },
+      "stateDisplayModes": [
+        "play_pause",
+        "position"
+      ],
+      "playbackServices": {
+        "play_pause": "media_player.media_play_pause",
+        "previous": "media_player.media_previous_track",
+        "next": "media_player.media_next_track"
+      }
+    }
+  },
+  "default": {
+    "entity": "",
+    "label": "",
+    "icon": "Auto",
+    "icon_on": "Auto",
+    "sensor": "play_pause",
+    "unit": "",
+    "type": "media",
+    "precision": "",
+    "options": ""
+  }
+}

--- a/scripts/check_product_model_v2.py
+++ b/scripts/check_product_model_v2.py
@@ -25,14 +25,16 @@ def assert_equivalence() -> None:
     assert model.card_type in cards, "Product Model v2 sample card must exist in the legacy card contract"
     assert model.device_slug in devices, "Product Model v2 sample device must exist in the legacy device catalog"
 
-    # Canonical JSON makes this a byte-for-byte comparison of the selected
-    # legacy payload and the Product Model adapter view used by later generators.
-    legacy_card = json.dumps(cards[model.card_type], sort_keys=True, separators=(",", ":"))
-    adapter_card = json.dumps(model.sample_card(), sort_keys=True, separators=(",", ":"))
-    legacy_device = json.dumps(devices[model.device_slug], sort_keys=True, separators=(",", ":"))
-    adapter_device = json.dumps(model.sample_device(), sort_keys=True, separators=(",", ":"))
-    assert legacy_card == adapter_card, "selected card differs from its Product Model source"
-    assert legacy_device == adapter_device, "selected device differs from its Product Model source"
+    # Canonical JSON makes these byte-for-byte comparisons of each selected
+    # legacy payload and the Product Model adapter view used by generators.
+    for card_type in model.pilot_cards:
+        legacy_card = json.dumps(cards[card_type], sort_keys=True, separators=(",", ":"))
+        adapter_card = json.dumps(model.pilot_json("cards", card_type), sort_keys=True, separators=(",", ":"))
+        assert legacy_card == adapter_card, f"{card_type} card differs from its Product Model source"
+    for device_slug in model.pilot_devices:
+        legacy_device = json.dumps(devices[device_slug], sort_keys=True, separators=(",", ":"))
+        adapter_device = json.dumps(model.pilot_json("devices", device_slug), sort_keys=True, separators=(",", ":"))
+        assert legacy_device == adapter_device, f"{device_slug} device differs from its Product Model source"
 
     legacy_contract = json.dumps(load_json(model.source_path("cardContract")), sort_keys=True, separators=(",", ":"))
     generated_contract = json.dumps(model.card_contract_data(), sort_keys=True, separators=(",", ":"))
@@ -58,7 +60,7 @@ def run_self_test() -> None:
         else:
             raise AssertionError("missing product source must fail validation")
     invalid = copy.deepcopy(data)
-    invalid["pilots"]["cards"].pop("sensor")
+    invalid["pilots"]["cards"] = {}
     with TemporaryDirectory() as directory:
         path = Path(directory) / "model.json"
         path.write_text(json.dumps(invalid), encoding="utf-8")
@@ -80,7 +82,7 @@ def main() -> int:
             run_self_test()
         else:
             assert_equivalence()
-            print("Product Model v2 generated pilot matches its selected legacy card and device.")
+            print("Product Model v2 generated pilots match their legacy card and device outputs.")
     except (AssertionError, ProductModelV2Error, KeyError) as exc:
         print(f"ERROR: {exc}")
         return 1


### PR DESCRIPTION
## Purpose

Migrates the Media card, including cover-art settings, into its own authoritative Product Model v2 source.

## Practical impact

There is no user-visible behavior change. The generated firmware metadata, browser contract, documentation, and validation inputs remain byte-for-byte equivalent while future media and cover-art work now has one clear source file.

## Checked

- `npm run check:product`
- `npm run check:product-model-v2`
- Generated outputs verified current.

No physical-device test is needed: this is source ownership only, with no generated output changes.