### PR TITLE
Move image card into Product Model

### DIFF
--- a/product/README.md
+++ b/product/README.md
@@ -35,6 +35,7 @@ per-device composition path without changing the generated output.
 - `v2/cards/sensor.json` is the authoritative Sensor card definition.
 - `v2/cards/media.json` is the authoritative Media card definition, including
   the cover-art configuration used by media-player cards.
+- `v2/cards/image.json` is the authoritative Camera/Image card definition.
 - `v2/devices/guition-esp32-p4-jc8012p4a1.json` is the authoritative 10-inch
   V1 device entry; shared hardware profiles remain in `product/v2/device_catalog.json`.
 

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor and media card pilots plus the 10-inch V1 device pilot authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, and image card pilots plus the 10-inch V1 device pilot authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -46,7 +46,8 @@
   "pilots": {
     "cards": {
       "sensor": "product/v2/cards/sensor.json",
-      "media": "product/v2/cards/media.json"
+      "media": "product/v2/cards/media.json",
+      "image": "product/v2/cards/image.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json"

--- a/product/v2/cards/image.json
+++ b/product/v2/cards/image.json
@@ -1,0 +1,87 @@
+{
+  "label": "Camera Card",
+  "allowInSubpage": true,
+  "domains": [
+    "camera",
+    "image"
+  ],
+  "options": [
+    {
+      "name": "image_label",
+      "label": "Show Label",
+      "kind": "flag",
+      "omitDefault": true
+    },
+    {
+      "name": "image_icon",
+      "label": "Show Icon",
+      "kind": "flag",
+      "omitDefault": true
+    },
+    {
+      "name": "image_modal_mode",
+      "label": "Expanded Image",
+      "kind": "choice",
+      "values": [
+        "fill",
+        "fit"
+      ],
+      "defaultValue": "fill",
+      "omitDefault": true
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": {
+        "policy": "keep"
+      },
+      "label": {
+        "policy": "hook",
+        "hook": "normalize_image_fields"
+      },
+      "icon": {
+        "policy": "hook",
+        "hook": "normalize_image_fields"
+      },
+      "icon_on": {
+        "policy": "default",
+        "value": "Auto"
+      },
+      "sensor": {
+        "policy": "clear"
+      },
+      "unit": {
+        "policy": "clear"
+      },
+      "type": {
+        "policy": "default",
+        "value": "image"
+      },
+      "precision": {
+        "policy": "clear"
+      },
+      "options": {
+        "policy": "hook",
+        "hook": "normalize_image_options"
+      }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": [
+      "image_label",
+      "image_icon",
+      "image_modal_mode"
+    ],
+    "optionHook": "normalize_image_options"
+  },
+  "default": {
+    "entity": "",
+    "label": "",
+    "icon": "Auto",
+    "icon_on": "Auto",
+    "sensor": "",
+    "unit": "",
+    "type": "image",
+    "precision": "",
+    "options": ""
+  }
+}


### PR DESCRIPTION
## Summary
- make the Camera/Image card an authoritative Product Model v2 source
- compose it through the existing Product Model adapter
- retain byte-for-byte parity with the existing generated card contract

## Checks
- `npm run check:product-model-v2`
- `npm run check:generated`
- `npm run check:model-contract`
- `npm run check:product`

## Dependency
This follows PR #1486 (Media card pilot) and will automatically become a `main` PR after that prerequisite merges.