### PR TITLE
Retry timed out cover art reads safely

### DIFF
--- a/components/espcontrol/artwork_controller.h
+++ b/components/espcontrol/artwork_controller.h
@@ -196,6 +196,10 @@ constexpr bool artwork_timeout_exhaustion_preserves_current(
   return timeout_retry_exhausted && image_ready;
 }
 
+constexpr bool artwork_metadata_refresh_clears_retry(uint8_t retry_mask) {
+  return retry_mask != 0;
+}
+
 // Every active attribute-read batch needs a bounded deadline, including a
 // retry generation whose provider never invokes the queued callback.
 constexpr bool artwork_batch_needs_response_timer(bool batch_active,

--- a/components/espcontrol/artwork_controller.h
+++ b/components/espcontrol/artwork_controller.h
@@ -84,6 +84,10 @@ struct RefreshBatch {
            (this->received_mask & this->expected_mask) == this->expected_mask;
   }
 
+  uint8_t missing_mask() const {
+    return this->expected_mask & static_cast<uint8_t>(~this->received_mask);
+  }
+
   bool active() const { return this->expected_mask != 0; }
 
   bool finish() {
@@ -162,6 +166,19 @@ constexpr bool artwork_batch_waits_for_companion(bool batch_complete,
 constexpr bool artwork_empty_selection_preserves_pending_refresh(
     bool selection_empty, bool refresh_pending) {
   return selection_empty && refresh_pending;
+}
+
+constexpr bool artwork_empty_selection_preserves_retry(
+    bool selection_empty, uint8_t retry_mask) {
+  return selection_empty && retry_mask != 0;
+}
+
+constexpr uint8_t artwork_timeout_retry_mask(uint8_t current_retry_mask,
+                                             uint8_t missing_mask,
+                                             bool refresh_pending) {
+  return refresh_pending
+           ? 0
+           : static_cast<uint8_t>(current_retry_mask | missing_mask);
 }
 
 // Every active attribute-read batch needs a bounded deadline, including a

--- a/components/espcontrol/artwork_controller.h
+++ b/components/espcontrol/artwork_controller.h
@@ -186,6 +186,11 @@ constexpr bool artwork_pending_refresh_needs_reschedule(
   return refresh_pending && !timer_scheduled;
 }
 
+constexpr bool artwork_timeout_retry_allowed(uint8_t attempts,
+                                             uint8_t max_attempts) {
+  return attempts < max_attempts;
+}
+
 // Every active attribute-read batch needs a bounded deadline, including a
 // retry generation whose provider never invokes the queued callback.
 constexpr bool artwork_batch_needs_response_timer(bool batch_active,

--- a/components/espcontrol/artwork_controller.h
+++ b/components/espcontrol/artwork_controller.h
@@ -191,6 +191,11 @@ constexpr bool artwork_timeout_retry_allowed(uint8_t attempts,
   return attempts < max_attempts;
 }
 
+constexpr bool artwork_timeout_exhaustion_preserves_current(
+    bool timeout_retry_exhausted, bool image_ready) {
+  return timeout_retry_exhausted && image_ready;
+}
+
 // Every active attribute-read batch needs a bounded deadline, including a
 // retry generation whose provider never invokes the queued callback.
 constexpr bool artwork_batch_needs_response_timer(bool batch_active,

--- a/components/espcontrol/artwork_controller.h
+++ b/components/espcontrol/artwork_controller.h
@@ -175,10 +175,15 @@ constexpr bool artwork_empty_selection_preserves_retry(
 
 constexpr uint8_t artwork_timeout_retry_mask(uint8_t current_retry_mask,
                                              uint8_t missing_mask,
-                                             bool refresh_pending) {
-  return refresh_pending
+                                             bool replacement_refresh_scheduled) {
+  return replacement_refresh_scheduled
            ? 0
            : static_cast<uint8_t>(current_retry_mask | missing_mask);
+}
+
+constexpr bool artwork_pending_refresh_needs_reschedule(
+    bool refresh_pending, bool timer_scheduled) {
+  return refresh_pending && !timer_scheduled;
 }
 
 // Every active attribute-read batch needs a bounded deadline, including a

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -2368,6 +2368,12 @@ inline void image_card_schedule_media_artwork_refresh(ImageCardCtx *ctx,
 
 inline void image_card_refresh_media_artwork_on_metadata_change(ImageCardCtx *ctx) {
   if (!ctx || !ctx->active || !ctx->media_artwork) return;
+  if (espcontrol::artwork::artwork_metadata_refresh_clears_retry(
+        ctx->media_artwork_retry_mask)) {
+    ctx->media_artwork_retry_mask = 0;
+    ctx->media_artwork_timeout_retries = 0;
+    ctx->next_picture_retry_ms = 0;
+  }
   image_card_schedule_media_artwork_refresh(ctx, true);
 }
 

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -2131,14 +2131,27 @@ inline void image_card_process_media_artwork(ImageCardCtx *ctx,
     return;
   }
   if (response_window_expired) {
+    const bool replacement_refresh_scheduled =
+      ctx->media_artwork_trigger.pending &&
+      ctx->media_artwork_trigger_timer != nullptr;
     ctx->media_artwork_retry_mask = espcontrol::artwork::artwork_timeout_retry_mask(
       ctx->media_artwork_retry_mask,
       ctx->media_artwork_refresh.missing_mask(),
-      ctx->media_artwork_trigger.pending);
-    if (ctx->media_artwork_trigger.pending) ctx->next_picture_retry_ms = 0;
+      replacement_refresh_scheduled);
+    if (replacement_refresh_scheduled) ctx->next_picture_retry_ms = 0;
   }
   ctx->media_artwork_refresh.finish();
   ctx->media_artwork_remote_refresh_pending = false;
+  if (espcontrol::artwork::artwork_pending_refresh_needs_reschedule(
+        ctx->media_artwork_trigger.pending,
+        ctx->media_artwork_trigger_timer != nullptr)) {
+    const bool force_refresh = ctx->media_artwork_trigger.forced;
+    ctx->media_artwork_retry_mask = 0;
+    ctx->next_picture_retry_ms = 0;
+    image_card_schedule_media_artwork_refresh(ctx, force_refresh);
+    image_card_log_diagnostics(ctx, "media-artwork-pending-refresh-rescheduled");
+    return;
+  }
   if (ctx->media_artwork_retry_mask != 0) {
     image_card_schedule_picture_retry(
       ctx,

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -2130,11 +2130,26 @@ inline void image_card_process_media_artwork(ImageCardCtx *ctx,
     image_card_log_diagnostics(ctx, "media-artwork-waiting-for-companion");
     return;
   }
+  if (response_window_expired) {
+    ctx->media_artwork_retry_mask = espcontrol::artwork::artwork_timeout_retry_mask(
+      ctx->media_artwork_retry_mask,
+      ctx->media_artwork_refresh.missing_mask(),
+      ctx->media_artwork_trigger.pending);
+    if (ctx->media_artwork_trigger.pending) ctx->next_picture_retry_ms = 0;
+  }
   ctx->media_artwork_refresh.finish();
   ctx->media_artwork_remote_refresh_pending = false;
+  if (ctx->media_artwork_retry_mask != 0) {
+    image_card_schedule_picture_retry(
+      ctx,
+      ha_api_connected() ? IMAGE_CARD_API_RETRY_INTERVAL_MS : IMAGE_CARD_RETRY_INTERVAL_MS);
+    if (!ctx->image_ready) image_card_set_loading_state(ctx, "Loading", true);
+  }
   if (chosen.empty()) {
     if (espcontrol::artwork::artwork_empty_selection_preserves_pending_refresh(
-          true, ctx->media_artwork_trigger.pending)) {
+          true, ctx->media_artwork_trigger.pending) ||
+        espcontrol::artwork::artwork_empty_selection_preserves_retry(
+          true, ctx->media_artwork_retry_mask)) {
       image_card_log_diagnostics(ctx, "media-artwork-pending-refresh-preserved");
       return;
     }

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -25,6 +25,7 @@ constexpr uint32_t IMAGE_CARD_MODAL_CLEANUP_DELAY_MS = 100;
 constexpr uint32_t IMAGE_CARD_MODAL_CLOSE_GUARD_MS = 350;
 constexpr uint32_t IMAGE_CARD_MEDIA_ARTWORK_TRIGGER_DEBOUNCE_MS = 75;
 constexpr uint32_t IMAGE_CARD_MEDIA_ARTWORK_RESPONSE_DEBOUNCE_MS = 300;
+constexpr uint8_t IMAGE_CARD_MEDIA_ARTWORK_MAX_TIMEOUT_RETRIES = 3;
 constexpr uint8_t IMAGE_CARD_STARTUP_DOWNLOAD_RETRIES = 10;
 constexpr int IMAGE_CARD_MAX_CONTEXTS = 6;
 constexpr int IMAGE_CARD_MODAL_MAX_TARGET_SIDE_PX = 800;
@@ -82,6 +83,7 @@ struct ImageCardCtx {
   espcontrol::artwork::RefreshBatch media_artwork_refresh;
   espcontrol::artwork::RefreshTrigger media_artwork_trigger;
   uint8_t media_artwork_retry_mask = 0;
+  uint8_t media_artwork_timeout_retries = 0;
   lv_timer_t *media_artwork_trigger_timer = nullptr;
   lv_timer_t *media_artwork_timer = nullptr;
   lv_timer_t *modal_cleanup_timer = nullptr;
@@ -527,6 +529,7 @@ inline void image_card_clear_media_artwork(ImageCardCtx *ctx) {
   ctx->media_artwork_refresh.reset();
   ctx->media_artwork_trigger.reset();
   ctx->media_artwork_retry_mask = 0;
+  ctx->media_artwork_timeout_retries = 0;
   ctx->media_artwork_refresh_forced = false;
   ctx->media_artwork_remote_refresh_pending = false;
   if (ctx->media_artwork_trigger_timer) {
@@ -885,6 +888,7 @@ inline void reset_image_card_pool(const GridConfig &cfg) {
     contexts[i].media_artwork_refresh.reset();
     contexts[i].media_artwork_trigger.reset();
     contexts[i].media_artwork_retry_mask = 0;
+    contexts[i].media_artwork_timeout_retries = 0;
     if (contexts[i].media_artwork_trigger_timer) {
       lv_timer_del(contexts[i].media_artwork_trigger_timer);
       contexts[i].media_artwork_trigger_timer = nullptr;
@@ -1491,6 +1495,7 @@ inline void image_card_refresh_current_picture(ImageCardCtx *ctx) {
   if (!ctx) return;
   if (ctx->media_artwork) {
     ctx->media_artwork_retry_mask = 0;
+    ctx->media_artwork_timeout_retries = 0;
     ctx->pending_fallback_picture.clear();
     // Explicit recovery refreshes (notably after reconnect) supersede an
     // incomplete batch whose callbacks may have been lost with the old API
@@ -2125,21 +2130,34 @@ inline void image_card_process_media_artwork(ImageCardCtx *ctx,
   const espcontrol::artwork::SourceSelection selection =
       ctx->media_artwork_sources.select(ctx->source_url, prefer_refreshed_remote);
   const std::string &chosen = selection.primary;
+  bool timeout_retry_exhausted = false;
   if (espcontrol::artwork::artwork_batch_waits_for_companion(
           batch_complete, chosen.empty(), response_window_expired)) {
     image_card_log_diagnostics(ctx, "media-artwork-waiting-for-companion");
     return;
   }
   if (response_window_expired) {
+    const uint8_t missing_mask = ctx->media_artwork_refresh.missing_mask();
     const bool replacement_refresh_scheduled =
       ctx->media_artwork_trigger.pending &&
       ctx->media_artwork_trigger_timer != nullptr;
-    ctx->media_artwork_retry_mask = espcontrol::artwork::artwork_timeout_retry_mask(
-      ctx->media_artwork_retry_mask,
-      ctx->media_artwork_refresh.missing_mask(),
-      replacement_refresh_scheduled);
+    if (replacement_refresh_scheduled) {
+      ctx->media_artwork_retry_mask = 0;
+    } else if (missing_mask != 0 &&
+               espcontrol::artwork::artwork_timeout_retry_allowed(
+                 ctx->media_artwork_timeout_retries,
+                 IMAGE_CARD_MEDIA_ARTWORK_MAX_TIMEOUT_RETRIES)) {
+      ctx->media_artwork_retry_mask = espcontrol::artwork::artwork_timeout_retry_mask(
+        ctx->media_artwork_retry_mask, missing_mask, false);
+      ++ctx->media_artwork_timeout_retries;
+    } else if (missing_mask != 0) {
+      ctx->media_artwork_retry_mask = 0;
+      ctx->next_picture_retry_ms = 0;
+      timeout_retry_exhausted = true;
+    }
     if (replacement_refresh_scheduled) ctx->next_picture_retry_ms = 0;
   }
+  if (batch_complete) ctx->media_artwork_timeout_retries = 0;
   ctx->media_artwork_refresh.finish();
   ctx->media_artwork_remote_refresh_pending = false;
   if (espcontrol::artwork::artwork_pending_refresh_needs_reschedule(
@@ -2162,7 +2180,7 @@ inline void image_card_process_media_artwork(ImageCardCtx *ctx,
     if (espcontrol::artwork::artwork_empty_selection_preserves_pending_refresh(
           true, ctx->media_artwork_trigger.pending) ||
         espcontrol::artwork::artwork_empty_selection_preserves_retry(
-          true, ctx->media_artwork_retry_mask)) {
+          true, ctx->media_artwork_retry_mask) || timeout_retry_exhausted) {
       image_card_log_diagnostics(ctx, "media-artwork-pending-refresh-preserved");
       return;
     }
@@ -2246,6 +2264,8 @@ inline void image_card_request_media_artwork(ImageCardCtx *ctx, bool force_refre
   const uint32_t generation = ha_subscription_generation();
   uint8_t request_mask = espcontrol::artwork::artwork_source_request_mask(
     ctx->media_artwork_retry_mask);
+  const bool retry_request = ctx->media_artwork_retry_mask != 0;
+  if (!retry_request) ctx->media_artwork_timeout_retries = 0;
   const bool refresh_forced = espcontrol::artwork::artwork_refresh_forced(
     ctx->media_artwork_refresh.forced,
     ctx->media_artwork_refresh_forced,
@@ -2428,6 +2448,7 @@ inline bool image_card_bind_runtime(BtnSlot &s, const ParsedCfg &p,
   ctx->media_overlay = nullptr;
   ctx->pending_fallback_picture.clear();
   ctx->media_artwork_retry_mask = 0;
+  ctx->media_artwork_timeout_retries = 0;
   ctx->diagnostics_enabled = cfg.image_card_diagnostics;
   ctx->retry_deadline_ms = esphome::millis() + IMAGE_CARD_STARTUP_RETRY_MS;
   ctx->width_compensation_percent = cfg.width_compensation_percent;

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -2177,10 +2177,18 @@ inline void image_card_process_media_artwork(ImageCardCtx *ctx,
     if (!ctx->image_ready) image_card_set_loading_state(ctx, "Loading", true);
   }
   if (chosen.empty()) {
+    if (timeout_retry_exhausted && !ctx->image_ready) {
+      image_card_clear_media_artwork(ctx);
+      image_card_set_loading_state(ctx, "Unavailable", true);
+      image_card_log_diagnostics(ctx, "media-artwork-timeout-unavailable");
+      return;
+    }
     if (espcontrol::artwork::artwork_empty_selection_preserves_pending_refresh(
           true, ctx->media_artwork_trigger.pending) ||
         espcontrol::artwork::artwork_empty_selection_preserves_retry(
-          true, ctx->media_artwork_retry_mask) || timeout_retry_exhausted) {
+          true, ctx->media_artwork_retry_mask) ||
+        espcontrol::artwork::artwork_timeout_exhaustion_preserves_current(
+          timeout_retry_exhausted, ctx->image_ready)) {
       image_card_log_diagnostics(ctx, "media-artwork-pending-refresh-preserved");
       return;
     }

--- a/tests/firmware/artwork_controller_test.cpp
+++ b/tests/firmware/artwork_controller_test.cpp
@@ -20,6 +20,7 @@ using espcontrol::artwork::artwork_empty_selection_preserves_pending_refresh;
 using espcontrol::artwork::artwork_empty_selection_preserves_retry;
 using espcontrol::artwork::artwork_timeout_retry_mask;
 using espcontrol::artwork::artwork_pending_refresh_needs_reschedule;
+using espcontrol::artwork::artwork_timeout_retry_allowed;
 using espcontrol::artwork::artwork_refresh_forced;
 using espcontrol::artwork::artwork_response_needs_processing;
 using espcontrol::artwork::artwork_selection_needs_download;
@@ -113,6 +114,9 @@ int main() {
   assert(artwork_pending_refresh_needs_reschedule(true, false));
   assert(!artwork_pending_refresh_needs_reschedule(true, true));
   assert(!artwork_pending_refresh_needs_reschedule(false, false));
+  assert(artwork_timeout_retry_allowed(0, 3));
+  assert(artwork_timeout_retry_allowed(2, 3));
+  assert(!artwork_timeout_retry_allowed(3, 3));
   assert(artwork_batch_needs_response_timer(true, false));
   assert(!artwork_batch_needs_response_timer(true, true));
   assert(!artwork_batch_needs_response_timer(false, false));

--- a/tests/firmware/artwork_controller_test.cpp
+++ b/tests/firmware/artwork_controller_test.cpp
@@ -19,6 +19,7 @@ using espcontrol::artwork::artwork_batch_needs_response_timer;
 using espcontrol::artwork::artwork_empty_selection_preserves_pending_refresh;
 using espcontrol::artwork::artwork_empty_selection_preserves_retry;
 using espcontrol::artwork::artwork_timeout_retry_mask;
+using espcontrol::artwork::artwork_pending_refresh_needs_reschedule;
 using espcontrol::artwork::artwork_refresh_forced;
 using espcontrol::artwork::artwork_response_needs_processing;
 using espcontrol::artwork::artwork_selection_needs_download;
@@ -109,6 +110,9 @@ int main() {
          ARTWORK_SOURCE_BOTH);
   assert(artwork_timeout_retry_mask(ARTWORK_SOURCE_LOCAL,
                                     ARTWORK_SOURCE_REMOTE, true) == 0);
+  assert(artwork_pending_refresh_needs_reschedule(true, false));
+  assert(!artwork_pending_refresh_needs_reschedule(true, true));
+  assert(!artwork_pending_refresh_needs_reschedule(false, false));
   assert(artwork_batch_needs_response_timer(true, false));
   assert(!artwork_batch_needs_response_timer(true, true));
   assert(!artwork_batch_needs_response_timer(false, false));

--- a/tests/firmware/artwork_controller_test.cpp
+++ b/tests/firmware/artwork_controller_test.cpp
@@ -21,6 +21,7 @@ using espcontrol::artwork::artwork_empty_selection_preserves_retry;
 using espcontrol::artwork::artwork_timeout_retry_mask;
 using espcontrol::artwork::artwork_pending_refresh_needs_reschedule;
 using espcontrol::artwork::artwork_timeout_retry_allowed;
+using espcontrol::artwork::artwork_timeout_exhaustion_preserves_current;
 using espcontrol::artwork::artwork_refresh_forced;
 using espcontrol::artwork::artwork_response_needs_processing;
 using espcontrol::artwork::artwork_selection_needs_download;
@@ -117,6 +118,9 @@ int main() {
   assert(artwork_timeout_retry_allowed(0, 3));
   assert(artwork_timeout_retry_allowed(2, 3));
   assert(!artwork_timeout_retry_allowed(3, 3));
+  assert(artwork_timeout_exhaustion_preserves_current(true, true));
+  assert(!artwork_timeout_exhaustion_preserves_current(true, false));
+  assert(!artwork_timeout_exhaustion_preserves_current(false, true));
   assert(artwork_batch_needs_response_timer(true, false));
   assert(!artwork_batch_needs_response_timer(true, true));
   assert(!artwork_batch_needs_response_timer(false, false));

--- a/tests/firmware/artwork_controller_test.cpp
+++ b/tests/firmware/artwork_controller_test.cpp
@@ -17,6 +17,8 @@ using espcontrol::artwork::artwork_picture_response_clears_retry;
 using espcontrol::artwork::artwork_batch_waits_for_companion;
 using espcontrol::artwork::artwork_batch_needs_response_timer;
 using espcontrol::artwork::artwork_empty_selection_preserves_pending_refresh;
+using espcontrol::artwork::artwork_empty_selection_preserves_retry;
+using espcontrol::artwork::artwork_timeout_retry_mask;
 using espcontrol::artwork::artwork_refresh_forced;
 using espcontrol::artwork::artwork_response_needs_processing;
 using espcontrol::artwork::artwork_selection_needs_download;
@@ -97,6 +99,16 @@ int main() {
   assert(artwork_empty_selection_preserves_pending_refresh(true, true));
   assert(!artwork_empty_selection_preserves_pending_refresh(true, false));
   assert(!artwork_empty_selection_preserves_pending_refresh(false, true));
+  assert(artwork_empty_selection_preserves_retry(true, ARTWORK_SOURCE_REMOTE));
+  assert(!artwork_empty_selection_preserves_retry(true, 0));
+  assert(!artwork_empty_selection_preserves_retry(false, ARTWORK_SOURCE_REMOTE));
+  assert(artwork_timeout_retry_mask(0, ARTWORK_SOURCE_REMOTE, false) ==
+         ARTWORK_SOURCE_REMOTE);
+  assert(artwork_timeout_retry_mask(ARTWORK_SOURCE_LOCAL,
+                                    ARTWORK_SOURCE_REMOTE, false) ==
+         ARTWORK_SOURCE_BOTH);
+  assert(artwork_timeout_retry_mask(ARTWORK_SOURCE_LOCAL,
+                                    ARTWORK_SOURCE_REMOTE, true) == 0);
   assert(artwork_batch_needs_response_timer(true, false));
   assert(!artwork_batch_needs_response_timer(true, true));
   assert(!artwork_batch_needs_response_timer(false, false));
@@ -185,8 +197,18 @@ int main() {
   // companion must not replace the selected artwork mid-download.
   const uint32_t timed_out_read = batch.begin(ARTWORK_SOURCE_BOTH, false);
   assert(batch.receive(timed_out_read, false));
+  assert(batch.missing_mask() == ARTWORK_SOURCE_LOCAL);
   assert(batch.finish());
   assert(!batch.receive(timed_out_read, true));
+
+  // A queued provider that never invokes its callback remains eligible for a
+  // bounded retry instead of being treated as an authoritative empty result.
+  const uint32_t stalled_read = batch.begin(ARTWORK_SOURCE_BOTH, false);
+  assert(stalled_read != timed_out_read);
+  assert(batch.missing_mask() == ARTWORK_SOURCE_BOTH);
+  assert(batch.receive(stalled_read, true));
+  assert(batch.missing_mask() == ARTWORK_SOURCE_REMOTE);
+  assert(batch.finish());
 
   // Partial retry reads track only the failed source and complete after that
   // one response, preserving the existing source as the fallback.

--- a/tests/firmware/artwork_controller_test.cpp
+++ b/tests/firmware/artwork_controller_test.cpp
@@ -22,6 +22,7 @@ using espcontrol::artwork::artwork_timeout_retry_mask;
 using espcontrol::artwork::artwork_pending_refresh_needs_reschedule;
 using espcontrol::artwork::artwork_timeout_retry_allowed;
 using espcontrol::artwork::artwork_timeout_exhaustion_preserves_current;
+using espcontrol::artwork::artwork_metadata_refresh_clears_retry;
 using espcontrol::artwork::artwork_refresh_forced;
 using espcontrol::artwork::artwork_response_needs_processing;
 using espcontrol::artwork::artwork_selection_needs_download;
@@ -121,6 +122,9 @@ int main() {
   assert(artwork_timeout_exhaustion_preserves_current(true, true));
   assert(!artwork_timeout_exhaustion_preserves_current(true, false));
   assert(!artwork_timeout_exhaustion_preserves_current(false, true));
+  assert(artwork_metadata_refresh_clears_retry(ARTWORK_SOURCE_REMOTE));
+  assert(artwork_metadata_refresh_clears_retry(ARTWORK_SOURCE_BOTH));
+  assert(!artwork_metadata_refresh_clears_retry(0));
   assert(artwork_batch_needs_response_timer(true, false));
   assert(!artwork_batch_needs_response_timer(true, true));
   assert(!artwork_batch_needs_response_timer(false, false));


### PR DESCRIPTION
## Purpose

Follow up the merged cover-art recovery with the two timeout safeguards identified by review: slow Home Assistant callbacks and reads that fail to queue must not be treated as authoritative empty artwork.

## Practical impact

- preserves the current cover art while a missing source is retried
- retries every requested source that has not answered when the response window expires
- retains queue-failure retries instead of clearing their timer
- lets a newer metadata refresh supersede an older retry with a complete fresh read

## Automated checks

- all 26 firmware host tests pass
- targeted artwork tests cover missing-source masks, stalled callbacks, preserved retries, and pending-refresh supersession
- `git diff --check` passes

## Physical device testing

- Not yet tested with this follow-up commit.
- The immediately preceding merged revision was flashed successfully to the 7-inch P4 at 192.168.6.102 and verified for OTA restart, Home Assistant API, Wi-Fi, restored configuration, and web server HTTP 200.
- This PR still requires the exact-head six-device compile matrix and a final 7-inch flash before merge.