### PR TITLE
Move interaction cards into Product Model

### DIFF
--- a/product/README.md
+++ b/product/README.md
@@ -45,6 +45,8 @@ per-device composition path without changing the generated output.
   the system-card family.
 - `v2/cards/cover.json`, `door_window.json`, `garage.json`, `gate.json`, and
   `lock.json` are the access-card family.
+- `v2/cards/action.json`, `option_select.json`, `push.json`, `slider.json`,
+  and `subpage.json` are the interaction-card family.
 - `v2/devices/guition-esp32-p4-jc8012p4a1.json` and
   `guition-esp32-p4-jc8012p4a1-v2.json` are the 10-inch V1 and V2 device
   entries; shared hardware profiles remain in `product/v2/device_catalog.json`.

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, system, and access card families plus 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, system, access, and interaction card families plus 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -70,7 +70,12 @@
       "door_window": "product/v2/cards/door_window.json",
       "garage": "product/v2/cards/garage.json",
       "gate": "product/v2/cards/gate.json",
-      "lock": "product/v2/cards/lock.json"
+      "lock": "product/v2/cards/lock.json",
+      "action": "product/v2/cards/action.json",
+      "option_select": "product/v2/cards/option_select.json",
+      "push": "product/v2/cards/push.json",
+      "slider": "product/v2/cards/slider.json",
+      "subpage": "product/v2/cards/subpage.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/v2/cards/action.json
+++ b/product/v2/cards/action.json
@@ -1,0 +1,71 @@
+{
+  "label": "Action",
+  "allowInSubpage": true,
+  "domains": ["scene", "script", "automation", "button", "input_button", "input_boolean", "input_number", "input_select", "select"],
+  "options": [
+    { "name": "large_numbers", "label": "Large State Numbers", "kind": "flag", "omitDefault": true, "applicabilityHook": "action_large_numbers_supported" },
+    { "name": "state_entity", "label": "State Entity", "kind": "text", "hidden": true, "docsHidden": true, "omitDefault": true },
+    {
+      "name": "state_unit", "label": "State Unit", "kind": "text", "hidden": true, "docsHidden": true, "omitDefault": true,
+      "applicability": [
+        { "source": "option", "name": "state_entity", "operator": "present" },
+        { "source": "option", "name": "state_precision", "operator": "in", "value": ["icon", "text"], "negate": true }
+      ]
+    },
+    {
+      "name": "state_precision", "label": "State Precision", "kind": "choice", "values": ["", "0", "1", "2", "icon", "text"],
+      "defaultValue": "", "hidden": true, "docsHidden": true, "omitDefault": true,
+      "applicability": [{ "source": "option", "name": "state_entity", "operator": "present" }]
+    },
+    {
+      "name": "confirmation_required", "label": "Confirmation Required", "kind": "flag", "storage": ["confirm_on"], "omitDefault": true,
+      "applicability": [{ "source": "field", "name": "sensor", "operator": "equals", "value": "script.turn_on" }]
+    },
+    {
+      "name": "script_fields", "label": "Fields", "kind": "text", "omitDefault": true,
+      "applicability": [{ "source": "field", "name": "sensor", "operator": "equals", "value": "script.turn_on" }]
+    },
+    {
+      "name": "confirm_message", "label": "Message", "kind": "text", "defaultValue": "Run this script?", "omitDefault": true,
+      "applicability": [
+        { "source": "field", "name": "sensor", "operator": "equals", "value": "script.turn_on" },
+        { "source": "option", "name": "confirm_on", "operator": "present" }
+      ]
+    },
+    {
+      "name": "confirm_yes", "label": "Confirm Button", "kind": "text", "defaultValue": "Yes", "omitDefault": true,
+      "applicability": [
+        { "source": "field", "name": "sensor", "operator": "equals", "value": "script.turn_on" },
+        { "source": "option", "name": "confirm_on", "operator": "present" }
+      ]
+    },
+    {
+      "name": "confirm_no", "label": "Cancel Button", "kind": "text", "defaultValue": "No", "omitDefault": true,
+      "applicability": [
+        { "source": "field", "name": "sensor", "operator": "equals", "value": "script.turn_on" },
+        { "source": "option", "name": "confirm_on", "operator": "present" }
+      ]
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_action_fields" },
+      "icon_on": { "policy": "hook", "hook": "normalize_action_fields" },
+      "sensor": { "policy": "hook", "hook": "normalize_action_fields" },
+      "unit": { "policy": "hook", "hook": "normalize_action_fields" },
+      "type": { "policy": "hook", "hook": "normalize_action_fields" },
+      "precision": { "policy": "hook", "hook": "normalize_action_fields" },
+      "options": { "policy": "hook", "hook": "normalize_action_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["state_entity", "state_unit", "state_precision", "large_numbers", "script_fields", "confirm_on", "confirm_message", "confirm_yes", "confirm_no"],
+    "optionHook": "normalize_action_options",
+    "migrationActions": ["legacy_local_action", "legacy_option_select", "legacy_vacuum_start", "legacy_vacuum_dock"]
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Flash", "icon_on": "Auto",
+    "sensor": "scene.turn_on", "unit": "", "type": "action", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/option_select.json
+++ b/product/v2/cards/option_select.json
@@ -1,0 +1,10 @@
+{
+  "label": "Option Select",
+  "allowInSubpage": true,
+  "hidden": true,
+  "domains": ["select", "input_select"],
+  "default": {
+    "entity": "", "label": "", "icon": "Flash", "icon_on": "Auto",
+    "sensor": "input_select.select_option", "unit": "", "type": "action", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/push.json
+++ b/product/v2/cards/push.json
@@ -1,0 +1,22 @@
+{
+  "label": "Trigger",
+  "allowInSubpage": true,
+  "domains": [],
+  "behavior": {
+    "pushAction": { "defaultIcon": "Gesture Tap", "defaultIconOn": "Auto" }
+  },
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" }, "label": { "policy": "keep" },
+      "icon": { "policy": "keep" }, "icon_on": { "policy": "keep" },
+      "sensor": { "policy": "keep" }, "unit": { "policy": "keep" },
+      "type": { "policy": "default", "value": "push" },
+      "precision": { "policy": "keep" }, "options": { "policy": "clear" }
+    },
+    "unknownOptions": "drop", "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Gesture Tap", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "push", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/slider.json
+++ b/product/v2/cards/slider.json
@@ -1,0 +1,19 @@
+{
+  "label": "Slider",
+  "allowInSubpage": true,
+  "domains": ["light", "fan"],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" }, "label": { "policy": "keep" },
+      "icon": { "policy": "keep" }, "icon_on": { "policy": "keep" },
+      "sensor": { "policy": "clear" }, "unit": { "policy": "keep" },
+      "type": { "policy": "default", "value": "slider" },
+      "precision": { "policy": "keep" }, "options": { "policy": "clear" }
+    },
+    "unknownOptions": "drop", "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Auto", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "slider", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/subpage.json
+++ b/product/v2/cards/subpage.json
@@ -1,0 +1,33 @@
+{
+  "label": "Subpage",
+  "allowInSubpage": false,
+  "domains": [],
+  "options": [
+    {
+      "name": "subpage_kind", "label": "Subpage Type", "kind": "choice",
+      "values": ["", "switch", "lights", "climate", "presence", "media", "alarm", "cover", "garage", "gate", "lock", "vacuum", "lawn_mower", "weather", "sensor", "image"],
+      "defaultValue": "", "omitDefault": true
+    },
+    { "name": "large_numbers", "label": "Large State Numbers", "kind": "flag", "omitDefault": true }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "hook", "hook": "normalize_subpage_fields" },
+      "icon": { "policy": "hook", "hook": "normalize_subpage_fields" },
+      "icon_on": { "policy": "hook", "hook": "normalize_subpage_fields" },
+      "sensor": { "policy": "hook", "hook": "normalize_subpage_fields" },
+      "unit": { "policy": "hook", "hook": "normalize_subpage_fields" },
+      "type": { "policy": "default", "value": "subpage" },
+      "precision": { "policy": "hook", "hook": "normalize_subpage_fields" },
+      "options": { "policy": "hook", "hook": "normalize_subpage_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["subpage_kind", "large_numbers"],
+    "optionHook": "normalize_subpage_options"
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Auto", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "subpage", "precision": "", "options": ""
+  }
+}


### PR DESCRIPTION
## Summary
- make Action, Option Select, Trigger, Slider, and Subpage canonical Product Model v2 card sources
- preserve today’s generated contract exactly while keeping runtime card behaviour handwritten
- document the interaction-card family in the Product Model source map

## Practical impact
No device behaviour, generated output, or saved configuration format changes. This is an ownership-only migration.

## Verification
- `npm run check:product`
- Product Model equivalence checks for all interaction-card sources
- Generated-output freshness check

## Device testing
Not required for this metadata-only change; the 10-inch V1 remains the reference device for the wider refactor journey.