### PR TITLE
Move fan control card into Product Model

### DIFF
--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card family, fan variants, and 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card and fan-card families, and 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -56,7 +56,8 @@
       "fan_speed": "product/v2/cards/fan_speed.json",
       "fan_direction": "product/v2/cards/fan_direction.json",
       "fan_oscillate": "product/v2/cards/fan_oscillate.json",
-      "fan_preset": "product/v2/cards/fan_preset.json"
+      "fan_preset": "product/v2/cards/fan_preset.json",
+      "fan_control": "product/v2/cards/fan_control.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/v2/cards/fan_control.json
+++ b/product/v2/cards/fan_control.json
@@ -1,0 +1,42 @@
+{
+  "label": "Fans",
+  "allowInSubpage": true,
+  "pickerKey": "fan_speed",
+  "domains": ["fan"],
+  "options": [
+    {
+      "name": "fan_light_entity",
+      "label": "Light Entity",
+      "kind": "text",
+      "omitDefault": true
+    },
+    {
+      "name": "fan_tabs",
+      "label": "Visible Tabs",
+      "kind": "text",
+      "values": ["power", "speed", "preset", "oscillation", "direction", "light"],
+      "defaultValue": "power|speed|preset|oscillation|direction",
+      "omitDefault": true
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_fan_fields" },
+      "icon_on": { "policy": "hook", "hook": "normalize_fan_fields" },
+      "sensor": { "policy": "clear" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "fan_control" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "hook", "hook": "normalize_fan_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["fan_light_entity", "fan_tabs"],
+    "optionHook": "normalize_fan_options"
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Fan", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "fan_control", "precision": "", "options": ""
+  }
+}


### PR DESCRIPTION
## Purpose
Complete the fan-card Product Model migration by adding the full fan-control card source.

## Practical impact
The authored source exactly mirrors current fan tab and light-entity option metadata, normalisation, defaults, and generated outputs. Handwritten fan runtime behavior is unchanged.

## Checks
- `npm run check:product-model-v2`
- `npm run check:product-schema`
- `npm run check:product-snapshot`
- `npm run check:card-contract-outputs`
- `npm run check:model-contract`
- `npm run check:generated`