### PR TITLE
Move fan switch card into Product Model

### DIFF
--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, complete light-card family, and 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card family, base fan card, and 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -51,7 +51,8 @@
       "light_switch": "product/v2/cards/light_switch.json",
       "light_brightness": "product/v2/cards/light_brightness.json",
       "light_control": "product/v2/cards/light_control.json",
-      "light_temperature": "product/v2/cards/light_temperature.json"
+      "light_temperature": "product/v2/cards/light_temperature.json",
+      "fan_switch": "product/v2/cards/fan_switch.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/v2/cards/fan_switch.json
+++ b/product/v2/cards/fan_switch.json
@@ -1,0 +1,55 @@
+{
+  "label": "Fans",
+  "allowInSubpage": true,
+  "pickerKey": "fan_speed",
+  "domains": [
+    "fan"
+  ],
+  "normalization": {
+    "fields": {
+      "entity": {
+        "policy": "keep"
+      },
+      "label": {
+        "policy": "keep"
+      },
+      "icon": {
+        "policy": "hook",
+        "hook": "normalize_fan_fields"
+      },
+      "icon_on": {
+        "policy": "hook",
+        "hook": "normalize_fan_fields"
+      },
+      "sensor": {
+        "policy": "clear"
+      },
+      "unit": {
+        "policy": "clear"
+      },
+      "type": {
+        "policy": "default",
+        "value": "fan_switch"
+      },
+      "precision": {
+        "policy": "clear"
+      },
+      "options": {
+        "policy": "clear"
+      }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "",
+    "label": "",
+    "icon": "Fan Off",
+    "icon_on": "Fan",
+    "sensor": "",
+    "unit": "",
+    "type": "fan_switch",
+    "precision": "",
+    "options": ""
+  }
+}


### PR DESCRIPTION
## Purpose
Add the base fan-switch card as the next independently-authored Product Model v2 pilot.

## Practical impact
The authored source exactly mirrors current fan icon normalisation, defaults, and generated metadata. Handwritten fan runtime behaviour is unchanged.

## Checks
- `npm run check:product-model-v2`
- `npm run check:product-schema`
- `npm run check:product-snapshot`
- `npm run check:card-contract-outputs`
- `npm run check:model-contract`
- `npm run check:generated`