### PR TITLE
Bound Home Assistant artwork reads

### DIFF
--- a/common/device/core_infra.yaml
+++ b/common/device/core_infra.yaml
@@ -89,6 +89,7 @@ api:
         if (!is_home_assistant && ha_api_state_connected()) {
           return;
         }
+        ha_invalidate_retained_state();
         weather_forecast_cancel_pending_requests();
         cover_stop_cancel_pending_request();
         todo_cancel_pending_request("api disconnected");

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -467,7 +467,9 @@ inline void subscribe_media_cover_art(MediaNowPlayingCtx *ctx,
         // to obtain a matching remote/local pair instead of downloading from
         // this individual notification.
         image_card_schedule_media_artwork_refresh(art);
-      })
+      }),
+    HA_SUBSCRIPTION_SCOPE_DEFAULT,
+    true
   );
   ha_subscribe_attribute(
     entity_id,
@@ -487,7 +489,9 @@ inline void subscribe_media_cover_art(MediaNowPlayingCtx *ctx,
         // See the remote callback above: one notification starts one paired
         // refresh, which prevents either attribute winning by arrival order.
         image_card_schedule_media_artwork_refresh(art);
-      })
+      }),
+    HA_SUBSCRIPTION_SCOPE_DEFAULT,
+    true
   );
   subscribe_image_card_access_token(art, entity_id);
   image_card_schedule_media_artwork_refresh(art);

--- a/components/espcontrol/button_grid_ha.h
+++ b/components/espcontrol/button_grid_ha.h
@@ -288,8 +288,10 @@ inline bool ha_get_state(const std::string &entity_id,
 inline bool ha_subscribe_attribute(const std::string &entity_id,
                                    const std::string &attribute,
                                    HomeAssistantStateCallback callback,
-                                   uint32_t scope = HA_SUBSCRIPTION_SCOPE_DEFAULT) {
-  return ha_read_coordinator().subscribe(entity_id, attribute, std::move(callback), scope, ha_callback_owner());
+                                   uint32_t scope = HA_SUBSCRIPTION_SCOPE_DEFAULT,
+                                   bool retain_latest = false) {
+  return ha_read_coordinator().subscribe(
+      entity_id, attribute, std::move(callback), scope, ha_callback_owner(), retain_latest);
 }
 
 inline bool ha_get_attribute(const std::string &entity_id,

--- a/components/espcontrol/button_grid_ha.h
+++ b/components/espcontrol/button_grid_ha.h
@@ -151,6 +151,10 @@ inline void ha_reset_deferred_state_requests() {
 }
 #define ESPCONTROL_HA_DEFERRED_HELPERS_DEFINED 1
 
+inline void ha_invalidate_retained_state() {
+  ha_read_coordinator().invalidate_retained_state();
+}
+
 inline void bump_ha_subscription_generation() {
   ha_read_coordinator().bump_generation(
       HA_SUBSCRIPTION_SCOPE_DEFAULT | HA_SUBSCRIPTION_SCOPE_COVER_ART_PROGRESS);

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -2237,6 +2237,10 @@ inline void image_card_handle_media_artwork_picture(ImageCardCtx *ctx,
     ctx->media_artwork_retry_mask, local);
   std::string raw = string_ref_limited(picture, 4096);
   std::string url = image_card_join_url(image_card_base_url(ctx), raw);
+  ESP_LOGD("image_card", "Artwork %s response for %s: value=%s base_url=%s",
+           local ? "local" : "remote", ctx->entity_id.c_str(),
+           raw.empty() || raw == "unknown" || raw == "unavailable" ? "empty" : "present",
+           image_card_base_url(ctx).empty() ? "missing" : "ready");
   // These two attribute requests run independently. A delayed remote callback
   // must not discard a newer local proxy URL that has already arrived.
   bool source_changed = ctx->media_artwork_sources.update(
@@ -2300,6 +2304,9 @@ inline void image_card_request_media_artwork(ImageCardCtx *ctx, bool force_refre
   }
   const uint32_t request_generation = ctx->media_artwork_refresh.begin(
     request_mask, refresh_forced);
+  ESP_LOGD("image_card", "Requesting artwork pair for %s: mask=%u forced=%d state_connected=%d",
+           entity_id.c_str(), static_cast<unsigned>(request_mask), refresh_forced,
+           ha_api_state_connected());
   bool remote_queued = true;
   if ((request_mask & espcontrol::artwork::ARTWORK_SOURCE_REMOTE) != 0) {
     remote_queued = ha_get_attribute(

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -1666,7 +1666,9 @@ inline void subscribe_image_card_access_token(ImageCardCtx *ctx,
         if (token == ctx->access_token) return;
         ctx->access_token = token;
         image_card_request_picture(ctx);
-      })
+      }),
+    HA_SUBSCRIPTION_SCOPE_DEFAULT,
+    true
   );
 }
 
@@ -2516,7 +2518,9 @@ inline bool image_card_bind_runtime(BtnSlot &s, const ParsedCfg &p,
       [ctx, image_card_entity_id, image_card_generation](esphome::StringRef picture) {
         if (!image_card_context_current(ctx, image_card_entity_id, image_card_generation)) return;
         image_card_handle_picture(ctx, picture);
-      })
+      }),
+    HA_SUBSCRIPTION_SCOPE_DEFAULT,
+    true
   );
   subscribe_image_card_access_token(ctx, image_card_entity_id);
   subscribe_image_card_entity_state(ctx, p.entity);

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -1463,7 +1463,9 @@ inline void media_playback_subscribe_metadata(MediaPlaybackState *state) {
     std::function<void(esphome::StringRef)>(
       [state, generation](esphome::StringRef value) {
         media_playback_set_artist(state, generation, value);
-      })
+      }),
+    HA_SUBSCRIPTION_SCOPE_DEFAULT,
+    true
   );
 
   media_playback_subscribe_source(state);
