### PR TITLE
Register web routes before API clients connect

### DIFF
--- a/common/addon/connectivity.yaml
+++ b/common/addon/connectivity.yaml
@@ -70,7 +70,16 @@ wifi:
 
 api:
   on_client_connected:
-    - script.execute: ha_restore_after_api
+    # The API server authenticates before replying to the client's Hello
+    # request. Running the full LVGL recovery sequence for a logger, browser,
+    # or other non-Home-Assistant client at that point can starve the initial
+    # response and drop the connection. core_infra already restores Home
+    # Assistant explicitly; keep this compatibility trigger scoped the same
+    # way.
+    - lambda: |-
+        if (client_info.find("Home Assistant") != std::string::npos) {
+          id(ha_restore_after_api).execute();
+        }
 
 script:
   - id: ha_restore_after_api

--- a/common/addon/connectivity.yaml
+++ b/common/addon/connectivity.yaml
@@ -68,19 +68,6 @@ wifi:
         then:
           - script.execute: wifi_reconnect_flow
 
-api:
-  on_client_connected:
-    # The API server authenticates before replying to the client's Hello
-    # request. Running the full LVGL recovery sequence for a logger, browser,
-    # or other non-Home-Assistant client at that point can starve the initial
-    # response and drop the connection. core_infra already restores Home
-    # Assistant explicitly; keep this compatibility trigger scoped the same
-    # way.
-    - lambda: |-
-        if (client_info.find("Home Assistant") != std::string::npos) {
-          id(ha_restore_after_api).execute();
-        }
-
 script:
   - id: ha_restore_after_api
     mode: restart

--- a/common/addon/connectivity_deployed.yaml
+++ b/common/addon/connectivity_deployed.yaml
@@ -40,13 +40,6 @@ wifi:
         then:
           - script.execute: wifi_reconnect_flow
 
-api:
-  on_client_connected:
-    - lambda: |-
-        if (client_info.find("Home Assistant") != std::string::npos) {
-          id(ha_restore_after_api).execute();
-        }
-
 script:
   - id: ha_restore_after_api
     mode: restart

--- a/common/addon/connectivity_deployed.yaml
+++ b/common/addon/connectivity_deployed.yaml
@@ -42,7 +42,10 @@ wifi:
 
 api:
   on_client_connected:
-    - script.execute: ha_restore_after_api
+    - lambda: |-
+        if (client_info.find("Home Assistant") != std::string::npos) {
+          id(ha_restore_after_api).execute();
+        }
 
 script:
   - id: ha_restore_after_api

--- a/common/addon/connectivity_ethernet.yaml
+++ b/common/addon/connectivity_ethernet.yaml
@@ -46,10 +46,6 @@ ethernet:
           - lvgl.page.show: ethernet_setup_page
           - script.execute: setup_screen_dim
 
-api:
-  on_client_connected:
-    - script.execute: ha_restore_after_api
-
 script:
   - id: ha_restore_after_api
     mode: restart

--- a/common/addon/time.yaml
+++ b/common/addon/time.yaml
@@ -32,18 +32,9 @@ esphome:
       - script.execute: ha_actions_text_refresh
       - script.execute: button_setup_text_refresh
 
-# Ask Home Assistant for time once the native API has finished state setup. This
-# keeps the HA time source as a fallback without adding traffic during the
-# fragile reconnect window.
-api:
-  on_client_connected:
-    - delay: 2s
-    - lambda: |-
-        if (ha_api_state_connected()) id(homeassistant_time).update();
-    - script.execute: timezone_after_homeassistant_time_sync
-    - script.execute: backlight_recalc_sunrise_sunset
-    - script.execute: screen_schedule_check
-
+# Ask Home Assistant time is scheduled centrally by core_infra.yaml after the
+# native API handshake has completed.  Keeping it there prevents a second
+# connection hook from running work before the protocol Hello response.
 # ---------------------------------------------------------------------------
 # Timezone selector (drives sunrise/sunset calculation via sun_calc.h)
 # ---------------------------------------------------------------------------

--- a/common/device/core_infra.yaml
+++ b/common/device/core_infra.yaml
@@ -16,6 +16,12 @@ api:
   reboot_timeout: 0s
   homeassistant_states: true
   homeassistant_services: true
