### PR TITLE
Move climate cards into Product Model

### DIFF
--- a/product/README.md
+++ b/product/README.md
@@ -47,6 +47,8 @@ per-device composition path without changing the generated output.
   `lock.json` are the access-card family.
 - `v2/cards/action.json`, `option_select.json`, `push.json`, `slider.json`,
   and `subpage.json` are the interaction-card family.
+- `v2/cards/climate.json` and `climate_control.json` are the climate-card
+  family.
 - `v2/devices/guition-esp32-p4-jc8012p4a1.json` and
   `guition-esp32-p4-jc8012p4a1-v2.json` are the 10-inch V1 and V2 device
   entries; shared hardware profiles remain in `product/v2/device_catalog.json`.

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, system, access, and interaction card families plus 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, system, access, interaction, and climate card families plus 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -75,7 +75,9 @@
       "option_select": "product/v2/cards/option_select.json",
       "push": "product/v2/cards/push.json",
       "slider": "product/v2/cards/slider.json",
-      "subpage": "product/v2/cards/subpage.json"
+      "subpage": "product/v2/cards/subpage.json",
+      "climate": "product/v2/cards/climate.json",
+      "climate_control": "product/v2/cards/climate_control.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/v2/cards/climate.json
+++ b/product/v2/cards/climate.json
@@ -1,0 +1,35 @@
+{
+  "label": "Climate",
+  "allowInSubpage": true,
+  "domains": ["climate"],
+  "options": [
+    { "name": "label_display", "label": "Label Display", "kind": "choice", "values": ["label", "status", "actual", "target"], "defaultValue": "label", "omitDefault": true },
+    { "name": "number_display", "label": "Icon & Temperatures", "kind": "choice", "values": ["icon", "actual", "target"], "defaultValue": "target", "omitDefault": true },
+    { "name": "temperature_step", "label": "Temperature Step", "kind": "choice", "values": ["1", "0.5"], "defaultValue": "1", "omitDefault": true },
+    { "name": "large_numbers", "label": "Large Temperature Numbers", "kind": "flag", "omitDefault": true }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" }, "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_climate_fields" },
+      "icon_on": { "policy": "hook", "hook": "normalize_climate_fields" },
+      "sensor": { "policy": "clear" }, "unit": { "policy": "clear" },
+      "type": { "policy": "alias", "aliases": { "climate": "climate_control" } },
+      "precision": { "policy": "hook", "hook": "normalize_climate_fields" },
+      "options": { "policy": "hook", "hook": "normalize_climate_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["label_display", "number_display", "temperature_step", "large_numbers"],
+    "optionHook": "normalize_climate_options"
+  },
+  "behavior": {
+    "climate": {
+      "defaultLabelDisplay": "label", "defaultNumberDisplay": "target", "defaultTemperatureStep": "1",
+      "precisionValues": ["", "1", "2", "3"]
+    }
+  },
+  "default": {
+    "entity": "", "label": "Climate", "icon": "Thermostat", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "climate_control", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/climate_control.json
+++ b/product/v2/cards/climate_control.json
@@ -1,0 +1,38 @@
+{
+  "label": "All Controls",
+  "allowInSubpage": true,
+  "pickerKey": "climate",
+  "hidden": true,
+  "domains": ["climate"],
+  "options": [
+    { "name": "label_display", "label": "Label Display", "kind": "choice", "values": ["label", "status", "actual", "target"], "defaultValue": "label", "omitDefault": true },
+    { "name": "number_display", "label": "Icon & Temperatures", "kind": "choice", "values": ["icon", "actual", "target"], "defaultValue": "target", "omitDefault": true },
+    { "name": "temperature_step", "label": "Temperature Step", "kind": "choice", "values": ["1", "0.5"], "defaultValue": "1", "omitDefault": true },
+    { "name": "large_numbers", "label": "Large Temperature Numbers", "kind": "flag", "omitDefault": true },
+    { "name": "climate_tabs", "label": "Visible Tabs", "kind": "text", "defaultValue": "temperature|mode|preset|fan|swing", "omitDefault": true }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" }, "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_climate_fields" },
+      "icon_on": { "policy": "hook", "hook": "normalize_climate_fields" },
+      "sensor": { "policy": "clear" }, "unit": { "policy": "clear" },
+      "type": { "policy": "alias", "aliases": { "climate": "climate_control" } },
+      "precision": { "policy": "hook", "hook": "normalize_climate_fields" },
+      "options": { "policy": "hook", "hook": "normalize_climate_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["label_display", "number_display", "temperature_step", "large_numbers", "climate_tabs"],
+    "optionHook": "normalize_climate_options"
+  },
+  "behavior": {
+    "climate": {
+      "defaultLabelDisplay": "label", "defaultNumberDisplay": "target", "defaultTemperatureStep": "1",
+      "precisionValues": ["", "1", "2", "3"]
+    }
+  },
+  "default": {
+    "entity": "", "label": "Climate", "icon": "Thermostat", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "climate_control", "precision": "", "options": ""
+  }
+}


### PR DESCRIPTION
## Summary
- make Climate and All Controls canonical Product Model v2 card sources
- preserve the current generated contract exactly while keeping card behaviour handwritten
- document the climate-card family in the Product Model source map

## Practical impact
No device behaviour, generated output, or saved configuration format changes. This is an ownership-only migration.

## Verification
- `npm run check:product`
- Product Model equivalence checks for both climate-card sources
- Generated-output freshness check

## Device testing
Not required for this metadata-only change; the 10-inch V1 remains the reference device for the wider refactor journey.