### PR TITLE
Fix All Controls cover card tile and merge latest main

### DIFF
--- a/components/espcontrol/button_grid_actions.h
+++ b/components/espcontrol/button_grid_actions.h
@@ -519,41 +519,41 @@ inline void send_cover_command_action(const CoverCommandCtx &ctx) {
 }
 
 // Send HA action for a slider change: toggle (value<0), brightness, or cover position/tilt
-inline void send_slider_action(const std::string &entity_id, int value, bool cover_tilt = false) {
+inline bool send_slider_action(const std::string &entity_id, int value, bool cover_tilt = false) {
   esphome::api::HomeassistantActionRequest req;
   if (value < 0) {
-    if (!ha_action_begin(req, "homeassistant.toggle", false, 1)) return;
+    if (!ha_action_begin(req, "homeassistant.toggle", false, 1)) return false;
     ha_action_add_entity(req, entity_id);
   } else if (is_cover_entity(entity_id)) {
     if (!ha_action_begin(req,
       cover_tilt ? "cover.set_cover_tilt_position" : "cover.set_cover_position",
-      false, 2)) return;
+      false, 2)) return false;
     ha_action_add_entity(req, entity_id);
     char buf[12];
     snprintf(buf, sizeof(buf), "%d", value);
     ha_action_add_data(req, cover_tilt ? "tilt_position" : "position", buf);
   } else if (is_fan_entity(entity_id)) {
     if (value == 0) {
-      if (!ha_action_begin(req, "fan.turn_off", false, 1)) return;
+      if (!ha_action_begin(req, "fan.turn_off", false, 1)) return false;
       ha_action_add_entity(req, entity_id);
     } else {
-      if (!ha_action_begin(req, "fan.turn_on", false, 2)) return;
+      if (!ha_action_begin(req, "fan.turn_on", false, 2)) return false;
       ha_action_add_entity(req, entity_id);
       char buf[12];
       snprintf(buf, sizeof(buf), "%d", value);
       ha_action_add_data(req, "percentage", buf);
     }
   } else if (value == 0) {
-    if (!ha_action_begin(req, "light.turn_off", false, 1)) return;
+    if (!ha_action_begin(req, "light.turn_off", false, 1)) return false;
     ha_action_add_entity(req, entity_id);
   } else {
-    if (!ha_action_begin(req, "light.turn_on", false, 2)) return;
+    if (!ha_action_begin(req, "light.turn_on", false, 2)) return false;
     ha_action_add_entity(req, entity_id);
     char buf[12];
     snprintf(buf, sizeof(buf), "%d", value);
     ha_action_add_data(req, "brightness_pct", buf);
   }
-  ha_action_send(req);
+  return ha_action_send(req);
 }
 
 // Parse "min-max" kelvin range from the unit config field (e.g. "2000-6500").

