### PR TITLE
Update ESP32-C6 firmware to 2.12.12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,7 +317,7 @@ jobs:
               --version "${VERSION}" \
               --manifest "dist/firmware/${{ matrix.slug }}.recovery.manifest.json" \
               --recovery "dist/firmware/${{ matrix.slug }}.recovery.bin" \
-              --c6-firmware "espcontrol-${{ matrix.slug }}/.firmware-deps/esp32-c6/2.12.9/network_adapter_esp32c6.bin" \
+              --c6-firmware "espcontrol-${{ matrix.slug }}/.firmware-deps/esp32-c6/2.12.12/network_adapter_esp32c6.bin" \
               --normal-factory "dist/firmware/${{ matrix.slug }}.factory.bin" \
               --normal-ota "dist/firmware/${{ matrix.slug }}.ota.bin"
           fi

--- a/common/device/esp32_c6_recovery.yaml
+++ b/common/device/esp32_c6_recovery.yaml
@@ -11,6 +11,6 @@ external_components:
 
 c6_recovery:
   id: c6_offline_recovery
-  version: "2.12.9"
-  path: "../.firmware-deps/esp32-c6/2.12.9/network_adapter_esp32c6.bin"
-  sha256: "9d8cec9dcca632e9ded31de555a5b49c70316d30b87ae06bd933fd35a5a11513"
+  version: "2.12.12"
+  path: "../.firmware-deps/esp32-c6/2.12.12/network_adapter_esp32c6.bin"
+  sha256: "bad97ce81e7fcf5f3365898f633b80941ae863db9c754d87a78f89c8f61f2e94"

--- a/scripts/prepare_c6_firmware.py
+++ b/scripts/prepare_c6_firmware.py
@@ -12,8 +12,8 @@ import urllib.request
 
 
 ROOT = Path(__file__).resolve().parent.parent
-C6_VERSION = "2.12.9"
-C6_SHA256 = "9d8cec9dcca632e9ded31de555a5b49c70316d30b87ae06bd933fd35a5a11513"
+C6_VERSION = "2.12.12"
+C6_SHA256 = "bad97ce81e7fcf5f3365898f633b80941ae863db9c754d87a78f89c8f61f2e94"
 C6_URL = (
     "https://esphome.github.io/esp-hosted-firmware/"
     f"v{C6_VERSION}/network_adapter_esp32c6.bin"


### PR DESCRIPTION
## Purpose

Update the bundled ESP32-C6 hosted Wi-Fi recovery firmware from 2.12.9 to 2.12.12, matching the latest version reported by ESPHome 2026.8.0 devices.

## Practical impact

Recovery builds and release verification now download, checksum, embed, and verify ESP32-C6 firmware 2.12.12 consistently.

## Automated checks

- `npm run check:firmware-release`
- Fresh official firmware download and SHA-256 verification

## Physical device testing

The normal ESPHome 2026.8.0 firmware was flashed successfully to all five displays and runtime logs were checked. This PR specifically changes the offline C6 recovery dependency; a recovery flash has not been physically tested.