### PR TITLE
Fix local ESPHome component loading

### DIFF
--- a/scripts/local_esphome.py
+++ b/scripts/local_esphome.py
@@ -94,6 +94,9 @@ def build_esphome_command(
         "-s",
         "firmware_version",
         firmware_version,
+        "-s",
+        "espcontrol_component_url",
+        ROOT.resolve().as_uri(),
         command,
         str(yaml_path),
         *command_args,
@@ -196,6 +199,9 @@ class LocalEsphomeTests(unittest.TestCase):
                 "-s",
                 "firmware_version",
                 "dev",
+                "-s",
+                "espcontrol_component_url",
+                ROOT.resolve().as_uri(),
                 "run",
                 "/tmp/dev.yaml",
                 "--device",
@@ -234,7 +240,8 @@ class LocalEsphomeTests(unittest.TestCase):
             redirect_stdout(output):
             self.assertEqual(run(["--dry-run", str(path), "run", "--device", "192.0.2.10"]), 0)
             run_mock.assert_not_called()
-        self.assertIn("-s firmware_version local-version run", output.getvalue())
+        self.assertIn("-s firmware_version local-version", output.getvalue())
+        self.assertIn(f"-s espcontrol_component_url {ROOT.resolve().as_uri()}", output.getvalue())
         self.assertIn("--device 192.0.2.10", output.getvalue())
 
 


### PR DESCRIPTION
## Purpose

Restore local `dev.yaml` compile and flash commands with ESPHome 2026.7.4. Relative paths are no longer accepted as Git URLs for external components.

## Practical impact

The local ESPHome wrapper now supplies the current worktree as a proper `file://` component source. Developers and device-test worktrees can compile the exact checked-out source without editing device YAML. Published firmware configs and network contracts are unchanged.

## Automated checks

- `python3 scripts/local_esphome.py --self-test`
- `python3 scripts/local_esphome.py dev.yaml config` for all six supported profiles

## Physical testing

- Exact merged v2.8.1 candidate compiled and uploaded to 10-inch V1 over OTA using the equivalent file URL override
- Device returned online with native config generation 275 preserved
- Capabilities, native config, web server, Wi-Fi, ESPHome API, and Home Assistant-derived state verified