@@ -1487,7 +1489,9 @@ inline void media_playback_subscribe_source(MediaPlaybackState *state) {
   };
   ha_subscribe_attribute(
     entity_id, std::string("source"),
-    std::function<void(esphome::StringRef)>(handle_media_source)
+    std::function<void(esphome::StringRef)>(handle_media_source),
+    HA_SUBSCRIPTION_SCOPE_DEFAULT,
+    true
   );
   ha_get_attribute(entity_id, std::string("source"), handle_media_source);
 }

--- a/components/espcontrol/ha_read_coordinator.h
+++ b/components/espcontrol/ha_read_coordinator.h
@@ -102,6 +102,16 @@ class HaReadCoordinator {
     std::vector<DeferredRequest>().swap(deferred_);
   }
 
+  void invalidate_retained_state() {
+    // Retained values are scoped to one Home Assistant API connection.  In
+    // particular, artwork URLs and access tokens may change while the panel is
+    // offline, so reads after a reconnect must wait for a fresh announcement.
+    for (auto &channel : subscription_channels_) {
+      channel.cached_state.clear();
+      channel.has_cached_state = false;
+    }
+  }
+
   void reset_subscriptions(uint32_t scope = 0) {
     if (callback_depth_ != 0) {
       pending_reset_mask_ = scope == 0 ? UINT32_MAX : (pending_reset_mask_ | scope);

--- a/components/espcontrol/ha_read_coordinator.h
+++ b/components/espcontrol/ha_read_coordinator.h
@@ -175,6 +175,7 @@ class HaReadCoordinator {
   };
 
   static constexpr size_t MAX_DEFERRED_REQUESTS = 64;
+  static constexpr size_t MAX_PENDING_CHANNEL_READS = 64;
 
   uint32_t owner_generation(void *owner) {
     if (!owner) return 0;
@@ -252,7 +253,7 @@ class HaReadCoordinator {
         }
       } else {
         for (auto &callback_ref : callbacks) {
-          subscription.pending_reads.push_back(std::move(callback_ref));
+          queue_pending_channel_read(subscription, std::move(callback_ref));
         }
       }
       return;
@@ -336,9 +337,26 @@ class HaReadCoordinator {
       State state(subscription.cached_state);
       if (owner_generation_current(callback_ref)) invoke(callback_ref.callback, state);
     } else {
-      subscription.pending_reads.push_back(std::move(callback_ref));
+      queue_pending_channel_read(subscription, std::move(callback_ref));
     }
     return true;
+  }
+
+  void queue_pending_channel_read(SubscriptionChannel &subscription,
+                                  CallbackRef callback_ref) {
+    // Repeated refreshes for one card supersede its earlier pending callback.
+    // Keep distinct card owners independent, but cap them as a final guard
+    // against a channel that Home Assistant never publishes.
+    for (auto &pending : subscription.pending_reads) {
+      if (pending.owner == callback_ref.owner) {
+        pending = std::move(callback_ref);
+        return;
+      }
+    }
+    if (subscription.pending_reads.size() >= MAX_PENDING_CHANNEL_READS) {
+      subscription.pending_reads.erase(subscription.pending_reads.begin());
+    }
+    subscription.pending_reads.push_back(std::move(callback_ref));
   }
 
   bool channel_reuses_reads(size_t channel) const {

--- a/components/espcontrol/ha_read_coordinator.h
+++ b/components/espcontrol/ha_read_coordinator.h
@@ -51,7 +51,8 @@ class HaReadCoordinator {
                  const std::string &attribute,
                  Callback callback,
                  uint32_t scope,
-                 void *owner = nullptr) {
+                 void *owner = nullptr,
+                 bool retain_latest = false) {
     if (!available() || entity_id.empty() || !callback) return false;
     auto callback_ref = std::make_shared<Callback>(std::move(callback));
     size_t channel = subscription_channels_.size();
@@ -71,7 +72,7 @@ class HaReadCoordinator {
           entity_id, attribute,
           [this, channel](State state) { invoke_subscription_channel(channel, state); });
     }
-    subscriptions_.push_back({callback_ref, scope, owner, channel});
+    subscriptions_.push_back({callback_ref, scope, owner, channel, retain_latest});
     return true;
   }
 
@@ -162,6 +163,7 @@ class HaReadCoordinator {
     uint32_t scope = 0;
     void *owner = nullptr;
     size_t channel = 0;
+    bool retain_latest = false;
   };
 
   struct SubscriptionChannel {
@@ -241,7 +243,7 @@ class HaReadCoordinator {
                      bool has_attribute,
                      uint32_t generation) {
     size_t channel = find_subscription_channel(entity_id, attribute, has_attribute);
-    if (channel != subscription_channels_.size()) {
+    if (channel != subscription_channels_.size() && channel_reuses_reads(channel)) {
       auto &subscription = subscription_channels_[channel];
       if (subscription.has_cached_state) {
         State state(subscription.cached_state);
@@ -286,16 +288,23 @@ class HaReadCoordinator {
   void invoke_subscription_channel(size_t channel, State state) {
     if (channel >= subscription_channels_.size()) return;
     SubscriptionChannel &subscription = subscription_channels_[channel];
-    subscription.cached_state.assign(state.c_str(), state.size());
-    subscription.has_cached_state = true;
     std::vector<CallbackRef> pending_reads;
     pending_reads.swap(subscription.pending_reads);
     std::vector<std::shared_ptr<Callback>> callbacks;
     callbacks.reserve(subscriptions_.size());
+    bool retain_latest = false;
     for (const auto &ref : subscriptions_) {
       if (ref.channel == channel && ref.callback && *ref.callback) {
         callbacks.push_back(ref.callback);
+        retain_latest = retain_latest || ref.retain_latest;
       }
+    }
+    if (retain_latest) {
+      subscription.cached_state.assign(state.c_str(), state.size());
+      subscription.has_cached_state = true;
+    } else {
+      subscription.cached_state.clear();
+      subscription.has_cached_state = false;
     }
     for (const auto &callback_ref : pending_reads) {
       if (owner_generation_current(callback_ref)) invoke(callback_ref.callback, state);
@@ -321,7 +330,7 @@ class HaReadCoordinator {
                                       CallbackRef callback_ref,
                                       bool has_attribute) {
     size_t channel = find_subscription_channel(entity_id, attribute, has_attribute);
-    if (channel == subscription_channels_.size()) return false;
+    if (channel == subscription_channels_.size() || !channel_reuses_reads(channel)) return false;
     SubscriptionChannel &subscription = subscription_channels_[channel];
     if (subscription.has_cached_state) {
       State state(subscription.cached_state);
@@ -330,6 +339,23 @@ class HaReadCoordinator {
       subscription.pending_reads.push_back(std::move(callback_ref));
     }
     return true;
+  }
+
+  bool channel_reuses_reads(size_t channel) const {
+    for (const auto &ref : subscriptions_) {
+      if (ref.channel == channel && ref.retain_latest && ref.callback && *ref.callback) return true;
+    }
+    return false;
+  }
+
+  void release_inactive_channel_state() {
+    for (size_t channel = 0; channel < subscription_channels_.size(); channel++) {
+      if (channel_reuses_reads(channel)) continue;
+      SubscriptionChannel &subscription = subscription_channels_[channel];
+      subscription.cached_state.clear();
+      subscription.pending_reads.clear();
+      subscription.has_cached_state = false;
+    }
   }
 
   void release_subscriptions(uint32_t scope) {
@@ -345,6 +371,7 @@ class HaReadCoordinator {
     }
     subscriptions_.resize(write_index);
     if (subscriptions_.empty()) std::vector<SubscriptionRef>().swap(subscriptions_);
+    release_inactive_channel_state();
   }
 
   void release_owner_subscriptions(void *owner) {
@@ -360,6 +387,7 @@ class HaReadCoordinator {
     }
     subscriptions_.resize(write_index);
     if (subscriptions_.empty()) std::vector<SubscriptionRef>().swap(subscriptions_);
+    release_inactive_channel_state();
   }
 
   void release_empty_deferred_storage() {

--- a/components/espcontrol/ha_read_coordinator.h
+++ b/components/espcontrol/ha_read_coordinator.h
@@ -63,7 +63,10 @@ class HaReadCoordinator {
       }
     }
     if (channel == subscription_channels_.size()) {
-      subscription_channels_.push_back({entity_id, attribute});
+      SubscriptionChannel subscription_channel;
+      subscription_channel.entity_id = entity_id;
+      subscription_channel.attribute = attribute;
+      subscription_channels_.push_back(std::move(subscription_channel));
       transport_.subscribe(
           entity_id, attribute,
           [this, channel](State state) { invoke_subscription_channel(channel, state); });
@@ -110,12 +113,23 @@ class HaReadCoordinator {
     generation_++;
     if (generation_ == 0) generation_ = 1;
     reset_deferred();
+    for (auto &channel : subscription_channels_) {
+      channel.pending_reads.clear();
+      channel.cached_state.clear();
+      channel.has_cached_state = false;
+    }
     reset_subscriptions(default_scope);
   }
 
   void release_owner(void *owner) {
     if (!owner) return;
     release_owner_generation(owner);
+    for (auto &channel : subscription_channels_) {
+      channel.pending_reads.erase(
+          std::remove_if(channel.pending_reads.begin(), channel.pending_reads.end(),
+                         [owner](const CallbackRef &ref) { return ref.owner == owner; }),
+          channel.pending_reads.end());
+    }
     if (callback_depth_ != 0) {
       pending_owner_releases_.push_back(owner);
       return;
@@ -153,6 +167,9 @@ class HaReadCoordinator {
   struct SubscriptionChannel {
     std::string entity_id;
     std::string attribute;
+    std::string cached_state;
+    std::vector<CallbackRef> pending_reads;
+    bool has_cached_state = false;
   };
 
   static constexpr size_t MAX_DEFERRED_REQUESTS = 64;
@@ -206,6 +223,9 @@ class HaReadCoordinator {
                     CallbackRef callback_ref,
                     bool has_attribute,
                     uint32_t generation) {
+    if (queue_on_subscription_channel(entity_id, attribute, callback_ref, has_attribute)) {
+      return;
+    }
     transport_.get(
         std::move(entity_id), has_attribute ? std::move(attribute) : std::string(),
         [this, callback_ref, generation](State state) {
@@ -220,6 +240,21 @@ class HaReadCoordinator {
                      std::vector<CallbackRef> callbacks,
                      bool has_attribute,
                      uint32_t generation) {
+    size_t channel = find_subscription_channel(entity_id, attribute, has_attribute);
+    if (channel != subscription_channels_.size()) {
+      auto &subscription = subscription_channels_[channel];
+      if (subscription.has_cached_state) {
+        State state(subscription.cached_state);
+        for (const auto &callback_ref : callbacks) {
+          if (owner_generation_current(callback_ref)) invoke(callback_ref.callback, state);
+        }
+      } else {
+        for (auto &callback_ref : callbacks) {
+          subscription.pending_reads.push_back(std::move(callback_ref));
+        }
+      }
+      return;
+    }
     auto callback_refs = std::make_shared<std::vector<CallbackRef>>(std::move(callbacks));
     transport_.get(
         std::move(entity_id), has_attribute ? std::move(attribute) : std::string(),
@@ -249,6 +284,12 @@ class HaReadCoordinator {
   }
 
   void invoke_subscription_channel(size_t channel, State state) {
+    if (channel >= subscription_channels_.size()) return;
+    SubscriptionChannel &subscription = subscription_channels_[channel];
+    subscription.cached_state.assign(state.c_str(), state.size());
+    subscription.has_cached_state = true;
+    std::vector<CallbackRef> pending_reads;
+    pending_reads.swap(subscription.pending_reads);
     std::vector<std::shared_ptr<Callback>> callbacks;
     callbacks.reserve(subscriptions_.size());
     for (const auto &ref : subscriptions_) {
@@ -256,7 +297,39 @@ class HaReadCoordinator {
         callbacks.push_back(ref.callback);
       }
     }
+    for (const auto &callback_ref : pending_reads) {
+      if (owner_generation_current(callback_ref)) invoke(callback_ref.callback, state);
+    }
     for (const auto &callback : callbacks) invoke(callback, state);
+  }
+
+  size_t find_subscription_channel(const std::string &entity_id,
+                                   const std::string &attribute,
+                                   bool has_attribute) const {
+    const std::string expected_attribute = has_attribute ? attribute : std::string();
+    for (size_t i = 0; i < subscription_channels_.size(); i++) {
+      if (subscription_channels_[i].entity_id == entity_id &&
+          subscription_channels_[i].attribute == expected_attribute) {
+        return i;
+      }
+    }
+    return subscription_channels_.size();
+  }
+
+  bool queue_on_subscription_channel(const std::string &entity_id,
+                                      const std::string &attribute,
+                                      CallbackRef callback_ref,
+                                      bool has_attribute) {
+    size_t channel = find_subscription_channel(entity_id, attribute, has_attribute);
+    if (channel == subscription_channels_.size()) return false;
+    SubscriptionChannel &subscription = subscription_channels_[channel];
+    if (subscription.has_cached_state) {
+      State state(subscription.cached_state);
+      if (owner_generation_current(callback_ref)) invoke(callback_ref.callback, state);
+    } else {
+      subscription.pending_reads.push_back(std::move(callback_ref));
+    }
+    return true;
   }
 
   void release_subscriptions(uint32_t scope) {

--- a/components/espcontrol/ha_read_coordinator.h
+++ b/components/espcontrol/ha_read_coordinator.h
@@ -358,7 +358,7 @@ class HaReadCoordinator {
     // Keep distinct card owners independent, but cap them as a final guard
     // against a channel that Home Assistant never publishes.
     for (auto &pending : subscription.pending_reads) {
-      if (pending.owner == callback_ref.owner) {
+      if (callback_ref.owner != nullptr && pending.owner == callback_ref.owner) {
         pending = std::move(callback_ref);
         return;
       }

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -34,9 +34,10 @@ esp32:
       disable_vfs_support_dir: false
     sdkconfig_options:
       CONFIG_SDMMC_HOST_DEFAULT: "y"
-      # Keep the socket pool within ESP-IDF 5.5's supported maximum while
-      # leaving room for Home Assistant, diagnostics, HTTP, and artwork.
-      CONFIG_LWIP_MAX_SOCKETS: "16"
+      # ESPHome needs 18 sockets for this panel's API, web, diagnostics, and
+      # artwork services. Keep two spare so short-lived HTTP requests do not
+      # displace Home Assistant or remote connections.
+      CONFIG_LWIP_MAX_SOCKETS: "20"
       # HTTPS firmware checks need more stack on ESP32-P4; the default main
       # task stack can trip the stack protector during mbedTLS setup.
       CONFIG_ESP_MAIN_TASK_STACK_SIZE: "8192"
@@ -242,8 +243,7 @@ safe_mode:
 packages:
   core_infra: !include ../../../common/device/core_infra.yaml
 
-# Keep additional native-API capacity local to this large panel without
-# exhausting the supported 16-socket pool.
+# Keep additional native-API capacity local to this large panel.
 api:
   max_connections: 5
 

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -140,7 +140,8 @@ ATTRIBUTE_HELPER_PATTERN = re.compile(
     re.DOTALL,
 )
 SUBSCRIPTION_TRACKING_PATTERN = re.compile(
-    r"subscriptions_\.push_back\(\s*\{\s*callback_ref\s*,\s*scope(?:\s*,\s*owner)?(?:\s*,\s*channel)?\s*\}\s*\)"
+    r"subscriptions_\.push_back\(\s*\{\s*callback_ref\s*,\s*scope(?:\s*,\s*owner)?"
+    r"(?:\s*,\s*channel)?(?:\s*,\s*retain_latest)?\s*\}\s*\)"
 )
 DEFERRED_CALLBACK_FANOUT_PATTERN = re.compile(
     r"for\s*\(\s*const\s+auto\s*&\s*callback(?:_ref)?\s*:\s*\*callback_refs\s*\)"

--- a/tests/firmware/ha_read_coordinator_test.cpp
+++ b/tests/firmware/ha_read_coordinator_test.cpp
@@ -179,6 +179,53 @@ void rebuilt_subscriptions_share_one_transport_channel() {
           "shared transport channel did not invoke only the current callback");
 }
 
+void subscription_backed_reads_reuse_the_live_channel() {
+  Coordinator coordinator;
+  int subscription_calls = 0;
+  require(coordinator.subscribe(
+              "media_player.room", "entity_picture",
+              [&](std::string) { subscription_calls++; }, 1u),
+          "artwork subscription should register");
+
+  std::string first_read;
+  require(coordinator.get(
+              "media_player.room", "entity_picture",
+              [&](std::string value) { first_read = value; }, true, 10, 5),
+          "first artwork read should wait on its live subscription");
+  require(coordinator.transport().reads.empty(),
+          "subscription-backed artwork read created an unbounded one-shot request");
+
+  coordinator.transport().publish(0, "/api/media_player_proxy/room");
+  require(first_read == "/api/media_player_proxy/room" && subscription_calls == 1,
+          "live artwork response did not satisfy the pending read");
+
+  std::string cached_read;
+  require(coordinator.get(
+              "media_player.room", "entity_picture",
+              [&](std::string value) { cached_read = value; }, true, 10, 5),
+          "later artwork read should reuse the live channel");
+  require(cached_read == "/api/media_player_proxy/room" &&
+              coordinator.transport().reads.empty(),
+          "later artwork read did not reuse the latest live value");
+}
+
+void generation_change_discards_cached_and_pending_channel_reads() {
+  Coordinator coordinator;
+  require(coordinator.subscribe("media_player.room", "entity_picture",
+                                [](std::string) {}, 1u),
+          "artwork subscription should register");
+  coordinator.transport().publish(0, "old");
+  coordinator.bump_generation(1u);
+
+  int calls = 0;
+  require(coordinator.get("media_player.room", "entity_picture",
+                          [&](std::string) { calls++; }, true, 10, 5),
+          "new generation artwork read should wait for a current value");
+  require(calls == 0, "new generation consumed stale cached artwork");
+  coordinator.transport().publish(0, "new");
+  require(calls == 1, "new generation artwork read did not receive the current value");
+}
+
 void stale_generations_do_not_deliver() {
   Coordinator coordinator;
   int calls = 0;
@@ -278,6 +325,8 @@ int main() {
   reentrant_reads_are_deferred();
   cancellation_is_safe_during_callback();
   rebuilt_subscriptions_share_one_transport_channel();
+  subscription_backed_reads_reuse_the_live_channel();
+  generation_change_discards_cached_and_pending_channel_reads();
   stale_generations_do_not_deliver();
   attribute_requests_preserve_attribute();
   released_owner_drops_pending_reads_even_if_its_address_is_reused();

--- a/tests/firmware/ha_read_coordinator_test.cpp
+++ b/tests/firmware/ha_read_coordinator_test.cpp
@@ -302,6 +302,25 @@ void stalled_reusable_channel_coalesces_reads_per_owner() {
           "stalled artwork retries retained superseded callbacks for one owner");
 }
 
+void unowned_reusable_channel_keeps_independent_reads() {
+  Coordinator coordinator;
+  require(coordinator.subscribe("media_player.room", "entity_picture",
+                                [](std::string) {}, 1u, nullptr, true),
+          "reusable artwork subscription should register");
+
+  int first_calls = 0;
+  int second_calls = 0;
+  require(coordinator.get("media_player.room", "entity_picture",
+                          [&](std::string) { first_calls++; }, true, 10, 5),
+          "first unowned artwork read should wait");
+  require(coordinator.get("media_player.room", "entity_picture",
+                          [&](std::string) { second_calls++; }, true, 10, 5),
+          "second unowned artwork read should wait independently");
+  coordinator.transport().publish(0, "new");
+  require(first_calls == 1 && second_calls == 1,
+          "duplicate cards did not both receive the first artwork update");
+}
+
 void stale_generations_do_not_deliver() {
   Coordinator coordinator;
   int calls = 0;
@@ -407,6 +426,7 @@ int main() {
   ordinary_subscriptions_do_not_retain_state_for_reads();
   inactive_reusable_channels_release_cached_state();
   stalled_reusable_channel_coalesces_reads_per_owner();
+  unowned_reusable_channel_keeps_independent_reads();
   stale_generations_do_not_deliver();
   attribute_requests_preserve_attribute();
   released_owner_drops_pending_reads_even_if_its_address_is_reused();

--- a/tests/firmware/ha_read_coordinator_test.cpp
+++ b/tests/firmware/ha_read_coordinator_test.cpp
@@ -264,6 +264,26 @@ void inactive_reusable_channels_release_cached_state() {
   require(calls == 1, "reannounced artwork did not satisfy the recreated read");
 }
 
+void stalled_reusable_channel_coalesces_reads_per_owner() {
+  Coordinator coordinator;
+  int owner = 0;
+  require(coordinator.subscribe("media_player.room", "entity_picture_local",
+                                [](std::string) {}, 1u, &owner, true),
+          "reusable local artwork subscription should register");
+
+  int stale_calls = 0;
+  int current_calls = 0;
+  require(coordinator.get("media_player.room", "entity_picture_local",
+                          [&](std::string) { stale_calls++; }, true, 10, 5, &owner),
+          "first local artwork read should wait");
+  require(coordinator.get("media_player.room", "entity_picture_local",
+                          [&](std::string) { current_calls++; }, true, 10, 5, &owner),
+          "replacement local artwork read should wait");
+  coordinator.transport().publish(0, "new");
+  require(stale_calls == 0 && current_calls == 1,
+          "stalled artwork retries retained superseded callbacks for one owner");
+}
+
 void stale_generations_do_not_deliver() {
   Coordinator coordinator;
   int calls = 0;
@@ -367,6 +387,7 @@ int main() {
   generation_change_discards_cached_and_pending_channel_reads();
   ordinary_subscriptions_do_not_retain_state_for_reads();
   inactive_reusable_channels_release_cached_state();
+  stalled_reusable_channel_coalesces_reads_per_owner();
   stale_generations_do_not_deliver();
   attribute_requests_preserve_attribute();
   released_owner_drops_pending_reads_even_if_its_address_is_reused();

--- a/tests/firmware/ha_read_coordinator_test.cpp
+++ b/tests/firmware/ha_read_coordinator_test.cpp
@@ -184,7 +184,7 @@ void subscription_backed_reads_reuse_the_live_channel() {
   int subscription_calls = 0;
   require(coordinator.subscribe(
               "media_player.room", "entity_picture",
-              [&](std::string) { subscription_calls++; }, 1u),
+              [&](std::string) { subscription_calls++; }, 1u, nullptr, true),
           "artwork subscription should register");
 
   std::string first_read;
@@ -212,10 +212,13 @@ void subscription_backed_reads_reuse_the_live_channel() {
 void generation_change_discards_cached_and_pending_channel_reads() {
   Coordinator coordinator;
   require(coordinator.subscribe("media_player.room", "entity_picture",
-                                [](std::string) {}, 1u),
+                                [](std::string) {}, 1u, nullptr, true),
           "artwork subscription should register");
   coordinator.transport().publish(0, "old");
   coordinator.bump_generation(1u);
+  require(coordinator.subscribe("media_player.room", "entity_picture",
+                                [](std::string) {}, 1u, nullptr, true),
+          "new generation artwork subscription should register");
 
   int calls = 0;
   require(coordinator.get("media_player.room", "entity_picture",
@@ -224,6 +227,41 @@ void generation_change_discards_cached_and_pending_channel_reads() {
   require(calls == 0, "new generation consumed stale cached artwork");
   coordinator.transport().publish(0, "new");
   require(calls == 1, "new generation artwork read did not receive the current value");
+}
+
+void ordinary_subscriptions_do_not_retain_state_for_reads() {
+  Coordinator coordinator;
+  require(coordinator.subscribe("sensor.room", "friendly_name",
+                                [](std::string) {}, 1u),
+          "ordinary subscription should register");
+  coordinator.transport().publish(0, "A deliberately retained label");
+
+  int calls = 0;
+  require(coordinator.get("sensor.room", "friendly_name",
+                          [&](std::string) { calls++; }, true, 10, 5),
+          "ordinary one-shot read should be dispatched");
+  require(calls == 0 && coordinator.transport().reads.size() == 1,
+          "ordinary subscription unexpectedly retained a persistent state copy");
+}
+
+void inactive_reusable_channels_release_cached_state() {
+  Coordinator coordinator;
+  require(coordinator.subscribe("media_player.room", "entity_picture",
+                                [](std::string) {}, 1u, nullptr, true),
+          "reusable artwork subscription should register");
+  coordinator.transport().publish(0, "old");
+  coordinator.reset_subscriptions();
+  require(coordinator.subscribe("media_player.room", "entity_picture",
+                                [](std::string) {}, 1u, nullptr, true),
+          "artwork subscription should be reusable after reset");
+
+  int calls = 0;
+  require(coordinator.get("media_player.room", "entity_picture",
+                          [&](std::string) { calls++; }, true, 10, 5),
+          "recreated artwork read should wait for reannouncement");
+  require(calls == 0, "inactive artwork channel retained stale cached state");
+  coordinator.transport().publish(0, "new");
+  require(calls == 1, "reannounced artwork did not satisfy the recreated read");
 }
 
 void stale_generations_do_not_deliver() {
@@ -327,6 +365,8 @@ int main() {
   rebuilt_subscriptions_share_one_transport_channel();
   subscription_backed_reads_reuse_the_live_channel();
   generation_change_discards_cached_and_pending_channel_reads();
+  ordinary_subscriptions_do_not_retain_state_for_reads();
+  inactive_reusable_channels_release_cached_state();
   stale_generations_do_not_deliver();
   attribute_requests_preserve_attribute();
   released_owner_drops_pending_reads_even_if_its_address_is_reused();

--- a/tests/firmware/ha_read_coordinator_test.cpp
+++ b/tests/firmware/ha_read_coordinator_test.cpp
@@ -229,6 +229,24 @@ void generation_change_discards_cached_and_pending_channel_reads() {
   require(calls == 1, "new generation artwork read did not receive the current value");
 }
 
+void reconnect_discards_retained_channel_state() {
+  Coordinator coordinator;
+  require(coordinator.subscribe("media_player.room", "entity_picture",
+                                [](std::string) {}, 1u, nullptr, true),
+          "artwork subscription should register");
+  coordinator.transport().publish(0, "old-token");
+  coordinator.invalidate_retained_state();
+
+  std::string received;
+  require(coordinator.get("media_player.room", "entity_picture",
+                          [&](std::string value) { received = value; }, true, 10, 5),
+          "reconnected artwork read should wait for a current value");
+  require(received.empty(), "reconnected artwork read reused stale credentials");
+  coordinator.transport().publish(0, "new-token");
+  require(received == "new-token",
+          "reconnected artwork read did not receive the current credentials");
+}
+
 void ordinary_subscriptions_do_not_retain_state_for_reads() {
   Coordinator coordinator;
   require(coordinator.subscribe("sensor.room", "friendly_name",
@@ -385,6 +403,7 @@ int main() {
   rebuilt_subscriptions_share_one_transport_channel();
   subscription_backed_reads_reuse_the_live_channel();
   generation_change_discards_cached_and_pending_channel_reads();
+  reconnect_discards_retained_channel_state();
   ordinary_subscriptions_do_not_retain_state_for_reads();
   inactive_reusable_channels_release_cached_state();
   stalled_reusable_channel_coalesces_reads_per_owner();


### PR DESCRIPTION
## Purpose

Fix cover-art cards that stop displaying images after Home Assistant reconnects or repeated refreshes.

## Practical impact

- Reuses the existing live Home Assistant attribute subscription instead of accumulating one-shot artwork requests.
- Clears cached artwork state safely when a configuration generation changes.
- Adds safe artwork-request diagnostics without logging URLs or tokens.
- Restores the 10-inch V1 socket pool to 20 because ESPHome calculates that its enabled services require at least 18; this prevents artwork HTTP work from displacing Home Assistant, web, or remote connections.

## Automated checks

- `npm run test:firmware`: 26/26 passed.
- `npm run check:fast`: passed.
- ESPHome 2026.7.4 factory compile passed for all six supported profiles:
  - 7-inch P4
  - 10-inch V1
  - 10-inch V2
  - P4-86
  - 4.3-inch P4
  - 4-inch S3

## Physical testing

Passed on the 10-inch V1 using the combined #1662 + #1676 acceptance build: live `media_player.office` artwork downloaded through Home Assistant (97,449-byte JPEG), decoded in hardware, and produced the expected 758×749 artwork buffer after restart. Home Assistant API, web server, and Wi-Fi remained stable with the 20-socket limit.

The 7-inch confirmation remains pending because its known address `192.168.6.102` is offline and no 7-inch USB serial device is currently present.
