### PR TITLE
Move light brightness card into Product Model

### DIFF
--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, and light-switch card pilots plus the 10-inch V1 device pilot authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-switch, and light-brightness card pilots plus the 10-inch V1 device pilot authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -48,7 +48,8 @@
       "sensor": "product/v2/cards/sensor.json",
       "media": "product/v2/cards/media.json",
       "image": "product/v2/cards/image.json",
-      "light_switch": "product/v2/cards/light_switch.json"
+      "light_switch": "product/v2/cards/light_switch.json",
+      "light_brightness": "product/v2/cards/light_brightness.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json"

--- a/product/v2/cards/light_brightness.json
+++ b/product/v2/cards/light_brightness.json
@@ -1,0 +1,52 @@
+{
+  "label": "Lights",
+  "allowInSubpage": true,
+  "domains": [
+    "light"
+  ],
+  "normalization": {
+    "fields": {
+      "entity": {
+        "policy": "keep"
+      },
+      "label": {
+        "policy": "keep"
+      },
+      "icon": {
+        "policy": "keep"
+      },
+      "icon_on": {
+        "policy": "keep"
+      },
+      "sensor": {
+        "policy": "clear"
+      },
+      "unit": {
+        "policy": "keep"
+      },
+      "type": {
+        "policy": "default",
+        "value": "light_brightness"
+      },
+      "precision": {
+        "policy": "keep"
+      },
+      "options": {
+        "policy": "clear"
+      }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "",
+    "label": "",
+    "icon": "Lightbulb Outline",
+    "icon_on": "Lightbulb",
+    "sensor": "",
+    "unit": "",
+    "type": "light_brightness",
+    "precision": "",
+    "options": ""
+  }
+}


### PR DESCRIPTION
## Purpose
Add light-brightness as the next independently-authored Product Model v2 card pilot.

## Practical impact
The authored source exactly mirrors the current contract metadata, preserving existing light-card defaults, normalisation, generated outputs, and handwritten runtime behaviour.

## Checks
- `npm run check:product-model-v2`
- `npm run check:product-schema`
- `npm run check:product-snapshot`
- `npm run check:card-contract-outputs`
- `npm run check:model-contract`
- `npm run check:generated`