### PR TITLE
Move light control card into Product Model

### DIFF
--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-switch, and light-brightness card pilots plus the 10-inch V1 device pilot authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-switch, light-brightness, and light-control card pilots plus the 10-inch V1 device pilot authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -49,7 +49,8 @@
       "media": "product/v2/cards/media.json",
       "image": "product/v2/cards/image.json",
       "light_switch": "product/v2/cards/light_switch.json",
-      "light_brightness": "product/v2/cards/light_brightness.json"
+      "light_brightness": "product/v2/cards/light_brightness.json",
+      "light_control": "product/v2/cards/light_control.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json"

--- a/product/v2/cards/light_control.json
+++ b/product/v2/cards/light_control.json
@@ -1,0 +1,73 @@
+{
+  "label": "Lights",
+  "allowInSubpage": true,
+  "pickerKey": "light_brightness",
+  "hidden": true,
+  "domains": [
+    "light"
+  ],
+  "options": [
+    {
+      "name": "light_tabs",
+      "label": "Visible Tabs",
+      "kind": "text",
+      "values": [
+        "power",
+        "brightness",
+        "temperature",
+        "color"
+      ],
+      "defaultValue": "power|brightness|temperature|color",
+      "omitDefault": true
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": {
+        "policy": "keep"
+      },
+      "label": {
+        "policy": "keep"
+      },
+      "icon": {
+        "policy": "keep"
+      },
+      "icon_on": {
+        "policy": "keep"
+      },
+      "sensor": {
+        "policy": "clear"
+      },
+      "unit": {
+        "policy": "clear"
+      },
+      "type": {
+        "policy": "default",
+        "value": "light_control"
+      },
+      "precision": {
+        "policy": "clear"
+      },
+      "options": {
+        "policy": "hook",
+        "hook": "normalize_light_control_options"
+      }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": [
+      "light_tabs"
+    ],
+    "optionHook": "normalize_light_control_options"
+  },
+  "default": {
+    "entity": "",
+    "label": "",
+    "icon": "Lightbulb Outline",
+    "icon_on": "Lightbulb",
+    "sensor": "",
+    "unit": "",
+    "type": "light_control",
+    "precision": "",
+    "options": ""
+  }
+}


### PR DESCRIPTION
## Purpose
Add light-control as the next independently-authored Product Model v2 card pilot.

## Practical impact
The authored source exactly mirrors the existing metadata, including the light-tab normalisation hook. Generated outputs and handwritten runtime behaviour are unchanged.

## Checks
- `npm run check:product-model-v2`
- `npm run check:product-schema`
- `npm run check:product-snapshot`
- `npm run check:card-contract-outputs`
- `npm run check:model-contract`
- `npm run check:generated`