### PR TITLE
Complete Product Model v2 source migration

### DIFF
--- a/product/README.md
+++ b/product/README.md
@@ -2,8 +2,8 @@
 
 This directory is the Product Model ownership boundary. The initial reset stage
 mapped established source locations into one validated model. The current
-generated-pilot stage moves the Sensor card and Guition JC8012P4A1 (10-inch V1)
-device entry into [`v2/`](v2/) while preserving the existing generated output.
+generated-pilot stage moves selected card families and device entries into
+[`v2/`](v2/) while preserving the existing generated output.
 Generators and validators resolve their card and device inputs through this
 model, so later migrations change one controlled entry point.
 
@@ -32,12 +32,18 @@ per-device composition path without changing the generated output.
 
 ## Product Model v2 Pilots
 
-- `v2/cards/sensor.json` is the authoritative Sensor card definition.
-- `v2/cards/media.json` is the authoritative Media card definition, including
-  the cover-art configuration used by media-player cards.
-- `v2/cards/image.json` is the authoritative Camera/Image card definition.
-- `v2/devices/guition-esp32-p4-jc8012p4a1.json` is the authoritative 10-inch
-  V1 device entry; shared hardware profiles remain in `product/v2/device_catalog.json`.
+- `v2/cards/sensor.json`, `media.json`, and `image.json` are the original
+  sensor, media, and image pilots.
+- `v2/cards/light_*.json` is the complete light-card family: switch,
+  brightness, full control, and temperature.
+- `v2/cards/fan_*.json` is the complete fan-card family: switch, speed,
+  direction, oscillation, preset, and full control.
+- `v2/cards/clock.json`, `calendar.json`, and `timezone.json` are the
+  date-and-time family.
+- `v2/cards/weather.json` and `weather_forecast.json` are the weather family.
+- `v2/devices/guition-esp32-p4-jc8012p4a1.json` and
+  `guition-esp32-p4-jc8012p4a1-v2.json` are the 10-inch V1 and V2 device
+  entries; shared hardware profiles remain in `product/v2/device_catalog.json`.
 
 `python3 scripts/check_product_model_v2.py` proves that the composed model is
 byte-for-byte equivalent to the legacy card contract and device catalogue.

--- a/product/README.md
+++ b/product/README.md
@@ -49,6 +49,8 @@ per-device composition path without changing the generated output.
   and `subpage.json` are the interaction-card family.
 - `v2/cards/climate.json` and `climate_control.json` are the climate-card
   family.
+- `v2/cards/alarm.json`, `alarm_action.json`, and `presence.json` are the
+  alert-card family.
 - `v2/devices/guition-esp32-p4-jc8012p4a1.json` and
   `guition-esp32-p4-jc8012p4a1-v2.json` are the 10-inch V1 and V2 device
   entries; shared hardware profiles remain in `product/v2/device_catalog.json`.

--- a/product/README.md
+++ b/product/README.md
@@ -47,6 +47,8 @@ per-device composition path without changing the generated output.
   `lock.json` are the access-card family.
 - `v2/cards/action.json`, `option_select.json`, `push.json`, `slider.json`,
   and `subpage.json` are the interaction-card family.
+- `v2/cards/climate.json` and `climate_control.json` are the climate-card
+  family.
 - `v2/devices/guition-esp32-p4-jc8012p4a1.json` and
   `guition-esp32-p4-jc8012p4a1-v2.json` are the 10-inch V1 and V2 device
   entries; shared hardware profiles remain in `product/v2/device_catalog.json`.

--- a/product/README.md
+++ b/product/README.md
@@ -43,6 +43,8 @@ per-device composition path without changing the generated output.
 - `v2/cards/weather.json` and `weather_forecast.json` are the weather family.
 - `v2/cards/internal.json`, `local_sensor.json`, and `screen_lock.json` are
   the system-card family.
+- `v2/cards/cover.json`, `door_window.json`, `garage.json`, `gate.json`, and
+  `lock.json` are the access-card family.
 - `v2/devices/guition-esp32-p4-jc8012p4a1.json` and
   `guition-esp32-p4-jc8012p4a1-v2.json` are the 10-inch V1 and V2 device
   entries; shared hardware profiles remain in `product/v2/device_catalog.json`.

--- a/product/README.md
+++ b/product/README.md
@@ -45,6 +45,8 @@ per-device composition path without changing the generated output.
   the system-card family.
 - `v2/cards/cover.json`, `door_window.json`, `garage.json`, `gate.json`, and
   `lock.json` are the access-card family.
+- `v2/cards/action.json`, `option_select.json`, `push.json`, `slider.json`,
+  and `subpage.json` are the interaction-card family.
 - `v2/devices/guition-esp32-p4-jc8012p4a1.json` and
   `guition-esp32-p4-jc8012p4a1-v2.json` are the 10-inch V1 and V2 device
   entries; shared hardware profiles remain in `product/v2/device_catalog.json`.

--- a/product/README.md
+++ b/product/README.md
@@ -58,6 +58,8 @@ per-device composition path without changing the generated output.
 - `v2/devices/guition-esp32-p4-jc8012p4a1.json` and
   `guition-esp32-p4-jc8012p4a1-v2.json` are the 10-inch V1 and V2 device
   entries; shared hardware profiles remain in `product/v2/device_catalog.json`.
+- `v2/devices/guition-esp32-p4-jc1060p470.json` is the authoritative 7-inch
+  device entry, including its display and cover-art layout.
 
 `python3 scripts/check_product_model_v2.py` proves that the composed model is
 byte-for-byte equivalent to the legacy card contract and device catalogue.

--- a/product/README.md
+++ b/product/README.md
@@ -51,6 +51,10 @@ per-device composition path without changing the generated output.
   family.
 - `v2/cards/alarm.json`, `alarm_action.json`, and `presence.json` are the
   alert-card family.
+- `v2/cards/lawn_mower.json`, `vacuum.json`, and `webhook.json` are the
+  appliance-and-integration-card family.
+- `v2/cards/default_switch.json` owns the contract's unnamed default-switch
+  fallback entry.
 - `v2/devices/guition-esp32-p4-jc8012p4a1.json` and
   `guition-esp32-p4-jc8012p4a1-v2.json` are the 10-inch V1 and V2 device
   entries; shared hardware profiles remain in `product/v2/device_catalog.json`.

--- a/product/README.md
+++ b/product/README.md
@@ -41,6 +41,8 @@ per-device composition path without changing the generated output.
 - `v2/cards/clock.json`, `calendar.json`, and `timezone.json` are the
   date-and-time family.
 - `v2/cards/weather.json` and `weather_forecast.json` are the weather family.
+- `v2/cards/internal.json`, `local_sensor.json`, and `screen_lock.json` are
+  the system-card family.
 - `v2/devices/guition-esp32-p4-jc8012p4a1.json` and
   `guition-esp32-p4-jc8012p4a1-v2.json` are the 10-inch V1 and V2 device
   entries; shared hardware profiles remain in `product/v2/device_catalog.json`.

--- a/product/README.md
+++ b/product/README.md
@@ -60,6 +60,12 @@ per-device composition path without changing the generated output.
   entries; shared hardware profiles remain in `product/v2/device_catalog.json`.
 - `v2/devices/guition-esp32-p4-jc1060p470.json` is the authoritative 7-inch
   device entry, including its display and cover-art layout.
+- `v2/devices/guition-esp32-p4-jc4880p443.json` is the authoritative 4.3-inch
+  P4 device entry.
+- `v2/devices/esp32-p4-86.json` is the authoritative square P4-86 device
+  entry, including its local-voice and relay capabilities.
+- `v2/devices/guition-esp32-s3-4848s040.json` is the authoritative compact
+  S3 device entry.
 
 `python3 scripts/check_product_model_v2.py` proves that the composed model is
 byte-for-byte equivalent to the legacy card contract and device catalogue.

--- a/product/README.md
+++ b/product/README.md
@@ -2,8 +2,8 @@
 
 This directory is the Product Model ownership boundary. The initial reset stage
 mapped established source locations into one validated model. The current
-generated-pilot stage moves selected card families and device entries into
-[`v2/`](v2/) while preserving the existing generated output.
+generated-source stage owns every supported card-contract entry and device
+profile in [`v2/`](v2/) while preserving the existing generated output.
 Generators and validators resolve their card and device inputs through this
 model, so later migrations change one controlled entry point.
 
@@ -27,10 +27,11 @@ Edit these files when changing product behavior or supported hardware:
   layout, and migration fixtures that protect upgrades.
 
 `model_v2.json` records the complete card-contract and device-catalogue sources
-in `product/v2/`. The selected pilot overlays below prove the per-card and
-per-device composition path without changing the generated output.
+in `product/v2/`. The per-card and per-device sources below are required to
+cover every supported entry and prove the composed model has not changed the
+generated output.
 
-## Product Model v2 Pilots
+## Product Model v2 Sources
 
 - `v2/cards/sensor.json`, `media.json`, and `image.json` are the original
   sensor, media, and image pilots.
@@ -68,9 +69,8 @@ per-device composition path without changing the generated output.
   S3 device entry.
 
 `python3 scripts/check_product_model_v2.py` proves that the composed model is
-byte-for-byte equivalent to the legacy card contract and device catalogue.
-Until another family receives a per-item overlay, edit its shared definition in
-`product/v2/card_contract.json` or `product/v2/device_catalog.json`.
+byte-for-byte equivalent to the generated card contract and device catalogue,
+and rejects an incomplete card or device source set.
 
 ## Generated Outputs
 

--- a/product/README.md
+++ b/product/README.md
@@ -35,6 +35,7 @@ per-device composition path without changing the generated output.
 - `v2/cards/sensor.json` is the authoritative Sensor card definition.
 - `v2/cards/media.json` is the authoritative Media card definition, including
   the cover-art configuration used by media-player cards.
+- `v2/cards/image.json` is the authoritative Camera/Image card definition.
 - `v2/devices/guition-esp32-p4-jc8012p4a1.json` is the authoritative 10-inch
   V1 device entry; shared hardware profiles remain in `product/v2/device_catalog.json`.
 

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, system, access, interaction, and climate card families plus 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, system, access, interaction, climate, and alert card families plus 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -77,7 +77,10 @@
       "slider": "product/v2/cards/slider.json",
       "subpage": "product/v2/cards/subpage.json",
       "climate": "product/v2/cards/climate.json",
-      "climate_control": "product/v2/cards/climate_control.json"
+      "climate_control": "product/v2/cards/climate_control.json",
+      "alarm": "product/v2/cards/alarm.json",
+      "alarm_action": "product/v2/cards/alarm_action.json",
+      "presence": "product/v2/cards/presence.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, and date/time card families plus 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, and weather card families plus 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -60,7 +60,9 @@
       "fan_control": "product/v2/cards/fan_control.json",
       "clock": "product/v2/cards/clock.json",
       "calendar": "product/v2/cards/calendar.json",
-      "timezone": "product/v2/cards/timezone.json"
+      "timezone": "product/v2/cards/timezone.json",
+      "weather": "product/v2/cards/weather.json",
+      "weather_forecast": "product/v2/cards/weather_forecast.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, system, access, and interaction card families plus 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, system, access, interaction, and climate card families plus 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -75,7 +75,9 @@
       "option_select": "product/v2/cards/option_select.json",
       "push": "product/v2/cards/push.json",
       "slider": "product/v2/cards/slider.json",
-      "subpage": "product/v2/cards/subpage.json"
+      "subpage": "product/v2/cards/subpage.json",
+      "climate": "product/v2/cards/climate.json",
+      "climate_control": "product/v2/cards/climate_control.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, and weather card families plus 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, and system card families plus 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -62,7 +62,10 @@
       "calendar": "product/v2/cards/calendar.json",
       "timezone": "product/v2/cards/timezone.json",
       "weather": "product/v2/cards/weather.json",
-      "weather_forecast": "product/v2/cards/weather_forecast.json"
+      "weather_forecast": "product/v2/cards/weather_forecast.json",
+      "internal": "product/v2/cards/internal.json",
+      "local_sensor": "product/v2/cards/local_sensor.json",
+      "screen_lock": "product/v2/cards/screen_lock.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card family, base and speed fan cards, and 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card family, fan variants, and 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -53,7 +53,10 @@
       "light_control": "product/v2/cards/light_control.json",
       "light_temperature": "product/v2/cards/light_temperature.json",
       "fan_switch": "product/v2/cards/fan_switch.json",
