### PR TITLE
Move fan speed card into Product Model

### DIFF
--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card family, base fan card, and 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card family, base and speed fan cards, and 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -52,7 +52,8 @@
       "light_brightness": "product/v2/cards/light_brightness.json",
       "light_control": "product/v2/cards/light_control.json",
       "light_temperature": "product/v2/cards/light_temperature.json",
-      "fan_switch": "product/v2/cards/fan_switch.json"
+      "fan_switch": "product/v2/cards/fan_switch.json",
+      "fan_speed": "product/v2/cards/fan_speed.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/v2/cards/fan_speed.json
+++ b/product/v2/cards/fan_speed.json
@@ -1,0 +1,54 @@
+{
+  "label": "Fans",
+  "allowInSubpage": true,
+  "domains": [
+    "fan"
+  ],
+  "normalization": {
+    "fields": {
+      "entity": {
+        "policy": "keep"
+      },
+      "label": {
+        "policy": "keep"
+      },
+      "icon": {
+        "policy": "hook",
+        "hook": "normalize_fan_fields"
+      },
+      "icon_on": {
+        "policy": "hook",
+        "hook": "normalize_fan_fields"
+      },
+      "sensor": {
+        "policy": "clear"
+      },
+      "unit": {
+        "policy": "clear"
+      },
+      "type": {
+        "policy": "default",
+        "value": "fan_speed"
+      },
+      "precision": {
+        "policy": "clear"
+      },
+      "options": {
+        "policy": "clear"
+      }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "",
+    "label": "",
+    "icon": "Fan Speed 2",
+    "icon_on": "Auto",
+    "sensor": "",
+    "unit": "",
+    "type": "fan_speed",
+    "precision": "",
+    "options": ""
+  }
+}


### PR DESCRIPTION
## Purpose
Add the fan-speed card as the next independently-authored Product Model v2 pilot.

## Practical impact
The authored source exactly mirrors current fan icon normalisation, defaults, and generated metadata. Handwritten fan runtime behaviour is unchanged.

## Checks
- `npm run check:product-model-v2`
- `npm run check:product-schema`
- `npm run check:product-snapshot`
- `npm run check:card-contract-outputs`
- `npm run check:model-contract`
- `npm run check:generated`