### PR TITLE
Move date time cards into Product Model

### DIFF
--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card and fan-card families, clock card, and 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, and date/time card families plus 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -58,7 +58,9 @@
       "fan_oscillate": "product/v2/cards/fan_oscillate.json",
       "fan_preset": "product/v2/cards/fan_preset.json",
       "fan_control": "product/v2/cards/fan_control.json",
-      "clock": "product/v2/cards/clock.json"
+      "clock": "product/v2/cards/clock.json",
+      "calendar": "product/v2/cards/calendar.json",
+      "timezone": "product/v2/cards/timezone.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/v2/cards/calendar.json
+++ b/product/v2/cards/calendar.json
@@ -1,0 +1,37 @@
+{
+  "label": "Date & Time",
+  "allowInSubpage": true,
+  "domains": ["sensor"],
+  "options": [
+    {
+      "name": "date_time_mode",
+      "label": "Type",
+      "kind": "choice",
+      "values": ["clock", "datetime", "", "timezone"],
+      "defaultValue": "",
+      "storageField": "type",
+      "omitDefault": false
+    },
+    { "name": "large_numbers", "label": "Large Clock", "kind": "flag", "omitDefault": true }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "hook", "hook": "normalize_date_time_fields" },
+      "label": { "policy": "clear" },
+      "icon": { "policy": "default", "value": "Auto" },
+      "icon_on": { "policy": "default", "value": "Auto" },
+      "sensor": { "policy": "clear" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "calendar" },
+      "precision": { "policy": "allowed", "values": ["", "datetime"], "fallback": "" },
+      "options": { "policy": "hook", "hook": "normalize_date_time_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["large_numbers"],
+    "optionHook": "normalize_date_time_options"
+  },
+  "default": {
+    "entity": "sensor.date", "label": "", "icon": "Auto", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "calendar", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/timezone.json
+++ b/product/v2/cards/timezone.json
@@ -1,0 +1,38 @@
+{
+  "label": "Date & Time",
+  "allowInSubpage": true,
+  "pickerKey": "calendar",
+  "domains": [],
+  "options": [
+    {
+      "name": "date_time_mode",
+      "label": "Type",
+      "kind": "choice",
+      "values": ["clock", "datetime", "", "timezone"],
+      "defaultValue": "timezone",
+      "storageField": "type",
+      "omitDefault": false
+    },
+    { "name": "large_numbers", "label": "Large Clock", "kind": "flag", "omitDefault": true }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "hook", "hook": "normalize_date_time_fields" },
+      "label": { "policy": "clear" },
+      "icon": { "policy": "default", "value": "Auto" },
+      "icon_on": { "policy": "default", "value": "Auto" },
+      "sensor": { "policy": "clear" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "timezone" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "hook", "hook": "normalize_date_time_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["large_numbers"],
+    "optionHook": "normalize_date_time_options"
+  },
+  "default": {
+    "entity": "UTC (GMT+0)", "label": "", "icon": "Auto", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "timezone", "precision": "", "options": ""
+  }
+}


### PR DESCRIPTION
## Purpose
Complete the date/time Product Model migration with calendar and timezone card sources.

## Practical impact
Each source exactly mirrors current mode, normalisation, defaults, and generated metadata. Handwritten runtime behavior is unchanged.

## Checks
- `npm run check:product-model-v2`
- `npm run check:product-schema`
- `npm run check:product-snapshot`
- `npm run check:card-contract-outputs`
- `npm run check:model-contract`
- `npm run check:generated`