### PR TITLE
Restore cover art after card reloads

### DIFF
--- a/components/artwork_image/artwork_image.h
+++ b/components/artwork_image/artwork_image.h
@@ -138,6 +138,8 @@ class ArtworkImage : public PollingComponent,
     std::function<void()> cb(std::forward<F>(callback));
     if (cb) this->download_error_callback_.add(std::move(cb));
   }
+  bool has_on_finished_callbacks() const { return this->download_finished_callback_.size() != 0; }
+  bool has_on_error_callbacks() const { return this->download_error_callback_.size() != 0; }
 
   bool is_big_endian() const { return this->is_big_endian_; }
   bool hardware_acceleration_enabled() const { return this->hardware_acceleration_enabled_; }

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -63,7 +63,7 @@ struct ImageCardCtx {
   int width_compensation_percent = 100;
   int media_artwork_width_compensation_percent = 100;
   bool active = false;
-  bool callbacks_bound = false;
+  esphome::artwork_image::ArtworkImage *callbacks_bound_image = nullptr;
   bool requested_once = false;
   bool image_ready = false;
   bool download_active = false;
@@ -793,14 +793,20 @@ inline void image_card_handle_modal_download_error(ImageCardCtx *ctx) {
 }
 
 inline void image_card_bind_callbacks(ImageCardCtx *ctx) {
-  if (!ctx || !ctx->image || ctx->callbacks_bound) return;
-  ctx->callbacks_bound = true;
-  ctx->image->add_on_finished_callback([ctx](bool) {
-    image_card_apply_downloaded(ctx);
-  });
-  ctx->image->add_on_error_callback([ctx]() {
-    image_card_handle_download_error(ctx);
-  });
+  if (!ctx || !ctx->image) return;
+  auto *bound_image = ctx->image;
+  bool image_changed = ctx->callbacks_bound_image != bound_image;
+  if (image_changed || !bound_image->has_on_finished_callbacks()) {
+    bound_image->add_on_finished_callback([ctx, bound_image](bool) {
+      if (ctx->image == bound_image) image_card_apply_downloaded(ctx);
+    });
+  }
+  if (image_changed || !bound_image->has_on_error_callbacks()) {
+    bound_image->add_on_error_callback([ctx, bound_image]() {
+      if (ctx->image == bound_image) image_card_handle_download_error(ctx);
+    });
+  }
+  ctx->callbacks_bound_image = bound_image;
 }
 
 inline void image_card_bind_modal_callbacks(

--- a/scripts/check_firmware_card_runtime.py
+++ b/scripts/check_firmware_card_runtime.py
@@ -475,6 +475,17 @@ def check_root(root: Path) -> list[str]:
             failures.append(
                 f"components/espcontrol/{IMAGE_HEADER}: reset every image-card context, including disabled slots"
             )
+        callback_body = function_body(text, "image_card_bind_callbacks")
+        callback_guards = (
+            "callbacks_bound_image != bound_image",
+            "has_on_finished_callbacks()",
+            "has_on_error_callbacks()",
+            "ctx->image == bound_image",
+        )
+        if callback_body is None or any(guard not in callback_body for guard in callback_guards):
+            failures.append(
+                f"components/espcontrol/{IMAGE_HEADER}: rebind image completion callbacks after image-card lifecycle changes"
+            )
     status_entity_header = root / "components" / "espcontrol" / STATUS_ENTITY_HEADER
     if status_entity_header.exists():
         text = status_entity_header.read_text(encoding="utf-8")
@@ -1423,6 +1434,24 @@ inline void setup_light_temp_visual() {
         (
             {
                 "button_grid_image.h": (
+                    "inline void reset_image_card_pool(const GridConfig &cfg) {\n"
+                    "  for (int i = 0; i < IMAGE_CARD_MAX_CONTEXTS; i++) {}\n"
+                    "}\n"
+                )
+            },
+            ("rebind image completion callbacks after image-card lifecycle changes",),
+        ),
+        (
+            {
+                "button_grid_image.h": (
+                    "inline void image_card_bind_callbacks(ImageCardCtx *ctx) {\n"
+                    "  auto *bound_image = ctx->image;\n"
+                    "  bool changed = ctx->callbacks_bound_image != bound_image;\n"
+                    "  if (changed || !bound_image->has_on_finished_callbacks()) {\n"
+                    "    if (ctx->image == bound_image) {}\n"
+                    "  }\n"
+                    "  if (changed || !bound_image->has_on_error_callbacks()) {}\n"
+                    "}\n"
                     "inline void reset_image_card_pool(const GridConfig &cfg) {\n"
                     "  for (int i = 0; i < IMAGE_CARD_MAX_CONTEXTS; i++) {}\n"
                     "}\n"


### PR DESCRIPTION
## Purpose

Restore cover art images when a live card/configuration rebuild leaves the image downloader without its completion callbacks.

## Practical impact

Cover art cards reconnect their completion and error handlers to the current downloader. Callbacks from an older downloader are ignored, preventing stale images from updating a rebuilt card.

## Automated checks

- Complete repository CI and generated-output validation
- All 26 firmware host tests
- 105 browser tests and cover-art contract checks
- Full six-profile firmware matrix, including P4 recovery builds:
  - 7-inch P4
  - 4.3-inch P4
  - 10-inch P4 V1
  - 10-inch P4 V2
  - P4-86
  - 4-inch S3

## Physical device testing

Flashed to the 10-inch V1 at 192.168.6.103. It reconnected to Home Assistant and the web server, downloaded and decoded the configured media_player.office artwork, completed the restored card callback path, and remained online for over 45 minutes.