### PR TITLE
Fix repeated cover art idle stops

### DIFF
--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -9,6 +9,9 @@ globals:
   - id: cover_art_delay_interrupted_by_transition
     type: bool
     initial_value: 'false'
+  - id: cover_art_playback_generation
+    type: uint32_t
+    initial_value: '0'
   - id: cover_art_transition_generation
     type: uint32_t
     initial_value: '0'
@@ -776,6 +779,7 @@ script:
     mode: restart
     then:
       - script.stop: cover_art_delay_timer
+      - script.stop: cover_art_delayed_playback_stopped
       - script.stop: cover_art_show_track_overlay
       - script.stop: cover_art_download
       - script.stop: cover_art_deferred_download
@@ -792,6 +796,9 @@ script:
           id: cover_art_manual_pause_until_ms
           value: '0'
       - lambda: |-
+          id(cover_art_playback_generation) =
+            espcontrol::cover_art::advance_playback_generation(
+              id(cover_art_playback_generation));
           id(cover_art_runtime).clear_image();
           id(cover_art_artwork_trigger).reset();
           id(cover_art_artwork_retry_mask) = 0;
@@ -2243,9 +2250,17 @@ script:
                   subscription_generation != id(cover_art_subscription_generation) ||
                   cover_entity != id(cover_art_active_media_player_entity)) return;
               std::string state_text = string_ref_limited(state, HA_SHORT_STATE_MAX_LEN);
-              bool playing = state_text == "playing" || state_text == "buffering";
+              bool playing = espcontrol::cover_art::playback_state_active(state_text);
+              bool paused = espcontrol::cover_art::playback_state_paused(state_text);
               if (state_text == id(cover_art_last_playback_state) &&
                   id(cover_art_media_playing) == playing) {
+                return;
+              }
+              if (!playing && !paused &&
+                  id(cover_art_delayed_playback_stopped).is_running()) {
+                // Music Assistant can publish repeated state_changed events
+                // while remaining idle. Keep the original grace deadline.
+                id(cover_art_last_playback_state) = state_text;
                 return;
               }
               id(cover_art_last_playback_state) = state_text;
@@ -2257,6 +2272,9 @@ script:
               if (playing) {
                 bool restart_cover_art_delay = id(cover_art_delay_interrupted_by_transition);
                 id(cover_art_delay_interrupted_by_transition) = false;
+                id(cover_art_playback_generation) =
+                  espcontrol::cover_art::advance_playback_generation(
+                    id(cover_art_playback_generation));
                 id(cover_art_delayed_playback_stopped).stop();
                 bool was_playing = id(cover_art_media_playing);
                 id(cover_art_media_playing) = true;
@@ -2267,8 +2285,11 @@ script:
                 return;
               }
 
