### PR TITLE
Eliminate accumulating Home Assistant artwork reads

### DIFF
--- a/common/device/core_infra.yaml
+++ b/common/device/core_infra.yaml
@@ -45,6 +45,7 @@ api:
               id(cover_art_resolve_home_assistant_base_url).execute();
               if (ha_api_state_connected()) {
                 refresh_weather_forecast_cards();
+                ha_log_subscription_diagnostics("client-connected");
                 ha_flush_deferred_state_requests();
               }
           - delay: 2s

--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -1064,7 +1064,7 @@ script:
             };
           bool remote_queued = true;
           if ((request_mask & espcontrol::artwork::ARTWORK_SOURCE_REMOTE) != 0) {
-            remote_queued = ha_get_attribute(
+            remote_queued = ha_read_retained_attribute(
             cover_entity,
             std::string("entity_picture"),
             std::function<void(esphome::StringRef)>(
@@ -1075,7 +1075,7 @@ script:
           }
           bool local_queued = true;
           if ((request_mask & espcontrol::artwork::ARTWORK_SOURCE_LOCAL) != 0) {
-            local_queued = ha_get_attribute(
+            local_queued = ha_read_retained_attribute(
             cover_entity,
             std::string("entity_picture_local"),
             std::function<void(esphome::StringRef)>(
@@ -2544,7 +2544,8 @@ script:
                   if (subscription_generation != id(cover_art_subscription_generation)) return;
                   id(cover_art_schedule_paired_artwork).execute(false);
                 }),
-              HA_SUBSCRIPTION_SCOPE_COVER_ART
+              HA_SUBSCRIPTION_SCOPE_COVER_ART,
+              true
             );
             bool local_picture_subscribed = ha_subscribe_attribute(
               cover_entity,
@@ -2554,7 +2555,8 @@ script:
                   if (subscription_generation != id(cover_art_subscription_generation)) return;
                   id(cover_art_schedule_paired_artwork).execute(false);
                 }),
-              HA_SUBSCRIPTION_SCOPE_COVER_ART
+              HA_SUBSCRIPTION_SCOPE_COVER_ART,
+              true
             );
             ESP_LOGI("cover_art", "Artwork subscriptions entity_picture=%s entity_picture_local=%s",
                      picture_subscribed ? "ready" : "failed",

--- a/components/espcontrol/button_grid_ha.h
+++ b/components/espcontrol/button_grid_ha.h
@@ -74,11 +74,6 @@ struct EspHomeHaReadTransport {
   bool available() const { return ha_api_available(); }
   bool state_connected() const { return ha_api_state_connected(); }
 
-  void get(std::string entity_id, std::string attribute, Callback callback) {
-    esphome::api::global_api_server->get_home_assistant_state(
-        std::move(entity_id), std::move(attribute), std::move(callback));
-  }
-
   void subscribe(const std::string &entity_id,
                  const std::string &attribute,
                  Callback callback) {
@@ -146,6 +141,24 @@ inline void ha_reset_subscription_callbacks(uint32_t scope = HA_SUBSCRIPTION_SCO
 }
 #define ESPCONTROL_HA_SUBSCRIPTION_HELPERS_DEFINED 1
 
+inline void ha_log_subscription_diagnostics(const char *stage) {
+  auto &coordinator = ha_read_coordinator();
+  size_t upstream_subscriptions = 0;
+#ifdef USE_API_HOMEASSISTANT_STATES
+  if (ha_api_available()) {
+    upstream_subscriptions = esphome::api::global_api_server->get_state_subs().size();
+  }
+#endif
+  ESP_LOGD("ha", "Subscriptions %s: active=%u retained=%u channels=%u pending=%u deferred=%u upstream=%u",
+           stage ? stage : "status",
+           static_cast<unsigned>(coordinator.subscription_count()),
+           static_cast<unsigned>(coordinator.retained_channel_count()),
+           static_cast<unsigned>(coordinator.subscription_channel_count()),
+           static_cast<unsigned>(coordinator.pending_read_count()),
+           static_cast<unsigned>(coordinator.deferred_count()),
+           static_cast<unsigned>(upstream_subscriptions));
+}
+
 inline void ha_reset_deferred_state_requests() {
   ha_read_coordinator().reset_deferred();
 }
@@ -153,6 +166,7 @@ inline void ha_reset_deferred_state_requests() {
 
 inline void ha_invalidate_retained_state() {
   ha_read_coordinator().invalidate_retained_state();
+  ha_log_subscription_diagnostics("client-disconnected");
 }
 
 inline void bump_ha_subscription_generation() {
@@ -181,6 +195,7 @@ inline void ha_reannounce_state_subscriptions() {
     }
     client->on_subscribe_home_assistant_states_request();
   }
+  ha_log_subscription_diagnostics("grid-reannounce");
 }
 
 inline bool ha_action_begin(esphome::api::HomeassistantActionRequest &req,
@@ -275,20 +290,6 @@ inline bool ha_subscribe_state(const std::string &entity_id,
   return ha_read_coordinator().subscribe(entity_id, std::string(), std::move(callback), scope, ha_callback_owner());
 }
 
-inline bool ha_get_state(const std::string &entity_id,
-                         HomeAssistantStateCallback callback) {
-  void *owner = ha_callback_owner();
-  if (owner != nullptr) {
-    callback = [owner, callback = std::move(callback)](esphome::StringRef state) {
-      if (!lv_obj_is_valid(static_cast<lv_obj_t *>(owner))) return;
-      if (callback) callback(state);
-    };
-  }
-  return ha_read_coordinator().get(
-      entity_id, std::string(), std::move(callback), false,
-      HA_READ_INTERNAL_FREE_MIN_BYTES, HA_READ_INTERNAL_LARGEST_MIN_BYTES, owner);
-}
-
 inline bool ha_subscribe_attribute(const std::string &entity_id,
                                    const std::string &attribute,
                                    HomeAssistantStateCallback callback,
@@ -298,9 +299,9 @@ inline bool ha_subscribe_attribute(const std::string &entity_id,
       entity_id, attribute, std::move(callback), scope, ha_callback_owner(), retain_latest);
 }
 
-inline bool ha_get_attribute(const std::string &entity_id,
-                             const std::string &attribute,
-                             HomeAssistantStateCallback callback) {
+inline bool ha_read_retained_attribute(const std::string &entity_id,
+                                       const std::string &attribute,
+                                       HomeAssistantStateCallback callback) {
   void *owner = ha_callback_owner();
   if (owner != nullptr) {
     callback = [owner, callback = std::move(callback)](esphome::StringRef state) {
@@ -308,7 +309,7 @@ inline bool ha_get_attribute(const std::string &entity_id,
       if (callback) callback(state);
     };
   }
-  return ha_read_coordinator().get(
+  return ha_read_coordinator().read_retained(
       entity_id, attribute, std::move(callback), true,
       HA_READ_INTERNAL_FREE_MIN_BYTES, HA_READ_INTERNAL_LARGEST_MIN_BYTES, owner);
 }

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -1558,7 +1558,7 @@ inline void image_card_request_picture(ImageCardCtx *ctx) {
     }
     const uint32_t generation = ha_subscription_generation();
     ctx->access_token_request_pending = true;
-    bool requested = ha_get_attribute(
+    bool requested = ha_read_retained_attribute(
       entity_id,
       std::string("access_token"),
       std::function<void(esphome::StringRef)>(
@@ -1590,7 +1590,7 @@ inline void image_card_request_picture(ImageCardCtx *ctx) {
   }
   if (image_card_prefer_local_picture(ctx)) {
     const uint32_t generation = ha_subscription_generation();
-    bool requested_local = ha_get_attribute(
+    bool requested_local = ha_read_retained_attribute(
       entity_id,
       std::string("entity_picture_local"),
       std::function<void(esphome::StringRef)>(
@@ -1608,7 +1608,7 @@ inline void image_card_request_picture(ImageCardCtx *ctx) {
             image_card_handle_picture(ctx, esphome::StringRef(fallback));
             return;
           }
-          bool fallback_requested = ha_get_attribute(
+          bool fallback_requested = ha_read_retained_attribute(
             entity_id,
             std::string("entity_picture"),
             std::function<void(esphome::StringRef)>(
@@ -1623,7 +1623,7 @@ inline void image_card_request_picture(ImageCardCtx *ctx) {
     if (requested_local) return;
   }
   const uint32_t generation = ha_subscription_generation();
-  bool requested = ha_get_attribute(
+  bool requested = ha_read_retained_attribute(
     entity_id,
     std::string("entity_picture"),
     std::function<void(esphome::StringRef)>(
@@ -2064,7 +2064,7 @@ inline void image_card_handle_picture(ImageCardCtx *ctx, esphome::StringRef pict
     const std::string retry_picture = raw;
     const uint32_t generation = ha_subscription_generation();
     ctx->access_token_request_pending = true;
-    bool requested = ha_get_attribute(
+    bool requested = ha_read_retained_attribute(
       entity_id,
       std::string("access_token"),
       std::function<void(esphome::StringRef)>(
@@ -2311,7 +2311,7 @@ inline void image_card_request_media_artwork(ImageCardCtx *ctx, bool force_refre
            ha_api_state_connected());
   bool remote_queued = true;
   if ((request_mask & espcontrol::artwork::ARTWORK_SOURCE_REMOTE) != 0) {
-    remote_queued = ha_get_attribute(
+    remote_queued = ha_read_retained_attribute(
       entity_id,
       std::string("entity_picture"),
       std::function<void(esphome::StringRef)>(
@@ -2323,7 +2323,7 @@ inline void image_card_request_media_artwork(ImageCardCtx *ctx, bool force_refre
   }
   bool local_queued = true;
   if ((request_mask & espcontrol::artwork::ARTWORK_SOURCE_LOCAL) != 0) {
-    local_queued = ha_get_attribute(
+    local_queued = ha_read_retained_attribute(
       entity_id,
       std::string("entity_picture_local"),
       std::function<void(esphome::StringRef)>(

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -271,21 +271,6 @@ inline void media_set_now_playing_artist(MediaNowPlayingCtx *ctx,
   ctx->artist[sizeof(ctx->artist) - 1] = '\0';
 }
 
-inline void media_refresh_artist_text(MediaNowPlayingCtx *ctx,
-                                      const std::string &entity_id) {
-  if (!ctx || entity_id.empty()) return;
-  ctx->artist[0] = '\0';
-  media_apply_now_playing_artist_text(ctx);
-  ha_get_attribute(
-    entity_id, std::string("media_artist"),
-    std::function<void(esphome::StringRef)>(
-      [ctx](esphome::StringRef artist) {
-        media_set_now_playing_artist(ctx, artist);
-        media_apply_now_playing_artist_text(ctx);
-      })
-  );
-}
-
 inline bool media_position_timestamp_ms(esphome::StringRef value, uint32_t &updated_ms);
 inline bool media_control_seek_pending_active(MediaControlCtx *ctx);
 inline bool media_control_track_position_reset_active(MediaControlCtx *ctx);
@@ -1493,7 +1478,7 @@ inline void media_playback_subscribe_source(MediaPlaybackState *state) {
     HA_SUBSCRIPTION_SCOPE_DEFAULT,
     true
   );
-  ha_get_attribute(entity_id, std::string("source"), handle_media_source);
+  ha_read_retained_attribute(entity_id, std::string("source"), handle_media_source);
 }
 
 inline void media_playback_subscribe_progress(MediaPlaybackState *state,

--- a/components/espcontrol/ha_read_coordinator.h
+++ b/components/espcontrol/ha_read_coordinator.h
@@ -29,22 +29,37 @@ class HaReadCoordinator {
   uint32_t &generation_ref() { return generation_; }
   size_t deferred_count() const { return deferred_.size(); }
   size_t subscription_count() const { return subscriptions_.size(); }
+  size_t subscription_channel_count() const { return subscription_channels_.size(); }
+  size_t retained_channel_count() const {
+    size_t count = 0;
+    for (size_t i = 0; i < subscription_channels_.size(); i++) {
+      if (channel_reuses_reads(i)) count++;
+    }
+    return count;
+  }
+  size_t pending_read_count() const {
+    size_t count = 0;
+    for (const auto &channel : subscription_channels_) count += channel.pending_reads.size();
+    for (const auto &request : deferred_) count += request.callbacks.size();
+    return count;
+  }
 
-  bool get(const std::string &entity_id,
-           const std::string &attribute,
-           Callback callback,
-           bool has_attribute,
-           size_t min_free,
-           size_t min_largest,
-           void *owner = nullptr) {
+  bool read_retained(const std::string &entity_id,
+                     const std::string &attribute,
+                     Callback callback,
+                     bool has_attribute,
+                     size_t min_free,
+                     size_t min_largest,
+                     void *owner = nullptr) {
     if (!available() || entity_id.empty() || !callback) return false;
     if (!heap_probe_.available("Home Assistant state request", min_free, min_largest)) return false;
+    size_t channel = find_subscription_channel(entity_id, attribute, has_attribute);
+    if (channel == subscription_channels_.size() || !channel_reuses_reads(channel)) return false;
     CallbackRef callback_ref{std::make_shared<Callback>(std::move(callback)), owner, owner_generation(owner)};
-    if (callback_depth_ != 0 || !state_connected()) {
+    if (callback_depth_ != 0) {
       return queue(entity_id, attribute, std::move(callback_ref), has_attribute);
     }
-    dispatch_one(entity_id, attribute, std::move(callback_ref), has_attribute, generation_);
-    return true;
+    return queue_on_subscription_channel(entity_id, attribute, std::move(callback_ref), has_attribute);
   }
 
   bool subscribe(const std::string &entity_id,
@@ -92,7 +107,7 @@ class HaReadCoordinator {
       }
       dispatch_many(
           std::move(request.entity_id), std::move(request.attribute),
-          std::move(request.callbacks), request.has_attribute, request.generation);
+          std::move(request.callbacks), request.has_attribute);
       processed++;
     }
     release_empty_deferred_storage();
@@ -185,7 +200,7 @@ class HaReadCoordinator {
   };
 
   static constexpr size_t MAX_DEFERRED_REQUESTS = 64;
-  static constexpr size_t MAX_PENDING_CHANNEL_READS = 64;
+  static constexpr size_t MAX_PENDING_READS = 64;
 
   uint32_t owner_generation(void *owner) {
     if (!owner) return 0;
@@ -222,37 +237,19 @@ class HaReadCoordinator {
           request.has_attribute == has_attribute &&
           request.entity_id == entity_id &&
           request.attribute == attribute) {
-        request.callbacks.push_back(std::move(callback));
-        return true;
+        return queue_callback_ref(request.callbacks, std::move(callback));
       }
     }
-    if (deferred_.size() >= MAX_DEFERRED_REQUESTS) return false;
+    if (deferred_.size() >= MAX_DEFERRED_REQUESTS ||
+        pending_read_count() >= MAX_PENDING_READS) return false;
     deferred_.push_back({entity_id, attribute, {std::move(callback)}, generation_, has_attribute});
     return true;
-  }
-
-  void dispatch_one(std::string entity_id,
-                    std::string attribute,
-                    CallbackRef callback_ref,
-                    bool has_attribute,
-                    uint32_t generation) {
-    if (queue_on_subscription_channel(entity_id, attribute, callback_ref, has_attribute)) {
-      return;
-    }
-    transport_.get(
-        std::move(entity_id), has_attribute ? std::move(attribute) : std::string(),
-        [this, callback_ref, generation](State state) {
-          if (generation == generation_ && owner_generation_current(callback_ref)) {
-            invoke(callback_ref.callback, state);
-          }
-        });
   }
 
   void dispatch_many(std::string entity_id,
                      std::string attribute,
                      std::vector<CallbackRef> callbacks,
-                     bool has_attribute,
-                     uint32_t generation) {
+                     bool has_attribute) {
     size_t channel = find_subscription_channel(entity_id, attribute, has_attribute);
     if (channel != subscription_channels_.size() && channel_reuses_reads(channel)) {
       auto &subscription = subscription_channels_[channel];
@@ -266,17 +263,7 @@ class HaReadCoordinator {
           queue_pending_channel_read(subscription, std::move(callback_ref));
         }
       }
-      return;
     }
-    auto callback_refs = std::make_shared<std::vector<CallbackRef>>(std::move(callbacks));
-    transport_.get(
-        std::move(entity_id), has_attribute ? std::move(attribute) : std::string(),
-        [this, callback_refs, generation](State state) {
-          if (generation != generation_) return;
-          for (const auto &callback_ref : *callback_refs) {
-            if (owner_generation_current(callback_ref)) invoke(callback_ref.callback, state);
-          }
-        });
   }
 
   void invoke(const std::shared_ptr<Callback> &callback, State state) {
@@ -347,26 +334,30 @@ class HaReadCoordinator {
       State state(subscription.cached_state);
       if (owner_generation_current(callback_ref)) invoke(callback_ref.callback, state);
     } else {
-      queue_pending_channel_read(subscription, std::move(callback_ref));
+      return queue_pending_channel_read(subscription, std::move(callback_ref));
     }
     return true;
   }
 
-  void queue_pending_channel_read(SubscriptionChannel &subscription,
+  bool queue_pending_channel_read(SubscriptionChannel &subscription,
                                   CallbackRef callback_ref) {
     // Repeated refreshes for one card supersede its earlier pending callback.
-    // Keep distinct card owners independent, but cap them as a final guard
-    // against a channel that Home Assistant never publishes.
-    for (auto &pending : subscription.pending_reads) {
+    // Keep distinct card owners independent, but cap all retained-read work as
+    // a final guard against channels that Home Assistant never publishes.
+    return queue_callback_ref(subscription.pending_reads, std::move(callback_ref));
+  }
+
+  bool queue_callback_ref(std::vector<CallbackRef> &callbacks,
+                          CallbackRef callback_ref) {
+    for (auto &pending : callbacks) {
       if (callback_ref.owner != nullptr && pending.owner == callback_ref.owner) {
         pending = std::move(callback_ref);
-        return;
+        return true;
       }
     }
-    if (subscription.pending_reads.size() >= MAX_PENDING_CHANNEL_READS) {
-      subscription.pending_reads.erase(subscription.pending_reads.begin());
-    }
-    subscription.pending_reads.push_back(std::move(callback_ref));
+    if (pending_read_count() >= MAX_PENDING_READS) return false;
+    callbacks.push_back(std::move(callback_ref));
+    return true;
   }
 
   bool channel_reuses_reads(size_t channel) const {

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -124,6 +124,7 @@ HA_BOUNDARY_ALLOWLIST = {
     "button_grid_ha.h",
 }
 DIRECT_HA_PATTERNS = (
+    (re.compile(r"\bha_get_(?:state|attribute)\s*\("), "use retained Home Assistant reads instead of one-shot helpers"),
     (re.compile(r"\bglobal_api_server\b"), "access Home Assistant API through button_grid_ha.h helpers"),
     (re.compile(r"(?:->|\.)send_homeassistant_action\s*\("), "send Home Assistant actions through button_grid_ha.h helpers"),
     (re.compile(r"(?:->|\.)subscribe_home_assistant_state\s*\("), "subscribe to Home Assistant state through button_grid_ha.h helpers"),
@@ -232,19 +233,30 @@ def firmware_ha_boundary_errors(firmware_dir: Path, root: Path) -> list[str]:
     elif "HA_ACTION_INTERNAL_FREE_MIN_BYTES" not in action_send_match.group("body"):
         errors.append(f"{rel}: defer Home Assistant actions when S3 internal heap is critically low")
     if (
-        "ha_read_coordinator().get(" not in text
+        "ha_read_coordinator().read_retained(" not in text
         or "HA_READ_INTERNAL_FREE_MIN_BYTES" not in text
         or 'heap_probe_.available("Home Assistant state request"' not in coordinator_text
     ):
-        errors.append(f"{rel}: defer one-off Home Assistant attribute reads when S3 internal heap is critically low")
-    if "callback_depth_ != 0 || !state_connected()" not in coordinator_text:
-        errors.append(f"{rel}: queue one-off Home Assistant reads until state subscription is ready")
+        errors.append(f"{rel}: guard retained Home Assistant reads under low internal heap")
     if (
-        "request.callbacks.push_back(std::move(callback))" not in read_boundary_text
-        or "request.entity_id == entity_id" not in read_boundary_text
-        or not DEFERRED_CALLBACK_FANOUT_PATTERN.search(read_boundary_text)
+        "get_home_assistant_state" in read_boundary_text
+        or "transport_.get(" in coordinator_text
+        or "ha_get_state" in text
+        or "ha_get_attribute" in text
     ):
-        errors.append(f"{rel}: fan out duplicate deferred Home Assistant reads")
+        errors.append(f"{rel}: never register accumulating one-shot Home Assistant state reads")
+    if (
+        "find_subscription_channel(entity_id, attribute, has_attribute)" not in coordinator_text
+        or "!channel_reuses_reads(channel)" not in coordinator_text
+    ):
+        errors.append(f"{rel}: fail retained reads closed without an active retained subscription")
+    if (
+        "if (callback_depth_ != 0)" not in coordinator_text
+        or "queue_callback_ref(request.callbacks, std::move(callback))" not in coordinator_text
+        or "request.entity_id == entity_id" not in coordinator_text
+        or "for (const auto &callback_ref : callbacks)" not in coordinator_text
+    ):
+        errors.append(f"{rel}: queue and fan out bounded reentrant retained reads")
     if not SUBSCRIPTION_TRACKING_PATTERN.search(coordinator_text):
         errors.append(f"{rel}: track Home Assistant subscription callbacks for generation cleanup")
     if "release_subscriptions" not in coordinator_text or "*ref.callback = nullptr" not in coordinator_text:
@@ -262,6 +274,14 @@ def firmware_ha_boundary_errors(firmware_dir: Path, root: Path) -> list[str]:
         or "client->on_subscribe_home_assistant_states_request();" not in text
     ):
         errors.append(f"{rel}: re-announce runtime card subscriptions to the connected Home Assistant client")
+    if (
+        "ha_log_subscription_diagnostics" not in text
+        or "get_state_subs().size()" not in text
+        or "pending_read_count()" not in text
+        or "subscription_channel_count()" not in text
+        or "retained_channel_count()" not in text
+    ):
+        errors.append(f"{rel}: expose count-only Home Assistant subscription diagnostics")
     grid_path = firmware_dir / "button_grid_grid.h"
     if grid_path.exists() and "ha_reannounce_state_subscriptions();" not in grid_path.read_text(encoding="utf-8"):
         errors.append(f"{grid_path.relative_to(root)}: re-announce subscriptions after runtime grid rebuilds")
@@ -919,6 +939,9 @@ def firmware_cover_art_refresh_errors(path: Path, root: Path) -> list[str]:
     text = path.read_text(encoding="utf-8")
     errors: list[str] = []
 
+    if re.search(r"\bha_get_(?:state|attribute)\s*\(", text):
+        errors.append(f"{rel}: use retained Home Assistant reads instead of one-shot helpers")
+
     required_state = (
         ("cover_art_runtime).refresh_needed", "track/source metadata changes as stale artwork"),
         ("cover_art_runtime).effective_download_url", "keep source artwork URLs separate from downloader URLs"),
@@ -993,6 +1016,16 @@ def firmware_cover_art_refresh_errors(path: Path, root: Path) -> list[str]:
     if cached_body and "id(cover_art_runtime).select_source(chosen);" not in cached_body:
         errors.append(f"{rel}: mark changed cached artwork URLs as stale before downloading")
     resubscribe_body = yaml_script_body(text, "cover_art_resubscribe") or ""
+    for attribute in ("entity_picture", "entity_picture_local"):
+        retained_subscription = re.search(
+            rf'ha_subscribe_attribute\(\s*cover_entity,\s*std::string\("{attribute}"\),'
+            rf'[\s\S]{{0,700}}?HA_SUBSCRIPTION_SCOPE_COVER_ART,\s*true\s*\)',
+            resubscribe_body,
+        )
+        if not retained_subscription:
+            errors.append(
+                f"{rel}: retain {attribute} so artwork refreshes never register one-shot callbacks"
+            )
     artwork_refresh_body = (
         resubscribe_body +
         (yaml_script_body(text, "cover_art_request_paired_artwork") or "")
@@ -1516,9 +1549,9 @@ def firmware_media_group_lifecycle_errors(firmware_dir: Path, root: Path) -> lis
         subscribe_body = text.split("inline void media_control_refresh_speaker_state", 1)[1]
         subscribe_body = subscribe_body.split("\n}\n\ninline void media_control_add_speaker_candidate", 1)[0]
         for token in (
-            "ha_get_state(entity_id, state_callback)",
-            'ha_get_attribute(entity_id, std::string("friendly_name"), name_callback)',
-            'ha_get_attribute(entity_id, std::string("volume_level"), volume_callback)',
+            "ha_read_retained_state(entity_id, state_callback)",
+            'ha_read_retained_attribute(entity_id, std::string("friendly_name"), name_callback)',
+            'ha_read_retained_attribute(entity_id, std::string("volume_level"), volume_callback)',
         ):
             if token not in subscribe_body:
                 errors.append(f"{rel}: rehydrate a speaker row recreated during a live helper edit")
@@ -2192,7 +2225,7 @@ def firmware_image_card_startup_errors(
         errors.append(f"{rel}: retry image-card startup quickly after Home Assistant API connects")
     if "if (!ha_api_connected()) return;" not in text:
         errors.append(f"{rel}: arm image-card refresh from the Home Assistant API connection")
-    if "if (!ha_api_connected())" not in text or "ha_get_attribute(" not in text:
+    if "if (!ha_api_connected())" not in text or "ha_read_retained_attribute(" not in text:
         errors.append(f"{rel}: request image-card attributes once the Home Assistant API is connected")
     if '"access_token"' not in text or "image_card_proxy_path_with_token" not in text:
         errors.append(f"{rel}: load Home Assistant image-card proxy URLs with the entity access token")
@@ -4423,7 +4456,7 @@ def run_self_test() -> int:
         ("send Home Assistant actions only after state subscription is ready",),
     )
     expect_ha_boundary_errors(
-        "one-off state read before state connection",
+        "retained state read without channel validation",
         {
             "button_grid_ha.h": (
                 "inline bool ha_subscribe_state() {\n  return true;\n}\n"
@@ -4432,17 +4465,17 @@ def run_self_test() -> int:
                 "inline bool ha_action_send() {\n"
                 "  return ha_api_state_connected() && HA_ACTION_INTERNAL_FREE_MIN_BYTES;\n"
                 "}\n"
-                "inline bool ha_get_attribute() {\n"
+                "inline bool ha_read_retained_attribute() {\n"
                 "  ha_internal_heap_available(\"Home Assistant attribute request\");\n"
                 "  if (ha_state_callback_depth() != 0) return true;\n"
                 "  return true;\n"
                 "}\n"
             )
         },
-        ("queue one-off Home Assistant reads until state subscription is ready",),
+        ("fail retained reads closed without an active retained subscription",),
     )
     expect_ha_boundary_errors(
-        "duplicate deferred state reads",
+        "unbounded reentrant retained reads",
         {
             "button_grid_ha.h": (
                 "inline bool ha_subscribe_state() {\n  return true;\n}\n"
@@ -4451,18 +4484,18 @@ def run_self_test() -> int:
                 "inline bool ha_action_send() {\n"
                 "  return ha_api_state_connected() && HA_ACTION_INTERNAL_FREE_MIN_BYTES;\n"
                 "}\n"
-                "inline bool ha_get_state() {\n"
+                "inline bool ha_read_retained_state() {\n"
                 "  ha_internal_heap_available(\"Home Assistant attribute request\");\n"
                 "  if (ha_state_callback_depth() != 0 || !ha_api_state_connected()) return true;\n"
                 "  return true;\n"
                 "}\n"
-                "inline bool ha_get_attribute() {\n"
+                "inline bool ha_read_retained_attribute() {\n"
                 "  if (ha_state_callback_depth() != 0 || !ha_api_state_connected()) return true;\n"
                 "  return true;\n"
                 "}\n"
             )
         },
-        ("fan out duplicate deferred Home Assistant reads",),
+        ("queue and fan out bounded reentrant retained reads",),
     )
     expect_ha_boundary_errors(
         "subscription callback bodies retained",
@@ -4480,14 +4513,14 @@ def run_self_test() -> int:
                 "inline bool ha_action_send() {\n"
                 "  return ha_api_state_connected() && HA_ACTION_INTERNAL_FREE_MIN_BYTES;\n"
                 "}\n"
-                "inline bool ha_get_state() {\n"
+                "inline bool ha_read_retained_state() {\n"
                 "  ha_internal_heap_available(\"Home Assistant attribute request\");\n"
                 "  if (ha_state_callback_depth() != 0 || !ha_api_state_connected()) return true;\n"
                 "  request.callback = std::move(callback);\n"
                 "  request.entity_id == entity_id;\n"
                 "  return true;\n"
                 "}\n"
-                "inline bool ha_get_attribute() {\n"
+                "inline bool ha_read_retained_attribute() {\n"
                 "  if (ha_state_callback_depth() != 0 || !ha_api_state_connected()) return true;\n"
                 "  return true;\n"
                 "}\n"
@@ -5490,6 +5523,8 @@ def run_self_test() -> int:
         "          if (!url.empty() && url != id(cover_art_runtime).source_url) {\n"
         "            id(cover_art_runtime).refresh_needed = true;\n"
         "          }\n"
+        "          ha_subscribe_attribute(cover_entity, std::string(\"entity_picture\"), callback, HA_SUBSCRIPTION_SCOPE_COVER_ART, true);\n"
+        "          ha_subscribe_attribute(cover_entity, std::string(\"entity_picture_local\"), callback, HA_SUBSCRIPTION_SCOPE_COVER_ART, true);\n"
         "          ha_subscribe_attribute(cover_entity, std::string(\"media_album_name\"), handle_media_album);\n"
         "          // Live subscriptions supply both initial values and updates.\n",
         (),
@@ -6422,7 +6457,7 @@ def run_self_test() -> int:
     expect_image_card_startup_errors(
         "image card missing startup reconnect refresh",
         "inline void image_card_request_picture(ImageCardCtx *ctx) {\n"
-        "  bool requested = ha_get_attribute(ctx->entity_id, std::string(\"entity_picture\"), callback);\n"
+        "  bool requested = ha_read_retained_attribute(ctx->entity_id, std::string(\"entity_picture\"), callback);\n"
         "}\n"
         "inline void image_card_request_source_url(ImageCardCtx *ctx) {\n"
         "  ctx->url = image_card_cache_bust_url(ctx->source_url);\n"
@@ -6464,14 +6499,14 @@ def run_self_test() -> int:
         "}\n"
         "inline void image_card_request_picture(ImageCardCtx *ctx) {\n"
         "  if (!ha_api_connected()) return;\n"
-        "  ha_get_attribute(ctx->entity_id, std::string(\"access_token\"), callback);\n"
+        "  ha_read_retained_attribute(ctx->entity_id, std::string(\"access_token\"), callback);\n"
         "  image_card_proxy_path_with_token(proxy_path, token);\n"
-        "  ha_get_attribute(ctx->entity_id, std::string(\"entity_picture\"), callback);\n"
+        "  ha_read_retained_attribute(ctx->entity_id, std::string(\"entity_picture\"), callback);\n"
         "}\n"
         "inline void image_card_request_media_artwork(ImageCardCtx *ctx) {\n"
         "  uint8_t request_mask = artwork_source_request_mask(ctx->media_artwork_retry_mask);\n"
-        "  bool remote_queued = ha_get_attribute(ctx->entity_id, std::string(\"entity_picture\"), callback);\n"
-        "  bool local_queued = ha_get_attribute(ctx->entity_id, std::string(\"entity_picture_local\"), callback);\n"
+        "  bool remote_queued = ha_read_retained_attribute(ctx->entity_id, std::string(\"entity_picture\"), callback);\n"
+        "  bool local_queued = ha_read_retained_attribute(ctx->entity_id, std::string(\"entity_picture_local\"), callback);\n"
         "  ctx->media_artwork_retry_mask = artwork_source_failed_mask(request_mask, remote_queued, local_queued);\n"
         "  if (ctx->media_artwork_retry_mask != 0) image_card_schedule_picture_retry(ctx, 250);\n"
         "}\n"

--- a/tests/firmware/ha_read_coordinator_test.cpp
+++ b/tests/firmware/ha_read_coordinator_test.cpp
@@ -22,25 +22,15 @@ struct FakeTransport {
 
   bool api_available = true;
   bool connected = true;
-  std::vector<Request> reads;
   std::vector<Request> subscriptions;
 
   bool available() const { return api_available; }
   bool state_connected() const { return connected; }
 
-  void get(std::string entity_id, std::string attribute, Callback callback) {
-    reads.push_back({std::move(entity_id), std::move(attribute), std::move(callback)});
-  }
-
   void subscribe(const std::string &entity_id,
                  const std::string &attribute,
                  Callback callback) {
     subscriptions.push_back({entity_id, attribute, std::move(callback)});
-  }
-
-  void deliver_read(size_t index, const std::string &state) {
-    Callback callback = reads.at(index).callback;
-    callback(state);
   }
 
   void publish(size_t index, const std::string &state) {
@@ -71,74 +61,79 @@ void require(bool condition, const char *message) {
   if (!condition) fail(message);
 }
 
+
 void disconnected_read_flushes_after_reconnect() {
   Coordinator coordinator;
+  require(coordinator.subscribe("sensor.room", "", [](std::string) {}, 1u, nullptr, true),
+          "retained state subscription should register");
   coordinator.transport().connected = false;
   std::string received;
-  require(coordinator.get("sensor.room", "", [&](std::string value) { received = value; },
-                          false, 10, 5),
-          "disconnected read should queue");
-  require(coordinator.deferred_count() == 1 && coordinator.transport().reads.empty(),
-          "disconnected read was not deferred");
+  require(coordinator.read_retained(
+              "sensor.room", "", [&](std::string value) { received = value; }, false, 10, 5),
+          "disconnected retained read should wait");
+  require(coordinator.deferred_count() == 0 && coordinator.pending_read_count() == 1,
+          "disconnected read did not wait on its retained channel");
   coordinator.transport().connected = true;
-  coordinator.flush(8, 10, 5);
-  require(coordinator.transport().reads.size() == 1, "reconnected read was not sent");
-  coordinator.transport().deliver_read(0, "ready");
+  coordinator.transport().publish(0, "ready");
   require(received == "ready", "reconnected callback was not invoked");
 }
 
-void low_memory_preserves_deferred_work() {
+
+void low_memory_rejects_retained_read_without_pending_work() {
   Coordinator coordinator;
-  coordinator.transport().connected = false;
-  int calls = 0;
-  require(coordinator.get("sensor.heap", "", [&](std::string) { calls++; }, false, 10, 5),
-          "read should queue before heap pressure");
-  coordinator.transport().connected = true;
+  require(coordinator.subscribe("sensor.heap", "", [](std::string) {}, 1u, nullptr, true),
+          "retained state subscription should register");
   coordinator.heap_probe().enough = false;
-  coordinator.flush(8, 10, 5);
-  require(coordinator.deferred_count() == 1 && coordinator.transport().reads.empty(),
-          "low-memory flush should retain work");
-  coordinator.heap_probe().enough = true;
-  coordinator.flush(8, 10, 5);
-  coordinator.transport().deliver_read(0, "ok");
-  require(calls == 1, "deferred low-memory read did not recover");
+  int calls = 0;
+  require(!coordinator.read_retained(
+              "sensor.heap", "", [&](std::string) { calls++; }, false, 10, 5),
+          "low-memory retained read should fail safely");
+  require(calls == 0 && coordinator.pending_read_count() == 0,
+          "low-memory retained read left pending work");
 }
+
 
 void duplicate_reads_fan_out_once() {
   Coordinator coordinator;
-  coordinator.transport().connected = false;
+  require(coordinator.subscribe("sensor.same", "", [](std::string) {}, 1u, nullptr, true),
+          "retained state subscription should register");
   int first = 0;
   int second = 0;
-  require(coordinator.get("sensor.same", "", [&](std::string) { first++; }, false, 10, 5),
-          "first duplicate read should queue");
-  require(coordinator.get("sensor.same", "", [&](std::string) { second++; }, false, 10, 5),
-          "second duplicate read should join");
-  require(coordinator.deferred_count() == 1, "duplicate reads were not coalesced");
-  coordinator.transport().connected = true;
-  coordinator.flush(8, 10, 5);
-  require(coordinator.transport().reads.size() == 1, "duplicate reads sent more than once");
-  coordinator.transport().deliver_read(0, "on");
+  require(coordinator.read_retained(
+              "sensor.same", "", [&](std::string) { first++; }, false, 10, 5),
+          "first duplicate read should wait");
+  require(coordinator.read_retained(
+              "sensor.same", "", [&](std::string) { second++; }, false, 10, 5),
+          "second duplicate read should wait");
+  require(coordinator.pending_read_count() == 2, "independent reads were not retained");
+  coordinator.transport().publish(0, "on");
   require(first == 1 && second == 1, "duplicate callbacks did not fan out");
 }
 
+
 void reentrant_reads_are_deferred() {
   Coordinator coordinator;
+  require(coordinator.subscribe("sensor.outer", "", [](std::string) {}, 1u, nullptr, true),
+          "outer retained subscription should register");
+  require(coordinator.subscribe("sensor.inner", "", [](std::string) {}, 1u, nullptr, true),
+          "inner retained subscription should register");
   int nested = 0;
-  require(coordinator.get(
+  require(coordinator.read_retained(
               "sensor.outer", "",
               [&](std::string) {
-                require(coordinator.get("sensor.inner", "", [&](std::string) { nested++; },
-                                        false, 10, 5),
+                require(coordinator.read_retained(
+                            "sensor.inner", "", [&](std::string) { nested++; }, false, 10, 5),
                         "nested read should queue");
               },
               false, 10, 5),
-          "outer read should send");
-  coordinator.transport().deliver_read(0, "outer");
-  require(coordinator.deferred_count() == 1 && coordinator.transport().reads.size() == 1,
-          "reentrant read was sent inside callback");
+          "outer read should wait");
+  coordinator.transport().publish(0, "outer");
+  require(coordinator.deferred_count() == 1 && nested == 0,
+          "reentrant read was invoked inside callback");
   coordinator.flush(8, 10, 5);
-  require(coordinator.transport().reads.size() == 2, "reentrant read did not flush");
-  coordinator.transport().deliver_read(1, "inner");
+  require(coordinator.pending_read_count() == 1,
+          "reentrant read did not flush to retained channel");
+  coordinator.transport().publish(1, "inner");
   require(nested == 1, "reentrant callback did not run");
 }
 
@@ -188,25 +183,97 @@ void subscription_backed_reads_reuse_the_live_channel() {
           "artwork subscription should register");
 
   std::string first_read;
-  require(coordinator.get(
+  require(coordinator.read_retained(
               "media_player.room", "entity_picture",
               [&](std::string value) { first_read = value; }, true, 10, 5),
           "first artwork read should wait on its live subscription");
-  require(coordinator.transport().reads.empty(),
-          "subscription-backed artwork read created an unbounded one-shot request");
+  require(coordinator.transport().subscriptions.size() == 1 &&
+              coordinator.pending_read_count() == 1,
+          "subscription-backed artwork read created extra transport activity");
 
   coordinator.transport().publish(0, "/api/media_player_proxy/room");
   require(first_read == "/api/media_player_proxy/room" && subscription_calls == 1,
           "live artwork response did not satisfy the pending read");
 
   std::string cached_read;
-  require(coordinator.get(
+  require(coordinator.read_retained(
               "media_player.room", "entity_picture",
               [&](std::string value) { cached_read = value; }, true, 10, 5),
           "later artwork read should reuse the live channel");
   require(cached_read == "/api/media_player_proxy/room" &&
-              coordinator.transport().reads.empty(),
+              coordinator.transport().subscriptions.size() == 1 &&
+              coordinator.pending_read_count() == 0,
           "later artwork read did not reuse the latest live value");
+}
+
+
+void retained_reads_never_accumulate_transport_callbacks() {
+  Coordinator coordinator;
+  int subscription_calls = 0;
+  int read_calls = 0;
+  require(coordinator.subscribe(
+              "media_player.room", "entity_picture",
+              [&](std::string) { subscription_calls++; }, 1u, nullptr, true),
+          "retained artwork subscription should register");
+  coordinator.transport().publish(0, "cached");
+
+  for (size_t i = 0; i < 1000; i++) {
+    require(coordinator.read_retained(
+                "media_player.room", "entity_picture",
+                [&](std::string value) {
+                  require(value == "cached", "retained read received the wrong cached value");
+                  read_calls++;
+                },
+                true, 10, 5),
+            "cached retained read should succeed");
+  }
+
+  require(read_calls == 1000 && coordinator.subscription_channel_count() == 1 &&
+              coordinator.pending_read_count() == 0,
+          "repeated retained reads accumulated transport or pending callbacks");
+  coordinator.transport().publish(0, "new");
+  require(read_calls == 1000 && subscription_calls == 2,
+          "later state update invoked completed retained-read callbacks");
+}
+
+void missing_retained_channel_fails_closed() {
+  Coordinator coordinator;
+  int calls = 0;
+  require(!coordinator.read_retained(
+              "media_player.room", "entity_picture",
+              [&](std::string) { calls++; }, true, 10, 5),
+          "missing retained channel should fail");
+  require(calls == 0 && coordinator.subscription_channel_count() == 0 &&
+              coordinator.pending_read_count() == 0,
+          "missing retained channel created coordinator state");
+}
+
+void pending_unowned_reads_are_globally_capped() {
+  Coordinator coordinator;
+  int calls = 0;
+  size_t accepted = 0;
+  require(coordinator.subscribe(
+              "media_player.room", "entity_picture",
+              [](std::string) {}, 1u, nullptr, true),
+          "retained remote artwork subscription should register");
+  require(coordinator.subscribe(
+              "media_player.room", "entity_picture_local",
+              [](std::string) {}, 1u, nullptr, true),
+          "retained local artwork subscription should register");
+  for (size_t i = 0; i < 1000; i++) {
+    const char *attribute = (i % 2 == 0) ? "entity_picture" : "entity_picture_local";
+    if (coordinator.read_retained(
+            "media_player.room", attribute,
+            [&](std::string) { calls++; }, true, 10, 5)) {
+      accepted++;
+    }
+  }
+  require(accepted == 64 && coordinator.pending_read_count() == 64,
+          "pending retained reads exceeded the global cap");
+  coordinator.transport().publish(0, "remote");
+  coordinator.transport().publish(1, "local");
+  require(calls == 64 && coordinator.pending_read_count() == 0,
+          "globally capped pending retained reads were not released");
 }
 
 void generation_change_discards_cached_and_pending_channel_reads() {
@@ -221,7 +288,7 @@ void generation_change_discards_cached_and_pending_channel_reads() {
           "new generation artwork subscription should register");
 
   int calls = 0;
-  require(coordinator.get("media_player.room", "entity_picture",
+  require(coordinator.read_retained("media_player.room", "entity_picture",
                           [&](std::string) { calls++; }, true, 10, 5),
           "new generation artwork read should wait for a current value");
   require(calls == 0, "new generation consumed stale cached artwork");
@@ -238,7 +305,7 @@ void reconnect_discards_retained_channel_state() {
   coordinator.invalidate_retained_state();
 
   std::string received;
-  require(coordinator.get("media_player.room", "entity_picture",
+  require(coordinator.read_retained("media_player.room", "entity_picture",
                           [&](std::string value) { received = value; }, true, 10, 5),
           "reconnected artwork read should wait for a current value");
   require(received.empty(), "reconnected artwork read reused stale credentials");
@@ -247,19 +314,20 @@ void reconnect_discards_retained_channel_state() {
           "reconnected artwork read did not receive the current credentials");
 }
 
-void ordinary_subscriptions_do_not_retain_state_for_reads() {
+
+void ordinary_subscriptions_fail_closed_for_retained_reads() {
   Coordinator coordinator;
   require(coordinator.subscribe("sensor.room", "friendly_name",
                                 [](std::string) {}, 1u),
           "ordinary subscription should register");
-  coordinator.transport().publish(0, "A deliberately retained label");
+  coordinator.transport().publish(0, "Room");
 
   int calls = 0;
-  require(coordinator.get("sensor.room", "friendly_name",
-                          [&](std::string) { calls++; }, true, 10, 5),
-          "ordinary one-shot read should be dispatched");
-  require(calls == 0 && coordinator.transport().reads.size() == 1,
-          "ordinary subscription unexpectedly retained a persistent state copy");
+  require(!coordinator.read_retained(
+              "sensor.room", "friendly_name", [&](std::string) { calls++; }, true, 10, 5),
+          "ordinary subscription should reject retained reads");
+  require(calls == 0 && coordinator.pending_read_count() == 0,
+          "ordinary subscription retained an unsafe read");
 }
 
 void inactive_reusable_channels_release_cached_state() {
@@ -274,7 +342,7 @@ void inactive_reusable_channels_release_cached_state() {
           "artwork subscription should be reusable after reset");
 
   int calls = 0;
-  require(coordinator.get("media_player.room", "entity_picture",
+  require(coordinator.read_retained("media_player.room", "entity_picture",
                           [&](std::string) { calls++; }, true, 10, 5),
           "recreated artwork read should wait for reannouncement");
   require(calls == 0, "inactive artwork channel retained stale cached state");
@@ -291,10 +359,10 @@ void stalled_reusable_channel_coalesces_reads_per_owner() {
 
   int stale_calls = 0;
   int current_calls = 0;
-  require(coordinator.get("media_player.room", "entity_picture_local",
+  require(coordinator.read_retained("media_player.room", "entity_picture_local",
                           [&](std::string) { stale_calls++; }, true, 10, 5, &owner),
           "first local artwork read should wait");
-  require(coordinator.get("media_player.room", "entity_picture_local",
+  require(coordinator.read_retained("media_player.room", "entity_picture_local",
                           [&](std::string) { current_calls++; }, true, 10, 5, &owner),
           "replacement local artwork read should wait");
   coordinator.transport().publish(0, "new");
@@ -310,10 +378,10 @@ void unowned_reusable_channel_keeps_independent_reads() {
 
   int first_calls = 0;
   int second_calls = 0;
-  require(coordinator.get("media_player.room", "entity_picture",
+  require(coordinator.read_retained("media_player.room", "entity_picture",
                           [&](std::string) { first_calls++; }, true, 10, 5),
           "first unowned artwork read should wait");
-  require(coordinator.get("media_player.room", "entity_picture",
+  require(coordinator.read_retained("media_player.room", "entity_picture",
                           [&](std::string) { second_calls++; }, true, 10, 5),
           "second unowned artwork read should wait independently");
   coordinator.transport().publish(0, "new");
@@ -321,47 +389,55 @@ void unowned_reusable_channel_keeps_independent_reads() {
           "duplicate cards did not both receive the first artwork update");
 }
 
-void stale_generations_do_not_deliver() {
+
+void generation_change_drops_pending_retained_reads() {
   Coordinator coordinator;
+  require(coordinator.subscribe("sensor.stale", "", [](std::string) {}, 1u, nullptr, true),
+          "retained state subscription should register");
   int calls = 0;
-  require(coordinator.get("sensor.stale", "", [&](std::string) { calls++; }, false, 10, 5),
-          "stale read should send");
-  uint32_t old_generation = coordinator.generation();
+  require(coordinator.read_retained(
+              "sensor.stale", "", [&](std::string) { calls++; }, false, 10, 5),
+          "pending retained read should register");
   coordinator.bump_generation(1u);
-  require(coordinator.generation() != old_generation, "generation did not advance");
-  coordinator.transport().deliver_read(0, "late");
-  require(calls == 0, "stale in-flight callback was delivered");
-
-  coordinator.transport().connected = false;
-  require(coordinator.get("sensor.queued", "", [&](std::string) { calls++; }, false, 10, 5),
-          "queued stale read should be accepted");
-  coordinator.bump_generation(1u);
-  require(coordinator.deferred_count() == 0, "generation cleanup retained deferred work");
+  require(coordinator.pending_read_count() == 0,
+          "generation cleanup retained pending work");
+  require(coordinator.subscribe("sensor.stale", "", [](std::string) {}, 1u, nullptr, true),
+          "replacement retained state subscription should register");
+  coordinator.transport().publish(0, "late");
+  require(calls == 0, "stale retained callback was delivered");
 }
 
-void attribute_requests_preserve_attribute() {
+
+void retained_subscription_preserves_attribute() {
   Coordinator coordinator;
-  require(coordinator.get("media_player.room", "media_title", [](std::string) {}, true, 10, 5),
-          "attribute read should send");
-  require(coordinator.transport().reads.size() == 1 &&
-              coordinator.transport().reads[0].attribute == "media_title",
-          "attribute read lost its attribute");
+  require(coordinator.subscribe(
+              "media_player.room", "media_title", [](std::string) {}, 1u, nullptr, true),
+          "retained metadata subscription should register");
+  require(coordinator.transport().subscriptions.size() == 1 &&
+              coordinator.transport().subscriptions[0].attribute == "media_title",
+          "retained subscription lost its attribute");
 }
+
 
 void released_owner_drops_pending_reads_even_if_its_address_is_reused() {
   Coordinator coordinator;
-  int old_screen = 0;
+  int owner = 0;
   int old_calls = 0;
   int replacement_calls = 0;
-  require(coordinator.get("sensor.old", "", [&](std::string) { old_calls++; }, false, 10, 5,
-                          &old_screen),
-          "owned read should send");
-  coordinator.release_owner(&old_screen);
-  require(coordinator.get("sensor.replacement", "", [&](std::string) { replacement_calls++; },
-                          false, 10, 5, &old_screen),
-          "replacement owner should receive a fresh token");
-  coordinator.transport().deliver_read(0, "late");
-  coordinator.transport().deliver_read(1, "current");
+  require(coordinator.subscribe("sensor.old", "", [](std::string) {}, 1u, &owner, true),
+          "old retained subscription should register");
+  require(coordinator.read_retained(
+              "sensor.old", "", [&](std::string) { old_calls++; }, false, 10, 5, &owner),
+          "old owned read should wait");
+  coordinator.release_owner(&owner);
+  require(coordinator.subscribe("sensor.replacement", "", [](std::string) {}, 1u, &owner, true),
+          "replacement retained subscription should register");
+  require(coordinator.read_retained(
+              "sensor.replacement", "", [&](std::string) { replacement_calls++; },
+              false, 10, 5, &owner),
+          "replacement owned read should wait");
+  coordinator.transport().publish(0, "late");
+  coordinator.transport().publish(1, "current");
   require(old_calls == 0 && replacement_calls == 1,
           "released owner delivered a callback after its address was reused");
 }
@@ -415,20 +491,23 @@ void core_owns_binding_service_lifetime() {
 
 int main() {
   disconnected_read_flushes_after_reconnect();
-  low_memory_preserves_deferred_work();
+  low_memory_rejects_retained_read_without_pending_work();
   duplicate_reads_fan_out_once();
   reentrant_reads_are_deferred();
   cancellation_is_safe_during_callback();
   rebuilt_subscriptions_share_one_transport_channel();
   subscription_backed_reads_reuse_the_live_channel();
+  retained_reads_never_accumulate_transport_callbacks();
+  missing_retained_channel_fails_closed();
+  pending_unowned_reads_are_globally_capped();
   generation_change_discards_cached_and_pending_channel_reads();
   reconnect_discards_retained_channel_state();
-  ordinary_subscriptions_do_not_retain_state_for_reads();
+  ordinary_subscriptions_fail_closed_for_retained_reads();
   inactive_reusable_channels_release_cached_state();
   stalled_reusable_channel_coalesces_reads_per_owner();
   unowned_reusable_channel_keeps_independent_reads();
-  stale_generations_do_not_deliver();
-  attribute_requests_preserve_attribute();
+  generation_change_drops_pending_retained_reads();
+  retained_subscription_preserves_attribute();
   released_owner_drops_pending_reads_even_if_its_address_is_reused();
   callback_owner_scope_restores_the_previous_owner();
   app_owned_callback_owner_is_used_when_bound();


### PR DESCRIPTION
## Summary

Replace artwork and media attribute refreshes with subscription-backed retained reads so repeated refreshes cannot add ESPHome `get_home_assistant_state` callbacks.

Retained reads now fail safely unless a retaining subscription already exists. Existing cached, pending, reconnect, generation, owner-lifetime, duplicate-card, and re-entrant callback handling remains covered, with pending work coalesced by owner and capped globally.

Both screensaver artwork attributes now retain their latest value. Count-only diagnostics report active callbacks, retained channels, pending reads, and ESPHome upstream state subscriptions without logging entity values, artwork URLs, or access tokens.

Related to #1672. The issue should remain open until physical panel testing confirms the fix.

## Automated checks

- `npm run test:firmware` — 26/26 host tests passed
- `npm run check:fast` — passed
- Home Assistant binding checker and self-tests — passed
- ESPHome 2026.7.4 firmware compiles:
  - `guition-esp32-p4-jc1060p470`
  - `guition-esp32-p4-jc4880p443`
  - `guition-esp32-s3-4848s040`

## Physical testing required

Start with the 10-inch reference panel and repeat on a representative 7-inch panel when available:

- Record the subscription-count baseline after boot.
- Process at least 500 artwork changes or refreshes.
- Perform 20 Home Assistant reconnects and 20 same-configuration grid rebuilds.
- Alternate between two media entities; subscription growth should occur only on first registration.
- Confirm there are no callback bursts, artwork regressions, restarts, or progressive heap/largest-block decline.

Include the change in the later 72-hour release-candidate soak. Keep this PR open until physical testing is confirmed.

<!-- espcontrol-pr-testing-guidance -->
## Automated testing guidance

Device testing is expected before merge because this change affects firmware and the on-device artwork path.

Suggested devices include the 10.1-inch P4 reference panels, a representative 7-inch P4 panel, the 4.3-inch P4 panel, and the 4-inch S3/P4 panels.

Confirm each tested device boots normally, artwork and media cards refresh correctly, touch/navigation still works, and no restarts or visual regressions occur.