### PR TITLE
Move clock card into Product Model

### DIFF
--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card and fan-card families, and 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card and fan-card families, clock card, and 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -57,7 +57,8 @@
       "fan_direction": "product/v2/cards/fan_direction.json",
       "fan_oscillate": "product/v2/cards/fan_oscillate.json",
       "fan_preset": "product/v2/cards/fan_preset.json",
-      "fan_control": "product/v2/cards/fan_control.json"
+      "fan_control": "product/v2/cards/fan_control.json",
+      "clock": "product/v2/cards/clock.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/v2/cards/clock.json
+++ b/product/v2/cards/clock.json
@@ -1,0 +1,43 @@
+{
+  "label": "Date & Time",
+  "allowInSubpage": true,
+  "pickerKey": "calendar",
+  "domains": [],
+  "options": [
+    {
+      "name": "date_time_mode",
+      "label": "Type",
+      "kind": "choice",
+      "values": ["clock", "datetime", "", "timezone"],
+      "defaultValue": "clock",
+      "storageField": "type",
+      "omitDefault": false
+    },
+    {
+      "name": "large_numbers",
+      "label": "Large Clock",
+      "kind": "flag",
+      "omitDefault": true
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "clear" },
+      "label": { "policy": "clear" },
+      "icon": { "policy": "default", "value": "Auto" },
+      "icon_on": { "policy": "default", "value": "Auto" },
+      "sensor": { "policy": "clear" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "clock" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "hook", "hook": "normalize_date_time_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["large_numbers"],
+    "optionHook": "normalize_date_time_options"
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Auto", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "clock", "precision": "", "options": ""
+  }
+}


### PR DESCRIPTION
## Purpose
Add the date-and-time clock card as an independently-authored Product Model v2 source.

## Practical impact
The source exactly mirrors current date/time mode, large-number option, normalisation, defaults, and generated outputs. Handwritten runtime behavior is unchanged.

## Checks
- `npm run check:product-model-v2`
- `npm run check:product-schema`
- `npm run check:product-snapshot`
- `npm run check:card-contract-outputs`
- `npm run check:model-contract`
- `npm run check:generated`