### PR TITLE
Move weather cards into Product Model

### DIFF
--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, and date/time card families plus 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, and weather card families plus 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -60,7 +60,9 @@
       "fan_control": "product/v2/cards/fan_control.json",
       "clock": "product/v2/cards/clock.json",
       "calendar": "product/v2/cards/calendar.json",
-      "timezone": "product/v2/cards/timezone.json"
+      "timezone": "product/v2/cards/timezone.json",
+      "weather": "product/v2/cards/weather.json",
+      "weather_forecast": "product/v2/cards/weather_forecast.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/v2/cards/weather.json
+++ b/product/v2/cards/weather.json
@@ -1,0 +1,44 @@
+{
+  "label": "Weather",
+  "allowInSubpage": true,
+  "domains": ["weather"],
+  "options": [
+    {
+      "name": "weather_mode",
+      "label": "Type",
+      "kind": "choice",
+      "values": ["", "today", "tomorrow"],
+      "defaultValue": "",
+      "storageField": "precision",
+      "omitDefault": true
+    },
+    {
+      "name": "large_numbers",
+      "label": "Large Temperature Numbers",
+      "kind": "flag",
+      "omitDefault": true,
+      "supportedWhen": { "precision": ["today", "tomorrow"] }
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "hook", "hook": "normalize_weather_fields" },
+      "icon": { "policy": "keep" },
+      "icon_on": { "policy": "keep" },
+      "sensor": { "policy": "clear" },
+      "unit": { "policy": "keep" },
+      "type": { "policy": "default", "value": "weather" },
+      "precision": { "policy": "hook", "hook": "normalize_weather_fields" },
+      "options": { "policy": "hook", "hook": "normalize_weather_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["large_numbers"],
+    "migrationActions": ["legacy_weather_forecast"],
+    "optionHook": "normalize_weather_options"
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Auto", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "weather", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/weather_forecast.json
+++ b/product/v2/cards/weather_forecast.json
@@ -1,0 +1,10 @@
+{
+  "label": "Weather Forecast",
+  "allowInSubpage": true,
+  "hidden": true,
+  "domains": ["weather"],
+  "default": {
+    "entity": "", "label": "", "icon": "Auto", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "weather", "precision": "tomorrow", "options": ""
+  }
+}


### PR DESCRIPTION
## Purpose
Move the weather and weather-forecast card metadata into independently-authored Product Model v2 sources.

## Practical impact
The sources exactly mirror current forecast compatibility, normalisation, defaults, and generated outputs. Handwritten rendering behavior is unchanged.

## Checks
- `npm run check:product-model-v2`
- `npm run check:product-schema`
- `npm run check:product-snapshot`
- `npm run check:card-contract-outputs`
- `npm run check:model-contract`
- `npm run check:generated`