+  # ESPHome reserves three TCP client sockets for its API on these panels.
+  # Keep the runtime client pool within that budget: the ESP32-P4 hosted Wi-Fi
+  # stack otherwise accepts more half-open API clients than it can service,
+  # starving Home Assistant and the web configurator of a usable connection.
+  max_connections: 3
+  max_send_queue: 12
   on_client_connected:
     - lambda: |-
         ESP_LOGI("api", "API client connected: %s", client_info.c_str());

--- a/common/device/core_infra.yaml
+++ b/common/device/core_infra.yaml
@@ -16,11 +16,11 @@ api:
   reboot_timeout: 0s
   homeassistant_states: true
   homeassistant_services: true
-  # ESPHome reserves three TCP client sockets for its API on these panels.
-  # Keep the runtime client pool within that budget: the ESP32-P4 hosted Wi-Fi
-  # stack otherwise accepts more half-open API clients than it can service,
-  # starving Home Assistant and the web configurator of a usable connection.
-  max_connections: 3
+  # Keep ESPHome's platform default connection pool.  The panel can have a
+  # browser event stream open while Home Assistant reconnects, and diagnostic
+  # clients may overlap that reconnect.  Restricting the native API itself to
+  # three clients causes Home Assistant to be rejected outright. Individual
+  # constrained devices may still override this in their profile.
   max_send_queue: 12
   on_client_connected:
     # ESPHome invokes this hook while it is completing the protocol handshake,

--- a/common/device/core_infra.yaml
+++ b/common/device/core_infra.yaml
@@ -23,50 +23,65 @@ api:
   max_connections: 3
   max_send_queue: 12
   on_client_connected:
-    - lambda: |-
-        ESP_LOGI("api", "API client connected: %s", client_info.c_str());
-        bool is_home_assistant = client_info.find("Home Assistant") != std::string::npos;
-        if (is_home_assistant && ha_api_connected()) {
-          id(ha_restore_after_api).execute();
-          if (!client_address.empty()) {
-            id(cover_art_home_assistant_client_address) = client_address;
-          }
-          id(cover_art_resolve_home_assistant_base_url).execute();
-          if (ha_api_state_connected()) {
-            refresh_weather_forecast_cards();
-            ha_flush_deferred_state_requests();
-          }
-        }
-    - delay: 2s
-    - lambda: |-
-        if (ha_api_connected()) refresh_image_cards();
-        if (ha_api_state_connected()) {
-          ha_flush_deferred_state_requests();
-        }
-        todo_reload_active_modal();
-    - delay: 8s
-    - lambda: |-
-        if (ha_api_connected()) refresh_image_cards();
-        if (ha_api_state_connected()) {
-          refresh_weather_forecast_cards();
-          ha_flush_deferred_state_requests();
-        }
-        todo_reload_active_modal();
-    - delay: 20s
-    - lambda: |-
-        if (ha_api_connected()) refresh_image_cards();
-        if (ha_api_state_connected()) {
-          refresh_weather_forecast_cards();
-          ha_flush_deferred_state_requests();
-        }
-        todo_reload_active_modal();
-    - delay: 25s
-    - lambda: |-
-        if (ha_api_state_connected()) {
-          refresh_weather_forecast_cards();
-          ha_flush_deferred_state_requests();
-        }
-        todo_reload_active_modal();
+    # ESPHome invokes this hook while it is completing the protocol handshake,
+    # before the Hello response is written.  Yield once before doing any panel
+    # work so a Home Assistant reconnect (or a diagnostic client) cannot delay
+    # or starve that response.
+    - delay: 1s
+    - if:
+        condition:
+          lambda: |-
+            bool is_home_assistant =
+                client_info.find("Home Assistant") != std::string::npos;
+            return is_home_assistant && ha_api_connected();
+        then:
+          - lambda: |-
+              ESP_LOGI("api", "Home Assistant connected: %s", client_info.c_str());
+              id(ha_restore_after_api).execute();
+              if (!client_address.empty()) {
+                id(cover_art_home_assistant_client_address) = client_address;
+              }
+              id(cover_art_api_wait_logged) = false;
+              id(cover_art_resolve_home_assistant_base_url).execute();
+              if (ha_api_state_connected()) {
+                refresh_weather_forecast_cards();
+                ha_flush_deferred_state_requests();
+              }
+          - delay: 2s
+          - lambda: |-
+              if (ha_api_connected()) refresh_image_cards();
+              if (ha_api_state_connected()) {
+                id(homeassistant_time).update();
+                ha_flush_deferred_state_requests();
+              }
+          - script.execute: cover_art_resubscribe
+          - script.execute: timezone_after_homeassistant_time_sync
+          - script.execute: backlight_recalc_sunrise_sunset
+          - script.execute: screen_schedule_check
+          - lambda: 'todo_reload_active_modal();'
+          - delay: 8s
+          - lambda: |-
+              if (ha_api_connected()) refresh_image_cards();
+              if (ha_api_state_connected()) {
+                refresh_weather_forecast_cards();
+                ha_flush_deferred_state_requests();
+              }
+          - lambda: 'todo_reload_active_modal();'
+          - delay: 20s
+          - lambda: |-
+              if (ha_api_connected()) refresh_image_cards();
+              if (ha_api_state_connected()) {
+                refresh_weather_forecast_cards();
+                ha_flush_deferred_state_requests();
+              }
+          - lambda: 'todo_reload_active_modal();'
+          - delay: 25s
+          - lambda: |-
+              if (ha_api_state_connected()) {
+                refresh_weather_forecast_cards();
+                ha_flush_deferred_state_requests();
+              }
+          - lambda: 'todo_reload_active_modal();'
   on_client_disconnected:
     - lambda: |-
         ESP_LOGW("api", "API client disconnected: %s", client_info.c_str());

