### PR TITLE
Move system cards into Product Model

### DIFF
--- a/product/README.md
+++ b/product/README.md
@@ -41,6 +41,8 @@ per-device composition path without changing the generated output.
 - `v2/cards/clock.json`, `calendar.json`, and `timezone.json` are the
   date-and-time family.
 - `v2/cards/weather.json` and `weather_forecast.json` are the weather family.
+- `v2/cards/internal.json`, `local_sensor.json`, and `screen_lock.json` are
+  the system-card family.
 - `v2/devices/guition-esp32-p4-jc8012p4a1.json` and
   `guition-esp32-p4-jc8012p4a1-v2.json` are the 10-inch V1 and V2 device
   entries; shared hardware profiles remain in `product/v2/device_catalog.json`.

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, and weather card families plus 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, and system card families plus 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -62,7 +62,10 @@
       "calendar": "product/v2/cards/calendar.json",
       "timezone": "product/v2/cards/timezone.json",
       "weather": "product/v2/cards/weather.json",
-      "weather_forecast": "product/v2/cards/weather_forecast.json"
+      "weather_forecast": "product/v2/cards/weather_forecast.json",
+      "internal": "product/v2/cards/internal.json",
+      "local_sensor": "product/v2/cards/local_sensor.json",
+      "screen_lock": "product/v2/cards/screen_lock.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/v2/cards/internal.json
+++ b/product/v2/cards/internal.json
@@ -1,0 +1,36 @@
+{
+  "label": "Internal Switches",
+  "allowInSubpage": true,
+  "domains": [],
+  "options": [
+    {
+      "name": "internal_mode",
+      "label": "Mode",
+      "kind": "choice",
+      "values": ["switch", "push"],
+      "defaultValue": "switch",
+      "storageField": "sensor",
+      "omitDefault": false
+    }
+  ],
+  "behavior": {
+    "internalRelay": {
+      "defaultIcons": { "switch": "Lightbulb Outline", "push": "Gesture Tap" },
+      "defaultIconOn": "Lightbulb"
+    }
+  },
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" }, "label": { "policy": "keep" },
+      "icon": { "policy": "keep" }, "icon_on": { "policy": "keep" },
+      "sensor": { "policy": "keep" }, "unit": { "policy": "keep" },
+      "type": { "policy": "default", "value": "internal" },
+      "precision": { "policy": "keep" }, "options": { "policy": "clear" }
+    },
+    "unknownOptions": "drop", "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Lightbulb Outline", "icon_on": "Lightbulb",
+    "sensor": "", "unit": "", "type": "internal", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/local_sensor.json
+++ b/product/v2/cards/local_sensor.json
@@ -1,0 +1,11 @@
+{
+  "label": "Local Sensor",
+  "allowInSubpage": true,
+  "pickerKey": "sensor",
+  "hidden": true,
+  "domains": ["sensor", "text_sensor"],
+  "default": {
+    "entity": "", "label": "", "icon": "Auto", "icon_on": "Auto",
+    "sensor": "local", "unit": "", "type": "sensor", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/screen_lock.json
+++ b/product/v2/cards/screen_lock.json
@@ -1,0 +1,20 @@
+{
+  "label": "Screen Lock",
+  "allowInSubpage": true,
+  "domains": [],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "clear" }, "label": { "policy": "clear" },
+      "icon": { "policy": "default", "value": "Lock" },
+      "icon_on": { "policy": "default", "value": "Lock Open" },
+      "sensor": { "policy": "clear" }, "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "screen_lock" },
+      "precision": { "policy": "clear" }, "options": { "policy": "clear" }
+    },
+    "unknownOptions": "drop", "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Lock", "icon_on": "Lock Open",
+    "sensor": "", "unit": "", "type": "screen_lock", "precision": "", "options": ""
+  }
+}


### PR DESCRIPTION
## Summary
- make Internal Switches, Local Sensor, and Screen Lock canonical Product Model v2 card sources
- preserve the generated card contract exactly while keeping firmware drivers handwritten
- document the expanded Product Model pilot coverage

## Practical impact
No device behaviour or saved configuration format changes. This is an ownership-only migration that makes these card definitions safe to evolve through the Product Model.

## Verification
- `npm run check:product`
- Product Model equivalence check for all pilot cards
- Generated-output freshness check

## Device testing
Not required for this metadata-only change; the 10-inch V1 remains the reference device for the wider refactor journey.