### PR TITLE
Restore dimmed clock bar

### DIFF
--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -1259,8 +1259,6 @@ script:
                       static_cast<uint32_t>(generation), espcontrol::DisplayMode::DIMMED);
           then:
             - lvgl.resume:
-            - script.execute: clock_bar_hide
-            - script.wait: clock_bar_hide
             - lambda: |-
                 if (!id(espcontrol_app).display().transition_is_current(
                       static_cast<uint32_t>(generation), espcontrol::DisplayMode::DIMMED)) {
@@ -1270,6 +1268,7 @@ script:
             - lambda: 'refresh_screensaver_fullscreen(id(clock_screensaver), id(dim_screensaver_touch_guard));'
             - lvgl.widget.show: dim_screensaver_touch_guard
             - lambda: 'lv_obj_move_foreground(id(dim_screensaver_touch_guard));'
+            - script.execute: clock_bar_apply
             - script.execute:
                 id: backlight_note_internal_brightness
                 brightness: !lambda 'return id(screensaver_dimmed_target_level);'

--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -923,15 +923,19 @@ script:
 
   # Home Assistant exposes the physical backlight as a light entity. Treat an
   # OFF command as persistent manual sleep whenever another visible display
-  # mode is active. Internal automatic and scheduled OFF transitions already
-  # target DISPLAY_OFF, so they must not create a manual-sleep request.
+  # mode is active. Ignore restored OFF state during component setup: it is not
+  # a user command and can otherwise put the controller into MANUAL_SLEEP while
+  # the boot sequence turns the physical backlight back on. Internal automatic
+  # and scheduled OFF transitions already target DISPLAY_OFF, so they must not
+  # create a manual-sleep request.
   - id: display_backlight_handle_off
     mode: restart
     then:
       - if:
           condition:
             lambda: |-
-              return !id(espcontrol_app).display().target_mode_is(
+              return App.is_setup_complete() &&
+                     !id(espcontrol_app).display().target_mode_is(
                   espcontrol::DisplayMode::DISPLAY_OFF);
           then:
             - script.execute: screen_schedule_manual_sleep

--- a/common/addon/connectivity.yaml
+++ b/common/addon/connectivity.yaml
@@ -154,26 +154,15 @@ script:
           condition:
             lambda: 'return !id(button_order).state.empty();'
           then:
-            - if:
+            - wait_until:
                 condition:
                   lambda: |-
                     return id(espcontrol_app).display().target_mode_is(
                         espcontrol::DisplayMode::ACTIVE);
-                then:
-                  - globals.set:
-                      id: navigate_after_api_pending
-                      value: 'false'
-                  - lvgl.page.show: main_page
-                  - script.execute: clock_bar_apply
-                  - script.execute: screensaver_idle_check
-                else:
-                  - globals.set:
-                      id: navigate_after_api_pending
-                      value: 'true'
+            - lvgl.page.show: main_page
+            - script.execute: clock_bar_apply
+            - script.execute: screensaver_idle_check
           else:
-            - globals.set:
-                id: navigate_after_api_pending
-                value: 'false'
             - lambda: |-
                 auto ips = wifi::global_wifi_component->get_ip_addresses();
                 if (!ips.empty()) {

--- a/common/addon/connectivity.yaml
+++ b/common/addon/connectivity.yaml
@@ -155,7 +155,7 @@ script:
             lambda: 'return !id(button_order).state.empty();'
           then:
             - lvgl.page.show: main_page
-            - script.execute: clock_bar_apply
+            - script.execute: clock_bar_apply_after_page_show
             - script.execute: screensaver_idle_check
           else:
             - lambda: |-

--- a/common/addon/connectivity.yaml
+++ b/common/addon/connectivity.yaml
@@ -154,10 +154,26 @@ script:
           condition:
             lambda: 'return !id(button_order).state.empty();'
           then:
-            - lvgl.page.show: main_page
-            - script.execute: clock_bar_apply
-            - script.execute: screensaver_idle_check
+            - if:
+                condition:
+                  lambda: |-
+                    return id(espcontrol_app).display().target_mode_is(
+                        espcontrol::DisplayMode::ACTIVE);
+                then:
+                  - globals.set:
+                      id: navigate_after_api_pending
+                      value: 'false'
+                  - lvgl.page.show: main_page
+                  - script.execute: clock_bar_apply
+                  - script.execute: screensaver_idle_check
+                else:
+                  - globals.set:
+                      id: navigate_after_api_pending
+                      value: 'true'
           else:
+            - globals.set:
+                id: navigate_after_api_pending
+                value: 'false'
             - lambda: |-
                 auto ips = wifi::global_wifi_component->get_ip_addresses();
                 if (!ips.empty()) {

--- a/common/addon/connectivity.yaml
+++ b/common/addon/connectivity.yaml
@@ -154,9 +154,17 @@ script:
           condition:
             lambda: 'return !id(button_order).state.empty();'
           then:
-            - lvgl.page.show: main_page
-            - script.execute: clock_bar_apply_after_page_show
-            - script.execute: screensaver_idle_check
+            # Do not let a delayed connectivity callback replace a full-screen
+            # display mode while the controller still owns that mode.
+            - if:
+                condition:
+                  lambda: |-
+                    return id(espcontrol_app).display().target_mode_is(
+                        espcontrol::DisplayMode::ACTIVE);
+                then:
+                  - lvgl.page.show: main_page
+                  - script.execute: clock_bar_apply
+                  - script.execute: screensaver_idle_check
           else:
             - lambda: |-
                 auto ips = wifi::global_wifi_component->get_ip_addresses();

--- a/common/addon/connectivity.yaml
+++ b/common/addon/connectivity.yaml
@@ -154,17 +154,9 @@ script:
           condition:
             lambda: 'return !id(button_order).state.empty();'
           then:
-            # Do not let a delayed connectivity callback replace a full-screen
-            # display mode while the controller still owns that mode.
-            - if:
-                condition:
-                  lambda: |-
-                    return id(espcontrol_app).display().target_mode_is(
-                        espcontrol::DisplayMode::ACTIVE);
-                then:
-                  - lvgl.page.show: main_page
-                  - script.execute: clock_bar_apply
-                  - script.execute: screensaver_idle_check
+            - lvgl.page.show: main_page
+            - script.execute: clock_bar_apply
+            - script.execute: screensaver_idle_check
           else:
             - lambda: |-
                 auto ips = wifi::global_wifi_component->get_ip_addresses();

--- a/common/addon/connectivity_deployed.yaml
+++ b/common/addon/connectivity_deployed.yaml
@@ -105,10 +105,26 @@ script:
           condition:
             lambda: 'return !id(button_order).state.empty();'
           then:
-            - lvgl.page.show: main_page
-            - script.execute: clock_bar_apply
-            - script.execute: screensaver_idle_check
+            - if:
+                condition:
+                  lambda: |-
+                    return id(espcontrol_app).display().target_mode_is(
+                        espcontrol::DisplayMode::ACTIVE);
+                then:
+                  - globals.set:
+                      id: navigate_after_api_pending
+                      value: 'false'
+                  - lvgl.page.show: main_page
+                  - script.execute: clock_bar_apply
+                  - script.execute: screensaver_idle_check
+                else:
+                  - globals.set:
+                      id: navigate_after_api_pending
+                      value: 'true'
           else:
+            - globals.set:
+                id: navigate_after_api_pending
+                value: 'false'
             - lambda: |-
                 auto ips = wifi::global_wifi_component->get_ip_addresses();
                 if (!ips.empty()) {

--- a/common/addon/connectivity_deployed.yaml
+++ b/common/addon/connectivity_deployed.yaml
@@ -105,9 +105,17 @@ script:
           condition:
             lambda: 'return !id(button_order).state.empty();'
           then:
-            - lvgl.page.show: main_page
-            - script.execute: clock_bar_apply_after_page_show
-            - script.execute: screensaver_idle_check
+            # Do not let a delayed connectivity callback replace a full-screen
+            # display mode while the controller still owns that mode.
+            - if:
+                condition:
+                  lambda: |-
+                    return id(espcontrol_app).display().target_mode_is(
+                        espcontrol::DisplayMode::ACTIVE);
+                then:
+                  - lvgl.page.show: main_page
+                  - script.execute: clock_bar_apply
+                  - script.execute: screensaver_idle_check
           else:
             - lambda: |-
                 auto ips = wifi::global_wifi_component->get_ip_addresses();

--- a/common/addon/connectivity_deployed.yaml
+++ b/common/addon/connectivity_deployed.yaml
@@ -105,26 +105,15 @@ script:
           condition:
             lambda: 'return !id(button_order).state.empty();'
           then:
-            - if:
+            - wait_until:
                 condition:
                   lambda: |-
                     return id(espcontrol_app).display().target_mode_is(
                         espcontrol::DisplayMode::ACTIVE);
-                then:
-                  - globals.set:
-                      id: navigate_after_api_pending
-                      value: 'false'
-                  - lvgl.page.show: main_page
-                  - script.execute: clock_bar_apply
-                  - script.execute: screensaver_idle_check
-                else:
-                  - globals.set:
-                      id: navigate_after_api_pending
-                      value: 'true'
+            - lvgl.page.show: main_page
+            - script.execute: clock_bar_apply
+            - script.execute: screensaver_idle_check
           else:
-            - globals.set:
-                id: navigate_after_api_pending
-                value: 'false'
             - lambda: |-
                 auto ips = wifi::global_wifi_component->get_ip_addresses();
                 if (!ips.empty()) {

--- a/common/addon/connectivity_deployed.yaml
+++ b/common/addon/connectivity_deployed.yaml
@@ -105,17 +105,9 @@ script:
           condition:
             lambda: 'return !id(button_order).state.empty();'
           then:
-            # Do not let a delayed connectivity callback replace a full-screen
-            # display mode while the controller still owns that mode.
-            - if:
-                condition:
-                  lambda: |-
-                    return id(espcontrol_app).display().target_mode_is(
-                        espcontrol::DisplayMode::ACTIVE);
-                then:
-                  - lvgl.page.show: main_page
-                  - script.execute: clock_bar_apply
-                  - script.execute: screensaver_idle_check
+            - lvgl.page.show: main_page
+            - script.execute: clock_bar_apply
+            - script.execute: screensaver_idle_check
           else:
             - lambda: |-
                 auto ips = wifi::global_wifi_component->get_ip_addresses();

--- a/common/addon/connectivity_deployed.yaml
+++ b/common/addon/connectivity_deployed.yaml
@@ -106,7 +106,7 @@ script:
             lambda: 'return !id(button_order).state.empty();'
           then:
             - lvgl.page.show: main_page
-            - script.execute: clock_bar_apply
+            - script.execute: clock_bar_apply_after_page_show
             - script.execute: screensaver_idle_check
           else:
             - lambda: |-

--- a/common/addon/connectivity_ethernet.yaml
+++ b/common/addon/connectivity_ethernet.yaml
@@ -76,17 +76,9 @@ script:
           condition:
             lambda: 'return !id(button_order).state.empty();'
           then:
-            # Do not let a delayed connectivity callback replace a full-screen
-            # display mode while the controller still owns that mode.
-            - if:
-                condition:
-                  lambda: |-
-                    return id(espcontrol_app).display().target_mode_is(
-                        espcontrol::DisplayMode::ACTIVE);
-                then:
-                  - lvgl.page.show: main_page
-                  - script.execute: clock_bar_apply
-                  - script.execute: screensaver_idle_check
+            - lvgl.page.show: main_page
+            - script.execute: clock_bar_apply
+            - script.execute: screensaver_idle_check
           else:
             - lambda: |-
                 auto ips = ethernet::global_eth_component->get_ip_addresses();

--- a/common/addon/connectivity_ethernet.yaml
+++ b/common/addon/connectivity_ethernet.yaml
@@ -76,10 +76,26 @@ script:
           condition:
             lambda: 'return !id(button_order).state.empty();'
           then:
-            - lvgl.page.show: main_page
-            - script.execute: clock_bar_apply
-            - script.execute: screensaver_idle_check
+            - if:
+                condition:
+                  lambda: |-
+                    return id(espcontrol_app).display().target_mode_is(
+                        espcontrol::DisplayMode::ACTIVE);
+                then:
+                  - globals.set:
+                      id: navigate_after_api_pending
+                      value: 'false'
+                  - lvgl.page.show: main_page
+                  - script.execute: clock_bar_apply
+                  - script.execute: screensaver_idle_check
+                else:
+                  - globals.set:
+                      id: navigate_after_api_pending
+                      value: 'true'
           else:
+            - globals.set:
+                id: navigate_after_api_pending
+                value: 'false'
             - lambda: |-
                 auto ips = ethernet::global_eth_component->get_ip_addresses();
                 if (!ips.empty()) {

--- a/common/addon/connectivity_ethernet.yaml
+++ b/common/addon/connectivity_ethernet.yaml
@@ -77,7 +77,7 @@ script:
             lambda: 'return !id(button_order).state.empty();'
           then:
             - lvgl.page.show: main_page
-            - script.execute: clock_bar_apply
+            - script.execute: clock_bar_apply_after_page_show
             - script.execute: screensaver_idle_check
           else:
             - lambda: |-

--- a/common/addon/connectivity_ethernet.yaml
+++ b/common/addon/connectivity_ethernet.yaml
@@ -76,26 +76,15 @@ script:
           condition:
             lambda: 'return !id(button_order).state.empty();'
           then:
-            - if:
+            - wait_until:
                 condition:
                   lambda: |-
                     return id(espcontrol_app).display().target_mode_is(
                         espcontrol::DisplayMode::ACTIVE);
-                then:
-                  - globals.set:
-                      id: navigate_after_api_pending
-                      value: 'false'
-                  - lvgl.page.show: main_page
-                  - script.execute: clock_bar_apply
-                  - script.execute: screensaver_idle_check
-                else:
-                  - globals.set:
-                      id: navigate_after_api_pending
-                      value: 'true'
+            - lvgl.page.show: main_page
+            - script.execute: clock_bar_apply
+            - script.execute: screensaver_idle_check
           else:
-            - globals.set:
-                id: navigate_after_api_pending
-                value: 'false'
             - lambda: |-
                 auto ips = ethernet::global_eth_component->get_ip_addresses();
                 if (!ips.empty()) {

--- a/common/addon/connectivity_ethernet.yaml
+++ b/common/addon/connectivity_ethernet.yaml
@@ -76,9 +76,17 @@ script:
           condition:
             lambda: 'return !id(button_order).state.empty();'
           then:
-            - lvgl.page.show: main_page
-            - script.execute: clock_bar_apply_after_page_show
-            - script.execute: screensaver_idle_check
+            # Do not let a delayed connectivity callback replace a full-screen
+            # display mode while the controller still owns that mode.
+            - if:
+                condition:
+                  lambda: |-
+                    return id(espcontrol_app).display().target_mode_is(
+                        espcontrol::DisplayMode::ACTIVE);
+                then:
+                  - lvgl.page.show: main_page
+                  - script.execute: clock_bar_apply
+                  - script.execute: screensaver_idle_check
           else:
             - lambda: |-
                 auto ips = ethernet::global_eth_component->get_ip_addresses();

--- a/common/config/display.yaml
+++ b/common/config/display.yaml
@@ -185,9 +185,7 @@ script:
           if (!visible) return;
 
           refresh_clock_bar_temperature_label_values(id(main_page)->obj,
-                                    visible &&
-                                      id(espcontrol_app).display().target_mode_is(
-                                          espcontrol::DisplayMode::ACTIVE),
+                                    visible,
                                     id(indoor_temp_enable).state,
                                     id(outdoor_temp_enable).state,
                                     id(indoor_temp), id(outdoor_temp));

--- a/common/config/display.yaml
+++ b/common/config/display.yaml
@@ -189,12 +189,20 @@ script:
                                     id(indoor_temp_enable).state,
                                     id(outdoor_temp_enable).state,
                                     id(indoor_temp), id(outdoor_temp));
-          // Clock-bar widgets live on LVGL's top layer. Some direct-render
-          // displays do not repaint that layer when an already-visible widget
-          // is merely repositioned during startup or a dimmed transition.
-          // Explicitly invalidate it so the complete bar is rendered without
-          // waiting for the first touch to invalidate the wake guard.
-          lv_obj_invalidate(lv_layer_top());
+
+  # Page changes are rendered asynchronously. Wait for the home page to
+  # become active before resolving visibility; otherwise the loading page can
+  # make the first clock-bar application hide every top-layer widget.
+  - id: clock_bar_apply_after_page_show
+    mode: restart
+    then:
+      - delay: 100ms
+      - if:
+          condition:
+            lambda: 'return lv_scr_act() == id(main_page)->obj;'
+          then:
+            - script.execute: clock_bar_apply
+            - script.wait: clock_bar_apply
 
 switch:
   - platform: template

--- a/common/config/display.yaml
+++ b/common/config/display.yaml
@@ -189,6 +189,12 @@ script:
                                     id(indoor_temp_enable).state,
                                     id(outdoor_temp_enable).state,
                                     id(indoor_temp), id(outdoor_temp));
+          // Clock-bar widgets live on LVGL's top layer. Some direct-render
+          // displays do not repaint that layer when an already-visible widget
+          // is merely repositioned during startup or a dimmed transition.
+          // Explicitly invalidate it so the complete bar is rendered without
+          // waiting for the first touch to invalidate the wake guard.
+          lv_obj_invalidate(lv_layer_top());
 
 switch:
   - platform: template

--- a/common/config/display.yaml
+++ b/common/config/display.yaml
@@ -28,10 +28,6 @@ esphome:
     - priority: -150
       then:
         - lambda: |-
-            set_dashboard_content_changed_callback([]() {
-              id(clock_bar_redraw_after_content_change).execute();
-            });
-        - lambda: |-
             bool preferences_changed = false;
             if (!id(media_player_sleep_prevention_default_on_migrated)) {
               id(media_player_sleep_prevention_enabled).turn_on();
@@ -193,48 +189,6 @@ script:
                                     id(indoor_temp_enable).state,
                                     id(outdoor_temp_enable).state,
                                     id(indoor_temp), id(outdoor_temp));
-
-  # Page changes are rendered asynchronously. Wait for the home page to
-  # become active before resolving visibility; otherwise the loading page can
-  # make the first clock-bar application hide every top-layer widget.
-  - id: clock_bar_apply_after_page_show
-    mode: restart
-    then:
-      - delay: 100ms
-      - if:
-          condition:
-            lambda: 'return lv_scr_act() == id(main_page)->obj;'
-          then:
-            - script.execute: clock_bar_apply
-            - script.wait: clock_bar_apply
-            - script.execute: clock_bar_force_redraw
-
-  # Dashboard cards can finish rendering after the home page and clock bar
-  # have already been drawn (notably while artwork downloads complete). The
-  # direct framebuffer keeps those later pixels, so debounce content changes
-  # and repaint the top-layer HUD once the dashboard has settled.
-  - id: clock_bar_redraw_after_content_change
-    mode: restart
-    then:
-      - delay: 100ms
-      - if:
-          condition:
-            lambda: 'return lv_scr_act() == id(main_page)->obj;'
-          then:
-            - script.execute: clock_bar_apply
-            - script.wait: clock_bar_apply
-            - script.execute: clock_bar_force_redraw
-
-  - id: clock_bar_force_redraw
-    mode: restart
-    then:
-      - lambda: |-
-          lv_obj_invalidate(id(temperatures));
-          lv_obj_invalidate(id(display_time));
-          lv_obj_invalidate(id(network_status_button));
-          lv_obj_invalidate(id(night_mode_status_icon));
-          lv_obj_invalidate(lv_layer_top());
-          lv_refr_now(nullptr);
 
 switch:
   - platform: template

--- a/common/config/display.yaml
+++ b/common/config/display.yaml
@@ -28,6 +28,10 @@ esphome:
     - priority: -150
       then:
         - lambda: |-
+            set_dashboard_content_changed_callback([]() {
+              id(clock_bar_redraw_after_content_change).execute();
+            });
+        - lambda: |-
             bool preferences_changed = false;
             if (!id(media_player_sleep_prevention_default_on_migrated)) {
               id(media_player_sleep_prevention_enabled).turn_on();
@@ -203,6 +207,34 @@ script:
           then:
             - script.execute: clock_bar_apply
             - script.wait: clock_bar_apply
+            - script.execute: clock_bar_force_redraw
+
+  # Dashboard cards can finish rendering after the home page and clock bar
+  # have already been drawn (notably while artwork downloads complete). The
+  # direct framebuffer keeps those later pixels, so debounce content changes
+  # and repaint the top-layer HUD once the dashboard has settled.
+  - id: clock_bar_redraw_after_content_change
+    mode: restart
+    then:
+      - delay: 100ms
+      - if:
+          condition:
+            lambda: 'return lv_scr_act() == id(main_page)->obj;'
+          then:
+            - script.execute: clock_bar_apply
+            - script.wait: clock_bar_apply
+            - script.execute: clock_bar_force_redraw
+
+  - id: clock_bar_force_redraw
+    mode: restart
+    then:
+      - lambda: |-
+          lv_obj_invalidate(id(temperatures));
+          lv_obj_invalidate(id(display_time));
+          lv_obj_invalidate(id(network_status_button));
+          lv_obj_invalidate(id(night_mode_status_icon));
+          lv_obj_invalidate(lv_layer_top());
+          lv_refr_now(nullptr);
 
 switch:
   - platform: template

--- a/components/espcontrol/clock_bar.h
+++ b/components/espcontrol/clock_bar.h
@@ -275,11 +275,14 @@ inline ClockBarVisibility clock_bar_resolve_visibility(
     espcontrol::DisplayMode display_mode,
     bool schedule_inactive) {
   ClockBarVisibility result;
-  // Full-screen screensavers hide the clock bar, but the grid should keep the
-  // same top padding so waking does not briefly resize the cards.
+  // Full-screen screensavers hide the clock bar, but the dimmed screensaver
+  // keeps the normal UI visible and should preserve its complete clock bar.
+  // Keep the same top padding in hidden modes so waking does not briefly
+  // resize the cards.
   result.reserve_space = enabled && !schedule_inactive;
   result.visible = result.reserve_space &&
-      display_mode == espcontrol::DisplayMode::ACTIVE &&
+      (display_mode == espcontrol::DisplayMode::ACTIVE ||
+       display_mode == espcontrol::DisplayMode::DIMMED) &&
       clock_bar_active_on_button_grid_page(main_page_obj);
   return result;
 }

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -2612,8 +2612,13 @@ def firmware_clock_screensaver_overlay_errors(backlight_path: Path, root: Path) 
     dimmed_body = yaml_script_body(text, "show_dimmed_view")
     if dimmed_body is None:
         errors.append(f"{rel}: missing show_dimmed_view script")
-    elif "lv_obj_move_foreground(id(dim_screensaver_touch_guard))" not in dimmed_body:
-        errors.append(f"{rel}: raise the dim screensaver touch guard above any existing top-layer elements")
+    else:
+        if "lv_obj_move_foreground(id(dim_screensaver_touch_guard))" not in dimmed_body:
+            errors.append(f"{rel}: raise the dim screensaver touch guard above any existing top-layer elements")
+        if "script.execute: clock_bar_hide" in dimmed_body or "script.wait: clock_bar_hide" in dimmed_body:
+            errors.append(f"{rel}: keep the complete clock bar visible over the dimmed home screen")
+        if "script.execute: clock_bar_apply" not in dimmed_body:
+            errors.append(f"{rel}: reapply the clock bar after raising the dim screensaver touch guard")
 
     return errors
 
@@ -6730,12 +6735,17 @@ def run_self_test() -> int:
         "          lv_obj_move_foreground(id(clock_screensaver));\n"
         "  - id: show_dimmed_view\n"
         "    then:\n"
+        "      - script.execute: clock_bar_hide\n"
         "      - lambda: 'lv_obj_move_foreground(id(dim_screensaver_touch_guard));'\n"
+        "      - script.execute: clock_bar_apply\n"
         "interval:\n"
         "  - interval: 1s\n"
         "    then:\n"
         "      - script.execute: clock_screensaver_keep_on_top\n",
-        ("overlay the existing UI without closing it",),
+        (
+            "overlay the existing UI without closing it",
+            "keep the complete clock bar visible over the dimmed home screen",
+        ),
     )
     expect_clock_screensaver_overlay_errors(
         "clock screensaver overlays active UI",
@@ -6767,6 +6777,7 @@ def run_self_test() -> int:
         "  - id: show_dimmed_view\n"
         "    then:\n"
         "      - lambda: 'lv_obj_move_foreground(id(dim_screensaver_touch_guard));'\n"
+        "      - script.execute: clock_bar_apply\n"
         "interval:\n"
         "  - interval: 1s\n"
         "    then:\n"

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -2529,43 +2529,6 @@ def firmware_clock_bar_pending_wake_errors(display_path: Path, root: Path) -> li
         return [f"{rel}: missing clock_bar_apply script"]
     if "id(espcontrol_app).display().target_mode()" not in body:
         return [f"{rel}: resolve clock bar visibility from the pending display target"]
-    settled_body = yaml_script_body(text, "clock_bar_apply_after_page_show")
-    required_settled_tokens = (
-        "delay: 100ms",
-        "lv_scr_act() == id(main_page)->obj",
-        "script.execute: clock_bar_apply",
-        "script.wait: clock_bar_apply",
-    )
-    if settled_body is None or any(
-        token not in settled_body for token in required_settled_tokens
-    ):
-        return [f"{rel}: reapply the clock bar after the home page becomes active"]
-    repaint_body = yaml_script_body(text, "clock_bar_redraw_after_content_change")
-    force_body = yaml_script_body(text, "clock_bar_force_redraw")
-    required_repaint_tokens = (
-        "delay: 100ms",
-        "lv_scr_act() == id(main_page)->obj",
-        "script.execute: clock_bar_apply",
-        "script.wait: clock_bar_apply",
-        "script.execute: clock_bar_force_redraw",
-    )
-    required_force_tokens = (
-        "lv_obj_invalidate(id(temperatures));",
-        "lv_obj_invalidate(id(display_time));",
-        "lv_obj_invalidate(id(network_status_button));",
-        "lv_obj_invalidate(lv_layer_top());",
-        "lv_refr_now(nullptr);",
-    )
-    if (
-        "set_dashboard_content_changed_callback" not in text
-        or repaint_body is None
-        or any(token not in repaint_body for token in required_repaint_tokens)
-        or force_body is None
-        or any(token not in force_body for token in required_force_tokens)
-    ):
-        return [
-            f"{rel}: repaint the visible clock bar after asynchronous dashboard content settles"
-        ]
     return []
 
 
@@ -2581,11 +2544,17 @@ def firmware_clock_bar_navigation_errors(
         if body is None:
             errors.append(f"{rel}: missing navigate_after_api script")
             continue
-        page_index = body.find("lvgl.page.show: main_page")
-        settled_index = body.find("script.execute: clock_bar_apply_after_page_show")
-        if page_index == -1 or settled_index < page_index:
+        active_guard = body.find("target_mode_is(")
+        active_mode = body.find("DisplayMode::ACTIVE", active_guard)
+        page_show = body.find("lvgl.page.show: main_page")
+        if (
+            active_guard == -1
+            or active_mode == -1
+            or page_show == -1
+            or active_guard > page_show
+        ):
             errors.append(
-                f"{rel}: apply the clock bar only after showing and settling the home page"
+                f"{rel}: guard late home-page navigation behind the active display mode"
             )
     return errors
 
@@ -4037,6 +4006,21 @@ def expect_display_backlight_manual_sleep_errors(
         errors = firmware_display_backlight_manual_sleep_errors(
             backlight_path, tuple(device_paths), root
         )
+        for item in expected:
+            assert any(item in error for error in errors), f"{name}: missing {item!r} in {errors!r}"
+        if not expected:
+            assert not errors, f"{name}: expected no errors, got {errors!r}"
+
+
+def expect_clock_bar_navigation_errors(
+    name: str, text: str, expected: tuple[str, ...]
+) -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        path = root / "common" / "addon" / "connectivity.yaml"
+        path.parent.mkdir(parents=True)
+        path.write_text(text, encoding="utf-8")
+        errors = firmware_clock_bar_navigation_errors((path,), root)
         for item in expected:
             assert any(item in error for error in errors), f"{name}: missing {item!r} in {errors!r}"
         if not expected:
@@ -6764,6 +6748,28 @@ def run_self_test() -> int:
         valid_shared_wake_guard_widget,
         "",
         ("clear the shared wake guard after a stuck touch timeout",),
+    )
+    expect_clock_bar_navigation_errors(
+        "late navigation requires active display mode",
+        "script:\n"
+        "  - id: navigate_after_api\n"
+        "    then:\n"
+        "      - lvgl.page.show: main_page\n",
+        ("guard late home-page navigation",),
+    )
+    expect_clock_bar_navigation_errors(
+        "active navigation remains available",
+        "script:\n"
+        "  - id: navigate_after_api\n"
+        "    then:\n"
+        "      - if:\n"
+        "          condition:\n"
+        "            lambda: |-\n"
+        "              return id(espcontrol_app).display().target_mode_is(\n"
+        "                  espcontrol::DisplayMode::ACTIVE);\n"
+        "          then:\n"
+        "            - lvgl.page.show: main_page\n",
+        (),
     )
     expect_clock_screensaver_overlay_errors(
         "clock screensaver closes active UI before showing",

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -2529,13 +2529,39 @@ def firmware_clock_bar_pending_wake_errors(display_path: Path, root: Path) -> li
         return [f"{rel}: missing clock_bar_apply script"]
     if "id(espcontrol_app).display().target_mode()" not in body:
         return [f"{rel}: resolve clock bar visibility from the pending display target"]
-    visible_index = body.find("if (!visible) return;")
-    invalidate_index = body.find("lv_obj_invalidate(lv_layer_top());")
-    if visible_index == -1 or invalidate_index < visible_index:
-        return [
-            f"{rel}: invalidate the visible clock-bar top layer after applying its layout"
-        ]
+    settled_body = yaml_script_body(text, "clock_bar_apply_after_page_show")
+    required_settled_tokens = (
+        "delay: 100ms",
+        "lv_scr_act() == id(main_page)->obj",
+        "script.execute: clock_bar_apply",
+        "script.wait: clock_bar_apply",
+    )
+    if settled_body is None or any(
+        token not in settled_body for token in required_settled_tokens
+    ):
+        return [f"{rel}: reapply the clock bar after the home page becomes active"]
     return []
+
+
+def firmware_clock_bar_navigation_errors(
+    connectivity_paths: tuple[Path, ...], root: Path
+) -> list[str]:
+    errors: list[str] = []
+    for path in connectivity_paths:
+        if not path.exists():
+            continue
+        rel = path.relative_to(root)
+        body = yaml_script_body(path.read_text(encoding="utf-8"), "navigate_after_api")
+        if body is None:
+            errors.append(f"{rel}: missing navigate_after_api script")
+            continue
+        page_index = body.find("lvgl.page.show: main_page")
+        settled_index = body.find("script.execute: clock_bar_apply_after_page_show")
+        if page_index == -1 or settled_index < page_index:
+            errors.append(
+                f"{rel}: apply the clock bar only after showing and settling the home page"
+            )
+    return errors
 
 
 def firmware_clock_screensaver_overlay_errors(backlight_path: Path, root: Path) -> list[str]:
@@ -3304,6 +3330,7 @@ def run_scan() -> int:
         )
     )
     errors.extend(firmware_clock_bar_pending_wake_errors(DISPLAY_CONFIG_PATH, ROOT))
+    errors.extend(firmware_clock_bar_navigation_errors(CONNECTIVITY_PATHS, ROOT))
     errors.extend(firmware_clock_screensaver_overlay_errors(BACKLIGHT_PATH, ROOT))
     errors.extend(firmware_screen_schedule_screensaver_overlay_errors(COVER_ART_PATH, ROOT))
     errors.extend(firmware_screen_schedule_screensaver_override_errors(BACKLIGHT_PATH, ROOT))

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -2540,6 +2540,32 @@ def firmware_clock_bar_pending_wake_errors(display_path: Path, root: Path) -> li
         token not in settled_body for token in required_settled_tokens
     ):
         return [f"{rel}: reapply the clock bar after the home page becomes active"]
+    repaint_body = yaml_script_body(text, "clock_bar_redraw_after_content_change")
+    force_body = yaml_script_body(text, "clock_bar_force_redraw")
+    required_repaint_tokens = (
+        "delay: 100ms",
+        "lv_scr_act() == id(main_page)->obj",
+        "script.execute: clock_bar_apply",
+        "script.wait: clock_bar_apply",
+        "script.execute: clock_bar_force_redraw",
+    )
+    required_force_tokens = (
+        "lv_obj_invalidate(id(temperatures));",
+        "lv_obj_invalidate(id(display_time));",
+        "lv_obj_invalidate(id(network_status_button));",
+        "lv_obj_invalidate(lv_layer_top());",
+        "lv_refr_now(nullptr);",
+    )
+    if (
+        "set_dashboard_content_changed_callback" not in text
+        or repaint_body is None
+        or any(token not in repaint_body for token in required_repaint_tokens)
+        or force_body is None
+        or any(token not in force_body for token in required_force_tokens)
+    ):
+        return [
+            f"{rel}: repaint the visible clock bar after asynchronous dashboard content settles"
+        ]
     return []
 
 

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -2529,6 +2529,12 @@ def firmware_clock_bar_pending_wake_errors(display_path: Path, root: Path) -> li
         return [f"{rel}: missing clock_bar_apply script"]
     if "id(espcontrol_app).display().target_mode()" not in body:
         return [f"{rel}: resolve clock bar visibility from the pending display target"]
+    visible_index = body.find("if (!visible) return;")
+    invalidate_index = body.find("lv_obj_invalidate(lv_layer_top());")
+    if visible_index == -1 or invalidate_index < visible_index:
+        return [
+            f"{rel}: invalidate the visible clock-bar top layer after applying its layout"
+        ]
     return []
 
 

--- a/scripts/check_firmware_parser.py
+++ b/scripts/check_firmware_parser.py
@@ -245,6 +245,11 @@ int main() {
   assert(awake_clock_bar.reserve_space);
   assert(awake_clock_bar.visible);
 
+  auto dimmed_clock_bar = clock_bar_resolve_visibility(
+    true, &main_page, espcontrol::DisplayMode::DIMMED, false);
+  assert(dimmed_clock_bar.reserve_space);
+  assert(dimmed_clock_bar.visible);
+
   auto clock_screensaver_clock_bar = clock_bar_resolve_visibility(
     true, &main_page, espcontrol::DisplayMode::CLOCK, false);
   assert(clock_screensaver_clock_bar.reserve_space);


### PR DESCRIPTION
## Purpose

Restore the legacy screensaver behaviour so the complete clock bar remains visible on a dimmed home screen. The implementation is shared across display sizes.

## Root cause

Live diagnostics on the untouched 10-inch panel showed:

- display controller: `DISPLAY_OFF / MANUAL_SLEEP`
- active LVGL page: `main_page`
- clock-bar widgets: logically hidden
- physical backlight: on

The backlight light restored an OFF state during component setup. Its OFF callback treated that restored state as a real user command and requested persistent `MANUAL_SLEEP`. The later boot sequence turned the physical backlight on, but the logical controller remained in `DISPLAY_OFF`, so touching the panel cleared manual sleep and made the bar appear.

This was visible only on the 10-inch profile because its GSL3680 wake path keeps LVGL active during Display Off; older profiles suspend the UI and do not expose the inconsistent state.

## What changed

- Treat both `ACTIVE` and `DIMMED` home-screen modes as clock-bar-visible.
- Remove the explicit clock-bar hide/wait from the dimmed transition.
- Reapply the resolved bar after raising the transparent wake-touch guard.
- Use resolved visibility for temperature refresh.
- Ignore restored Display Backlight OFF events until ESPHome component setup is complete.
- Keep late connectivity navigation queued until the controller returns to `ACTIVE`, preserving full-screen Clock and Display Off modes.
- Do not add a display-specific flag, configuration option, or persisted-state migration.

## Automated checks

Passed with ESPHome 2026.7.4 after merging the latest `main`:

- Firmware parser
- Home Assistant bindings and self-tests
- Modal allocation and layout
- Device profiles, matrix, manifest, display tokens, and generated slots
- Release compile: `guition-esp32-p4-jc1060p470`
- Release compile: `guition-esp32-p4-jc4880p443`
- Release compile: `guition-esp32-s3-4848s040`
- 10-inch V1 compile and OTA upload

## Physical testing

The clean production build was OTA-flashed to the 10-inch V1 panel at `192.168.6.103`.

Confirmed on-device: the complete clock bar is visible immediately after startup without touching the screen.

Additional regression checks remain:

1. After the idle transition, brightness dims while the full bar remains visible.
2. The first touch wakes without activating a card.
3. Clock and Display Off modes hide the bar and restore it after wake.