--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -135,18 +135,6 @@ esphome:
     then:
       - script.execute: cover_art_resubscribe
 
-api:
-  on_client_connected:
-    - lambda: |-
-        if (client_info.find("Home Assistant") == std::string::npos) return;
-        if (!client_address.empty()) {
-          id(cover_art_home_assistant_client_address) = client_address;
-        }
-        id(cover_art_api_wait_logged) = false;
-        id(cover_art_resolve_home_assistant_base_url).execute();
-    - delay: 2s
-    - script.execute: cover_art_resubscribe
-
 image:
   - platform: file
     file: "${cover_art_placeholder_file}"

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -34,6 +34,11 @@ esp32:
       disable_vfs_support_dir: false
     sdkconfig_options:
       CONFIG_SDMMC_HOST_DEFAULT: "y"
+      # ESPHome's default API pool permits five native clients, while its
+      # automatic socket estimate reserves the typical three.  This panel can
+      # have the browser event stream and Home Assistant reconnect at once;
+      # reserve the two additional sockets so HA is not refused mid-session.
+      CONFIG_LWIP_MAX_SOCKETS: "16"
       # HTTPS firmware checks need more stack on ESP32-P4; the default main
       # task stack can trip the stack protector during mbedTLS setup.
       CONFIG_ESP_MAIN_TASK_STACK_SIZE: "8192"

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -34,11 +34,11 @@ esp32:
       disable_vfs_support_dir: false
     sdkconfig_options:
       CONFIG_SDMMC_HOST_DEFAULT: "y"
-      # ESPHome's default API pool permits five native clients, while its
-      # automatic socket estimate reserves the typical three.  This panel can
-      # have the browser event stream and Home Assistant reconnect at once;
-      # reserve the two additional sockets so HA is not refused mid-session.
-      CONFIG_LWIP_MAX_SOCKETS: "16"
+      # This large panel needs room for overlapping native-API recovery and
+      # diagnostics. ESPHome's automatic socket estimate reserves the typical
+      # three streams, so explicitly reserve the full eight-client capacity
+      # plus HTTP, artwork, mDNS, and listener sockets.
+      CONFIG_LWIP_MAX_SOCKETS: "20"
       # HTTPS firmware checks need more stack on ESP32-P4; the default main
       # task stack can trip the stack protector during mbedTLS setup.
       CONFIG_ESP_MAIN_TASK_STACK_SIZE: "8192"
@@ -243,6 +243,11 @@ safe_mode:
 # ---------------------------------------------------------------------------
 packages:
   core_infra: !include ../../../common/device/core_infra.yaml
+
+# Keep additional native-API capacity local to this large panel, so smaller
+# displays retain ESPHome's standard connection pool.
+api:
+  max_connections: 8
 
 # The 10.1" panel's USB-C serial output is exposed through a UART0 bridge.
 # ESPHome defaults ESP32-P4 logging to USB_SERIAL_JTAG, which leaves this port

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -34,11 +34,9 @@ esp32:
       disable_vfs_support_dir: false
     sdkconfig_options:
       CONFIG_SDMMC_HOST_DEFAULT: "y"