--- a/components/espcontrol/button_grid_sliders.h
+++ b/components/espcontrol/button_grid_sliders.h
@@ -1567,6 +1567,7 @@ struct CoverControlModalUi {
   lv_obj_t *presets_box = nullptr;
   lv_obj_t *preset_btns[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
   int selected_preset = -1;
+  int pending_preset = -1;
   lv_obj_t *position_slider = nullptr;
   lv_obj_t *position_fill = nullptr;
   lv_obj_t *position_handle = nullptr;
@@ -1920,16 +1921,23 @@ inline lv_obj_t *cover_control_create_preset_button(lv_obj_t *parent, int pct,
     int pct = static_cast<int>(reinterpret_cast<uintptr_t>(lv_event_get_user_data(e)));
     CoverControlModalUi &ui = cover_control_modal_ui();
     if (!ui.active || !ui.active->available || !cover_control_supports_position(ui.active)) return;
+    const bool previous_position_known = ui.active->current_position_known;
+    const int previous_position = ui.active->current_position;
     ui.active->current_position_known = true;
     ui.active->current_position = slider_clamp_pct(pct);
-    // Lock the tapped preset as the selection and treat the cover as moving so
-    // the highlight holds through travel (and any stale in-flight position
-    // reports) until Home Assistant reports the cover has stopped.
+    // Hold the tapped preset until Home Assistant publishes the next position;
+    // that update reconciles the highlight even when no opening/closing state exists.
     ui.selected_preset = ui.active->current_position;
-    ui.active->moving = true;
+    ui.pending_preset = ui.active->current_position;
     cover_control_set_position_value(ui.active, ui.active->current_position);
     cover_control_apply_card_visual(ui.active);
-    send_slider_action(ui.active->entity_id, ui.active->current_position, false);
+    if (!send_slider_action(ui.active->entity_id, ui.active->current_position, false)) {
+      ui.pending_preset = -1;
+      ui.active->current_position_known = previous_position_known;
+      ui.active->current_position = previous_position;
+      cover_control_set_position_value(ui.active, previous_position);
+      cover_control_apply_card_visual(ui.active);
+    }
   }, LV_EVENT_CLICKED, reinterpret_cast<void *>(static_cast<uintptr_t>(pct)));
 
   return btn;
@@ -2257,14 +2265,14 @@ inline void cover_control_set_slider_value(lv_obj_t *slider, bool &updating,
 }
 
 // Recolour the preset tiles so the highlighted one tracks the cover. While the
-// cover is moving the selection is held (a tapped preset stays lit and stale
-// in-flight position reports do not clear it); once it comes to rest the
+// cover is moving or a tapped preset is awaiting its first position update,
+// the selection is held; once it comes to rest the
 // selection reconciles with the exact position, clearing when it sits between
 // presets. ui.selected_preset carries the choice across updates.
 inline void cover_control_refresh_preset_selection(CoverControlCtx *ctx) {
   CoverControlModalUi &ui = cover_control_modal_ui();
   if (!ctx || ui.active != ctx || !ui.presets_box) return;
-  if (!ctx->moving) {
+  if (!ctx->moving && ui.pending_preset < 0) {
     int selected = -1;
     if (ctx->current_position_known) {
       int pos = slider_clamp_pct(ctx->current_position);
@@ -2612,6 +2620,8 @@ inline void subscribe_cover_control_state(CoverControlCtx *ctx) {
       [ctx](esphome::StringRef val) {
         int pct = 0;
         if (!slider_parse_pct(val, pct)) return;
+        CoverControlModalUi &ui = cover_control_modal_ui();
+        if (ui.active == ctx) ui.pending_preset = -1;
         ctx->current_position_known = true;
         ctx->current_position = pct;
         cover_control_set_position_value(ctx, pct);

--- a/components/espcontrol/ha_read_coordinator.h
+++ b/components/espcontrol/ha_read_coordinator.h
@@ -78,7 +78,8 @@ class HaReadCoordinator {
         break;
       }
     }
-    if (channel == subscription_channels_.size()) {
+    const bool new_channel = channel == subscription_channels_.size();
+    if (new_channel) {
       SubscriptionChannel subscription_channel;
       subscription_channel.entity_id = entity_id;
       subscription_channel.attribute = attribute;
@@ -88,6 +89,11 @@ class HaReadCoordinator {
           [this, channel](State state) { invoke_subscription_channel(channel, state); });
     }
     subscriptions_.push_back({callback_ref, scope, owner, channel, retain_latest});
+    // A grid rebuild re-subscribes on an existing channel; replay the last value
+    // so rebuilt cards reflect the live state immediately.
+    if (!new_channel && subscription_channels_[channel].has_last_state) {
+      invoke(callback_ref, State(subscription_channels_[channel].last_state));
+    }
     return true;
   }
 
@@ -122,6 +128,8 @@ class HaReadCoordinator {
     // particular, artwork URLs and access tokens may change while the panel is
     // offline, so reads after a reconnect must wait for a fresh announcement.
     for (auto &channel : subscription_channels_) {
+      channel.last_state.clear();
+      channel.has_last_state = false;
       channel.cached_state.clear();
       channel.has_cached_state = false;
     }
@@ -194,6 +202,8 @@ class HaReadCoordinator {
   struct SubscriptionChannel {
     std::string entity_id;
     std::string attribute;
+    std::string last_state;
+    bool has_last_state = false;
     std::string cached_state;
     std::vector<CallbackRef> pending_reads;
     bool has_cached_state = false;
@@ -201,6 +211,7 @@ class HaReadCoordinator {
 
   static constexpr size_t MAX_DEFERRED_REQUESTS = 64;
   static constexpr size_t MAX_PENDING_READS = 64;
+  static constexpr size_t MAX_REPLAY_STATES = 64;
 
   uint32_t owner_generation(void *owner) {
     if (!owner) return 0;
@@ -297,6 +308,12 @@ class HaReadCoordinator {
         retain_latest = retain_latest || ref.retain_latest;
       }
     }
+    if (callbacks.empty()) {
+      subscription.last_state.clear();
+      subscription.has_last_state = false;
+    } else {
+      retain_replay_state(channel, state);
+    }
     if (retain_latest) {
       subscription.cached_state.assign(state.c_str(), state.size());
       subscription.has_cached_state = true;
@@ -365,6 +382,26 @@ class HaReadCoordinator {
       if (ref.channel == channel && ref.retain_latest && ref.callback && *ref.callback) return true;
     }
     return false;
+  }
+
+  void retain_replay_state(size_t channel, const State &state) {
+    SubscriptionChannel &subscription = subscription_channels_[channel];
+    if (!subscription.has_last_state) {
+      size_t retained = 0;
+      for (const auto &candidate : subscription_channels_) {
+        if (candidate.has_last_state) retained++;
+      }
+      if (retained >= MAX_REPLAY_STATES) {
+        for (size_t candidate = 0; candidate < subscription_channels_.size(); candidate++) {
+          if (candidate == channel || !subscription_channels_[candidate].has_last_state) continue;
+          subscription_channels_[candidate].last_state.clear();
+          subscription_channels_[candidate].has_last_state = false;
+          break;
+        }
+      }
+    }
+    subscription.last_state.assign(state.c_str(), state.size());
+    subscription.has_last_state = true;
   }
 
   void release_inactive_channel_state() {

--- a/tests/firmware/ha_read_coordinator_test.cpp
+++ b/tests/firmware/ha_read_coordinator_test.cpp
@@ -174,6 +174,82 @@ void rebuilt_subscriptions_share_one_transport_channel() {
           "shared transport channel did not invoke only the current callback");
 }
 
+void rebuilt_subscription_replays_last_value() {
+  Coordinator coordinator;
+  constexpr uint32_t scope = 1u;
+  require(coordinator.subscribe("cover.blind", "current_position",
+                                [](std::string) {}, scope),
+          "initial cover subscription should register");
+  coordinator.transport().publish(0, "42");
+  coordinator.reset_subscriptions(scope);
+
+  std::string received;
+  require(coordinator.subscribe("cover.blind", "current_position",
+                                [&](std::string value) { received = value; }, scope),
+          "rebuilt cover subscription should register");
+  require(received == "42", "rebuilt subscription did not replay the latest value");
+}
+
+void reconnect_does_not_replay_previous_connection_state() {
+  Coordinator coordinator;
+  constexpr uint32_t scope = 1u;
+  require(coordinator.subscribe("cover.blind", "current_position",
+                                [](std::string) {}, scope),
+          "initial cover subscription should register");
+  coordinator.transport().publish(0, "42");
+  coordinator.reset_subscriptions(scope);
+  coordinator.invalidate_retained_state();
+
+  int calls = 0;
+  require(coordinator.subscribe("cover.blind", "current_position",
+                                [&](std::string) { calls++; }, scope),
+          "reconnected cover subscription should register");
+  require(calls == 0, "reconnected subscription replayed stale state");
+  coordinator.transport().publish(0, "43");
+  require(calls == 1, "reconnected subscription missed the fresh state");
+}
+
+void inactive_channels_do_not_retain_new_replay_values() {
+  Coordinator coordinator;
+  constexpr uint32_t scope = 1u;
+  require(coordinator.subscribe("cover.old", "current_position",
+                                [](std::string) {}, scope),
+          "initial cover subscription should register");
+  coordinator.transport().publish(0, "old");
+  coordinator.reset_subscriptions(scope);
+  coordinator.transport().publish(0, "inactive-update");
+
+  int calls = 0;
+  require(coordinator.subscribe("cover.old", "current_position",
+                                [&](std::string) { calls++; }, scope),
+          "inactive cover subscription should rebuild");
+  require(calls == 0, "inactive channel retained a new replay value");
+}
+
+void replay_state_cache_is_bounded() {
+  Coordinator coordinator;
+  constexpr uint32_t scope = 1u;
+  for (size_t i = 0; i < 65; i++) {
+    require(coordinator.subscribe("sensor.channel_" + std::to_string(i), "state",
+                                  [](std::string) {}, scope),
+            "bounded replay subscription should register");
+    coordinator.transport().publish(i, "value_" + std::to_string(i));
+  }
+  coordinator.reset_subscriptions(scope);
+
+  int oldest_calls = 0;
+  require(coordinator.subscribe("sensor.channel_0", "state",
+                                [&](std::string) { oldest_calls++; }, scope),
+          "oldest bounded replay subscription should rebuild");
+  require(oldest_calls == 0, "replay cache retained more than its bounded capacity");
+
+  std::string newest;
+  require(coordinator.subscribe("sensor.channel_64", "state",
+                                [&](std::string value) { newest = value; }, scope),
+          "newest bounded replay subscription should rebuild");
+  require(newest == "value_64", "bounded replay cache discarded the newest value");
+}
+
 void subscription_backed_reads_reuse_the_live_channel() {
   Coordinator coordinator;
   int subscription_calls = 0;
@@ -496,6 +572,10 @@ int main() {
   reentrant_reads_are_deferred();
   cancellation_is_safe_during_callback();
   rebuilt_subscriptions_share_one_transport_channel();
+  rebuilt_subscription_replays_last_value();
+  reconnect_does_not_replay_previous_connection_state();
+  inactive_channels_do_not_retain_new_replay_values();
+  replay_state_cache_is_bounded();
   subscription_backed_reads_reuse_the_live_channel();
   retained_reads_never_accumulate_transport_callbacks();
   missing_retained_channel_fails_closed();


### PR DESCRIPTION
Maintainer conflict-resolution replacement for #1671.

This branch carries the original cover tile fixes plus the latest `main` changes, with the coordinator conflicts resolved so the PR is mergeable again.

Checks:
- `git diff --check` passed.
- Firmware host test and Docker ESPHome compiles could not be run in this environment because CMake and Docker are unavailable.

Please test the affected Guition ESP32-P4 JC1060P470 display before merging. The original PR reported successful OTA testing of the cover fill bar, icon, presets highlight, and grid-rebuild state refresh.