### PR TITLE
Move alert cards into Product Model

### DIFF
--- a/product/README.md
+++ b/product/README.md
@@ -49,6 +49,8 @@ per-device composition path without changing the generated output.
   and `subpage.json` are the interaction-card family.
 - `v2/cards/climate.json` and `climate_control.json` are the climate-card
   family.
+- `v2/cards/alarm.json`, `alarm_action.json`, and `presence.json` are the
+  alert-card family.
 - `v2/devices/guition-esp32-p4-jc8012p4a1.json` and
   `guition-esp32-p4-jc8012p4a1-v2.json` are the 10-inch V1 and V2 device
   entries; shared hardware profiles remain in `product/v2/device_catalog.json`.

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, system, access, interaction, and climate card families plus 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, system, access, interaction, climate, and alert card families plus 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -77,7 +77,10 @@
       "slider": "product/v2/cards/slider.json",
       "subpage": "product/v2/cards/subpage.json",
       "climate": "product/v2/cards/climate.json",
-      "climate_control": "product/v2/cards/climate_control.json"
+      "climate_control": "product/v2/cards/climate_control.json",
+      "alarm": "product/v2/cards/alarm.json",
+      "alarm_action": "product/v2/cards/alarm_action.json",
+      "presence": "product/v2/cards/presence.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/v2/cards/alarm.json
+++ b/product/v2/cards/alarm.json
@@ -1,0 +1,44 @@
+{
+  "label": "Alarm",
+  "allowInSubpage": true,
+  "domains": ["alarm_control_panel"],
+  "options": [
+    { "name": "alarm_card_type", "label": "Type", "kind": "choice", "values": ["control_panel", "away", "home", "night", "vacation", "disarm"], "defaultValue": "control_panel", "storageField": "type", "omitDefault": false },
+    { "name": "pin_arm", "label": "PIN required for arming", "kind": "flag", "defaultValue": "1", "omitDefault": true },
+    { "name": "pin_disarm", "label": "PIN required for disarming", "kind": "flag", "defaultValue": "1", "omitDefault": true },
+    { "name": "actions", "label": "Visible Actions", "kind": "choice", "values": ["away", "home", "night", "vacation", "disarm"], "defaultValue": "away|home|disarm", "omitDefault": true },
+    { "name": "icon_display", "label": "Icon Display", "kind": "choice", "values": ["static", "status"], "defaultValue": "status", "omitDefault": true },
+    { "name": "label_display", "label": "Label Display", "kind": "choice", "values": ["name", "status"], "defaultValue": "status", "omitDefault": true }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" }, "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_security_fields" },
+      "icon_on": { "policy": "default", "value": "Auto" },
+      "sensor": { "policy": "clear" }, "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "alarm" }, "precision": { "policy": "clear" },
+      "options": { "policy": "hook", "hook": "normalize_security_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["pin_arm", "pin_disarm", "actions", "icon_display", "label_display"],
+    "optionHook": "normalize_security_options"
+  },
+  "behavior": {
+    "alarm": {
+      "controlPanelValue": "control_panel",
+      "defaultActions": ["away", "home", "disarm"],
+      "maxVisibleActions": 3,
+      "actions": [
+        { "value": "away", "label": "Arm Away", "service": "alarm_control_panel.alarm_arm_away", "icon": "Shield Lock", "legacyIcon": "Security" },
+        { "value": "home", "label": "Arm Home", "service": "alarm_control_panel.alarm_arm_home", "icon": "Shield Home", "legacyIcon": "Home" },
+        { "value": "night", "label": "Arm Night", "service": "alarm_control_panel.alarm_arm_night", "icon": "Weather Night", "legacyIcon": "Weather Night" },
+        { "value": "vacation", "label": "Arm Vacation", "service": "alarm_control_panel.alarm_arm_vacation", "icon": "Airplane", "legacyIcon": "Airplane" },
+        { "value": "disarm", "label": "Disarm", "service": "alarm_control_panel.alarm_disarm", "icon": "Shield Off", "legacyIcon": "Lock Open" }
+      ]
+    }
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Security", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "alarm", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/alarm_action.json
+++ b/product/v2/cards/alarm_action.json
@@ -1,0 +1,23 @@
+{
+  "label": "Alarm",
+  "allowInSubpage": true,
+  "pickerKey": "alarm",
+  "domains": ["alarm_control_panel"],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "hook", "hook": "normalize_security_fields" },
+      "icon": { "policy": "hook", "hook": "normalize_security_fields" },
+      "icon_on": { "policy": "default", "value": "Auto" },
+      "sensor": { "policy": "hook", "hook": "normalize_security_fields" },
+      "unit": { "policy": "clear" }, "type": { "policy": "default", "value": "alarm_action" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "hook", "hook": "normalize_security_options" }
+    },
+    "unknownOptions": "drop", "canonicalOptionOrder": [], "optionHook": "normalize_security_options"
+  },
+  "default": {
+    "entity": "", "label": "Arm Away", "icon": "Shield Lock", "icon_on": "Auto",
+    "sensor": "away", "unit": "", "type": "alarm_action", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/presence.json
+++ b/product/v2/cards/presence.json
@@ -1,0 +1,21 @@
+{
+  "label": "Presence",
+  "allowInSubpage": true,
+  "domains": ["binary_sensor", "sensor", "text_sensor"],
+  "options": [{ "name": "active_color", "label": "Lit When Detected", "kind": "flag", "omitDefault": true }],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "clear" }, "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_occupancy_fields" },
+      "icon_on": { "policy": "hook", "hook": "normalize_occupancy_fields" },
+      "sensor": { "policy": "keep" }, "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "presence" }, "precision": { "policy": "clear" },
+      "options": { "policy": "hook", "hook": "normalize_occupancy_options" }
+    },
+    "unknownOptions": "drop", "canonicalOptionOrder": ["active_color"], "optionHook": "normalize_occupancy_options"
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Motion Sensor Off", "icon_on": "Motion Sensor",
+    "sensor": "", "unit": "", "type": "presence", "precision": "", "options": "active_color"
+  }
+}


### PR DESCRIPTION
## Summary
- make Alarm, Alarm Action, and Presence canonical Product Model v2 card sources
- preserve the current generated contract exactly while keeping card behaviour handwritten
- document the alert-card family in the Product Model source map

## Practical impact
No device behaviour, generated output, or saved configuration format changes. This is an ownership-only migration.

## Verification
- `npm run check:product`
- Product Model equivalence checks for all alert-card sources
- Generated-output freshness check

## Device testing
Not required for this metadata-only change; the 10-inch V1 remains the reference device for the wider refactor journey.