-              if (state_text == "paused") {
+              if (paused) {
                 id(cover_art_delay_interrupted_by_transition) = false;
+                id(cover_art_playback_generation) =
+                  espcontrol::cover_art::advance_playback_generation(
+                    id(cover_art_playback_generation));
                 id(cover_art_delayed_playback_stopped).stop();
                 if (id(espcontrol_app).display().target_mode_is(espcontrol::DisplayMode::COVER_ART)) id(cover_art_refresh_progress).execute();
                 id(cover_art_media_playing) = false;
@@ -2286,8 +2307,11 @@ script:
               id(cover_art_delay_interrupted_by_transition) =
                 id(cover_art_delay_interrupted_by_transition) || id(cover_art_delay_timer).is_running();
               id(cover_art_delay_timer).stop();
+              id(cover_art_playback_generation) =
+                espcontrol::cover_art::advance_playback_generation(
+                  id(cover_art_playback_generation));
               id(cover_art_delayed_playback_stopped).execute(
-                  static_cast<int32_t>(id(espcontrol_app).display().generation()));
+                  static_cast<int32_t>(id(cover_art_playback_generation)));
             };
           if (!already_subscribed) {
             bool state_subscribed = ha_subscribe_state(
@@ -2703,51 +2727,18 @@ script:
                   - script.execute: screensaver_idle_check
 
   - id: cover_art_delayed_playback_stopped
-    mode: restart
+    mode: single
     parameters:
-      generation: int
+      playback_generation: int
     then:
       - delay: 2s
       - if:
           condition:
             lambda: |-
-              return !id(espcontrol_app).display().generation_is_current(
-                  static_cast<uint32_t>(generation));
-          then:
-            - if:
-                condition:
-                  lambda: |-
-                    const std::string &state = id(cover_art_last_playback_state);
-                    return state != "playing" && state != "buffering" && state != "paused";
-                then:
-                  # The obsolete callback may retire its old request from live
-                  # playback state, but it must not touch presentation widgets.
-                  # Reset the non-visual playback state first so later schedule
-                  # and wake checks cannot reopen cover art for stopped media.
-                  - globals.set:
-                      id: cover_art_delay_interrupted_by_transition
-                      value: 'false'
-                  - globals.set:
-                      id: cover_art_media_playing
-                      value: 'false'
-                  - globals.set:
-                      id: cover_art_manual_pause_until_ms
-                      value: '0'
-                  - lambda: |-
-                      id(cover_art_media_position) = 0.0f;
-                      id(cover_art_position_anchor) = 0.0f;
-                      id(cover_art_media_duration) = 0.0f;
-                      id(cover_art_position_anchor_epoch) = 0;
-                      id(cover_art_last_position_timestamp) = 0;
-                      id(cover_art_last_progress_percent) = -1;
-                  - script.execute: display_mode_clear_cover_art
-                  - script.wait: display_mode_clear_cover_art
-            - script.stop: cover_art_delayed_playback_stopped
-      - if:
-          condition:
-            lambda: |-
-              const std::string &state = id(cover_art_last_playback_state);
-              return state != "playing" && state != "buffering" && state != "paused";
+              return espcontrol::cover_art::playback_stop_generation_current(
+                  static_cast<uint32_t>(playback_generation),
+                  id(cover_art_playback_generation),
+                  id(cover_art_last_playback_state));
           then:
             - script.execute: cover_art_playback_stopped
 
@@ -2755,6 +2746,10 @@ script:
     mode: restart
     then:
       - script.stop: cover_art_delayed_playback_stopped
+      - lambda: |-
+          id(cover_art_playback_generation) =
+            espcontrol::cover_art::advance_playback_generation(
+              id(cover_art_playback_generation));
       - globals.set:
           id: cover_art_delay_interrupted_by_transition
           value: 'false'

--- a/components/espcontrol/cover_art.h
+++ b/components/espcontrol/cover_art.h
@@ -51,6 +51,32 @@ inline bool media_entity_state_usable(const std::string &state) {
          normalized == "buffering";
 }
 
+inline bool playback_state_active(const std::string &state) {
+  const std::string normalized = normalized_media_source(state);
+  return normalized == "playing" || normalized == "buffering";
+}
+
+inline bool playback_state_paused(const std::string &state) {
+  return normalized_media_source(state) == "paused";
+}
+
+inline bool playback_state_stopped(const std::string &state) {
+  return !playback_state_active(state) && !playback_state_paused(state);
+}
+
+inline uint32_t advance_playback_generation(uint32_t generation) {
+  generation++;
+  return generation == 0 ? 1 : generation;
+}
+
+inline bool playback_stop_generation_current(uint32_t expected_generation,
+                                             uint32_t current_generation,
+                                             const std::string &state) {
+  return expected_generation != 0 &&
+         expected_generation == current_generation &&
+         playback_state_stopped(state);
+}
+
 inline bool use_secondary_media_entity(bool primary_external,
                                        bool secondary_configured,
                                        bool secondary_available,

--- a/scripts/check_cover_art_contract.py
+++ b/scripts/check_cover_art_contract.py
@@ -23,6 +23,18 @@ int main() {
   assert(!media_entity_state_usable("idle"));
   assert(!media_entity_state_usable("off"));
   assert(!media_entity_state_usable(" unavailable "));
+  assert(playback_state_active("playing"));
+  assert(playback_state_active(" BUFFERING "));
+  assert(!playback_state_active("paused"));
+  assert(playback_state_paused(" paused "));
+  assert(playback_state_stopped("idle"));
+  assert(playback_state_stopped("off"));
+  assert(!playback_state_stopped("playing"));
+  assert(advance_playback_generation(0) == 1);
+  assert(advance_playback_generation(std::numeric_limits<uint32_t>::max()) == 1);
+  assert(playback_stop_generation_current(3, 3, "idle"));
+  assert(!playback_stop_generation_current(3, 4, "idle"));
+  assert(!playback_stop_generation_current(3, 3, "playing"));
   assert(!use_secondary_media_entity(false, true, true, true));
   assert(!use_secondary_media_entity(true, false, true, true));
   assert(!use_secondary_media_entity(true, true, false, true));

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -1104,28 +1104,39 @@ def firmware_cover_art_playback_grace_errors(path: Path, root: Path) -> list[str
     if not delayed_body:
         errors.append(f"{rel}: buffer brief non-playing states between tracks")
     else:
+        if "mode: single" not in delayed_body:
+            errors.append(f"{rel}: keep repeated inactive updates from restarting playback grace")
         if "delay: 2s" not in delayed_body:
             errors.append(f"{rel}: keep the cover art stop grace period at two seconds")
         if "script.execute: cover_art_playback_stopped" not in delayed_body:
             errors.append(f"{rel}: apply a sustained playback stop after the grace period")
-        if (
-            'state != "playing"' not in delayed_body
-            or 'state != "buffering"' not in delayed_body
-            or 'state != "paused"' not in delayed_body
-        ):
+        if "playback_stop_generation_current(" not in delayed_body:
             errors.append(f"{rel}: recheck playback before applying a delayed stop")
+        if "playback_generation: int" not in delayed_body:
+            errors.append(f"{rel}: bind delayed playback cleanup to its playback generation")
 
     if "id(cover_art_delayed_playback_stopped).execute(" not in text:
         errors.append(f"{rel}: delay non-playing playback transitions")
+    grace_markers = (
+        "id(cover_art_delay_interrupted_by_transition) || id(cover_art_delay_timer).is_running()",
+        "id(cover_art_delay_timer).stop();",
+        "advance_playback_generation(",
+        "id(cover_art_delayed_playback_stopped).execute(",
+        "id(cover_art_playback_generation)",
+    )
+    if any(marker not in text for marker in grace_markers):
+        errors.append(f"{rel}: remember and cancel a pending cover art opening when playback stops")
+    if (
+        "id: cover_art_playback_generation" not in text
+        or "playback_stop_generation_current(" not in text
+    ):
+        errors.append(f"{rel}: track playback stop validity independently of display transitions")
     if not re.search(
-        r"id\(cover_art_delay_interrupted_by_transition\)\s*=\s*"
-        r"id\(cover_art_delay_interrupted_by_transition\)\s*\|\|\s*"
-        r"id\(cover_art_delay_timer\)\.is_running\(\);\s+"
-        r"id\(cover_art_delay_timer\)\.stop\(\);\s+"
-        r"id\(cover_art_delayed_playback_stopped\)\.execute\([^;]*\);",
+        r"if\s*\(!playing\s*&&\s*!paused\s*&&\s*"
+        r"id\(cover_art_delayed_playback_stopped\)\.is_running\(\)\)\s*\{",
         text,
     ):
-        errors.append(f"{rel}: remember and cancel a pending cover art opening when playback stops")
+        errors.append(f"{rel}: ignore repeated inactive updates during playback grace")
     if (
         "bool restart_cover_art_delay = id(cover_art_delay_interrupted_by_transition);" not in text
         or "if (!was_playing || restart_cover_art_delay) id(cover_art_playback_started).execute();" not in text
@@ -1139,6 +1150,8 @@ def firmware_cover_art_playback_grace_errors(path: Path, root: Path) -> list[str
     stopped_body = yaml_script_body(text, "cover_art_playback_stopped")
     if not stopped_body or "script.stop: cover_art_delayed_playback_stopped" not in stopped_body:
         errors.append(f"{rel}: cancel pending playback grace during an immediate stop")
+    elif "advance_playback_generation(" not in stopped_body:
+        errors.append(f"{rel}: invalidate delayed playback cleanup after a completed stop")
     return errors
 
 
@@ -1251,22 +1264,11 @@ def firmware_cover_art_lifecycle_controller_errors(
         "cover_art_deferred_download": "transition_is_current(",
         "cover_art_retry_download": "cover_art_download_generation",
         "cover_art_refresh_progress": "transition_is_current(",
-        "cover_art_delayed_playback_stopped": "generation_is_current(",
     }
     for script_id, marker in guarded_scripts.items():
         body = yaml_script_body(cover_art_text, script_id) or ""
         if marker not in body:
             errors.append(f"{cover_art_rel}: guard {script_id} against obsolete display generations")
-    stopped_body = yaml_script_body(cover_art_text, "cover_art_delayed_playback_stopped") or ""
-    if (
-        "id: cover_art_media_playing" not in stopped_body
-        or "id: cover_art_delay_interrupted_by_transition" not in stopped_body
-        or "script.execute: display_mode_clear_cover_art" not in stopped_body
-        or "script.wait: display_mode_clear_cover_art" not in stopped_body
-    ):
-        errors.append(
-            f"{cover_art_rel}: retire stopped playback state before clearing an obsolete cover art request"
-        )
     return errors
 
 
@@ -5587,6 +5589,8 @@ def run_self_test() -> int:
             "buffer brief non-playing states between tracks",
             "delay non-playing playback transitions",
             "remember and cancel a pending cover art opening when playback stops",
+            "track playback stop validity independently of display transitions",
+            "ignore repeated inactive updates during playback grace",
             "restart an interrupted cover art opening when playback resumes",
             "cancel a pending stop when playback resumes or pauses",
             "keep cached artwork when Home Assistant clears it during a brief playback transition",
@@ -5595,6 +5599,8 @@ def run_self_test() -> int:
     )
     expect_cover_art_playback_grace_errors(
         "cover art playback grace present",
+        "globals:\n"
+        "  - id: cover_art_playback_generation\n"
         "script:\n"
         "  - id: cover_art_resubscribe\n"
         "    then:\n"
@@ -5603,24 +5609,30 @@ def run_self_test() -> int:
         "          if (!was_playing || restart_cover_art_delay) id(cover_art_playback_started).execute();\n"
         "          id(cover_art_delayed_playback_stopped).stop();\n"
         "          id(cover_art_delayed_playback_stopped).stop();\n"
-        "          id(cover_art_delay_interrupted_by_transition) =\n"
-        "            id(cover_art_delay_interrupted_by_transition) || id(cover_art_delay_timer).is_running();\n"
+        "          id(cover_art_delay_interrupted_by_transition) = id(cover_art_delay_interrupted_by_transition) || id(cover_art_delay_timer).is_running();\n"
         "          id(cover_art_delay_timer).stop();\n"
-        "          id(cover_art_delayed_playback_stopped).execute();\n"
+        "          id(cover_art_playback_generation) = advance_playback_generation(id(cover_art_playback_generation));\n"
+        "          id(cover_art_delayed_playback_stopped).execute(id(cover_art_playback_generation));\n"
+        "          if (!playing && !paused && id(cover_art_delayed_playback_stopped).is_running()) {\n"
+        "            return;\n"
+        "          }\n"
         "          if (url.empty() && id(cover_art_delayed_playback_stopped).is_running()) return;\n"
         "  - id: cover_art_delayed_playback_stopped\n"
-        "    mode: restart\n"
+        "    mode: single\n"
+        "    parameters:\n"
+        "      playback_generation: int\n"
         "    then:\n"
         "      - delay: 2s\n"
         "      - if:\n"
         "          condition:\n"
         "            lambda: |-\n"
-        "              return state != \"playing\" && state != \"buffering\" && state != \"paused\";\n"
+        "              return playback_stop_generation_current(playback_generation, id(cover_art_playback_generation), state);\n"
         "          then:\n"
         "            - script.execute: cover_art_playback_stopped\n"
         "  - id: cover_art_playback_stopped\n"
         "    then:\n"
-        "      - script.stop: cover_art_delayed_playback_stopped\n",
+        "      - script.stop: cover_art_delayed_playback_stopped\n"
+        "      - lambda: id(cover_art_playback_generation) = advance_playback_generation(id(cover_art_playback_generation));\n",
         (),
     )
     expect_cover_art_disable_errors(


### PR DESCRIPTION
## Summary

- Prevent repeated Music Assistant inactive updates from restarting the existing two-second cover-art stop grace period.
- Use a playback-specific generation token so resumed playback invalidates stale stop callbacks independently of display lifecycle transitions.
- Preserve immediate dismissal for paused playback and return genuine stops to EspControl's configured cards, clock, dim, Display Off, screensaver, or schedule state.

The root cause was that repeated `idle`/attribute updates could keep re-executing the restart-mode delayed-stop script while cover art remained logically active, so its two-second delay never completed.

Relates to #1690.

## Automated checks

- `npm run check:cover-art-contract`
- `npm run check:firmware-ha-bindings`
- `npm run test:firmware` — 26/26 passed
- `npm run check:fast`
- ESPHome 2026.7.4 factory compile:
  - `guition-esp32-p4-jc1060p470` — passed
  - `guition-esp32-p4-jc4880p443` — passed
  - `guition-esp32-s3-4848s040` — passed

No documentation change is needed because this restores existing cover-art behavior without changing settings, APIs, or user workflows.

## Physical Music Assistant testing requested

Flash the affected display and confirm:

- Natural and manual track changes retain artwork without flashing or dismissing it.
- Stop plus clear queue closes stale artwork after about two seconds.
- Pausing dismisses artwork immediately.
- Restarting playback restores cover art normally.
- The configured clock, dim, Display Off, cards, screensaver, or schedule state resumes correctly after dismissal.

Automated compilation is complete; physical device behavior is not yet user-confirmed.