### PR TITLE
Move 10-inch V2 profile into Product Model

### DIFF
--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, and complete light-card family plus the 10-inch V1 device pilot authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, complete light-card family, and 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -54,7 +54,8 @@
       "light_temperature": "product/v2/cards/light_temperature.json"
     },
     "devices": {
-      "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json"
+      "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",
+      "guition-esp32-p4-jc8012p4a1-v2": "product/v2/devices/guition-esp32-p4-jc8012p4a1-v2.json"
     }
   }
 }

--- a/product/v2/devices/guition-esp32-p4-jc8012p4a1-v2.json
+++ b/product/v2/devices/guition-esp32-p4-jc8012p4a1-v2.json
@@ -1,0 +1,16 @@
+{
+  "profiles": {
+    "platform": "esp32-p4",
+    "display": "jc8012p4a1-1280x800",
+    "modal": "large-landscape",
+    "fonts": "large-panel-p4",
+    "network": "c6-firmware-update",
+    "artwork": "landscape-1280x800"
+  },
+  "config": {
+    "public": {
+      "name": "Guition JC8012P4A1 new panel (2628+)",
+      "docsPath": "/screens/jc8012p4a1-v2"
+    }
+  }
+}


### PR DESCRIPTION
## Purpose
Add the 10-inch V2 profile as the next independently-authored Product Model v2 device pilot.

## Practical impact
The source exactly mirrors the existing platform, display, modal, font, network, artwork, and public documentation metadata. Generated device outputs and firmware behavior are unchanged.

## Checks
- `npm run check:product-model-v2`
- `npm run check:product-schema`
- `npm run check:product-snapshot`
- `npm run check:card-contract-outputs`
- `npm run check:model-contract`
- `npm run check:generated`