### PR TITLE
Move fan variants into Product Model

### DIFF
--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card family, base and speed fan cards, and 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card family, fan variants, and 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -53,7 +53,10 @@
       "light_control": "product/v2/cards/light_control.json",
       "light_temperature": "product/v2/cards/light_temperature.json",
       "fan_switch": "product/v2/cards/fan_switch.json",
-      "fan_speed": "product/v2/cards/fan_speed.json"
+      "fan_speed": "product/v2/cards/fan_speed.json",
+      "fan_direction": "product/v2/cards/fan_direction.json",
+      "fan_oscillate": "product/v2/cards/fan_oscillate.json",
+      "fan_preset": "product/v2/cards/fan_preset.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/v2/cards/fan_direction.json
+++ b/product/v2/cards/fan_direction.json
@@ -1,0 +1,25 @@
+{
+  "label": "Fans",
+  "allowInSubpage": true,
+  "pickerKey": "fan_speed",
+  "domains": ["fan"],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_fan_fields" },
+      "icon_on": { "policy": "hook", "hook": "normalize_fan_fields" },
+      "sensor": { "policy": "clear" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "fan_direction" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "clear" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Swap Horizontal", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "fan_direction", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/fan_oscillate.json
+++ b/product/v2/cards/fan_oscillate.json
@@ -1,0 +1,25 @@
+{
+  "label": "Fans",
+  "allowInSubpage": true,
+  "pickerKey": "fan_speed",
+  "domains": ["fan"],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_fan_fields" },
+      "icon_on": { "policy": "hook", "hook": "normalize_fan_fields" },
+      "sensor": { "policy": "clear" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "fan_oscillate" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "clear" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Fan", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "fan_oscillate", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/fan_preset.json
+++ b/product/v2/cards/fan_preset.json
@@ -1,0 +1,25 @@
+{
+  "label": "Fans",
+  "allowInSubpage": true,
+  "pickerKey": "fan_speed",
+  "domains": ["fan"],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_fan_fields" },
+      "icon_on": { "policy": "hook", "hook": "normalize_fan_fields" },
+      "sensor": { "policy": "clear" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "fan_preset" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "clear" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Fan Auto", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "fan_preset", "precision": "", "options": ""
+  }
+}


### PR DESCRIPTION
## Purpose
Add the fan-direction, fan-oscillation, and fan-preset variants as independently-authored Product Model v2 sources.

## Practical impact
Each source exactly mirrors current fan normalisation and defaults. Generated metadata and handwritten runtime behavior are unchanged.

## Checks
- `npm run check:product-model-v2`
- `npm run check:product-schema`
- `npm run check:product-snapshot`
- `npm run check:card-contract-outputs`
- `npm run check:model-contract`
- `npm run check:generated`