### PR TITLE
Move light switch card into Product Model

### DIFF
--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, and image card pilots plus the 10-inch V1 device pilot authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, and light-switch card pilots plus the 10-inch V1 device pilot authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -47,7 +47,8 @@
     "cards": {
       "sensor": "product/v2/cards/sensor.json",
       "media": "product/v2/cards/media.json",
-      "image": "product/v2/cards/image.json"
+      "image": "product/v2/cards/image.json",
+      "light_switch": "product/v2/cards/light_switch.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json"

--- a/product/v2/cards/light_switch.json
+++ b/product/v2/cards/light_switch.json
@@ -1,0 +1,53 @@
+{
+  "label": "Lights",
+  "allowInSubpage": true,
+  "pickerKey": "light_brightness",
+  "domains": [
+    "light"
+  ],
+  "normalization": {
+    "fields": {
+      "entity": {
+        "policy": "keep"
+      },
+      "label": {
+        "policy": "keep"
+      },
+      "icon": {
+        "policy": "keep"
+      },
+      "icon_on": {
+        "policy": "keep"
+      },
+      "sensor": {
+        "policy": "clear"
+      },
+      "unit": {
+        "policy": "clear"
+      },
+      "type": {
+        "policy": "default",
+        "value": "light_switch"
+      },
+      "precision": {
+        "policy": "clear"
+      },
+      "options": {
+        "policy": "clear"
+      }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "",
+    "label": "",
+    "icon": "Lightbulb Outline",
+    "icon_on": "Lightbulb",
+    "sensor": "",
+    "unit": "",
+    "type": "light_switch",
+    "precision": "",
+    "options": ""
+  }
+}


### PR DESCRIPTION
## Purpose
Add the light-switch card as the next independently-authored Product Model v2 pilot.

## Practical impact
The pilot exactly mirrors the existing contract metadata, preserving all current normalisation, card defaults, and generated firmware/browser/documentation outputs. Runtime light-card behaviour remains handwritten and unchanged.

## Checks
- `npm run check:product-model-v2`
- `npm run check:product-schema`
- `npm run check:product-snapshot`
- `npm run check:card-contract-outputs`
- `npm run check:model-contract`
- `npm run check:generated`