### PR TITLE
Move light temperature card into Product Model

### DIFF
--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-switch, light-brightness, and light-control card pilots plus the 10-inch V1 device pilot authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, and complete light-card family plus the 10-inch V1 device pilot authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -50,7 +50,8 @@
       "image": "product/v2/cards/image.json",
       "light_switch": "product/v2/cards/light_switch.json",
       "light_brightness": "product/v2/cards/light_brightness.json",
-      "light_control": "product/v2/cards/light_control.json"
+      "light_control": "product/v2/cards/light_control.json",
+      "light_temperature": "product/v2/cards/light_temperature.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json"

--- a/product/v2/cards/light_temperature.json
+++ b/product/v2/cards/light_temperature.json
@@ -1,0 +1,65 @@
+{
+  "label": "Lights",
+  "allowInSubpage": true,
+  "pickerKey": "light_brightness",
+  "domains": [
+    "light"
+  ],
+  "behavior": {
+    "lightTemperature": {
+      "defaultRange": "2000-6500",
+      "min": 1000,
+      "max": 10000,
+      "minMax": 9900,
+      "step": 100,
+      "legacySensorValues": [
+        "kelvin"
+      ]
+    }
+  },
+  "normalization": {
+    "fields": {
+      "entity": {
+        "policy": "keep"
+      },
+      "label": {
+        "policy": "keep"
+      },
+      "icon": {
+        "policy": "keep"
+      },
+      "icon_on": {
+        "policy": "keep"
+      },
+      "sensor": {
+        "policy": "keep"
+      },
+      "unit": {
+        "policy": "keep"
+      },
+      "type": {
+        "policy": "default",
+        "value": "light_temperature"
+      },
+      "precision": {
+        "policy": "keep"
+      },
+      "options": {
+        "policy": "clear"
+      }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "",
+    "label": "",
+    "icon": "Lightbulb",
+    "icon_on": "Auto",
+    "sensor": "",
+    "unit": "2000-6500",
+    "type": "light_temperature",
+    "precision": "",
+    "options": ""
+  }
+}


### PR DESCRIPTION
## Purpose
Complete the general light-card family by adding light-temperature as an independently-authored Product Model v2 pilot.

## Practical impact
The authored source exactly mirrors current light-temperature ranges, legacy compatibility metadata, normalisation, generated outputs, and handwritten runtime behavior.

## Checks
- `npm run check:product-model-v2`
- `npm run check:product-schema`
- `npm run check:product-snapshot`
- `npm run check:card-contract-outputs`
- `npm run check:model-contract`
- `npm run check:generated`