### PR TITLE
Prepare immutable web assets for v2.8.1

### DIFF
--- a/docs/public/webserver/web-assets.json
+++ b/docs/public/webserver/web-assets.json
@@ -15,11 +15,11 @@
       ],
       "firmwareVersions": [
         "dev",
+        "v2.8.1",
         "v2.8.0",
         "v2.7.1",
         "v2.7.0",
-        "v2.6.3",
-        "v2.6.2"
+        "v2.6.3"
       ],
       "webAssetVersion": 1
     }

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -48,11 +48,11 @@ WEB_SOURCE_DIR = ROOT / "src" / "webserver"
 # list aligned with the GitHub Pages release catalogue in pages.yml.
 WEB_ASSET_SUPPORTED_FIRMWARE_VERSIONS = (
     "dev",
+    "v2.8.1",
     "v2.8.0",
     "v2.7.1",
     "v2.7.0",
     "v2.6.3",
-    "v2.6.2",
 )
 
 # Fixed editor controls use a few MDI glyphs that are not selectable Product


### PR DESCRIPTION
## Purpose

Prepare the immutable browser asset compatibility catalogue for the second qualifying dual-write release, v2.8.1.

## Practical impact

The hosted bridge loader and embedded firmware can select the firmware-matched v2.8.1 bundle while retaining the supported rollback window. No network API, PanelConfig, backup, or firmware behaviour changes are included.

## Automated checks

- `python3 scripts/build.py --check`
- `npm run check:release-preflight`
- 26 firmware host tests
- browser and six-profile compatibility journeys
- Product Model/generated output/release contract/docs checks

## Physical testing

The accepted source revision was exercised on the 10-inch V1 for configuration persistence, Home Assistant and web-server connectivity, restart, and cover-art display. The final v2.8.1 release firmware will be tested on the 10-inch V1 again before publication.