-      "fan_speed": "product/v2/cards/fan_speed.json"
+      "fan_speed": "product/v2/cards/fan_speed.json",
+      "fan_direction": "product/v2/cards/fan_direction.json",
+      "fan_oscillate": "product/v2/cards/fan_oscillate.json",
+      "fan_preset": "product/v2/cards/fan_preset.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, and light-switch card pilots plus the 10-inch V1 device pilot authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-switch, and light-brightness card pilots plus the 10-inch V1 device pilot authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -48,7 +48,8 @@
       "sensor": "product/v2/cards/sensor.json",
       "media": "product/v2/cards/media.json",
       "image": "product/v2/cards/image.json",
-      "light_switch": "product/v2/cards/light_switch.json"
+      "light_switch": "product/v2/cards/light_switch.json",
+      "light_brightness": "product/v2/cards/light_brightness.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json"

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card family, base fan card, and 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card family, base and speed fan cards, and 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -52,7 +52,8 @@
       "light_brightness": "product/v2/cards/light_brightness.json",
       "light_control": "product/v2/cards/light_control.json",
       "light_temperature": "product/v2/cards/light_temperature.json",
-      "fan_switch": "product/v2/cards/fan_switch.json"
+      "fan_switch": "product/v2/cards/fan_switch.json",
+      "fan_speed": "product/v2/cards/fan_speed.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card and fan-card families, clock card, and 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, and date/time card families plus 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -58,7 +58,9 @@
       "fan_oscillate": "product/v2/cards/fan_oscillate.json",
       "fan_preset": "product/v2/cards/fan_preset.json",
       "fan_control": "product/v2/cards/fan_control.json",
-      "clock": "product/v2/cards/clock.json"
+      "clock": "product/v2/cards/clock.json",
+      "calendar": "product/v2/cards/calendar.json",
+      "timezone": "product/v2/cards/timezone.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, and system card families plus 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, system, and access card families plus 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -65,7 +65,12 @@
       "weather_forecast": "product/v2/cards/weather_forecast.json",
       "internal": "product/v2/cards/internal.json",
       "local_sensor": "product/v2/cards/local_sensor.json",
-      "screen_lock": "product/v2/cards/screen_lock.json"
+      "screen_lock": "product/v2/cards/screen_lock.json",
+      "cover": "product/v2/cards/cover.json",
+      "door_window": "product/v2/cards/door_window.json",
+      "garage": "product/v2/cards/garage.json",
+      "gate": "product/v2/cards/gate.json",
+      "lock": "product/v2/cards/lock.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card and fan-card families, and 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card and fan-card families, clock card, and 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -57,7 +57,8 @@
       "fan_direction": "product/v2/cards/fan_direction.json",
       "fan_oscillate": "product/v2/cards/fan_oscillate.json",
       "fan_preset": "product/v2/cards/fan_preset.json",
-      "fan_control": "product/v2/cards/fan_control.json"
+      "fan_control": "product/v2/cards/fan_control.json",
+      "clock": "product/v2/cards/clock.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, and image card pilots plus the 10-inch V1 device pilot authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, and light-switch card pilots plus the 10-inch V1 device pilot authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -47,7 +47,8 @@
     "cards": {
       "sensor": "product/v2/cards/sensor.json",
       "media": "product/v2/cards/media.json",
-      "image": "product/v2/cards/image.json"
+      "image": "product/v2/cards/image.json",
+      "light_switch": "product/v2/cards/light_switch.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json"

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, and complete light-card family plus the 10-inch V1 device pilot authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, complete light-card family, and 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -54,7 +54,8 @@
       "light_temperature": "product/v2/cards/light_temperature.json"
     },
     "devices": {
-      "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json"
+      "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",
+      "guition-esp32-p4-jc8012p4a1-v2": "product/v2/devices/guition-esp32-p4-jc8012p4a1-v2.json"
     }
   }
 }

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -88,7 +88,8 @@
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",
-      "guition-esp32-p4-jc8012p4a1-v2": "product/v2/devices/guition-esp32-p4-jc8012p4a1-v2.json"
+      "guition-esp32-p4-jc8012p4a1-v2": "product/v2/devices/guition-esp32-p4-jc8012p4a1-v2.json",
+      "guition-esp32-p4-jc1060p470": "product/v2/devices/guition-esp32-p4-jc1060p470.json"
     }
   }
 }

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -89,7 +89,10 @@
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",
       "guition-esp32-p4-jc8012p4a1-v2": "product/v2/devices/guition-esp32-p4-jc8012p4a1-v2.json",
