### PR TITLE
Move appliance cards into Product Model

### DIFF
--- a/product/README.md
+++ b/product/README.md
@@ -51,6 +51,10 @@ per-device composition path without changing the generated output.
   family.
 - `v2/cards/alarm.json`, `alarm_action.json`, and `presence.json` are the
   alert-card family.
+- `v2/cards/lawn_mower.json`, `vacuum.json`, and `webhook.json` are the
+  appliance-and-integration-card family.
+- `v2/cards/default_switch.json` owns the contract's unnamed default-switch
+  fallback entry.
 - `v2/devices/guition-esp32-p4-jc8012p4a1.json` and
   `guition-esp32-p4-jc8012p4a1-v2.json` are the 10-inch V1 and V2 device
   entries; shared hardware profiles remain in `product/v2/device_catalog.json`.

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, system, access, interaction, climate, and alert card families plus 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, system, access, interaction, climate, alert, and appliance/integration card families plus 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -80,7 +80,11 @@
       "climate_control": "product/v2/cards/climate_control.json",
       "alarm": "product/v2/cards/alarm.json",
       "alarm_action": "product/v2/cards/alarm_action.json",
-      "presence": "product/v2/cards/presence.json"
+      "presence": "product/v2/cards/presence.json",
+      "lawn_mower": "product/v2/cards/lawn_mower.json",
+      "vacuum": "product/v2/cards/vacuum.json",
+      "webhook": "product/v2/cards/webhook.json",
+      "": "product/v2/cards/default_switch.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/v2/cards/default_switch.json
+++ b/product/v2/cards/default_switch.json
@@ -1,0 +1,33 @@
+{
+  "label": "Switch",
+  "allowInSubpage": true,
+  "domains": ["light", "switch", "input_boolean", "fan"],
+  "options": [
+    { "name": "large_numbers", "label": "Large Active Display Numbers", "kind": "flag", "omitDefault": true },
+    { "name": "confirmation_mode", "label": "Confirmation Required", "kind": "choice", "values": ["", "off", "on", "both"], "defaultValue": "", "omitDefault": true, "storage": ["confirm_off", "confirm_on"] },
+    { "name": "on_pattern", "label": "On State Pattern", "kind": "choice", "values": ["", "stripes"], "defaultValue": "", "omitDefault": true },
+    {
+      "name": "confirm_message", "label": "Message", "kind": "text", "defaultValue": "Turn off this device?", "omitDefault": true,
+      "defaultValueByMode": { "off": "Turn off this device?", "on": "Turn on this device?", "both": "Toggle this device?" }
+    },
+    { "name": "confirm_yes", "label": "Confirm Button", "kind": "text", "defaultValue": "Yes", "omitDefault": true },
+    { "name": "confirm_no", "label": "Cancel Button", "kind": "text", "defaultValue": "No", "omitDefault": true }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" }, "label": { "policy": "keep" },
+      "icon": { "policy": "default_if_empty", "value": "Auto" },
+      "icon_on": { "policy": "default_if_empty", "value": "Auto" },
+      "sensor": { "policy": "keep" }, "unit": { "policy": "keep" },
+      "type": { "policy": "default", "value": "" }, "precision": { "policy": "keep" },
+      "options": { "policy": "hook", "hook": "normalize_switch_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["large_numbers", "on_pattern", "confirm_off", "confirm_on", "confirm_message", "confirm_yes", "confirm_no"],
+    "optionHook": "normalize_switch_options"
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Auto", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/lawn_mower.json
+++ b/product/v2/cards/lawn_mower.json
@@ -1,0 +1,23 @@
+{
+  "label": "Lawn Mower",
+  "allowInSubpage": true,
+  "domains": ["lawn_mower"],
+  "options": [
+    { "name": "lawn_mower_mode", "label": "Type", "kind": "choice", "values": ["status", "start_mowing", "dock", "pause_resume"], "defaultValue": "start_mowing", "storageField": "sensor", "omitDefault": false }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" }, "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_mower_fields" },
+      "icon_on": { "policy": "default", "value": "Auto" },
+      "sensor": { "policy": "hook", "hook": "normalize_mower_fields" },
+      "unit": { "policy": "clear" }, "type": { "policy": "default", "value": "lawn_mower" },
+      "precision": { "policy": "clear" }, "options": { "policy": "clear" }
+    },
+    "unknownOptions": "drop", "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Robot Mower", "icon_on": "Auto",
+    "sensor": "start_mowing", "unit": "", "type": "lawn_mower", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/vacuum.json
+++ b/product/v2/cards/vacuum.json
@@ -1,0 +1,31 @@
+{
+  "label": "Vacuum",
+  "allowInSubpage": true,
+  "domains": ["vacuum"],
+  "options": [
+    { "name": "vacuum_mode", "label": "Type", "kind": "choice", "values": ["status", "start_stop", "dock", "pause_resume", "clean_spot", "locate", "clean_area"], "defaultValue": "start_stop", "storageField": "sensor", "omitDefault": false }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" }, "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_vacuum_fields" },
+      "icon_on": { "policy": "default", "value": "Auto" },
+      "sensor": { "policy": "allowed", "values": ["status", "start_stop", "dock", "pause_resume", "clean_spot", "locate", "clean_area"], "aliases": { "vacuum.start": "start_stop", "vacuum.return_to_base": "dock" }, "fallback": "start_stop" },
+      "unit": { "policy": "hook", "hook": "normalize_vacuum_fields" },
+      "type": { "policy": "default", "value": "vacuum" }, "precision": { "policy": "clear" },
+      "options": { "policy": "clear" }
+    },
+    "unknownOptions": "drop", "canonicalOptionOrder": [],
+    "migrationActions": ["legacy_vacuum_start", "legacy_vacuum_dock"],
+    "hookData": {
+      "normalize_vacuum_fields": {
+        "preserveUnitForModes": ["clean_area"],
+        "defaultIcons": { "dock": "Robot Vacuum Variant", "clean_spot": "Vacuum", "locate": "Robot Vacuum Alert", "clean_area": "Vacuum Outline", "default": "Robot Vacuum" }
+      }
+    }
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Robot Vacuum", "icon_on": "Auto",
+    "sensor": "start_stop", "unit": "", "type": "vacuum", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/webhook.json
+++ b/product/v2/cards/webhook.json
@@ -1,0 +1,22 @@
+{
+  "label": "Webhook",
+  "allowInSubpage": true,
+  "domains": [],
+  "options": [{ "name": "webhook_headers", "label": "Headers", "kind": "text", "defaultValue": "", "omitDefault": true }],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" }, "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_webhook_fields" },
+      "icon_on": { "policy": "default", "value": "Auto" },
+      "sensor": { "policy": "hook", "hook": "normalize_webhook_fields" },
+      "unit": { "policy": "hook", "hook": "normalize_webhook_fields" },
+      "type": { "policy": "default", "value": "webhook" }, "precision": { "policy": "clear" },
+      "options": { "policy": "hook", "hook": "normalize_webhook_options" }
+    },
+    "unknownOptions": "drop", "canonicalOptionOrder": ["webhook_headers"], "optionHook": "normalize_webhook_options"
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Auto", "icon_on": "Auto",
+    "sensor": "GET", "unit": "", "type": "webhook", "precision": "", "options": ""
+  }
+}

--- a/scripts/check_product_model_v2.py
+++ b/scripts/check_product_model_v2.py
@@ -70,6 +70,24 @@ def run_self_test() -> None:
             assert "pilots.cards must be a non-empty object" in str(exc)
         else:
             raise AssertionError("a generated pilot must define its sample card")
+    default_card = copy.deepcopy(data)
+    default_card["pilots"]["cards"][""] = default_card["pilots"]["cards"]["sensor"]
+    with TemporaryDirectory() as directory:
+        path = Path(directory) / "model.json"
+        path.write_text(json.dumps(default_card), encoding="utf-8")
+        model = load_product_model_v2(path)
+        assert "" in model.pilot_cards, "the default switch fallback must be a valid card pilot"
+    invalid = copy.deepcopy(data)
+    invalid["pilots"]["devices"][""] = invalid["pilots"]["devices"][next(iter(invalid["pilots"]["devices"]))]
+    with TemporaryDirectory() as directory:
+        path = Path(directory) / "model.json"
+        path.write_text(json.dumps(invalid), encoding="utf-8")
+        try:
+            load_product_model_v2(path)
+        except ProductModelV2Error as exc:
+            assert "pilots.devices identifiers must be non-empty strings" in str(exc)
+        else:
+            raise AssertionError("an unnamed device pilot must fail validation")
     print("Product Model v2 self-test passed.")
 
 

--- a/scripts/product_model_v2.py
+++ b/scripts/product_model_v2.py
@@ -183,7 +183,11 @@ def _pilot_sources(kind: str, data: Any) -> dict[str, Path]:
         raise ProductModelV2Error(f"pilots.{kind} must be a non-empty object")
     sources: dict[str, Path] = {}
     for identifier, path_value in data.items():
-        if not isinstance(identifier, str) or not identifier:
+        # The card contract's default switch is intentionally keyed by an
+        # empty string. It is a fallback entry, not a user-selectable card
+        # type, so allow it only for card pilots. Device identifiers must
+        # remain explicit non-empty slugs.
+        if not isinstance(identifier, str) or (not identifier and kind != "cards"):
             raise ProductModelV2Error(f"pilots.{kind} identifiers must be non-empty strings")
         if not isinstance(path_value, str) or not path_value:
             raise ProductModelV2Error(f"pilots.{kind}.{identifier} must be a non-empty path")


### PR DESCRIPTION
## Summary
- make Lawn Mower, Vacuum, Webhook, and the default-switch fallback canonical Product Model v2 sources
- keep the unnamed fallback explicitly limited to card contracts; device identifiers remain non-empty
- preserve the current generated contract exactly and document the final card family

## Practical impact
No device behaviour, generated output, or saved configuration format changes. This completes Product Model v2 coverage of every card-contract entry.

## Verification
- `npm run check:product`
- Product Model equivalence checks for every card-contract entry
- Generated-output freshness check

## Device testing
Not required for this metadata-only change; the 10-inch V1 remains the reference device for the wider refactor journey.