### PR TITLE
Use local secrets file for display flashing

### DIFF
--- a/.agents/skills/flash-displays/SKILL.md
+++ b/.agents/skills/flash-displays/SKILL.md
@@ -47,19 +47,19 @@ Use `dev.yaml` by default. If the user names another YAML file, use that file in
 
 ## Secrets File
 
-All development YAML files require a local `secrets.yaml` containing `wifi_ssid` and `wifi_password`. Use this existing file as the only secrets source:
+All development YAML files require a local `secrets.yaml` containing `wifi_ssid` and `wifi_password`. Always use this existing local file as the only secrets source:
 
 ```text
-/Users/jtenniswood/Git/espcontrol/secrets.yaml
+/home/jtenniswood/git/espcontrol/secrets.yaml
 ```
 
 Before flashing each selected display:
 
-1. Confirm the source exists with `test -f /Users/jtenniswood/Git/espcontrol/secrets.yaml`. If it is missing, stop and tell the user; do not create or guess secret values.
+1. Confirm the source exists with `test -f /home/jtenniswood/git/espcontrol/secrets.yaml`. If it is missing, stop and tell the user; do not create or guess secret values.
 2. Run the following from the selected display's config directory. This creates the ignored local symlink only when `secrets.yaml` is absent, and verifies that any existing file or symlink resolves to the required source:
 
    ```bash
-   SECRETS_SOURCE=/Users/jtenniswood/Git/espcontrol/secrets.yaml
+   SECRETS_SOURCE=/home/jtenniswood/git/espcontrol/secrets.yaml
    if [ ! -e secrets.yaml ] && [ ! -L secrets.yaml ]; then
      ln -s "$SECRETS_SOURCE" secrets.yaml
    fi


### PR DESCRIPTION
## Purpose

Update the display-flashing skill to use the canonical Linux-local secrets source at `/home/jtenniswood/git/espcontrol/secrets.yaml` instead of the unavailable macOS path.

## Practical impact

Display-level `secrets.yaml` links are now verified against the secrets file that exists in this development environment, allowing local compile and OTA workflows to proceed without copying or exposing credentials.

## Checks

- Confirmed every device-level `secrets.yaml` resolves to the canonical repository-root file.
- Ran the skill creator `quick_validate.py` validator successfully.
- Ran `git diff --check` successfully.