### PR TITLE
Prepare web assets for v2.8.0

### DIFF
--- a/docs/public/webserver/web-assets.json
+++ b/docs/public/webserver/web-assets.json
@@ -15,11 +15,11 @@
       ],
       "firmwareVersions": [
         "dev",
+        "v2.8.0",
         "v2.7.1",
         "v2.7.0",
         "v2.6.3",
-        "v2.6.2",
-        "v2.6.1"
+        "v2.6.2"
       ],
       "webAssetVersion": 1
     }

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -47,7 +47,12 @@ WEB_SOURCE_DIR = ROOT / "src" / "webserver"
 # current stable release and its four supported rollback releases. Keep this
 # list aligned with the GitHub Pages release catalogue in pages.yml.
 WEB_ASSET_SUPPORTED_FIRMWARE_VERSIONS = (
-    "dev", "v2.7.1", "v2.7.0", "v2.6.3", "v2.6.2", "v2.6.1",
+    "dev",
+    "v2.8.0",
+    "v2.7.1",
+    "v2.7.0",
+    "v2.6.3",
+    "v2.6.2",
 )
 
 # Fixed editor controls use a few MDI glyphs that are not selectable Product


### PR DESCRIPTION
## Purpose

Declares the immutable browser bundle compatible with the first qualifying stable dual-write release, v2.8.0.

## Practical impact

- Adds v2.8.0 to the hosted bridge compatibility list.
- Keeps the supported stable rollback window bounded by dropping v2.6.1.
- Does not change PanelConfig v1, backup v2, firmware APIs, or live configuration behavior.

## Automated checks

- Generated outputs rebuilt and `scripts/build.py --check` passed.
- Firmware host tests: 26/26 passed.
- Browser unit tests: 122/122 passed.
- Browser smoke, migration baseline, web-asset manifest, Product Model, and saved-config parity checks passed locally.
- Full release preflight will run in PR CI with a complete checkout; the local sparse worktree reached only missing sparse-only files after all preceding checks passed.

## Physical testing

No additional display flash is required for this metadata-only preparation PR. The source revision it follows passed the complete 10-inch V1 physical journey and full six-device compile matrix in #1654.