-      "guition-esp32-p4-jc1060p470": "product/v2/devices/guition-esp32-p4-jc1060p470.json"
+      "guition-esp32-p4-jc1060p470": "product/v2/devices/guition-esp32-p4-jc1060p470.json",
+      "guition-esp32-p4-jc4880p443": "product/v2/devices/guition-esp32-p4-jc4880p443.json",
+      "esp32-p4-86": "product/v2/devices/esp32-p4-86.json",
+      "guition-esp32-s3-4848s040": "product/v2/devices/guition-esp32-s3-4848s040.json"
     }
   }
 }

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor and media card pilots plus the 10-inch V1 device pilot authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, and image card pilots plus the 10-inch V1 device pilot authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -46,7 +46,8 @@
   "pilots": {
     "cards": {
       "sensor": "product/v2/cards/sensor.json",
-      "media": "product/v2/cards/media.json"
+      "media": "product/v2/cards/media.json",
+      "image": "product/v2/cards/image.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json"

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, system, and access card families plus 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, system, access, and interaction card families plus 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -70,7 +70,12 @@
       "door_window": "product/v2/cards/door_window.json",
       "garage": "product/v2/cards/garage.json",
       "gate": "product/v2/cards/gate.json",
-      "lock": "product/v2/cards/lock.json"
+      "lock": "product/v2/cards/lock.json",
+      "action": "product/v2/cards/action.json",
+      "option_select": "product/v2/cards/option_select.json",
+      "push": "product/v2/cards/push.json",
+      "slider": "product/v2/cards/slider.json",
+      "subpage": "product/v2/cards/subpage.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-switch, and light-brightness card pilots plus the 10-inch V1 device pilot authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-switch, light-brightness, and light-control card pilots plus the 10-inch V1 device pilot authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -49,7 +49,8 @@
       "media": "product/v2/cards/media.json",
       "image": "product/v2/cards/image.json",
       "light_switch": "product/v2/cards/light_switch.json",
-      "light_brightness": "product/v2/cards/light_brightness.json"
+      "light_brightness": "product/v2/cards/light_brightness.json",
+      "light_control": "product/v2/cards/light_control.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json"

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-switch, light-brightness, and light-control card pilots plus the 10-inch V1 device pilot authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, and complete light-card family plus the 10-inch V1 device pilot authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -50,7 +50,8 @@
       "image": "product/v2/cards/image.json",
       "light_switch": "product/v2/cards/light_switch.json",
       "light_brightness": "product/v2/cards/light_brightness.json",
-      "light_control": "product/v2/cards/light_control.json"
+      "light_control": "product/v2/cards/light_control.json",
+      "light_temperature": "product/v2/cards/light_temperature.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json"

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
-  "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, system, access, interaction, climate, alert, and appliance/integration card families plus 10-inch device profiles authored under product/.",
+  "stage": "generated-source",
+  "description": "The Product Model v2 ownership boundary, with every supported card-contract entry and device profile authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card family, fan variants, and 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card and fan-card families, and 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -56,7 +56,8 @@
       "fan_speed": "product/v2/cards/fan_speed.json",
       "fan_direction": "product/v2/cards/fan_direction.json",
       "fan_oscillate": "product/v2/cards/fan_oscillate.json",
-      "fan_preset": "product/v2/cards/fan_preset.json"
+      "fan_preset": "product/v2/cards/fan_preset.json",
+      "fan_control": "product/v2/cards/fan_control.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, system, access, interaction, climate, and alert card families plus 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card, fan-card, date/time, weather, system, access, interaction, climate, alert, and appliance/integration card families plus 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -80,7 +80,11 @@
       "climate_control": "product/v2/cards/climate_control.json",
       "alarm": "product/v2/cards/alarm.json",
       "alarm_action": "product/v2/cards/alarm_action.json",
-      "presence": "product/v2/cards/presence.json"
+      "presence": "product/v2/cards/presence.json",
+      "lawn_mower": "product/v2/cards/lawn_mower.json",
+      "vacuum": "product/v2/cards/vacuum.json",
+      "webhook": "product/v2/cards/webhook.json",
+      "": "product/v2/cards/default_switch.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/model_v2.json
+++ b/product/model_v2.json
@@ -1,7 +1,7 @@
 {
   "modelVersion": 2,
   "stage": "generated-pilot",
-  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, complete light-card family, and 10-inch device profiles authored under product/.",
+  "description": "The Product Model v2 ownership boundary, with the sensor, media, image, light-card family, base fan card, and 10-inch device profiles authored under product/.",
   "sources": {
     "cardContract": {
       "path": "product/v2/card_contract.json",
@@ -51,7 +51,8 @@
       "light_switch": "product/v2/cards/light_switch.json",
       "light_brightness": "product/v2/cards/light_brightness.json",
       "light_control": "product/v2/cards/light_control.json",
-      "light_temperature": "product/v2/cards/light_temperature.json"
+      "light_temperature": "product/v2/cards/light_temperature.json",
+      "fan_switch": "product/v2/cards/fan_switch.json"
     },
     "devices": {
       "guition-esp32-p4-jc8012p4a1": "product/v2/devices/guition-esp32-p4-jc8012p4a1.json",

--- a/product/v2/cards/action.json
+++ b/product/v2/cards/action.json
@@ -1,0 +1,71 @@
+{
+  "label": "Action",
+  "allowInSubpage": true,
+  "domains": ["scene", "script", "automation", "button", "input_button", "input_boolean", "input_number", "input_select", "select"],
+  "options": [
+    { "name": "large_numbers", "label": "Large State Numbers", "kind": "flag", "omitDefault": true, "applicabilityHook": "action_large_numbers_supported" },
+    { "name": "state_entity", "label": "State Entity", "kind": "text", "hidden": true, "docsHidden": true, "omitDefault": true },
+    {
+      "name": "state_unit", "label": "State Unit", "kind": "text", "hidden": true, "docsHidden": true, "omitDefault": true,
+      "applicability": [
+        { "source": "option", "name": "state_entity", "operator": "present" },
+        { "source": "option", "name": "state_precision", "operator": "in", "value": ["icon", "text"], "negate": true }
+      ]
+    },
+    {
+      "name": "state_precision", "label": "State Precision", "kind": "choice", "values": ["", "0", "1", "2", "icon", "text"],
+      "defaultValue": "", "hidden": true, "docsHidden": true, "omitDefault": true,
+      "applicability": [{ "source": "option", "name": "state_entity", "operator": "present" }]
+    },
+    {
+      "name": "confirmation_required", "label": "Confirmation Required", "kind": "flag", "storage": ["confirm_on"], "omitDefault": true,
+      "applicability": [{ "source": "field", "name": "sensor", "operator": "equals", "value": "script.turn_on" }]
+    },
+    {
+      "name": "script_fields", "label": "Fields", "kind": "text", "omitDefault": true,
+      "applicability": [{ "source": "field", "name": "sensor", "operator": "equals", "value": "script.turn_on" }]
+    },
+    {
+      "name": "confirm_message", "label": "Message", "kind": "text", "defaultValue": "Run this script?", "omitDefault": true,
+      "applicability": [
+        { "source": "field", "name": "sensor", "operator": "equals", "value": "script.turn_on" },
+        { "source": "option", "name": "confirm_on", "operator": "present" }
+      ]
+    },
+    {
+      "name": "confirm_yes", "label": "Confirm Button", "kind": "text", "defaultValue": "Yes", "omitDefault": true,
+      "applicability": [
+        { "source": "field", "name": "sensor", "operator": "equals", "value": "script.turn_on" },
+        { "source": "option", "name": "confirm_on", "operator": "present" }
+      ]
+    },
+    {
+      "name": "confirm_no", "label": "Cancel Button", "kind": "text", "defaultValue": "No", "omitDefault": true,
+      "applicability": [
+        { "source": "field", "name": "sensor", "operator": "equals", "value": "script.turn_on" },
+        { "source": "option", "name": "confirm_on", "operator": "present" }
+      ]
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_action_fields" },
+      "icon_on": { "policy": "hook", "hook": "normalize_action_fields" },
+      "sensor": { "policy": "hook", "hook": "normalize_action_fields" },
+      "unit": { "policy": "hook", "hook": "normalize_action_fields" },
+      "type": { "policy": "hook", "hook": "normalize_action_fields" },
+      "precision": { "policy": "hook", "hook": "normalize_action_fields" },
+      "options": { "policy": "hook", "hook": "normalize_action_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["state_entity", "state_unit", "state_precision", "large_numbers", "script_fields", "confirm_on", "confirm_message", "confirm_yes", "confirm_no"],
+    "optionHook": "normalize_action_options",
+    "migrationActions": ["legacy_local_action", "legacy_option_select", "legacy_vacuum_start", "legacy_vacuum_dock"]
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Flash", "icon_on": "Auto",
+    "sensor": "scene.turn_on", "unit": "", "type": "action", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/alarm.json
+++ b/product/v2/cards/alarm.json
@@ -1,0 +1,44 @@
+{
+  "label": "Alarm",
+  "allowInSubpage": true,
+  "domains": ["alarm_control_panel"],
+  "options": [
+    { "name": "alarm_card_type", "label": "Type", "kind": "choice", "values": ["control_panel", "away", "home", "night", "vacation", "disarm"], "defaultValue": "control_panel", "storageField": "type", "omitDefault": false },
+    { "name": "pin_arm", "label": "PIN required for arming", "kind": "flag", "defaultValue": "1", "omitDefault": true },
+    { "name": "pin_disarm", "label": "PIN required for disarming", "kind": "flag", "defaultValue": "1", "omitDefault": true },
+    { "name": "actions", "label": "Visible Actions", "kind": "choice", "values": ["away", "home", "night", "vacation", "disarm"], "defaultValue": "away|home|disarm", "omitDefault": true },
+    { "name": "icon_display", "label": "Icon Display", "kind": "choice", "values": ["static", "status"], "defaultValue": "status", "omitDefault": true },
+    { "name": "label_display", "label": "Label Display", "kind": "choice", "values": ["name", "status"], "defaultValue": "status", "omitDefault": true }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" }, "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_security_fields" },
+      "icon_on": { "policy": "default", "value": "Auto" },
+      "sensor": { "policy": "clear" }, "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "alarm" }, "precision": { "policy": "clear" },
+      "options": { "policy": "hook", "hook": "normalize_security_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["pin_arm", "pin_disarm", "actions", "icon_display", "label_display"],
+    "optionHook": "normalize_security_options"
+  },
+  "behavior": {
+    "alarm": {
+      "controlPanelValue": "control_panel",
+      "defaultActions": ["away", "home", "disarm"],
+      "maxVisibleActions": 3,
+      "actions": [
+        { "value": "away", "label": "Arm Away", "service": "alarm_control_panel.alarm_arm_away", "icon": "Shield Lock", "legacyIcon": "Security" },
+        { "value": "home", "label": "Arm Home", "service": "alarm_control_panel.alarm_arm_home", "icon": "Shield Home", "legacyIcon": "Home" },
+        { "value": "night", "label": "Arm Night", "service": "alarm_control_panel.alarm_arm_night", "icon": "Weather Night", "legacyIcon": "Weather Night" },
+        { "value": "vacation", "label": "Arm Vacation", "service": "alarm_control_panel.alarm_arm_vacation", "icon": "Airplane", "legacyIcon": "Airplane" },
+        { "value": "disarm", "label": "Disarm", "service": "alarm_control_panel.alarm_disarm", "icon": "Shield Off", "legacyIcon": "Lock Open" }
+      ]
+    }
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Security", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "alarm", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/alarm_action.json
+++ b/product/v2/cards/alarm_action.json
@@ -1,0 +1,23 @@
+{
+  "label": "Alarm",
+  "allowInSubpage": true,
+  "pickerKey": "alarm",
+  "domains": ["alarm_control_panel"],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "hook", "hook": "normalize_security_fields" },
+      "icon": { "policy": "hook", "hook": "normalize_security_fields" },
+      "icon_on": { "policy": "default", "value": "Auto" },
+      "sensor": { "policy": "hook", "hook": "normalize_security_fields" },
+      "unit": { "policy": "clear" }, "type": { "policy": "default", "value": "alarm_action" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "hook", "hook": "normalize_security_options" }
+    },
+    "unknownOptions": "drop", "canonicalOptionOrder": [], "optionHook": "normalize_security_options"
+  },
+  "default": {
+    "entity": "", "label": "Arm Away", "icon": "Shield Lock", "icon_on": "Auto",
+    "sensor": "away", "unit": "", "type": "alarm_action", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/calendar.json
+++ b/product/v2/cards/calendar.json
@@ -1,0 +1,37 @@
+{
+  "label": "Date & Time",
+  "allowInSubpage": true,
+  "domains": ["sensor"],
+  "options": [
+    {
+      "name": "date_time_mode",
+      "label": "Type",
+      "kind": "choice",
+      "values": ["clock", "datetime", "", "timezone"],
+      "defaultValue": "",
+      "storageField": "type",
+      "omitDefault": false
+    },
+    { "name": "large_numbers", "label": "Large Clock", "kind": "flag", "omitDefault": true }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "hook", "hook": "normalize_date_time_fields" },
+      "label": { "policy": "clear" },
+      "icon": { "policy": "default", "value": "Auto" },
+      "icon_on": { "policy": "default", "value": "Auto" },
+      "sensor": { "policy": "clear" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "calendar" },
+      "precision": { "policy": "allowed", "values": ["", "datetime"], "fallback": "" },
+      "options": { "policy": "hook", "hook": "normalize_date_time_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["large_numbers"],
+    "optionHook": "normalize_date_time_options"
+  },
+  "default": {
+    "entity": "sensor.date", "label": "", "icon": "Auto", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "calendar", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/climate.json
+++ b/product/v2/cards/climate.json
@@ -1,0 +1,35 @@
+{
+  "label": "Climate",
+  "allowInSubpage": true,
+  "domains": ["climate"],
+  "options": [
+    { "name": "label_display", "label": "Label Display", "kind": "choice", "values": ["label", "status", "actual", "target"], "defaultValue": "label", "omitDefault": true },
+    { "name": "number_display", "label": "Icon & Temperatures", "kind": "choice", "values": ["icon", "actual", "target"], "defaultValue": "target", "omitDefault": true },
+    { "name": "temperature_step", "label": "Temperature Step", "kind": "choice", "values": ["1", "0.5"], "defaultValue": "1", "omitDefault": true },
+    { "name": "large_numbers", "label": "Large Temperature Numbers", "kind": "flag", "omitDefault": true }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" }, "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_climate_fields" },
+      "icon_on": { "policy": "hook", "hook": "normalize_climate_fields" },
+      "sensor": { "policy": "clear" }, "unit": { "policy": "clear" },
+      "type": { "policy": "alias", "aliases": { "climate": "climate_control" } },
+      "precision": { "policy": "hook", "hook": "normalize_climate_fields" },
+      "options": { "policy": "hook", "hook": "normalize_climate_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["label_display", "number_display", "temperature_step", "large_numbers"],
+    "optionHook": "normalize_climate_options"
+  },
+  "behavior": {
+    "climate": {
+      "defaultLabelDisplay": "label", "defaultNumberDisplay": "target", "defaultTemperatureStep": "1",
+      "precisionValues": ["", "1", "2", "3"]
+    }
+  },
+  "default": {
+    "entity": "", "label": "Climate", "icon": "Thermostat", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "climate_control", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/climate_control.json
+++ b/product/v2/cards/climate_control.json
@@ -1,0 +1,38 @@
+{
+  "label": "All Controls",
+  "allowInSubpage": true,
+  "pickerKey": "climate",
+  "hidden": true,
+  "domains": ["climate"],
+  "options": [
+    { "name": "label_display", "label": "Label Display", "kind": "choice", "values": ["label", "status", "actual", "target"], "defaultValue": "label", "omitDefault": true },
+    { "name": "number_display", "label": "Icon & Temperatures", "kind": "choice", "values": ["icon", "actual", "target"], "defaultValue": "target", "omitDefault": true },
+    { "name": "temperature_step", "label": "Temperature Step", "kind": "choice", "values": ["1", "0.5"], "defaultValue": "1", "omitDefault": true },
+    { "name": "large_numbers", "label": "Large Temperature Numbers", "kind": "flag", "omitDefault": true },
+    { "name": "climate_tabs", "label": "Visible Tabs", "kind": "text", "defaultValue": "temperature|mode|preset|fan|swing", "omitDefault": true }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" }, "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_climate_fields" },
+      "icon_on": { "policy": "hook", "hook": "normalize_climate_fields" },
+      "sensor": { "policy": "clear" }, "unit": { "policy": "clear" },
+      "type": { "policy": "alias", "aliases": { "climate": "climate_control" } },
+      "precision": { "policy": "hook", "hook": "normalize_climate_fields" },
+      "options": { "policy": "hook", "hook": "normalize_climate_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["label_display", "number_display", "temperature_step", "large_numbers", "climate_tabs"],
+    "optionHook": "normalize_climate_options"
+  },
+  "behavior": {
+    "climate": {
+      "defaultLabelDisplay": "label", "defaultNumberDisplay": "target", "defaultTemperatureStep": "1",
+      "precisionValues": ["", "1", "2", "3"]
+    }
+  },
+  "default": {
+    "entity": "", "label": "Climate", "icon": "Thermostat", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "climate_control", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/clock.json
+++ b/product/v2/cards/clock.json
@@ -1,0 +1,43 @@
+{
+  "label": "Date & Time",
+  "allowInSubpage": true,
+  "pickerKey": "calendar",
+  "domains": [],
+  "options": [
+    {
+      "name": "date_time_mode",
+      "label": "Type",
+      "kind": "choice",
+      "values": ["clock", "datetime", "", "timezone"],
+      "defaultValue": "clock",
+      "storageField": "type",
+      "omitDefault": false
+    },
+    {
+      "name": "large_numbers",
+      "label": "Large Clock",
+      "kind": "flag",
+      "omitDefault": true
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "clear" },
+      "label": { "policy": "clear" },
+      "icon": { "policy": "default", "value": "Auto" },
+      "icon_on": { "policy": "default", "value": "Auto" },
+      "sensor": { "policy": "clear" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "clock" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "hook", "hook": "normalize_date_time_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["large_numbers"],
+    "optionHook": "normalize_date_time_options"
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Auto", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "clock", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/cover.json
+++ b/product/v2/cards/cover.json
@@ -1,0 +1,65 @@
+{
+  "label": "Cover",
+  "allowInSubpage": true,
+  "domains": ["cover"],
+  "options": [
+    {
+      "name": "cover_mode",
+      "label": "Type",
+      "kind": "choice",
+      "values": ["modal", "", "tilt", "toggle", "open", "close", "stop", "set_position"],
+      "defaultValue": "modal",
+      "storageField": "sensor",
+      "omitDefault": false
+    },
+    {
+      "name": "cover_position",
+      "label": "Position",
+      "kind": "number",
+      "defaultValue": "50",
+      "storageField": "unit",
+      "omitDefault": false,
+      "min": 0,
+      "max": 100,
+      "step": 1
+    },
+    {
+      "name": "cover_tabs",
+      "label": "Visible Tabs",
+      "kind": "text",
+      "values": ["position", "controls", "tilt", "presets"],
+      "defaultValue": "position|controls|tilt|presets",
+      "omitDefault": true
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "keep" },
+      "icon": { "policy": "keep" },
+      "icon_on": { "policy": "keep" },
+      "sensor": { "policy": "hook", "hook": "normalize_access_fields" },
+      "unit": { "policy": "hook", "hook": "normalize_access_fields" },
+      "type": { "policy": "default", "value": "cover" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "hook", "hook": "normalize_access_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["cover_tabs"],
+    "optionHook": "normalize_access_options"
+  },
+  "behavior": {
+    "cover": {
+      "commandServices": {
+        "open": "cover.open_cover",
+        "close": "cover.close_cover",
+        "stop": "cover.stop_cover",
+        "set_position": "cover.set_cover_position"
+      }
+    }
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Blinds", "icon_on": "Blinds Open",
+    "sensor": "modal", "unit": "", "type": "cover", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/default_switch.json
+++ b/product/v2/cards/default_switch.json
@@ -1,0 +1,33 @@
+{
+  "label": "Switch",
+  "allowInSubpage": true,
+  "domains": ["light", "switch", "input_boolean", "fan"],
+  "options": [
+    { "name": "large_numbers", "label": "Large Active Display Numbers", "kind": "flag", "omitDefault": true },
+    { "name": "confirmation_mode", "label": "Confirmation Required", "kind": "choice", "values": ["", "off", "on", "both"], "defaultValue": "", "omitDefault": true, "storage": ["confirm_off", "confirm_on"] },
+    { "name": "on_pattern", "label": "On State Pattern", "kind": "choice", "values": ["", "stripes"], "defaultValue": "", "omitDefault": true },
+    {
+      "name": "confirm_message", "label": "Message", "kind": "text", "defaultValue": "Turn off this device?", "omitDefault": true,
+      "defaultValueByMode": { "off": "Turn off this device?", "on": "Turn on this device?", "both": "Toggle this device?" }
+    },
+    { "name": "confirm_yes", "label": "Confirm Button", "kind": "text", "defaultValue": "Yes", "omitDefault": true },
+    { "name": "confirm_no", "label": "Cancel Button", "kind": "text", "defaultValue": "No", "omitDefault": true }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" }, "label": { "policy": "keep" },
+      "icon": { "policy": "default_if_empty", "value": "Auto" },
+      "icon_on": { "policy": "default_if_empty", "value": "Auto" },
+      "sensor": { "policy": "keep" }, "unit": { "policy": "keep" },
+      "type": { "policy": "default", "value": "" }, "precision": { "policy": "keep" },
+      "options": { "policy": "hook", "hook": "normalize_switch_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["large_numbers", "on_pattern", "confirm_off", "confirm_on", "confirm_message", "confirm_yes", "confirm_no"],
+    "optionHook": "normalize_switch_options"
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Auto", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/door_window.json
+++ b/product/v2/cards/door_window.json
@@ -1,0 +1,33 @@
+{
+  "label": "Doors & Windows",
+  "allowInSubpage": true,
+  "domains": ["binary_sensor", "sensor"],
+  "options": [
+    {
+      "name": "active_color",
+      "label": "Lit When Open",
+      "kind": "flag",
+      "omitDefault": true
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "clear" },
+      "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_occupancy_fields" },
+      "icon_on": { "policy": "hook", "hook": "normalize_occupancy_fields" },
+      "sensor": { "policy": "keep" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "door_window" },
+      "precision": { "policy": "hook", "hook": "normalize_occupancy_fields" },
+      "options": { "policy": "hook", "hook": "normalize_occupancy_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["active_color"],
+    "optionHook": "normalize_occupancy_options"
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Door", "icon_on": "Door Open",
+    "sensor": "", "unit": "", "type": "door_window", "precision": "door", "options": "active_color"
+  }
+}

--- a/product/v2/cards/fan_control.json
+++ b/product/v2/cards/fan_control.json
@@ -1,0 +1,42 @@
+{
+  "label": "Fans",
+  "allowInSubpage": true,
+  "pickerKey": "fan_speed",
+  "domains": ["fan"],
+  "options": [
+    {
+      "name": "fan_light_entity",
+      "label": "Light Entity",
+      "kind": "text",
+      "omitDefault": true
+    },
+    {
+      "name": "fan_tabs",
+      "label": "Visible Tabs",
+      "kind": "text",
+      "values": ["power", "speed", "preset", "oscillation", "direction", "light"],
+      "defaultValue": "power|speed|preset|oscillation|direction",
+      "omitDefault": true
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_fan_fields" },
+      "icon_on": { "policy": "hook", "hook": "normalize_fan_fields" },
+      "sensor": { "policy": "clear" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "fan_control" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "hook", "hook": "normalize_fan_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["fan_light_entity", "fan_tabs"],
+    "optionHook": "normalize_fan_options"
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Fan", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "fan_control", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/fan_direction.json
+++ b/product/v2/cards/fan_direction.json
@@ -1,0 +1,25 @@
+{
+  "label": "Fans",
+  "allowInSubpage": true,
+  "pickerKey": "fan_speed",
+  "domains": ["fan"],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_fan_fields" },
+      "icon_on": { "policy": "hook", "hook": "normalize_fan_fields" },
+      "sensor": { "policy": "clear" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "fan_direction" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "clear" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Swap Horizontal", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "fan_direction", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/fan_oscillate.json
+++ b/product/v2/cards/fan_oscillate.json
@@ -1,0 +1,25 @@
+{
+  "label": "Fans",
+  "allowInSubpage": true,
+  "pickerKey": "fan_speed",
+  "domains": ["fan"],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_fan_fields" },
+      "icon_on": { "policy": "hook", "hook": "normalize_fan_fields" },
+      "sensor": { "policy": "clear" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "fan_oscillate" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "clear" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Fan", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "fan_oscillate", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/fan_preset.json
+++ b/product/v2/cards/fan_preset.json
@@ -1,0 +1,25 @@
+{
+  "label": "Fans",
+  "allowInSubpage": true,
+  "pickerKey": "fan_speed",
+  "domains": ["fan"],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_fan_fields" },
+      "icon_on": { "policy": "hook", "hook": "normalize_fan_fields" },
+      "sensor": { "policy": "clear" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "fan_preset" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "clear" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Fan Auto", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "fan_preset", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/fan_speed.json
+++ b/product/v2/cards/fan_speed.json
@@ -1,0 +1,54 @@
+{
+  "label": "Fans",
+  "allowInSubpage": true,
+  "domains": [
+    "fan"
+  ],
+  "normalization": {
+    "fields": {
+      "entity": {
+        "policy": "keep"
+      },
+      "label": {
+        "policy": "keep"
+      },
+      "icon": {
+        "policy": "hook",
+        "hook": "normalize_fan_fields"
+      },
+      "icon_on": {
+        "policy": "hook",
+        "hook": "normalize_fan_fields"
+      },
+      "sensor": {
+        "policy": "clear"
+      },
+      "unit": {
+        "policy": "clear"
+      },
+      "type": {
+        "policy": "default",
+        "value": "fan_speed"
+      },
+      "precision": {
+        "policy": "clear"
+      },
+      "options": {
+        "policy": "clear"
+      }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "",
+    "label": "",
+    "icon": "Fan Speed 2",
+    "icon_on": "Auto",
+    "sensor": "",
+    "unit": "",
+    "type": "fan_speed",
+    "precision": "",
+    "options": ""
+  }
+}

--- a/product/v2/cards/fan_switch.json
+++ b/product/v2/cards/fan_switch.json
@@ -1,0 +1,55 @@
+{
+  "label": "Fans",
+  "allowInSubpage": true,
+  "pickerKey": "fan_speed",
+  "domains": [
+    "fan"
+  ],
+  "normalization": {
+    "fields": {
+      "entity": {
+        "policy": "keep"
+      },
+      "label": {
+        "policy": "keep"
+      },
+      "icon": {
+        "policy": "hook",
+        "hook": "normalize_fan_fields"
+      },
+      "icon_on": {
+        "policy": "hook",
+        "hook": "normalize_fan_fields"
+      },
+      "sensor": {
+        "policy": "clear"
+      },
+      "unit": {
+        "policy": "clear"
+      },
+      "type": {
+        "policy": "default",
+        "value": "fan_switch"
+      },
+      "precision": {
+        "policy": "clear"
+      },
+      "options": {
+        "policy": "clear"
+      }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "",
+    "label": "",
+    "icon": "Fan Off",
+    "icon_on": "Fan",
+    "sensor": "",
+    "unit": "",
+    "type": "fan_switch",
+    "precision": "",
+    "options": ""
+  }
+}

--- a/product/v2/cards/garage.json
+++ b/product/v2/cards/garage.json
@@ -1,0 +1,79 @@
+{
+  "label": "Garage Door",
+  "allowInSubpage": true,
+  "domains": ["cover"],
+  "options": [
+    {
+      "name": "garage_mode",
+      "label": "Interaction",
+      "kind": "choice",
+      "values": ["", "open", "close"],
+      "defaultValue": "",
+      "storageField": "sensor",
+      "omitDefault": false
+    },
+    {
+      "name": "label_display",
+      "label": "Display",
+      "kind": "choice",
+      "values": ["label", "status"],
+      "defaultValue": "label",
+      "omitDefault": true
+    },
+    {
+      "name": "confirmation_mode",
+      "label": "Confirmation Required",
+      "kind": "choice",
+      "values": ["", "off", "on", "both"],
+      "defaultValue": "",
+      "omitDefault": true,
+      "storage": ["confirm_off", "confirm_on"]
+    },
+    {
+      "name": "confirm_message",
+      "label": "Message",
+      "kind": "text",
+      "defaultValue": "Close the garage door?",
+      "omitDefault": true,
+      "defaultValueByMode": {
+        "off": "Close the garage door?",
+        "on": "Open the garage door?",
+        "both": "Open or close the garage door?"
+      }
+    },
+    {
+      "name": "confirm_yes",
+      "label": "Confirm Button",
+      "kind": "text",
+      "defaultValue": "Yes",
+      "omitDefault": true
+    },
+    {
+      "name": "confirm_no",
+      "label": "Cancel Button",
+      "kind": "text",
+      "defaultValue": "No",
+      "omitDefault": true
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "keep" },
+      "icon": { "policy": "keep" },
+      "icon_on": { "policy": "hook", "hook": "normalize_access_fields" },
+      "sensor": { "policy": "hook", "hook": "normalize_access_fields" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "garage" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "hook", "hook": "normalize_access_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["label_display", "confirm_off", "confirm_on", "confirm_message", "confirm_yes", "confirm_no"],
+    "optionHook": "normalize_access_options"
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Garage", "icon_on": "Garage Open",
+    "sensor": "", "unit": "", "type": "garage", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/gate.json
+++ b/product/v2/cards/gate.json
@@ -1,0 +1,44 @@
+{
+  "label": "Gate",
+  "allowInSubpage": true,
+  "domains": ["cover"],
+  "options": [
+    {
+      "name": "gate_mode",
+      "label": "Interaction",
+      "kind": "choice",
+      "values": ["", "open", "close", "stop"],
+      "defaultValue": "",
+      "storageField": "sensor",
+      "omitDefault": false
+    },
+    {
+      "name": "label_display",
+      "label": "Display",
+      "kind": "choice",
+      "values": ["label", "status"],
+      "defaultValue": "label",
+      "omitDefault": true
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "keep" },
+      "icon": { "policy": "keep" },
+      "icon_on": { "policy": "hook", "hook": "normalize_access_fields" },
+      "sensor": { "policy": "hook", "hook": "normalize_access_fields" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "gate" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "hook", "hook": "normalize_access_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["label_display"],
+    "optionHook": "normalize_access_options"
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Gate", "icon_on": "Gate Open",
+    "sensor": "", "unit": "", "type": "gate", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/image.json
+++ b/product/v2/cards/image.json
@@ -1,0 +1,87 @@
+{
+  "label": "Camera Card",
+  "allowInSubpage": true,
+  "domains": [
+    "camera",
+    "image"
+  ],
+  "options": [
+    {
+      "name": "image_label",
+      "label": "Show Label",
+      "kind": "flag",
+      "omitDefault": true
+    },
+    {
+      "name": "image_icon",
+      "label": "Show Icon",
+      "kind": "flag",
+      "omitDefault": true
+    },
+    {
+      "name": "image_modal_mode",
+      "label": "Expanded Image",
+      "kind": "choice",
+      "values": [
+        "fill",
+        "fit"
+      ],
+      "defaultValue": "fill",
+      "omitDefault": true
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": {
+        "policy": "keep"
+      },
+      "label": {
+        "policy": "hook",
+        "hook": "normalize_image_fields"
+      },
+      "icon": {
+        "policy": "hook",
+        "hook": "normalize_image_fields"
+      },
+      "icon_on": {
+        "policy": "default",
+        "value": "Auto"
+      },
+      "sensor": {
+        "policy": "clear"
+      },
+      "unit": {
+        "policy": "clear"
+      },
+      "type": {
+        "policy": "default",
+        "value": "image"
+      },
+      "precision": {
+        "policy": "clear"
+      },
+      "options": {
+        "policy": "hook",
+        "hook": "normalize_image_options"
+      }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": [
+      "image_label",
+      "image_icon",
+      "image_modal_mode"
+    ],
+    "optionHook": "normalize_image_options"
+  },
+  "default": {
+    "entity": "",
+    "label": "",
+    "icon": "Auto",
+    "icon_on": "Auto",
+    "sensor": "",
+    "unit": "",
+    "type": "image",
+    "precision": "",
+    "options": ""
+  }
+}

--- a/product/v2/cards/internal.json
+++ b/product/v2/cards/internal.json
@@ -1,0 +1,36 @@
+{
+  "label": "Internal Switches",
+  "allowInSubpage": true,
+  "domains": [],
+  "options": [
+    {
+      "name": "internal_mode",
+      "label": "Mode",
+      "kind": "choice",
+      "values": ["switch", "push"],
+      "defaultValue": "switch",
+      "storageField": "sensor",
+      "omitDefault": false
+    }
+  ],
+  "behavior": {
+    "internalRelay": {
+      "defaultIcons": { "switch": "Lightbulb Outline", "push": "Gesture Tap" },
+      "defaultIconOn": "Lightbulb"
+    }
+  },
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" }, "label": { "policy": "keep" },
+      "icon": { "policy": "keep" }, "icon_on": { "policy": "keep" },
+      "sensor": { "policy": "keep" }, "unit": { "policy": "keep" },
+      "type": { "policy": "default", "value": "internal" },
+      "precision": { "policy": "keep" }, "options": { "policy": "clear" }
+    },
+    "unknownOptions": "drop", "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Lightbulb Outline", "icon_on": "Lightbulb",
+    "sensor": "", "unit": "", "type": "internal", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/lawn_mower.json
+++ b/product/v2/cards/lawn_mower.json
@@ -1,0 +1,23 @@
+{
+  "label": "Lawn Mower",
+  "allowInSubpage": true,
+  "domains": ["lawn_mower"],
+  "options": [
+    { "name": "lawn_mower_mode", "label": "Type", "kind": "choice", "values": ["status", "start_mowing", "dock", "pause_resume"], "defaultValue": "start_mowing", "storageField": "sensor", "omitDefault": false }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" }, "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_mower_fields" },
+      "icon_on": { "policy": "default", "value": "Auto" },
+      "sensor": { "policy": "hook", "hook": "normalize_mower_fields" },
+      "unit": { "policy": "clear" }, "type": { "policy": "default", "value": "lawn_mower" },
+      "precision": { "policy": "clear" }, "options": { "policy": "clear" }
+    },
+    "unknownOptions": "drop", "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Robot Mower", "icon_on": "Auto",
+    "sensor": "start_mowing", "unit": "", "type": "lawn_mower", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/light_brightness.json
+++ b/product/v2/cards/light_brightness.json
@@ -1,0 +1,52 @@
+{
+  "label": "Lights",
+  "allowInSubpage": true,
+  "domains": [
+    "light"
+  ],
+  "normalization": {
+    "fields": {
+      "entity": {
+        "policy": "keep"
+      },
+      "label": {
+        "policy": "keep"
+      },
+      "icon": {
+        "policy": "keep"
+      },
+      "icon_on": {
+        "policy": "keep"
+      },
+      "sensor": {
+        "policy": "clear"
+      },
+      "unit": {
+        "policy": "keep"
+      },
+      "type": {
+        "policy": "default",
+        "value": "light_brightness"
+      },
+      "precision": {
+        "policy": "keep"
+      },
+      "options": {
+        "policy": "clear"
+      }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "",
+    "label": "",
+    "icon": "Lightbulb Outline",
+    "icon_on": "Lightbulb",
+    "sensor": "",
+    "unit": "",
+    "type": "light_brightness",
+    "precision": "",
+    "options": ""
+  }
+}

--- a/product/v2/cards/light_control.json
+++ b/product/v2/cards/light_control.json
@@ -1,0 +1,73 @@
+{
+  "label": "Lights",
+  "allowInSubpage": true,
+  "pickerKey": "light_brightness",
+  "hidden": true,
+  "domains": [
+    "light"
+  ],
+  "options": [
+    {
+      "name": "light_tabs",
+      "label": "Visible Tabs",
+      "kind": "text",
+      "values": [
+        "power",
+        "brightness",
+        "temperature",
+        "color"
+      ],
+      "defaultValue": "power|brightness|temperature|color",
+      "omitDefault": true
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": {
+        "policy": "keep"
+      },
+      "label": {
+        "policy": "keep"
+      },
+      "icon": {
+        "policy": "keep"
+      },
+      "icon_on": {
+        "policy": "keep"
+      },
+      "sensor": {
+        "policy": "clear"
+      },
+      "unit": {
+        "policy": "clear"
+      },
+      "type": {
+        "policy": "default",
+        "value": "light_control"
+      },
+      "precision": {
+        "policy": "clear"
+      },
+      "options": {
+        "policy": "hook",
+        "hook": "normalize_light_control_options"
+      }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": [
+      "light_tabs"
+    ],
+    "optionHook": "normalize_light_control_options"
+  },
+  "default": {
+    "entity": "",
+    "label": "",
+    "icon": "Lightbulb Outline",
+    "icon_on": "Lightbulb",
+    "sensor": "",
+    "unit": "",
+    "type": "light_control",
+    "precision": "",
+    "options": ""
+  }
+}

--- a/product/v2/cards/light_switch.json
+++ b/product/v2/cards/light_switch.json
@@ -1,0 +1,53 @@
+{
+  "label": "Lights",
+  "allowInSubpage": true,
+  "pickerKey": "light_brightness",
+  "domains": [
+    "light"
+  ],
+  "normalization": {
+    "fields": {
+      "entity": {
+        "policy": "keep"
+      },
+      "label": {
+        "policy": "keep"
+      },
+      "icon": {
+        "policy": "keep"
+      },
+      "icon_on": {
+        "policy": "keep"
+      },
+      "sensor": {
+        "policy": "clear"
+      },
+      "unit": {
+        "policy": "clear"
+      },
+      "type": {
+        "policy": "default",
+        "value": "light_switch"
+      },
+      "precision": {
+        "policy": "clear"
+      },
+      "options": {
+        "policy": "clear"
+      }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "",
+    "label": "",
+    "icon": "Lightbulb Outline",
+    "icon_on": "Lightbulb",
+    "sensor": "",
+    "unit": "",
+    "type": "light_switch",
+    "precision": "",
+    "options": ""
+  }
+}

--- a/product/v2/cards/light_temperature.json
+++ b/product/v2/cards/light_temperature.json
@@ -1,0 +1,65 @@
+{
+  "label": "Lights",
+  "allowInSubpage": true,
+  "pickerKey": "light_brightness",
+  "domains": [
+    "light"
+  ],
+  "behavior": {
+    "lightTemperature": {
+      "defaultRange": "2000-6500",
+      "min": 1000,
+      "max": 10000,
+      "minMax": 9900,
+      "step": 100,
+      "legacySensorValues": [
+        "kelvin"
+      ]
+    }
+  },
+  "normalization": {
+    "fields": {
+      "entity": {
+        "policy": "keep"
+      },
+      "label": {
+        "policy": "keep"
+      },
+      "icon": {
+        "policy": "keep"
+      },
+      "icon_on": {
+        "policy": "keep"
+      },
+      "sensor": {
+        "policy": "keep"
+      },
+      "unit": {
+        "policy": "keep"
+      },
+      "type": {
+        "policy": "default",
+        "value": "light_temperature"
+      },
+      "precision": {
+        "policy": "keep"
+      },
+      "options": {
+        "policy": "clear"
+      }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "",
+    "label": "",
+    "icon": "Lightbulb",
+    "icon_on": "Auto",
+    "sensor": "",
+    "unit": "2000-6500",
+    "type": "light_temperature",
+    "precision": "",
+    "options": ""
+  }
+}

--- a/product/v2/cards/local_sensor.json
+++ b/product/v2/cards/local_sensor.json
@@ -1,0 +1,11 @@
+{
+  "label": "Local Sensor",
+  "allowInSubpage": true,
+  "pickerKey": "sensor",
+  "hidden": true,
+  "domains": ["sensor", "text_sensor"],
+  "default": {
+    "entity": "", "label": "", "icon": "Auto", "icon_on": "Auto",
+    "sensor": "local", "unit": "", "type": "sensor", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/lock.json
+++ b/product/v2/cards/lock.json
@@ -1,0 +1,41 @@
+{
+  "label": "Lock",
+  "allowInSubpage": true,
+  "domains": ["lock"],
+  "options": [
+    {
+      "name": "lock_mode",
+      "label": "Type",
+      "kind": "choice",
+      "values": ["", "lock", "unlock"],
+      "defaultValue": "",
+      "storageField": "sensor",
+      "omitDefault": false
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "keep" },
+      "icon": { "policy": "keep" },
+      "icon_on": { "policy": "hook", "hook": "normalize_access_fields" },
+      "sensor": { "policy": "hook", "hook": "normalize_access_fields" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "lock" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "clear" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": []
+  },
+  "behavior": {
+    "lock": {
+      "commandServices": { "lock": "lock.lock", "unlock": "lock.unlock" },
+      "toggleServices": { "locked": "lock.unlock", "default": "lock.lock" }
+    }
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Lock", "icon_on": "Lock Open",
+    "sensor": "", "unit": "", "type": "lock", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/option_select.json
+++ b/product/v2/cards/option_select.json
@@ -1,0 +1,10 @@
+{
+  "label": "Option Select",
+  "allowInSubpage": true,
+  "hidden": true,
+  "domains": ["select", "input_select"],
+  "default": {
+    "entity": "", "label": "", "icon": "Flash", "icon_on": "Auto",
+    "sensor": "input_select.select_option", "unit": "", "type": "action", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/presence.json
+++ b/product/v2/cards/presence.json
@@ -1,0 +1,21 @@
+{
+  "label": "Presence",
+  "allowInSubpage": true,
+  "domains": ["binary_sensor", "sensor", "text_sensor"],
+  "options": [{ "name": "active_color", "label": "Lit When Detected", "kind": "flag", "omitDefault": true }],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "clear" }, "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_occupancy_fields" },
+      "icon_on": { "policy": "hook", "hook": "normalize_occupancy_fields" },
+      "sensor": { "policy": "keep" }, "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "presence" }, "precision": { "policy": "clear" },
+      "options": { "policy": "hook", "hook": "normalize_occupancy_options" }
+    },
+    "unknownOptions": "drop", "canonicalOptionOrder": ["active_color"], "optionHook": "normalize_occupancy_options"
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Motion Sensor Off", "icon_on": "Motion Sensor",
+    "sensor": "", "unit": "", "type": "presence", "precision": "", "options": "active_color"
+  }
+}

--- a/product/v2/cards/push.json
+++ b/product/v2/cards/push.json
@@ -1,0 +1,22 @@
+{
+  "label": "Trigger",
+  "allowInSubpage": true,
+  "domains": [],
+  "behavior": {
+    "pushAction": { "defaultIcon": "Gesture Tap", "defaultIconOn": "Auto" }
+  },
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" }, "label": { "policy": "keep" },
+      "icon": { "policy": "keep" }, "icon_on": { "policy": "keep" },
+      "sensor": { "policy": "keep" }, "unit": { "policy": "keep" },
+      "type": { "policy": "default", "value": "push" },
+      "precision": { "policy": "keep" }, "options": { "policy": "clear" }
+    },
+    "unknownOptions": "drop", "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Gesture Tap", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "push", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/screen_lock.json
+++ b/product/v2/cards/screen_lock.json
@@ -1,0 +1,20 @@
+{
+  "label": "Screen Lock",
+  "allowInSubpage": true,
+  "domains": [],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "clear" }, "label": { "policy": "clear" },
+      "icon": { "policy": "default", "value": "Lock" },
+      "icon_on": { "policy": "default", "value": "Lock Open" },
+      "sensor": { "policy": "clear" }, "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "screen_lock" },
+      "precision": { "policy": "clear" }, "options": { "policy": "clear" }
+    },
+    "unknownOptions": "drop", "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Lock", "icon_on": "Lock Open",
+    "sensor": "", "unit": "", "type": "screen_lock", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/slider.json
+++ b/product/v2/cards/slider.json
@@ -1,0 +1,19 @@
+{
+  "label": "Slider",
+  "allowInSubpage": true,
+  "domains": ["light", "fan"],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" }, "label": { "policy": "keep" },
+      "icon": { "policy": "keep" }, "icon_on": { "policy": "keep" },
+      "sensor": { "policy": "clear" }, "unit": { "policy": "keep" },
+      "type": { "policy": "default", "value": "slider" },
+      "precision": { "policy": "keep" }, "options": { "policy": "clear" }
+    },
+    "unknownOptions": "drop", "canonicalOptionOrder": []
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Auto", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "slider", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/subpage.json
+++ b/product/v2/cards/subpage.json
@@ -1,0 +1,33 @@
+{
+  "label": "Subpage",
+  "allowInSubpage": false,
+  "domains": [],
+  "options": [
+    {
+      "name": "subpage_kind", "label": "Subpage Type", "kind": "choice",
+      "values": ["", "switch", "lights", "climate", "presence", "media", "alarm", "cover", "garage", "gate", "lock", "vacuum", "lawn_mower", "weather", "sensor", "image"],
+      "defaultValue": "", "omitDefault": true
+    },
+    { "name": "large_numbers", "label": "Large State Numbers", "kind": "flag", "omitDefault": true }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "hook", "hook": "normalize_subpage_fields" },
+      "icon": { "policy": "hook", "hook": "normalize_subpage_fields" },
+      "icon_on": { "policy": "hook", "hook": "normalize_subpage_fields" },
+      "sensor": { "policy": "hook", "hook": "normalize_subpage_fields" },
+      "unit": { "policy": "hook", "hook": "normalize_subpage_fields" },
+      "type": { "policy": "default", "value": "subpage" },
+      "precision": { "policy": "hook", "hook": "normalize_subpage_fields" },
+      "options": { "policy": "hook", "hook": "normalize_subpage_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["subpage_kind", "large_numbers"],
+    "optionHook": "normalize_subpage_options"
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Auto", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "subpage", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/timezone.json
+++ b/product/v2/cards/timezone.json
@@ -1,0 +1,38 @@
+{
+  "label": "Date & Time",
+  "allowInSubpage": true,
+  "pickerKey": "calendar",
+  "domains": [],
+  "options": [
+    {
+      "name": "date_time_mode",
+      "label": "Type",
+      "kind": "choice",
+      "values": ["clock", "datetime", "", "timezone"],
+      "defaultValue": "timezone",
+      "storageField": "type",
+      "omitDefault": false
+    },
+    { "name": "large_numbers", "label": "Large Clock", "kind": "flag", "omitDefault": true }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "hook", "hook": "normalize_date_time_fields" },
+      "label": { "policy": "clear" },
+      "icon": { "policy": "default", "value": "Auto" },
+      "icon_on": { "policy": "default", "value": "Auto" },
+      "sensor": { "policy": "clear" },
+      "unit": { "policy": "clear" },
+      "type": { "policy": "default", "value": "timezone" },
+      "precision": { "policy": "clear" },
+      "options": { "policy": "hook", "hook": "normalize_date_time_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["large_numbers"],
+    "optionHook": "normalize_date_time_options"
+  },
+  "default": {
+    "entity": "UTC (GMT+0)", "label": "", "icon": "Auto", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "timezone", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/vacuum.json
+++ b/product/v2/cards/vacuum.json
@@ -1,0 +1,31 @@
+{
+  "label": "Vacuum",
+  "allowInSubpage": true,
+  "domains": ["vacuum"],
+  "options": [
+    { "name": "vacuum_mode", "label": "Type", "kind": "choice", "values": ["status", "start_stop", "dock", "pause_resume", "clean_spot", "locate", "clean_area"], "defaultValue": "start_stop", "storageField": "sensor", "omitDefault": false }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" }, "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_vacuum_fields" },
+      "icon_on": { "policy": "default", "value": "Auto" },
+      "sensor": { "policy": "allowed", "values": ["status", "start_stop", "dock", "pause_resume", "clean_spot", "locate", "clean_area"], "aliases": { "vacuum.start": "start_stop", "vacuum.return_to_base": "dock" }, "fallback": "start_stop" },
+      "unit": { "policy": "hook", "hook": "normalize_vacuum_fields" },
+      "type": { "policy": "default", "value": "vacuum" }, "precision": { "policy": "clear" },
+      "options": { "policy": "clear" }
+    },
+    "unknownOptions": "drop", "canonicalOptionOrder": [],
+    "migrationActions": ["legacy_vacuum_start", "legacy_vacuum_dock"],
+    "hookData": {
+      "normalize_vacuum_fields": {
+        "preserveUnitForModes": ["clean_area"],
+        "defaultIcons": { "dock": "Robot Vacuum Variant", "clean_spot": "Vacuum", "locate": "Robot Vacuum Alert", "clean_area": "Vacuum Outline", "default": "Robot Vacuum" }
+      }
+    }
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Robot Vacuum", "icon_on": "Auto",
+    "sensor": "start_stop", "unit": "", "type": "vacuum", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/weather.json
+++ b/product/v2/cards/weather.json
@@ -1,0 +1,44 @@
+{
+  "label": "Weather",
+  "allowInSubpage": true,
+  "domains": ["weather"],
+  "options": [
+    {
+      "name": "weather_mode",
+      "label": "Type",
+      "kind": "choice",
+      "values": ["", "today", "tomorrow"],
+      "defaultValue": "",
+      "storageField": "precision",
+      "omitDefault": true
+    },
+    {
+      "name": "large_numbers",
+      "label": "Large Temperature Numbers",
+      "kind": "flag",
+      "omitDefault": true,
+      "supportedWhen": { "precision": ["today", "tomorrow"] }
+    }
+  ],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" },
+      "label": { "policy": "hook", "hook": "normalize_weather_fields" },
+      "icon": { "policy": "keep" },
+      "icon_on": { "policy": "keep" },
+      "sensor": { "policy": "clear" },
+      "unit": { "policy": "keep" },
+      "type": { "policy": "default", "value": "weather" },
+      "precision": { "policy": "hook", "hook": "normalize_weather_fields" },
+      "options": { "policy": "hook", "hook": "normalize_weather_options" }
+    },
+    "unknownOptions": "drop",
+    "canonicalOptionOrder": ["large_numbers"],
+    "migrationActions": ["legacy_weather_forecast"],
+    "optionHook": "normalize_weather_options"
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Auto", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "weather", "precision": "", "options": ""
+  }
+}

--- a/product/v2/cards/weather_forecast.json
+++ b/product/v2/cards/weather_forecast.json
@@ -1,0 +1,10 @@
+{
+  "label": "Weather Forecast",
+  "allowInSubpage": true,
+  "hidden": true,
+  "domains": ["weather"],
+  "default": {
+    "entity": "", "label": "", "icon": "Auto", "icon_on": "Auto",
+    "sensor": "", "unit": "", "type": "weather", "precision": "tomorrow", "options": ""
+  }
+}

--- a/product/v2/cards/webhook.json
+++ b/product/v2/cards/webhook.json
@@ -1,0 +1,22 @@
+{
+  "label": "Webhook",
+  "allowInSubpage": true,
+  "domains": [],
+  "options": [{ "name": "webhook_headers", "label": "Headers", "kind": "text", "defaultValue": "", "omitDefault": true }],
+  "normalization": {
+    "fields": {
+      "entity": { "policy": "keep" }, "label": { "policy": "keep" },
+      "icon": { "policy": "hook", "hook": "normalize_webhook_fields" },
+      "icon_on": { "policy": "default", "value": "Auto" },
+      "sensor": { "policy": "hook", "hook": "normalize_webhook_fields" },
+      "unit": { "policy": "hook", "hook": "normalize_webhook_fields" },
+      "type": { "policy": "default", "value": "webhook" }, "precision": { "policy": "clear" },
+      "options": { "policy": "hook", "hook": "normalize_webhook_options" }
+    },
+    "unknownOptions": "drop", "canonicalOptionOrder": ["webhook_headers"], "optionHook": "normalize_webhook_options"
+  },
+  "default": {
+    "entity": "", "label": "", "icon": "Auto", "icon_on": "Auto",
+    "sensor": "GET", "unit": "", "type": "webhook", "precision": "", "options": ""
+  }
+}

--- a/product/v2/devices/esp32-p4-86.json
+++ b/product/v2/devices/esp32-p4-86.json
@@ -1,0 +1,30 @@
+{
+  "profiles": { "platform": "esp32-p4", "modal": "large-square", "fonts": "compact-panel", "network": ["c6-firmware-update", "network-coprocessor", "ethernet-selection"], "audio": "local-voice-services", "input": ["touchscreen", "physical-volume-buttons"] },
+  "config": {
+    "slots": 9,
+    "capabilities": { "imageSlots": 6 },
+    "public": { "name": "ESP32-P4 86 Panel", "docsPath": "/screens/p4-86", "screenSize": "4 inches", "resolution": "720 x 720", "orientation": "Square" },
+    "layout": { "cols": 3, "rows": 3, "firmwareGrid": "3x3" },
+    "rotation": { "enabled": true, "options": ["0", "90", "180", "270"] },
+    "internalRelays": [{ "key": "relay_1", "label": "Relay 1" }, { "key": "relay_2", "label": "Relay 2" }],
+    "web": {
+      "coverArtSquareOverlay": true, "dragMode": "displace", "dragAnimation": true,
+      "screen": { "width": "55%", "aspect": "1/1" },
+      "topbar": { "height": 8.0, "padding": "1.25cqw 0.83cqw 0.83cqw", "fontSize": 3.75 },
+      "grid": { "top": 8.33, "compactTop": 0.83, "left": 1.04, "right": 1.04, "bottom": 0.83, "gap": 1.39, "fr": "1fr" },
+      "btn": { "radius": 1.67, "padding": 2.92, "iconSize": 9.58, "labelSize": 3.96, "coverArtTitleSize": 14.583333, "coverArtArtistSize": 8.333333, "labelLines": 2, "labelLinesDouble": 3 },
+      "emptyCell": { "radius": 1.67 }, "sensorBadge": { "top": 2.08, "right": 2.08, "fontSize": 3.33 }, "subpageBadge": { "bottom": 2.08, "right": 2.08, "fontSize": 4 }
+    },
+    "firmware": {
+      "display": {
+        "wrapTallLabels": false, "refreshRebuildsSubpages": true,
+        "coverArt": { "cover_art_size": "720", "cover_art_decode_size": "720", "cover_art_x": "0", "cover_art_y": "0", "cover_art_accent_x": "0", "cover_art_accent_y": "0", "cover_art_accent_width": "720", "cover_art_accent_height": "720", "cover_art_accent_bg_opa": "80%", "cover_art_accent_opa": "80%", "cover_art_panel_x": "0", "cover_art_panel_y": "0", "cover_art_panel_width": "720", "cover_art_panel_height": "720", "cover_art_panel_pad_top": "36", "cover_art_panel_pad_bottom": "24", "cover_art_panel_pad_left": "36", "cover_art_panel_pad_right": "36", "cover_art_panel_pad_row": "0", "cover_art_title_font": "font_cover_art_title", "cover_art_title_max_height": "495", "cover_art_title_line_space": "0", "cover_art_artist_font": "font_cover_art_artist", "cover_art_artist_pad_top": "9", "cover_art_artist_long_mode": "dot", "cover_art_time_font": "font_cover_art_time", "cover_art_time_pad_top": "18", "cover_art_progress_width": "720", "cover_art_progress_height": "4", "cover_art_text_color": "0xFFFFFF", "cover_art_square_overlay": "true", "cover_art_live_image_updates": "false" }
+      },
+      "package": {
+        "firmwareVersion": "dev",
+        "substitutions": { "screen_width": "\"720\"", "screen_height": "\"720\"", "content_width": "\"570\"", "setup_icon_font_id": "font_icon_main", "setup_title_font_id": "font_text_title", "setup_body_font_id": "font_text_body", "setup_pad_row": "\"30\"", "setup_loading_pad_row": "\"60\"", "setup_action_button_width": "\"300\"", "setup_action_button_height": "\"84\"", "setup_action_button_radius": "\"18\"", "icon_font": "font_icon_main", "subpage_chevron_font": "font_icon_status", "label_font": "font_text_body", "media_title_font": "font_text_title", "unit_font": "font_text_body", "sensor_value_font": "font_number_value", "padding": "21px", "radius": "12px", "main_page_card_gap": "\"15\"", "main_page_pad_top": "\"60\"", "main_page_compact_pad_top": "\"6\"", "clock_bar_item_gap": "\"96\"", "clock_bar_visual_gap": "\"12\"", "clock_font_size": "\"224\"", "clock_cx": "\"360\"", "clock_cy": "\"360\"", "screen_saver_clock_min_brightness": "\"1\"", "screen_saver_clock_default_brightness": "\"35\"", "screen_schedule_clock_min_brightness": "\"1\"", "screen_schedule_clock_default_brightness": "\"10\"", "voice_wake_chime_file": "\"https://raw.githubusercontent.com/jtenniswood/espcontrol/main/devices/esp32-p4-86/device/voice_wake_chime.flac\"", "voice_timer_alert_file": "\"https://raw.githubusercontent.com/jtenniswood/espcontrol/main/devices/esp32-p4-86/device/voice_timer_alert.flac\"", "voice_stt_failure_chime_file": "\"https://raw.githubusercontent.com/jtenniswood/espcontrol/main/devices/esp32-p4-86/device/voice_stt_failure_chime.flac\"", "alarm_delay_entry_beep_file": "\"https://raw.githubusercontent.com/jtenniswood/espcontrol/30ea813b1e2d4008b019c30862dce478d238a697/devices/esp32-p4-86/device/alarm_delay_entry_beep.flac\"", "alarm_delay_exit_beep_file": "\"https://raw.githubusercontent.com/jtenniswood/espcontrol/30ea813b1e2d4008b019c30862dce478d238a697/devices/esp32-p4-86/device/alarm_delay_exit_beep.flac\"" }
+      }
+    }
+  },
+  "overrides": { "firmware": { "package": { "backlightPwmFrequency": { "wifi": "100Hz", "ethernet": "20000Hz" } } } }
+}

--- a/product/v2/devices/guition-esp32-p4-jc1060p470.json
+++ b/product/v2/devices/guition-esp32-p4-jc1060p470.json
@@ -1,0 +1,183 @@
+{
+  "profiles": {
+    "platform": "esp32-p4",
+    "modal": "wide-landscape",
+    "fonts": "large-panel-p4",
+    "network": [
+      "c6-firmware-update",
+      "network-coprocessor",
+      "ethernet-selection"
+    ]
+  },
+  "config": {
+    "slots": 15,
+    "capabilities": {
+      "imageSlots": 6
+    },
+    "public": {
+      "name": "Guition JC1060P470",
+      "docsPath": "/screens/jc1060p470",
+      "screenSize": "7 inches",
+      "resolution": "1024 x 600",
+      "orientation": "Landscape"
+    },
+    "layout": {
+      "cols": 5,
+      "rows": 3,
+      "firmwareGrid": "3x5",
+      "portraitCols": 3
+    },
+    "rotation": {
+      "enabled": true,
+      "options": [
+        "0",
+        "90",
+        "180",
+        "270"
+      ],
+      "displayOffset": 180,
+      "rotateWidthCompensation": true
+    },
+    "web": {
+      "dragMode": "swap",
+      "dragAnimation": true,
+      "screen": {
+        "width": "100%",
+        "aspect": "1024/600"
+      },
+      "portrait": {
+        "cols": 3,
+        "rows": 5,
+        "screen": {
+          "width": "59%",
+          "aspect": "600/1024"
+        }
+      },
+      "topbar": {
+        "height": 3.2,
+        "padding": "0.39cqw",
+        "fontSize": 1.95
+      },
+      "grid": {
+        "top": 4.4,
+        "compactTop": 0.49,
+        "left": 0.49,
+        "right": 0.49,
+        "bottom": 0.49,
+        "gap": 0.76,
+        "fr": "1fr"
+      },
+      "btn": {
+        "radius": 0.78,
+        "padding": 1.37,
+        "iconSize": 4.69,
+        "labelSize": 1.8,
+        "coverArtTitleSize": 7.421875,
+        "coverArtArtistSize": 3.90625,
+        "labelLines": 2,
+        "labelLinesDouble": 3
+      },
+      "emptyCell": {
+        "radius": 0.78
+      },
+      "sensorBadge": {
+        "top": 1,
+        "right": 1,
+        "fontSize": 1.6
+      },
+      "subpageBadge": {
+        "bottom": 1,
+        "right": 1,
+        "fontSize": 2
+      }
+    },
+    "firmware": {
+      "display": {
+        "wrapTallLabels": true,
+        "volumeWidthCompensationPercent": 95,
+        "refreshRebuildsSubpages": true,
+        "mediaArtworkWidthCompensationPercent": 98,
+        "coverArt": {
+          "cover_art_size": "600",
+          "cover_art_decode_size": "600",
+          "cover_art_x": "0",
+          "cover_art_y": "0",
+          "cover_art_accent_x": "585",
+          "cover_art_accent_y": "0",
+          "cover_art_accent_width": "439",
+          "cover_art_accent_height": "600",
+          "cover_art_accent_bg_opa": "100%",
+          "cover_art_accent_opa": "100%",
+          "cover_art_panel_x": "615",
+          "cover_art_panel_y": "34",
+          "cover_art_panel_width": "377",
+          "cover_art_panel_height": "430",
+          "cover_art_panel_pad_top": "0",
+          "cover_art_panel_pad_bottom": "0",
+          "cover_art_panel_pad_left": "0",
+          "cover_art_panel_pad_right": "0",
+          "cover_art_panel_pad_row": "0",
+          "cover_art_title_font": "font_cover_art_title",
+          "cover_art_title_max_height": "260",
+          "cover_art_title_line_space": "-8",
+          "cover_art_artist_font": "font_cover_art_artist",
+          "cover_art_artist_pad_top": "10",
+          "cover_art_artist_long_mode": "dot",
+          "cover_art_time_font": "font_cover_art_time",
+          "cover_art_time_pad_top": "14",
+          "cover_art_progress_width": "1024",
+          "cover_art_progress_height": "4",
+          "cover_art_text_color": "0xFFFFFF",
+          "cover_art_square_overlay": "false",
+          "cover_art_live_image_updates": "false"
+        }
+      },
+      "package": {
+        "firmwareVersion": "dev",
+        "substitutions": {
+          "screen_width": "\"1024\"",
+          "screen_height": "\"600\"",
+          "content_width": "\"550\"",
+          "setup_icon_font_id": "font_icon_main",
+          "setup_title_font_id": "font_text_title",
+          "setup_body_font_id": "font_text_body",
+          "setup_pad_row": "\"20\"",
+          "setup_loading_pad_row": "\"40\"",
+          "setup_action_button_width": "\"200\"",
+          "setup_action_button_height": "\"56\"",
+          "setup_action_button_radius": "\"12\"",
+          "icon_font": "font_icon_main",
+          "subpage_chevron_font": "font_icon_status",
+          "label_font": "font_text_body",
+          "media_title_font": "font_text_title",
+          "unit_font": "font_text_body",
+          "sensor_value_font": "font_number_value",
+          "padding": "16px",
+          "radius": "10px",
+          "main_page_card_gap": "\"10\"",
+          "main_page_pad_top": "\"42\"",
+          "main_page_compact_pad_top": "\"5\"",
+          "clock_bar_item_gap": "\"80\"",
+          "clock_bar_visual_gap": "\"10\"",
+          "clock_font_size": "\"200\"",
+          "clock_cx": "\"512\"",
+          "clock_cy": "\"300\"",
+          "screen_saver_clock_min_brightness": "\"1\"",
+          "screen_saver_clock_default_brightness": "\"35\"",
+          "screen_schedule_clock_min_brightness": "\"1\"",
+          "screen_schedule_clock_default_brightness": "\"10\""
+        }
+      }
+    }
+  },
+  "overrides": {
+    "firmware": {
+      "package": {
+        "backlightPwmFrequency": {
+          "wifi": "1000Hz",
+          "ethernet": "20000Hz"
+        }
+      }
+    }
+  }
+}

--- a/product/v2/devices/guition-esp32-p4-jc4880p443.json
+++ b/product/v2/devices/guition-esp32-p4-jc4880p443.json
@@ -1,0 +1,33 @@
+{
+  "profiles": { "platform": "esp32-p4", "modal": "compact-portrait", "fonts": "portrait-panel-p4", "network": "c6-firmware-update" },
+  "config": {
+    "slots": 6,
+    "capabilities": { "imageSlots": 6 },
+    "public": { "name": "Guition JC4880P443", "docsPath": "/screens/jc4880p443", "screenSize": "4.3 inches", "resolution": "480 x 800", "orientation": "Portrait" },
+    "layout": { "cols": 2, "rows": 3, "firmwareGrid": "3x2", "portraitCols": 3 },
+    "rotation": { "enabled": true, "options": ["0", "90", "180", "270"], "displayOffset": 180 },
+    "web": {
+      "dragMode": "displace", "dragAnimation": true,
+      "screen": { "width": "44%", "aspect": "480/800" },
+      "portrait": { "cols": 3, "rows": 2, "screen": { "width": "74%", "aspect": "800/480" } },
+      "topbar": { "height": 6.45, "padding": "1.2cqw 0.59cqw 0.59cqw", "fontSize": 4.5 },
+      "grid": { "top": 8.58, "compactTop": 1.5, "left": 1.5, "right": 1.5, "bottom": 1.5, "gap": 1.74, "fr": "1fr" },
+      "btn": { "radius": 1.18, "padding": 2.73, "iconSize": 14, "labelSize": 5.5, "coverArtTitleSize": 7.375, "coverArtArtistSize": 5, "labelLines": 2, "labelLinesDouble": 3 },
+      "emptyCell": { "radius": 1.18 },
+      "sensorBadge": { "top": 1.52, "right": 1.52, "fontSize": 3.22 },
+      "subpageBadge": { "bottom": 1.52, "right": 1.52, "fontSize": 4.03 }
+    },
+    "firmware": {
+      "display": {
+        "wrapTallLabels": false, "refreshRebuildsSubpages": true, "subpageChevronX": 3, "subpageChevronY": -2, "subpageChevronTextWidthPercent": 96,
+        "coverArt": {
+          "cover_art_size": "480", "cover_art_decode_size": "480", "cover_art_x": "0", "cover_art_y": "0", "cover_art_accent_x": "0", "cover_art_accent_y": "480", "cover_art_accent_width": "480", "cover_art_accent_height": "320", "cover_art_accent_bg_opa": "100%", "cover_art_accent_opa": "100%", "cover_art_panel_x": "24", "cover_art_panel_y": "514", "cover_art_panel_width": "432", "cover_art_panel_height": "262", "cover_art_panel_pad_top": "0", "cover_art_panel_pad_bottom": "0", "cover_art_panel_pad_left": "0", "cover_art_panel_pad_right": "0", "cover_art_panel_pad_row": "0", "cover_art_title_font": "font_cover_art_title", "cover_art_title_max_height": "130", "cover_art_title_line_space": "0", "cover_art_artist_font": "font_cover_art_artist", "cover_art_artist_pad_top": "10", "cover_art_artist_long_mode": "dot", "cover_art_time_font": "font_cover_art_time", "cover_art_time_pad_top": "14", "cover_art_progress_width": "480", "cover_art_progress_height": "4", "cover_art_text_color": "0xFFFFFF", "cover_art_square_overlay": "false", "cover_art_live_image_updates": "false"
+        }
+      },
+      "package": {
+        "firmwareVersion": "dev",
+        "substitutions": { "screen_width": "\"480\"", "screen_height": "\"800\"", "content_width": "\"440\"", "setup_icon_font_id": "font_icon_main", "setup_title_font_id": "font_text_title", "setup_body_font_id": "font_text_body", "setup_pad_row": "\"20\"", "setup_loading_pad_row": "\"40\"", "setup_action_button_width": "\"200\"", "setup_action_button_height": "\"56\"", "setup_action_button_radius": "\"12\"", "icon_font": "font_icon_main", "subpage_chevron_font": "font_icon_status", "label_font": "font_text_body", "media_title_font": "font_text_title", "unit_font": "font_text_body", "sensor_value_font": "font_number_value", "padding": "21px", "radius": "10px", "main_page_card_gap": "\"14\"", "main_page_pad_top": "\"50\"", "main_page_compact_pad_top": "\"5\"", "clock_bar_item_gap": "\"96\"", "clock_bar_visual_gap": "\"12\"", "clock_font_size": "\"160\"", "clock_cx": "\"240\"", "clock_cy": "\"400\"", "screen_saver_clock_min_brightness": "\"1\"", "screen_saver_clock_default_brightness": "\"35\"", "screen_schedule_clock_min_brightness": "\"1\"", "screen_schedule_clock_default_brightness": "\"10\"" }
+      }
+    }
+  }
+}

--- a/product/v2/devices/guition-esp32-p4-jc8012p4a1-v2.json
+++ b/product/v2/devices/guition-esp32-p4-jc8012p4a1-v2.json
@@ -1,0 +1,16 @@
+{
+  "profiles": {
+    "platform": "esp32-p4",
+    "display": "jc8012p4a1-1280x800",
+    "modal": "large-landscape",
+    "fonts": "large-panel-p4",
+    "network": "c6-firmware-update",
+    "artwork": "landscape-1280x800"
+  },
+  "config": {
+    "public": {
+      "name": "Guition JC8012P4A1 new panel (2628+)",
+      "docsPath": "/screens/jc8012p4a1-v2"
+    }
+  }
+}

--- a/product/v2/devices/guition-esp32-s3-4848s040.json
+++ b/product/v2/devices/guition-esp32-s3-4848s040.json
@@ -1,0 +1,29 @@
+{
+  "profiles": { "platform": "esp32-s3", "modal": "compact-square-constrained", "fonts": "compact-panel" },
+  "config": {
+    "slots": 9, "capabilities": { "imageSlots": 1 },
+    "public": { "name": "Guition 4848S040", "docsPath": "/screens/4848s040", "screenSize": "4 inches", "resolution": "480 x 480", "orientation": "Square" },
+    "layout": { "cols": 3, "rows": 3, "firmwareGrid": "3x3" },
+    "rotation": { "enabled": true, "options": ["0", "90", "180", "270"], "default": "180", "displayOffset": 180 },
+    "internalRelays": [{ "key": "relay_1", "label": "Relay 1" }, { "key": "relay_2", "label": "Relay 2" }, { "key": "relay_3", "label": "Relay 3" }],
+    "web": {
+      "coverArtSquareOverlay": true, "dragMode": "displace", "dragAnimation": true, "disabledCardTypes": ["weather_forecast", "image"],
+      "screen": { "width": "55%", "aspect": "1/1" },
+      "topbar": { "height": 8.0, "padding": "1.25cqw 0.83cqw 0.83cqw", "fontSize": 3.75 },
+      "grid": { "top": 8.33, "compactTop": 0.83, "left": 1.04, "right": 1.04, "bottom": 0.83, "gap": 1.39, "fr": "1fr" },
+      "btn": { "radius": 1.67, "padding": 2.92, "iconSize": 9.58, "labelSize": 4.583333, "mediaTitleSize": 7.083333, "coverArtTitleSize": 14.583333, "coverArtArtistSize": 8.333333, "labelLines": 2, "labelLinesDouble": 3 },
+      "emptyCell": { "radius": 1.67 }, "sensorBadge": { "top": 2.08, "right": 2.08, "fontSize": 3.33 }, "subpageBadge": { "bottom": 2.08, "right": 2.08, "fontSize": 4 }
+    },
+    "firmware": {
+      "display": {
+        "wrapTallLabels": false, "refreshRebuildsSubpages": true, "subpageChevronX": 3, "subpageChevronY": -2, "subpageChevronTextWidthPercent": 96,
+        "coverArt": { "cover_art_size": "480", "cover_art_decode_size": "320", "cover_art_x": "0", "cover_art_y": "0", "cover_art_accent_x": "0", "cover_art_accent_y": "0", "cover_art_accent_width": "480", "cover_art_accent_height": "480", "cover_art_accent_bg_opa": "80%", "cover_art_accent_opa": "80%", "cover_art_panel_x": "0", "cover_art_panel_y": "0", "cover_art_panel_width": "480", "cover_art_panel_height": "480", "cover_art_panel_pad_top": "24", "cover_art_panel_pad_bottom": "16", "cover_art_panel_pad_left": "24", "cover_art_panel_pad_right": "24", "cover_art_panel_pad_row": "0", "cover_art_title_font": "font_cover_art_title", "cover_art_title_max_height": "330", "cover_art_title_line_space": "0", "cover_art_artist_font": "font_cover_art_artist", "cover_art_artist_pad_top": "6", "cover_art_artist_long_mode": "dot", "cover_art_time_font": "font_cover_art_time", "cover_art_time_pad_top": "12", "cover_art_progress_width": "480", "cover_art_progress_height": "4", "cover_art_text_color": "0xFFFFFF", "cover_art_square_overlay": "true", "cover_art_live_image_updates": "false" }
+      },
+      "package": {
+        "firmwareVersion": "dev", "subpageConfigChunks": 4,
+        "substitutions": { "screen_width": "\"480\"", "screen_height": "\"480\"", "content_width": "\"380\"", "setup_icon_font_id": "font_icon_main", "setup_title_font_id": "font_text_title", "setup_body_font_id": "font_text_body", "setup_pad_row": "\"20\"", "setup_loading_pad_row": "\"40\"", "setup_action_button_width": "\"200\"", "setup_action_button_height": "\"56\"", "setup_action_button_radius": "\"12\"", "icon_font": "font_icon_main", "subpage_chevron_font": "font_icon_status", "label_font": "font_text_body", "media_title_font": "font_text_title", "unit_font": "font_text_body", "sensor_value_font": "font_number_value", "padding": "14px", "radius": "8px", "main_page_card_gap": "\"10\"", "main_page_pad_top": "\"40\"", "main_page_compact_pad_top": "\"4\"", "clock_bar_item_gap": "\"60\"", "clock_bar_visual_gap": "\"8\"", "clock_font_size": "\"160\"", "clock_cx": "\"240\"", "clock_cy": "\"240\"", "screen_saver_clock_min_brightness": "\"1\"", "screen_saver_clock_default_brightness": "\"35\"", "screen_schedule_clock_min_brightness": "\"1\"", "screen_schedule_clock_default_brightness": "\"10\"" },
+        "apiNavigateAction": false
+      }
+    }
+  }
+}

--- a/scripts/check_product_model_v2.py
+++ b/scripts/check_product_model_v2.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify that Product Model v2 pilot sources preserve legacy output exactly."""
+"""Verify that Product Model v2 sources preserve generated output exactly."""
 
 from __future__ import annotations
 
@@ -88,6 +88,32 @@ def run_self_test() -> None:
             assert "pilots.devices identifiers must be non-empty strings" in str(exc)
         else:
             raise AssertionError("an unnamed device pilot must fail validation")
+    incomplete = copy.deepcopy(data)
+    incomplete["pilots"]["cards"].pop(
+        next(card_type for card_type in incomplete["pilots"]["cards"] if card_type != "sensor")
+    )
+    with TemporaryDirectory() as directory:
+        path = Path(directory) / "model.json"
+        path.write_text(json.dumps(incomplete), encoding="utf-8")
+        try:
+            load_product_model_v2(path)
+        except ProductModelV2Error as exc:
+            assert "generated-source cards must define every card-contract entry exactly once" in str(exc)
+        else:
+            raise AssertionError("an incomplete generated Product Model card source set must fail validation")
+    incomplete = copy.deepcopy(data)
+    incomplete["pilots"]["devices"].pop(
+        next(device_slug for device_slug in incomplete["pilots"]["devices"] if device_slug != data["equivalenceSamples"]["deviceSlug"])
+    )
+    with TemporaryDirectory() as directory:
+        path = Path(directory) / "model.json"
+        path.write_text(json.dumps(incomplete), encoding="utf-8")
+        try:
+            load_product_model_v2(path)
+        except ProductModelV2Error as exc:
+            assert "generated-source devices must define every device-catalog entry exactly once" in str(exc)
+        else:
+            raise AssertionError("an incomplete generated Product Model device source set must fail validation")
     print("Product Model v2 self-test passed.")
 
 

--- a/scripts/check_product_model_v2.py
+++ b/scripts/check_product_model_v2.py
@@ -70,6 +70,24 @@ def run_self_test() -> None:
             assert "pilots.cards must be a non-empty object" in str(exc)
         else:
             raise AssertionError("a generated pilot must define its sample card")
+    default_card = copy.deepcopy(data)
+    default_card["pilots"]["cards"][""] = default_card["pilots"]["cards"]["sensor"]
+    with TemporaryDirectory() as directory:
+        path = Path(directory) / "model.json"
+        path.write_text(json.dumps(default_card), encoding="utf-8")
+        model = load_product_model_v2(path)
+        assert "" in model.pilot_cards, "the default switch fallback must be a valid card pilot"
+    invalid = copy.deepcopy(data)
+    invalid["pilots"]["devices"][""] = invalid["pilots"]["devices"][next(iter(invalid["pilots"]["devices"]))]
+    with TemporaryDirectory() as directory:
+        path = Path(directory) / "model.json"
+        path.write_text(json.dumps(invalid), encoding="utf-8")
+        try:
+            load_product_model_v2(path)
+        except ProductModelV2Error as exc:
+            assert "pilots.devices identifiers must be non-empty strings" in str(exc)
+        else:
+            raise AssertionError("an unnamed device pilot must fail validation")
     print("Product Model v2 self-test passed.")
 
 

--- a/scripts/product_model_v2.py
+++ b/scripts/product_model_v2.py
@@ -183,7 +183,11 @@ def _pilot_sources(kind: str, data: Any) -> dict[str, Path]:
         raise ProductModelV2Error(f"pilots.{kind} must be a non-empty object")
     sources: dict[str, Path] = {}
     for identifier, path_value in data.items():
-        if not isinstance(identifier, str) or not identifier:
+        # The card contract's default switch is intentionally keyed by an
+        # empty string. It is a fallback entry, not a user-selectable card
+        # type, so allow it only for card pilots. Device identifiers must
+        # remain explicit non-empty slugs.
+        if not isinstance(identifier, str) or (not identifier and kind != "cards"):
             raise ProductModelV2Error(f"pilots.{kind} identifiers must be non-empty strings")
         if not isinstance(path_value, str) or not path_value:
             raise ProductModelV2Error(f"pilots.{kind}.{identifier} must be a non-empty path")

--- a/scripts/product_model_v2.py
+++ b/scripts/product_model_v2.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Load and validate Product Model v2, including its generated-source pilots.
+"""Load and validate Product Model v2, including its generated-source entries.
 
 The model makes current product ownership explicit without moving stable source
 files yet. Generators and validators can resolve their inputs through this
@@ -28,7 +28,7 @@ REQUIRED_SOURCES = {
     "translations": ("glob", "authored"),
     "compatibilityFixtures": ("file", "authored"),
 }
-PRODUCT_MODEL_STAGES = {"legacy-adapter", "generated-pilot"}
+PRODUCT_MODEL_STAGES = {"legacy-adapter", "generated-pilot", "generated-source"}
 
 
 class ProductModelV2Error(RuntimeError):
@@ -204,7 +204,9 @@ def load_product_model_v2(path: Path = PRODUCT_MODEL_V2_JSON) -> ProductModelV2:
         raise ProductModelV2Error(f"modelVersion must be {PRODUCT_MODEL_V2_VERSION}")
     stage = data.get("stage")
     if stage not in PRODUCT_MODEL_STAGES:
-        raise ProductModelV2Error("stage must be 'legacy-adapter' or 'generated-pilot'")
+        raise ProductModelV2Error(
+            "stage must be 'legacy-adapter', 'generated-pilot', or 'generated-source'"
+        )
     if not isinstance(data.get("description"), str) or not data["description"].strip():
         raise ProductModelV2Error("description must be a non-empty string")
     sources_data = data.get("sources")
@@ -231,11 +233,22 @@ def load_product_model_v2(path: Path = PRODUCT_MODEL_V2_JSON) -> ProductModelV2:
         pilot_devices: dict[str, Path] = {}
     else:
         if not isinstance(pilots, dict) or set(pilots) != {"cards", "devices"}:
-            raise ProductModelV2Error("generated-pilot models must declare cards and devices pilots")
+            raise ProductModelV2Error("generated Product Model sources must declare cards and devices pilots")
         pilot_cards = _pilot_sources("cards", pilots["cards"])
         pilot_devices = _pilot_sources("devices", pilots["devices"])
         if card_type not in pilot_cards or device_slug not in pilot_devices:
             raise ProductModelV2Error("equivalence samples must be Product Model pilot sources")
+        if stage == "generated-source":
+            contract_cards = _load_json(sources["cardContract"].path).get("cards")
+            catalog_devices = _load_json(sources["deviceCatalog"].path).get("devices")
+            if not isinstance(contract_cards, dict) or set(pilot_cards) != set(contract_cards):
+                raise ProductModelV2Error(
+                    "generated-source cards must define every card-contract entry exactly once"
+                )
+            if not isinstance(catalog_devices, dict) or set(pilot_devices) != set(catalog_devices):
+                raise ProductModelV2Error(
+                    "generated-source devices must define every device-catalog entry exactly once"
+                )
     return ProductModelV2(sources, card_type, device_slug, pilot_cards, pilot_devices)
 
 


### PR DESCRIPTION
## Summary
- make every card-contract entry and all supported device profiles canonical Product Model v2 sources
- promote Product Model v2 from generated pilot to generated source
- reject incomplete source sets so a new card or device cannot silently fall back to a legacy definition

## Practical impact
No runtime, generated-output, or saved-configuration behaviour changes. This is the complete Product Model ownership migration, with byte-for-byte parity against the existing generated contract and catalogue.

## Verification
- `npm run check:product`
- Product Model parity for every card-contract entry and all six supported device profiles
- Guardrail tests for missing card/device sources
- Generated-output freshness checks

## Device testing
Metadata and generation-boundary only. Representative on-device coverage remains the final 10-inch V1 end-to-end journey.