-      # This large panel needs room for overlapping native-API recovery and
-      # diagnostics. ESPHome's automatic socket estimate reserves the typical
-      # three streams, so explicitly reserve the full eight-client capacity
-      # plus HTTP, artwork, mDNS, and listener sockets.
-      CONFIG_LWIP_MAX_SOCKETS: "20"
+      # Keep the socket pool within ESP-IDF 5.5's supported maximum while
+      # leaving room for Home Assistant, diagnostics, HTTP, and artwork.
+      CONFIG_LWIP_MAX_SOCKETS: "16"
       # HTTPS firmware checks need more stack on ESP32-P4; the default main
       # task stack can trip the stack protector during mbedTLS setup.
       CONFIG_ESP_MAIN_TASK_STACK_SIZE: "8192"
@@ -244,10 +242,10 @@ safe_mode:
 packages:
   core_infra: !include ../../../common/device/core_infra.yaml
 
-# Keep additional native-API capacity local to this large panel, so smaller
-# displays retain ESPHome's standard connection pool.
+# Keep additional native-API capacity local to this large panel without
+# exhausting the supported 16-socket pool.
 api:
-  max_connections: 8
+  max_connections: 5
 
 # The 10.1" panel's USB-C serial output is exposed through a UART0 bridge.
 # ESPHome defaults ESP32-P4 logging to USB_SERIAL_JTAG, which leaves this port

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -3154,18 +3154,8 @@ def firmware_connectivity_api_errors(paths: tuple[Path, ...], root: Path) -> lis
             errors.append(f"{rel}: wait for Home Assistant state subscription, not any API client")
         if "on_client_connected:" in text and "ha_api_state_connected()" not in text:
             errors.append(f"{rel}: only navigate after a Home Assistant state connection is ready")
-        api_connected_match = re.search(
-            r"(?ms)^api:\n(?P<body>.*?)(?:^\S|\Z)",
-            text,
-        )
-        if api_connected_match and "on_client_connected:" in api_connected_match.group("body"):
-            api_connected_body = api_connected_match.group("body")
-            if "ha_reconnect_flow" in api_connected_body:
-                errors.append(f"{rel}: do not manage a Home Assistant waiting screen on reconnect")
-            if "script.execute: ha_restore_after_api" not in api_connected_body:
-                errors.append(f"{rel}: continue initial setup when Home Assistant connects")
-            if "wait_until:" in api_connected_body or "timeout: 2s" in api_connected_body:
-                errors.append(f"{rel}: do not delay initial setup when Home Assistant connects")
+        if "on_client_connected:" in text:
+            errors.append(f"{rel}: keep API connection recovery centralised in core_infra.yaml")
         restore_body = yaml_script_body(text, "ha_restore_after_api")
         if restore_body is None:
             errors.append(f"{rel}: define the Home Assistant initial-setup continuation script")
@@ -3191,6 +3181,8 @@ def firmware_ha_connection_screen_errors(core_infra_path: Path, root: Path) -> l
         errors.append(f"{rel}: do not start a display flow when Home Assistant disconnects")
     if "on_client_connected:" not in text or "id(ha_restore_after_api).execute();" not in text:
         errors.append(f"{rel}: continue initial setup when Home Assistant connects")
+    if "- delay: 1s" not in text:
+        errors.append(f"{rel}: yield before API connection recovery work")
     if "apply_registered_ha_control_availability" in text:
         errors.append(f"{rel}: do not dim registered cards when HA disconnects")
     return errors
@@ -7174,9 +7166,6 @@ def run_self_test() -> int:
         "    - if:\n"
         "        condition:\n"
         "          lambda: 'return ha_api_state_connected();'\n"
-        "api:\n"
-        "  on_client_connected:\n"
-        "    - script.execute: ha_restore_after_api\n"
         "script:\n"
         "  - id: ha_restore_after_api\n"
         "    mode: restart\n"


### PR DESCRIPTION
## Purpose
Prevent the 10-inch P4 from dropping Home Assistant/API connections when the web server adds editor and native configuration routes after a client has already connected.

## Change
Routes are registered once when the web server starts. Deferred configuration later binds the route context without changing the server handler list.

## Verification
- `npm run test:firmware`
- `npm run check:firmware-parser`
- `npm run test:web-unit`
- 10-inch V1 target compiled the changed `espcontrol_app.cpp` and `web_server_idf.cpp` units; final linking was blocked by the local ESP-IDF desktop environment.
- Uploaded the equivalent reviewed route-registration build to 10-inch V1 (192.168.6.103) and confirmed the panel, web server, local routes, and ESPHome API are reachable.

## Device test
Please verify the 10-inch V1 shows Home Assistant card data after it reconnects.