### PR TITLE
Fix slider-card alignment consistency

### DIFF
--- a/components/espcontrol/button_grid_cover_modal_driver.h
+++ b/components/espcontrol/button_grid_cover_modal_driver.h
@@ -39,8 +39,14 @@ inline bool cover_modal_driver_attach_interaction(
 }
 
 inline bool cover_modal_driver_refresh_layout(
-    BtnSlot &, const ParsedCfg &, const Context &context) {
-  return cover_modal_driver_matches(context);
+    BtnSlot &slot, const ParsedCfg &, const Context &context) {
+  if (!cover_modal_driver_matches(context)) return false;
+  // apply_card_label_line_clamp re-anchors the label to the button's padding,
+  // which the slider zeroed, so the label would otherwise sit flush at the
+  // bottom while the icon stays inset. Re-apply the slider inset so both match
+  // other cards, mirroring the position/tilt path in access_cover_driver.
+  refresh_slider_card_layout(slot);
+  return true;
 }
 
 inline bool cover_modal_driver_cleanup(

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -741,7 +741,7 @@ inline void refresh_media_card_layout(BtnSlot &s, const ParsedCfg &p,
       lv_obj_add_flag(s.text_lbl, LV_OBJ_FLAG_HIDDEN);
     }
     if (ctx->title_lbl && ctx->artist_lbl) {
-      const CardPadding &padding = ctx->content_padding;
+      const CardPadding padding = ctx->progress_slider ? ctx->content_padding : CardPadding{};
       const bool large = media_cover_art_uses_screensaver_fonts(row_span, col_span);
       const bool compact_large = media_cover_art_uses_compact_large_fonts(row_span, col_span);
       const bool compact_portrait =
@@ -792,7 +792,7 @@ inline void refresh_media_card_layout(BtnSlot &s, const ParsedCfg &p,
   if (mode == "now_playing") {
     MediaNowPlayingCtx *ctx = (MediaNowPlayingCtx *)lv_obj_get_user_data(s.sensor_container);
     if (!ctx) return;
-    const CardPadding &padding = ctx->content_padding;
+    const CardPadding padding = ctx->progress_slider ? ctx->content_padding : CardPadding{};
     if (ctx->title_lbl) display_apply_main_width(ctx->title_lbl, display);
     if (ctx->artist_lbl) display_apply_main_width(ctx->artist_lbl, display);
     setup_media_now_playing_layout(

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -732,8 +732,6 @@ inline void refresh_media_card_layout(BtnSlot &s, const ParsedCfg &p,
                                       int col_span = 1) {
   const DisplayProfile display = display_profile_from_grid_config(cfg);
   std::string mode = media_card_mode(p.sensor);
-  lv_coord_t pad = lv_obj_get_style_radius(s.btn, LV_PART_MAIN) + 4;
-
   if (mode == "cover_art") {
     MediaNowPlayingCtx *ctx = (MediaNowPlayingCtx *)lv_obj_get_user_data(s.sensor_container);
     if (!ctx) return;
@@ -743,6 +741,7 @@ inline void refresh_media_card_layout(BtnSlot &s, const ParsedCfg &p,
       lv_obj_add_flag(s.text_lbl, LV_OBJ_FLAG_HIDDEN);
     }
     if (ctx->title_lbl && ctx->artist_lbl) {
+      const CardPadding &padding = ctx->content_padding;
       const bool large = media_cover_art_uses_screensaver_fonts(row_span, col_span);
       const bool compact_large = media_cover_art_uses_compact_large_fonts(row_span, col_span);
       const bool compact_portrait =
@@ -769,7 +768,7 @@ inline void refresh_media_card_layout(BtnSlot &s, const ParsedCfg &p,
         lv_obj_set_style_text_font(ctx->artist_lbl, artist_font, LV_PART_MAIN);
       }
       ctx->artist_below_title = large;
-      ctx->artist_gap = pad > 1 ? pad / 2 : 0;
+      ctx->artist_gap = padding.top > 1 ? padding.top / 2 : 0;
       if (ctx->show_track_details || ctx->external_source_fallback) {
         lv_obj_clear_flag(ctx->title_lbl, LV_OBJ_FLAG_HIDDEN);
         lv_obj_clear_flag(ctx->artist_lbl, LV_OBJ_FLAG_HIDDEN);
@@ -781,7 +780,7 @@ inline void refresh_media_card_layout(BtnSlot &s, const ParsedCfg &p,
       display_apply_main_width(ctx->artist_lbl, display);
       setup_media_now_playing_layout(
         s.btn, s.icon_lbl, ctx->title_lbl, ctx->artist_lbl,
-        title_font, pad,
+        title_font, padding,
         media_cover_art_limits_title_to_two_lines(row_span, col_span),
         true, 0, false);
       media_position_now_playing_artist(ctx);
@@ -793,13 +792,14 @@ inline void refresh_media_card_layout(BtnSlot &s, const ParsedCfg &p,
   if (mode == "now_playing") {
     MediaNowPlayingCtx *ctx = (MediaNowPlayingCtx *)lv_obj_get_user_data(s.sensor_container);
     if (!ctx) return;
+    const CardPadding &padding = ctx->content_padding;
     if (ctx->title_lbl) display_apply_main_width(ctx->title_lbl, display);
     if (ctx->artist_lbl) display_apply_main_width(ctx->artist_lbl, display);
     setup_media_now_playing_layout(
       s.btn, s.icon_lbl, ctx->title_lbl, ctx->artist_lbl,
-      display_media_title_font(display), pad,
+      display_media_title_font(display), padding,
       row_span == 1, ctx->play_pause_background,
-      ctx->progress_slider ? pad : 0, false);
+      ctx->progress_slider ? padding.left : 0, false);
     media_cover_art_refresh_geometry(ctx);
     if (ctx->progress_slider) slider_refresh_geometry(ctx->progress_slider);
     return;
@@ -808,16 +808,22 @@ inline void refresh_media_card_layout(BtnSlot &s, const ParsedCfg &p,
   if (mode == "position") {
     lv_obj_t *slider = (lv_obj_t *)lv_obj_get_user_data(s.sensor_container);
     SliderCtx *ctx = slider ? (SliderCtx *)lv_obj_get_user_data(slider) : nullptr;
-    lv_coord_t position_pad = ctx && ctx->content_pad > 0
-      ? ctx->content_pad
+    const lv_coord_t position_left = ctx && ctx->content_pad_left > 0
+      ? ctx->content_pad_left
+      : lv_obj_get_style_pad_left(s.btn, LV_PART_MAIN);
+    const lv_coord_t position_top = ctx && ctx->content_pad_top > 0
+      ? ctx->content_pad_top
       : lv_obj_get_style_pad_top(s.btn, LV_PART_MAIN);
+    const lv_coord_t position_bottom = ctx && ctx->content_pad_bottom > 0
+      ? ctx->content_pad_bottom
+      : lv_obj_get_style_pad_bottom(s.btn, LV_PART_MAIN);
     if (ctx && ctx->media_value_lbl) {
       display_apply_main_width(ctx->media_value_lbl, display);
-      lv_obj_align(ctx->media_value_lbl, LV_ALIGN_TOP_LEFT, position_pad, position_pad);
+      lv_obj_align(ctx->media_value_lbl, LV_ALIGN_TOP_LEFT, position_left, position_top);
       lv_obj_move_foreground(ctx->media_value_lbl);
     }
     if (s.text_lbl) {
-      lv_obj_align(s.text_lbl, LV_ALIGN_BOTTOM_LEFT, position_pad, -position_pad);
+      lv_obj_align(s.text_lbl, LV_ALIGN_BOTTOM_LEFT, position_left, -position_bottom);
       configure_button_label_wrap(s.text_lbl);
       lv_obj_move_foreground(s.text_lbl);
     }
@@ -845,14 +851,24 @@ inline void refresh_media_card_layout(BtnSlot &s, const ParsedCfg &p,
   if (mode == "volume") return;
 
   lv_obj_t *slider = (lv_obj_t *)lv_obj_get_user_data(s.sensor_container);
-  if (slider) slider_refresh_geometry(slider);
+  if (slider) {
+    refresh_slider_card_layout(s);
+  }
 }
 
 inline void refresh_slider_card_layout(BtnSlot &s) {
   lv_obj_t *slider = (lv_obj_t *)lv_obj_get_user_data(s.sensor_container);
-  lv_coord_t pad = lv_obj_get_style_radius(s.btn, LV_PART_MAIN) + 4;
-  if (s.icon_lbl) lv_obj_align(s.icon_lbl, LV_ALIGN_TOP_LEFT, pad, pad);
-  if (s.text_lbl) lv_obj_align(s.text_lbl, LV_ALIGN_BOTTOM_LEFT, pad, -pad);
+  SliderCtx *ctx = slider ? (SliderCtx *)lv_obj_get_user_data(slider) : nullptr;
+  // Reuse the padding captured before the slider zeroed it so the icon and label
+  // stay aligned with every non-slider card.
+  const lv_coord_t pad_left = ctx
+    ? ctx->label_pad_left : lv_obj_get_style_pad_left(s.btn, LV_PART_MAIN);
+  const lv_coord_t pad_top = ctx
+    ? ctx->label_pad_top : lv_obj_get_style_pad_top(s.btn, LV_PART_MAIN);
+  const lv_coord_t pad_bottom = ctx
+    ? ctx->label_pad_bottom : lv_obj_get_style_pad_bottom(s.btn, LV_PART_MAIN);
+  if (s.icon_lbl) lv_obj_align(s.icon_lbl, LV_ALIGN_TOP_LEFT, pad_left, pad_top);
+  if (s.text_lbl) lv_obj_align(s.text_lbl, LV_ALIGN_BOTTOM_LEFT, pad_left, -pad_bottom);
   if (slider) slider_refresh_geometry(slider);
 }
 
@@ -887,6 +903,9 @@ inline void refresh_card_layout(BtnSlot &s, const ParsedCfg &p,
     return;
   } else if (espcontrol::cards::media_driver_refresh_layout(
                s, p, context, cfg, row_span, col_span)) {
+    return;
+  } else if (espcontrol::cards::cover_modal_driver_refresh_layout(
+               s, p, context)) {
     return;
   } else {
     espcontrol::cards::access_cover_driver_refresh_layout(

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -4152,6 +4152,7 @@ inline void setup_media_card(BtnSlot &s, const ParsedCfg &p, uint32_t on_color,
     if (mode == "now_playing" && media_now_playing_progress_enabled(p)) {
       ctx->progress_slider = setup_media_progress_background(s.btn, secondary_color, tertiary_color, p.entity);
     }
+    const CardPadding layout_padding = ctx->progress_slider ? padding : CardPadding{};
     lv_obj_set_user_data(s.sensor_container, (void *)ctx);
     if (mode == "cover_art") {
       if (s.icon_lbl) lv_obj_add_flag(s.icon_lbl, LV_OBJ_FLAG_HIDDEN);
@@ -4178,10 +4179,10 @@ inline void setup_media_card(BtnSlot &s, const ParsedCfg &p, uint32_t on_color,
       }
       ctx->artist_below_title = media_cover_art_uses_screensaver_fonts(
         row_span, col_span);
-      ctx->artist_gap = padding.top > 1 ? padding.top / 2 : 0;
+      ctx->artist_gap = layout_padding.top > 1 ? layout_padding.top / 2 : 0;
       setup_media_now_playing_layout(
         s.btn, s.icon_lbl, ctx->title_lbl, ctx->artist_lbl,
-        media_title_font, padding,
+        media_title_font, layout_padding,
         media_cover_art_limits_title_to_two_lines(row_span, col_span),
         true, 0);
       media_position_now_playing_artist(ctx);
@@ -4194,10 +4195,10 @@ inline void setup_media_card(BtnSlot &s, const ParsedCfg &p, uint32_t on_color,
     ctx->title_lbl = title_lbl;
     ctx->artist_lbl = s.text_lbl;
     setup_media_now_playing_layout(
-      s.btn, s.icon_lbl, s.sensor_lbl, s.text_lbl, media_title_font, padding,
+      s.btn, s.icon_lbl, s.sensor_lbl, s.text_lbl, media_title_font, layout_padding,
       row_span == 1, ctx->play_pause_background,
       mode == "now_playing" && media_now_playing_progress_enabled(p)
-        ? padding.left : 0);
+        ? layout_padding.left : 0);
     return;
   }
   if (mode == "position") {

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -4179,7 +4179,7 @@ inline void setup_media_card(BtnSlot &s, const ParsedCfg &p, uint32_t on_color,
       }
       ctx->artist_below_title = media_cover_art_uses_screensaver_fonts(
         row_span, col_span);
-      ctx->artist_gap = layout_padding.top > 1 ? layout_padding.top / 2 : 0;
+      ctx->artist_gap = padding.top > 1 ? padding.top / 2 : 0;
       setup_media_now_playing_layout(
         s.btn, s.icon_lbl, ctx->title_lbl, ctx->artist_lbl,
         media_title_font, layout_padding,

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -1826,17 +1826,17 @@ inline void setup_media_now_playing_layout(lv_obj_t *btn, lv_obj_t *icon_lbl,
                                            lv_obj_t *title_lbl,
                                            lv_obj_t *artist_lbl,
                                            const lv_font_t *title_font,
-                                           lv_coord_t pad,
+                                           const CardPadding &padding,
                                            bool limit_title_lines,
                                            bool tappable,
                                            lv_coord_t content_inset = 0,
                                            bool reset_text = true) {
   constexpr lv_coord_t TITLE_LINE_SPACE = -1;
-  lv_coord_t text_inset = content_inset > 0 ? content_inset : 0;
+  lv_coord_t text_inset = content_inset > 0 ? content_inset : padding.left;
   lv_coord_t text_width = lv_pct(100);
   if (btn && text_inset > 0) {
     lv_obj_update_layout(btn);
-    lv_coord_t available_width = lv_obj_get_width(btn) - text_inset * 2;
+    lv_coord_t available_width = lv_obj_get_width(btn) - padding.left - padding.right;
     if (available_width > 1) text_width = available_width;
   }
   if (tappable) {
@@ -1864,7 +1864,7 @@ inline void setup_media_now_playing_layout(lv_obj_t *btn, lv_obj_t *icon_lbl,
       lv_obj_set_width(title_lbl, text_width);
       lv_obj_set_height(title_lbl, LV_SIZE_CONTENT);
     }
-    lv_obj_align(title_lbl, LV_ALIGN_TOP_LEFT, text_inset, text_inset);
+    lv_obj_align(title_lbl, LV_ALIGN_TOP_LEFT, padding.left, padding.top);
     if (reset_text) lv_label_set_text(title_lbl, "--");
     lv_obj_move_foreground(title_lbl);
   }
@@ -1874,7 +1874,7 @@ inline void setup_media_now_playing_layout(lv_obj_t *btn, lv_obj_t *icon_lbl,
     lv_label_set_long_mode(artist_lbl, LV_LABEL_LONG_DOT);
     if (font && font->line_height > 0) lv_obj_set_size(artist_lbl, text_width, font->line_height);
     else lv_obj_set_width(artist_lbl, text_width);
-    lv_obj_align(artist_lbl, LV_ALIGN_BOTTOM_LEFT, text_inset, -text_inset);
+    lv_obj_align(artist_lbl, LV_ALIGN_BOTTOM_LEFT, padding.left, -padding.bottom);
     lv_obj_move_foreground(artist_lbl);
   }
 }
@@ -1889,6 +1889,7 @@ inline lv_obj_t *setup_media_progress_background(lv_obj_t *btn,
     static_cast<lv_style_selector_t>(LV_PART_MAIN) |
       static_cast<lv_style_selector_t>(LV_STATE_CHECKED));
 
+  const CardPadding padding = capture_card_padding(btn);
   lv_obj_t *slider = setup_slider_widget(btn, progress_color, true);
   lv_obj_t *fill = lv_obj_get_child(btn, 0);
 
@@ -1899,6 +1900,13 @@ inline lv_obj_t *setup_media_progress_background(lv_obj_t *btn,
   ctx->cover_tilt = false;
   ctx->inverted = false;
   ctx->radius = lv_obj_get_style_radius(btn, LV_PART_MAIN);
+  ctx->label_pad_left = padding.left;
+  ctx->label_pad_top = padding.top;
+  ctx->label_pad_bottom = padding.bottom;
+  ctx->content_pad_left = padding.left;
+  ctx->content_pad_top = padding.top;
+  ctx->content_pad_right = padding.right;
+  ctx->content_pad_bottom = padding.bottom;
   ctx->media_position = true;
   ctx->media_slider = slider;
   lv_obj_set_user_data(slider, (void *)ctx);
@@ -1958,7 +1966,7 @@ inline lv_obj_t *setup_media_slider_layout(lv_obj_t *btn, lv_obj_t *icon_lbl,
                                            const ParsedCfg &p,
                                            uint32_t on_color,
                                            uint32_t /*track_color*/,
-                                           lv_coord_t pad) {
+                                           const CardPadding &padding) {
   std::string mode = media_card_mode(p.sensor);
   bool position = mode == "position";
   bool horizontal = true;
@@ -1972,7 +1980,7 @@ inline lv_obj_t *setup_media_slider_layout(lv_obj_t *btn, lv_obj_t *icon_lbl,
     if (text_lbl) {
       lv_obj_clear_flag(text_lbl, LV_OBJ_FLAG_HIDDEN);
       lv_label_set_text(text_lbl, media_position_show_state(p) ? espcontrol_i18n("Paused") : media_action_label(p, mode).c_str());
-      lv_obj_align(text_lbl, LV_ALIGN_BOTTOM_LEFT, pad, -pad);
+      lv_obj_align(text_lbl, LV_ALIGN_BOTTOM_LEFT, padding.left, -padding.bottom);
       configure_button_label_wrap(text_lbl);
       lv_obj_move_foreground(text_lbl);
     }
@@ -1980,12 +1988,12 @@ inline lv_obj_t *setup_media_slider_layout(lv_obj_t *btn, lv_obj_t *icon_lbl,
     if (icon_lbl) {
       lv_obj_clear_flag(icon_lbl, LV_OBJ_FLAG_HIDDEN);
       lv_label_set_text(icon_lbl, media_default_icon(mode, p.icon));
-      lv_obj_align(icon_lbl, LV_ALIGN_TOP_LEFT, pad, pad);
+      lv_obj_align(icon_lbl, LV_ALIGN_TOP_LEFT, padding.left, padding.top);
       lv_obj_move_foreground(icon_lbl);
     }
     if (text_lbl) {
       lv_label_set_text(text_lbl, media_label(p).c_str());
-      lv_obj_align(text_lbl, LV_ALIGN_BOTTOM_LEFT, pad, -pad);
+      lv_obj_align(text_lbl, LV_ALIGN_BOTTOM_LEFT, padding.left, -padding.bottom);
       configure_button_label_wrap(text_lbl);
       lv_obj_move_foreground(text_lbl);
     }
@@ -2006,12 +2014,18 @@ inline lv_obj_t *setup_media_slider_layout(lv_obj_t *btn, lv_obj_t *icon_lbl,
   ctx->cover_tilt = false;
   ctx->inverted = false;
   ctx->radius = lv_obj_get_style_radius(btn, LV_PART_MAIN);
+  ctx->label_pad_left = padding.left;
+  ctx->label_pad_top = padding.top;
+  ctx->label_pad_bottom = padding.bottom;
+  ctx->content_pad_left = padding.left;
+  ctx->content_pad_top = padding.top;
+  ctx->content_pad_right = padding.right;
+  ctx->content_pad_bottom = padding.bottom;
   ctx->media_position = position;
   ctx->media_slider = slider;
   ctx->media_track_bg = track;
   ctx->media_value_lbl = value_lbl;
   ctx->media_status_lbl = position && media_position_show_state(p) ? text_lbl : nullptr;
-  ctx->content_pad = pad;
   lv_obj_set_user_data(slider, (void *)ctx);
   slider_bind_geometry_refresh(btn, slider);
   if (position) {
@@ -2055,21 +2069,21 @@ inline lv_obj_t *setup_media_position_layout(lv_obj_t *btn, lv_obj_t *icon_lbl,
                                              uint32_t background_color,
                                              const lv_font_t *value_font,
                                              lv_color_t text_color,
-                                             lv_coord_t pad,
+                                             const CardPadding &padding,
                                              int width_compensation_percent = 100) {
   lv_obj_t *value_lbl = lv_label_create(btn);
   if (value_font) lv_obj_set_style_text_font(value_lbl, value_font, LV_PART_MAIN);
   lv_obj_set_style_text_color(value_lbl, text_color, LV_PART_MAIN);
   apply_width_compensation(value_lbl, width_compensation_percent);
   lv_label_set_text(value_lbl, "0:00");
-  lv_obj_align(value_lbl, LV_ALIGN_TOP_LEFT, pad, pad);
+  lv_obj_align(value_lbl, LV_ALIGN_TOP_LEFT, padding.left, padding.top);
   lv_obj_set_style_bg_color(btn, lv_color_hex(background_color), LV_PART_MAIN);
   lv_obj_set_style_bg_color(
     btn, lv_color_hex(background_color),
     static_cast<lv_style_selector_t>(LV_PART_MAIN) |
       static_cast<lv_style_selector_t>(LV_STATE_CHECKED));
   return setup_media_slider_layout(
-    btn, icon_lbl, text_lbl, value_lbl, p, progress_color, background_color, pad);
+    btn, icon_lbl, text_lbl, value_lbl, p, progress_color, background_color, padding);
 }
 
 inline std::string media_control_card_label(const ParsedCfg &p) {
@@ -4107,7 +4121,6 @@ inline void setup_media_card(BtnSlot &s, const ParsedCfg &p, uint32_t on_color,
                              int row_span = 1,
                              int col_span = 1) {
   lv_obj_add_flag(s.sensor_container, LV_OBJ_FLAG_HIDDEN);
-  lv_coord_t pad = lv_obj_get_style_radius(s.btn, LV_PART_MAIN) + 4;
   std::string mode = media_card_mode(p.sensor);
   if (mode == "playlist") {
     setup_media_action_layout(s.btn, s.icon_lbl, s.text_lbl, p);
@@ -4128,10 +4141,12 @@ inline void setup_media_card(BtnSlot &s, const ParsedCfg &p, uint32_t on_color,
     return;
   }
   if (mode == "now_playing" || mode == "cover_art") {
+    const CardPadding padding = capture_card_padding(s.btn);
     lv_obj_add_flag(s.sensor_container, LV_OBJ_FLAG_HIDDEN);
     lv_color_t text_color = lv_obj_get_style_text_color(s.sensor_lbl, LV_PART_MAIN);
     MediaNowPlayingCtx *ctx = new MediaNowPlayingCtx();
     ctx->btn = s.btn;
+    ctx->content_padding = padding;
     ctx->show_track_details = mode != "cover_art" || media_cover_art_details_enabled(p);
     ctx->play_pause_background = mode == "now_playing" && media_now_playing_play_pause_enabled(p);
     if (mode == "now_playing" && media_now_playing_progress_enabled(p)) {
@@ -4163,10 +4178,10 @@ inline void setup_media_card(BtnSlot &s, const ParsedCfg &p, uint32_t on_color,
       }
       ctx->artist_below_title = media_cover_art_uses_screensaver_fonts(
         row_span, col_span);
-      ctx->artist_gap = pad > 1 ? pad / 2 : 0;
+      ctx->artist_gap = padding.top > 1 ? padding.top / 2 : 0;
       setup_media_now_playing_layout(
         s.btn, s.icon_lbl, ctx->title_lbl, ctx->artist_lbl,
-        media_title_font, pad,
+        media_title_font, padding,
         media_cover_art_limits_title_to_two_lines(row_span, col_span),
         true, 0);
       media_position_now_playing_artist(ctx);
@@ -4179,22 +4194,24 @@ inline void setup_media_card(BtnSlot &s, const ParsedCfg &p, uint32_t on_color,
     ctx->title_lbl = title_lbl;
     ctx->artist_lbl = s.text_lbl;
     setup_media_now_playing_layout(
-      s.btn, s.icon_lbl, s.sensor_lbl, s.text_lbl, media_title_font, pad,
+      s.btn, s.icon_lbl, s.sensor_lbl, s.text_lbl, media_title_font, padding,
       row_span == 1, ctx->play_pause_background,
-      mode == "now_playing" && media_now_playing_progress_enabled(p) ? pad : 0);
+      mode == "now_playing" && media_now_playing_progress_enabled(p)
+        ? padding.left : 0);
     return;
   }
   if (mode == "position") {
-    lv_coord_t position_pad = lv_obj_get_style_pad_top(s.btn, LV_PART_MAIN);
+    const CardPadding padding = capture_card_padding(s.btn);
     lv_color_t text_color = lv_obj_get_style_text_color(s.sensor_lbl, LV_PART_MAIN);
     lv_obj_t *slider = setup_media_position_layout(
       s.btn, s.icon_lbl, s.text_lbl, p, secondary_color, tertiary_color,
-      sensor_font, text_color, position_pad, width_compensation_percent);
+      sensor_font, text_color, padding, width_compensation_percent);
     lv_obj_set_user_data(s.sensor_container, (void *)slider);
     return;
   }
+  const CardPadding padding = capture_card_padding(s.btn);
   lv_obj_t *slider = setup_media_slider_layout(s.btn, s.icon_lbl, s.text_lbl,
-    nullptr, p, on_color, tertiary_color, pad);
+    nullptr, p, on_color, tertiary_color, padding);
   lv_obj_set_user_data(s.sensor_container, (void *)slider);
 }
 

--- a/components/espcontrol/button_grid_sliders.h
+++ b/components/espcontrol/button_grid_sliders.h
@@ -10,6 +10,29 @@ inline void image_card_set_media_artwork_suppressed(ImageCardCtx *ctx,
                                                      bool suppressed);
 inline void image_card_refresh_media_artwork_on_metadata_change(ImageCardCtx *ctx);
 
+struct CardPadding {
+  lv_coord_t left = 0;
+  lv_coord_t top = 0;
+  lv_coord_t right = 0;
+  lv_coord_t bottom = 0;
+};
+
+inline CardPadding capture_card_padding(lv_obj_t *btn) {
+  CardPadding padding;
+  if (!btn) return padding;
+  // Slider fills cover the entire button, so their setup clears local button
+  // padding. Remove that stale override before reading the themed inset.
+  lv_obj_remove_local_style_prop(btn, LV_STYLE_PAD_LEFT, LV_PART_MAIN);
+  lv_obj_remove_local_style_prop(btn, LV_STYLE_PAD_TOP, LV_PART_MAIN);
+  lv_obj_remove_local_style_prop(btn, LV_STYLE_PAD_RIGHT, LV_PART_MAIN);
+  lv_obj_remove_local_style_prop(btn, LV_STYLE_PAD_BOTTOM, LV_PART_MAIN);
+  padding.left = lv_obj_get_style_pad_left(btn, LV_PART_MAIN);
+  padding.top = lv_obj_get_style_pad_top(btn, LV_PART_MAIN);
+  padding.right = lv_obj_get_style_pad_right(btn, LV_PART_MAIN);
+  padding.bottom = lv_obj_get_style_pad_bottom(btn, LV_PART_MAIN);
+  return padding;
+}
+
 // ── Slider widgets ───────────────────────────────────────────────────
 
 // Context attached to each LVGL slider via user_data
@@ -40,7 +63,15 @@ struct SliderCtx {
   lv_timer_t *geometry_timer = nullptr;
   lv_obj_t *media_value_lbl = nullptr;
   lv_obj_t *media_status_lbl = nullptr;
-  lv_coord_t content_pad = 0;
+  // Button padding captured before the slider widget zeroes it, so the icon and
+  // label can be inset to match every non-slider card (see setup_slider_visual).
+  lv_coord_t label_pad_left = 0;
+  lv_coord_t label_pad_top = 0;
+  lv_coord_t label_pad_bottom = 0;
+  lv_coord_t content_pad_left = 0;
+  lv_coord_t content_pad_top = 0;
+  lv_coord_t content_pad_right = 0;
+  lv_coord_t content_pad_bottom = 0;
   bool available = true;
   bool interactive = true;
   // light_temperature fields
@@ -77,6 +108,7 @@ struct MediaNowPlayingCtx {
   bool play_pause_background = false;
   bool artist_below_title = false;
   lv_coord_t artist_gap = 0;
+  CardPadding content_padding;
 };
 
 struct MediaPlaylistCtx {
@@ -2672,6 +2704,8 @@ inline void setup_slider_visual(BtnSlot &s, const ParsedCfg &p, uint32_t on_colo
   if (p.type == "cover")
     lv_label_set_text(s.icon_lbl, slider_icon_off(p.type, p.entity, p.icon));
 
+  const CardPadding padding = capture_card_padding(s.btn);
+
   bool horizontal = false;
   lv_obj_t *slider = setup_slider_widget(s.btn, on_color, horizontal);
   if (!slider) {
@@ -2684,9 +2718,8 @@ inline void setup_slider_visual(BtnSlot &s, const ParsedCfg &p, uint32_t on_colo
     return;
   }
   ESP_LOGI("slider", "Slider object created for %s", p.entity.c_str());
-  lv_coord_t pad = lv_obj_get_style_radius(s.btn, LV_PART_MAIN) + 4;
-  lv_obj_align(s.icon_lbl, LV_ALIGN_TOP_LEFT, pad, pad);
-  lv_obj_align(s.text_lbl, LV_ALIGN_BOTTOM_LEFT, pad, -pad);
+  lv_obj_align(s.icon_lbl, LV_ALIGN_TOP_LEFT, padding.left, padding.top);
+  lv_obj_align(s.text_lbl, LV_ALIGN_BOTTOM_LEFT, padding.left, -padding.bottom);
   lv_obj_set_user_data(s.sensor_container, (void *)slider);
 
   lv_obj_t *fill = lv_obj_get_child(s.btn, 0);
@@ -2707,6 +2740,9 @@ inline void setup_slider_visual(BtnSlot &s, const ParsedCfg &p, uint32_t on_colo
   ctx->cover_tilt = p.type == "cover" && cover_tilt_mode(p.sensor);
   ctx->inverted = is_cover_entity(p.entity);
   ctx->radius = lv_obj_get_style_radius(s.btn, LV_PART_MAIN);
+  ctx->label_pad_left = padding.left;
+  ctx->label_pad_top = padding.top;
+  ctx->label_pad_bottom = padding.bottom;
   ctx->interactive = interactive;
   lv_obj_set_user_data(slider, (void *)ctx);
   slider_bind_geometry_refresh(s.btn, slider);
@@ -2993,13 +3029,13 @@ inline void setup_light_temp_visual(BtnSlot &s, const ParsedCfg &p, uint32_t on_
   int min_k = 2000, max_k = 6500;
   parse_kelvin_range(p.unit, min_k, max_k);
   bool kcolor = (p.precision == "color");
+  const CardPadding padding = capture_card_padding(s.btn);
 
   lv_obj_t *slider = setup_slider_widget(s.btn, on_color, false);
-  lv_coord_t pad = lv_obj_get_style_radius(s.btn, LV_PART_MAIN) + 4;
-  lv_obj_align(s.icon_lbl, LV_ALIGN_TOP_LEFT, pad, pad);
+  lv_obj_align(s.icon_lbl, LV_ALIGN_TOP_LEFT, padding.left, padding.top);
   lv_label_set_long_mode(s.icon_lbl, LV_LABEL_LONG_CLIP);
   lv_obj_set_width(s.icon_lbl, lv_pct(100));
-  lv_obj_align(s.text_lbl, LV_ALIGN_BOTTOM_LEFT, pad, -pad);
+  lv_obj_align(s.text_lbl, LV_ALIGN_BOTTOM_LEFT, padding.left, -padding.bottom);
   lv_obj_set_user_data(s.sensor_container, (void *)slider);
 
   lv_obj_t *fill = lv_obj_get_child(s.btn, 0);
@@ -3011,6 +3047,9 @@ inline void setup_light_temp_visual(BtnSlot &s, const ParsedCfg &p, uint32_t on_
   ctx->cover_tilt = false;
   ctx->inverted = false;
   ctx->radius = lv_obj_get_style_radius(s.btn, LV_PART_MAIN);
+  ctx->label_pad_left = padding.left;
+  ctx->label_pad_top = padding.top;
+  ctx->label_pad_bottom = padding.bottom;
   ctx->light_temp = true;
   ctx->kelvin_min = min_k;
   ctx->kelvin_max = max_k;

--- a/components/espcontrol/button_grid_sliders.h
+++ b/components/espcontrol/button_grid_sliders.h
@@ -20,16 +20,24 @@ struct CardPadding {
 inline CardPadding capture_card_padding(lv_obj_t *btn) {
   CardPadding padding;
   if (!btn) return padding;
-  // Slider fills cover the entire button, so their setup clears local button
-  // padding. Remove that stale override before reading the themed inset.
-  lv_obj_remove_local_style_prop(btn, LV_STYLE_PAD_LEFT, LV_PART_MAIN);
-  lv_obj_remove_local_style_prop(btn, LV_STYLE_PAD_TOP, LV_PART_MAIN);
-  lv_obj_remove_local_style_prop(btn, LV_STYLE_PAD_RIGHT, LV_PART_MAIN);
-  lv_obj_remove_local_style_prop(btn, LV_STYLE_PAD_BOTTOM, LV_PART_MAIN);
   padding.left = lv_obj_get_style_pad_left(btn, LV_PART_MAIN);
   padding.top = lv_obj_get_style_pad_top(btn, LV_PART_MAIN);
   padding.right = lv_obj_get_style_pad_right(btn, LV_PART_MAIN);
   padding.bottom = lv_obj_get_style_pad_bottom(btn, LV_PART_MAIN);
+  // Preserve an intentional local inset, such as a subpage's calculated
+  // padding. A reused slider button leaves a local zero override behind;
+  // only in that all-zero case remove the stale override and read the theme.
+  if (padding.left == 0 && padding.top == 0 &&
+      padding.right == 0 && padding.bottom == 0) {
+    lv_obj_remove_local_style_prop(btn, LV_STYLE_PAD_LEFT, LV_PART_MAIN);
+    lv_obj_remove_local_style_prop(btn, LV_STYLE_PAD_TOP, LV_PART_MAIN);
+    lv_obj_remove_local_style_prop(btn, LV_STYLE_PAD_RIGHT, LV_PART_MAIN);
+    lv_obj_remove_local_style_prop(btn, LV_STYLE_PAD_BOTTOM, LV_PART_MAIN);
+    padding.left = lv_obj_get_style_pad_left(btn, LV_PART_MAIN);
+    padding.top = lv_obj_get_style_pad_top(btn, LV_PART_MAIN);
+    padding.right = lv_obj_get_style_pad_right(btn, LV_PART_MAIN);
+    padding.bottom = lv_obj_get_style_pad_bottom(btn, LV_PART_MAIN);
+  }
   return padding;
 }
 


### PR DESCRIPTION
## Summary

Carry the slider-card alignment fix into the upstream repository after rebasing the contribution onto the latest main.

The changes preserve the actual themed card padding before slider creation clears it, and reuse that padding for slider-backed card layout refreshes. This covers standard sliders, covers, light-temperature cards, and media cards.

## Contribution note

Changes have been made before merging the contribution. The original fork PR #1666 was closed because its fork branch could not be updated; this replacement PR contains the rebased and extended implementation.

## Testing

- 7-inch Guition JC1060P470 P4 firmware compiled successfully.
- Local artifact and Home Assistant binding checks passed.
- No local secrets or generated build artifacts are tracked.