### PR TITLE
Move access cards into Product Model

### DIFF
--- a/product/README.md
+++ b/product/README.md
@@ -43,6 +43,8 @@ per-device composition path without changing the generated output.
 - `v2/cards/weather.json` and `weather_forecast.json` are the weather family.
 - `v2/cards/internal.json`, `local_sensor.json`, and `screen_lock.json` are
   the system-card family.
+- `v2/cards/cover.json`, `door_window.json`, `garage.json`, `gate.json`, and
+  `lock.json` are the access-card family.
 - `v2/devices/guition-esp32-p4-jc8012p4a1.json` and
   `guition-esp32-p4-jc8012p4a1-v2.json` are the 10-inch V1 and V2 device
   entries; shared hardware profiles remain in `product/v2/device_catalog.json`.

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, and system card families plus 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, system, and access card families plus 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -65,7 +65,12 @@
       "weather_forecast": "product/v2/cards/weather_forecast.json",
       "internal": "product/v2/cards/internal.json",
       "local_sensor": "product/v2/cards/local_sensor.json",
-      "screen_lock": "product/v2/cards/screen_lock.json"
+      "screen_lock": "product/v2/cards/screen_lock.json",
+      "cover": "product/v2/cards/cover.json",
+      "door_window": "product/v2/cards/door_window.json",
+      "garage": "product/v2/cards/garage.json",
+      "gate": "product/v2/cards/gate.json",
+      "lock": "product/v2/cards/lock.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/v2/cards/cover.json
+++ b/product/v2/cards/cover.json
@@ -1,0 +1,65 @@
+{
+  "label": "Cover",
+  "allowInSubpage": true,
+  "domains": ["cover"],
+  "options": [
+    {
+      "name": "cover_mode",
+      "label": "Type",
+      "kind": "choice",
+      "values": ["modal", "", "tilt", "toggle", "open", "close", "stop", "set_position"],
+      "defaultValue": "modal",
+      "storageField": "sensor",
+      "omitDefault": false
+    },
+    {
+      "name": "cover_position",
+      "label": "Position",
+      "kind": "number",
+      "defaultValue": "50",
+      "storageField": "unit",
+      "omitDefault": false,
+      "min": 0,
+      "max": 100,
+      "step": 1
+    },
+    {
+      "name": "cover_tabs",
+      "label": "Visible Tabs",
+      "kind": "text",
+      "values": ["position", "controls", "tilt", "presets"],
+      "defaultValue": "position|controls|tilt|presets",
+      "omitDefault": true
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "keep" },
+      "icon": { "policy": "keep" },
+      "icon_on": { "policy": "keep" },
+      "sensor": { "policy": "hook", "hook": "normalize_access_fields" },
+      "unit": { "policy": "hook", "hook": "normalize_access_fields" },
+      "type": { "policy": "default", "value": "cover" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "hook", "hook": "normalize_access_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["cover_tabs"],
+    "optionHook": "normalize_access_options"
+  },
+  "behavior": {
+    "cover": {
+      "commandServices": {
+        "open": "cover.open_cover",
+        "close": "cover.close_cover",
+        "stop": "cover.stop_cover",
+        "set_position": "cover.set_cover_position"
+      }
+    }
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Blinds", "icon_on": "Blinds Open",
+    "sensor": "modal", "unit": "", "type": "cover", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/door_window.json
+++ b/product/v2/cards/door_window.json
@@ -1,0 +1,33 @@
+{
+  "label": "Doors & Windows",
+  "allowInSubpage": true,
+  "domains": ["binary_sensor", "sensor"],
+  "options": [
+    {
+      "name": "active_color",
+      "label": "Lit When Open",
+      "kind": "flag",
+      "omitDefault": true
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "clear" },
+      "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_occupancy_fields" },
+      "icon_on": { "policy": "hook", "hook": "normalize_occupancy_fields" },
+      "sensor": { "policy": "keep" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "door_window" },
+      "precision": { "policy": "hook", "hook": "normalize_occupancy_fields" },
+      "options": { "policy": "hook", "hook": "normalize_occupancy_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["active_color"],
+    "optionHook": "normalize_occupancy_options"
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Door", "icon_on": "Door Open",
+    "sensor": "", "unit": "", "type": "door_window", "precision": "door", "options": "active_color"
+  }
+}

--- a/product/v2/cards/garage.json
+++ b/product/v2/cards/garage.json
@@ -1,0 +1,79 @@
+{
+  "label": "Garage Door",
+  "allowInSubpage": true,
+  "domains": ["cover"],
+  "options": [
+    {
+      "name": "garage_mode",
+      "label": "Interaction",
+      "kind": "choice",
+      "values": ["", "open", "close"],
+      "defaultValue": "",
+      "storageField": "sensor",
+      "omitDefault": false
+    },
+    {
+      "name": "label_display",
+      "label": "Display",
+      "kind": "choice",
+      "values": ["label", "status"],
+      "defaultValue": "label",
+      "omitDefault": true
+    },
+    {
+      "name": "confirmation_mode",
+      "label": "Confirmation Required",
+      "kind": "choice",
+      "values": ["", "off", "on", "both"],
+      "defaultValue": "",
+      "omitDefault": true,
+      "storage": ["confirm_off", "confirm_on"]
+    },
+    {
+      "name": "confirm_message",
+      "label": "Message",
+      "kind": "text",
+      "defaultValue": "Close the garage door?",
+      "omitDefault": true,
+      "defaultValueByMode": {
+        "off": "Close the garage door?",
+        "on": "Open the garage door?",
+        "both": "Open or close the garage door?"
+      }
+    },
+    {
+      "name": "confirm_yes",
+      "label": "Confirm Button",
+      "kind": "text",
+      "defaultValue": "Yes",
+      "omitDefault": true
+    },
+    {
+      "name": "confirm_no",
+      "label": "Cancel Button",
+      "kind": "text",
+      "defaultValue": "No",
+      "omitDefault": true
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "keep" },
+      "icon": { "policy": "keep" },
+      "icon_on": { "policy": "hook", "hook": "normalize_access_fields" },
+      "sensor": { "policy": "hook", "hook": "normalize_access_fields" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "garage" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "hook", "hook": "normalize_access_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["label_display", "confirm_off", "confirm_on", "confirm_message", "confirm_yes", "confirm_no"],
+    "optionHook": "normalize_access_options"
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Garage", "icon_on": "Garage Open",
+    "sensor": "", "unit": "", "type": "garage", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/gate.json
+++ b/product/v2/cards/gate.json
@@ -1,0 +1,44 @@
+{
+  "label": "Gate",
+  "allowInSubpage": true,
+  "domains": ["cover"],
+  "options": [
+    {
+      "name": "gate_mode",
+      "label": "Interaction",
+      "kind": "choice",
+      "values": ["", "open", "close", "stop"],
+      "defaultValue": "",
+      "storageField": "sensor",
+      "omitDefault": false
+    },
+    {
+      "name": "label_display",
+      "label": "Display",
+      "kind": "choice",
+      "values": ["label", "status"],
+      "defaultValue": "label",
+      "omitDefault": true
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "keep" },
+      "icon": { "policy": "keep" },
+      "icon_on": { "policy": "hook", "hook": "normalize_access_fields" },
+      "sensor": { "policy": "hook", "hook": "normalize_access_fields" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "gate" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "hook", "hook": "normalize_access_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["label_display"],
+    "optionHook": "normalize_access_options"
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Gate", "icon_on": "Gate Open",
+    "sensor": "", "unit": "", "type": "gate", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/lock.json
+++ b/product/v2/cards/lock.json
@@ -1,0 +1,41 @@
+{
+  "label": "Lock",
+  "allowInSubpage": true,
+  "domains": ["lock"],
+  "options": [
+    {
+      "name": "lock_mode",
+      "label": "Type",
+      "kind": "choice",
+      "values": ["", "lock", "unlock"],
+      "defaultValue": "",
+      "storageField": "sensor",
+      "omitDefault": false
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "keep" },
+      "icon": { "policy": "keep" },
+      "icon_on": { "policy": "hook", "hook": "normalize_access_fields" },
+      "sensor": { "policy": "hook", "hook": "normalize_access_fields" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "lock" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "clear" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": []
+  },
+  "behavior": {
+    "lock": {
+      "commandServices": { "lock": "lock.lock", "unlock": "lock.unlock" },
+      "toggleServices": { "locked": "lock.unlock", "default": "lock.lock" }
+    }
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Lock", "icon_on": "Lock Open",
+    "sensor": "", "unit": "", "type": "lock", "precision": "", "options": ""
+  }
+}


### PR DESCRIPTION
## Summary
- make Cover, Doors & Windows, Garage, Gate, and Lock canonical Product Model v2 card sources
- retain the current generated contract exactly and keep card drivers handwritten
- document the access-card family in the Product Model source map

## Practical impact
No device behaviour, generated output, or saved configuration changes. This is an ownership-only migration.

## Verification
- `npm run check:product`
- Product Model equivalence checks for the access-card sources
- Generated-output freshness check

## Device testing
Not required for this metadata-only change; the 10-inch V1 remains the reference device for the wider refactor journey.