### PR TITLE
Increase web request header capacity

### DIFF
--- a/components/web_server_idf/__init__.py
+++ b/components/web_server_idf/__init__.py
@@ -13,4 +13,4 @@ AUTO_LOAD = ["web_server"]
 
 async def to_code(config):
     # Increase the maximum supported size of headers section in HTTP request packet to be processed by the server
-    add_idf_sdkconfig_option("CONFIG_HTTPD_MAX_REQ_HDR_LEN", 1024)
+    add_idf_sdkconfig_option("CONFIG_HTTPD_MAX_REQ_HDR_LEN", 4096)

--- a/components/web_server_idf/web_server_idf.cpp
+++ b/components/web_server_idf/web_server_idf.cpp
@@ -60,6 +60,8 @@ DefaultHeaders default_headers_instance;
 DefaultHeaders &DefaultHeaders::Instance() { return default_headers_instance; }
 
 namespace {
+static constexpr size_t MAX_FORM_URLENCODED_BODY_LENGTH = 1024;
+
 #ifdef ESPHOME_PROJECT_NAME
 static constexpr const char *ESPCONTROL_PROJECT_NAME = ESPHOME_PROJECT_NAME;
 #else
@@ -302,7 +304,7 @@ esp_err_t AsyncWebServer::request_post_handler(httpd_req_t *r) {
   }
 
   // Handle regular form data
-  if (r->content_len > CONFIG_HTTPD_MAX_REQ_HDR_LEN) {
+  if (r->content_len > MAX_FORM_URLENCODED_BODY_LENGTH) {
     ESP_LOGW(TAG, "Request size is to big: %zu", r->content_len);
     httpd_resp_send_err(r, HTTPD_400_BAD_REQUEST, nullptr);
     return ESP_FAIL;

--- a/scripts/check_device_profiles.py
+++ b/scripts/check_device_profiles.py
@@ -20,6 +20,8 @@ COMPAT_FIXTURES = ROOT / "product" / "v2" / "product_compatibility.json"
 BUTTON_GRID_CARDS = ROOT / "components" / "espcontrol" / "button_grid_cards.h"
 BUTTON_GRID_WEATHER_DRIVER = ROOT / "components" / "espcontrol" / "button_grid_weather_driver.h"
 BUTTON_GRID_WEATHER_FORECAST = ROOT / "components" / "espcontrol" / "button_grid_weather_forecast.h"
+WEB_SERVER_IDF_INIT = ROOT / "components" / "web_server_idf" / "__init__.py"
+WEB_SERVER_IDF_CPP = ROOT / "components" / "web_server_idf" / "web_server_idf.cpp"
 LEGACY_OTA_PARTITION_LAYOUTS = {
     "esp32-p4-86": "partitions_32mb_card_images.csv",
     "guition-esp32-p4-jc1060p470": "partitions_16mb_card_images.csv",
@@ -168,6 +170,27 @@ def test_generated_web(profiles: dict[str, dict]) -> None:
         assert "webserver/www.js?device=${device_slug}&v=${firmware_version}" in factory, (
             f"{slug}.factory.yaml: release firmware does not request its compatible hosted editor"
         )
+
+
+def test_web_server_request_limits() -> None:
+    init = WEB_SERVER_IDF_INIT.read_text(encoding="utf-8")
+    server = WEB_SERVER_IDF_CPP.read_text(encoding="utf-8")
+    header_limit = re.search(
+        r'add_idf_sdkconfig_option\("CONFIG_HTTPD_MAX_REQ_HDR_LEN",\s*(\d+)\)',
+        init,
+    )
+    assert header_limit and int(header_limit.group(1)) >= 4096, (
+        "web server request-header limit must support modern browser headers"
+    )
+    assert "static constexpr size_t MAX_FORM_URLENCODED_BODY_LENGTH = 1024;" in server, (
+        "form-encoded POST bodies must retain their independent 1024-byte limit"
+    )
+    assert "r->content_len > MAX_FORM_URLENCODED_BODY_LENGTH" in server, (
+        "form-encoded POST body validation must use its independent limit"
+    )
+    assert "r->content_len > CONFIG_HTTPD_MAX_REQ_HDR_LEN" not in server, (
+        "form-encoded POST bodies must not inherit the request-header limit"
+    )
 
 
 def test_generated_yaml(profiles: dict[str, dict]) -> None:
@@ -735,6 +758,7 @@ def main() -> int:
     assert profile_slugs == compatibility_required_slugs(), "current compatibility device slug fixture is stale"
     test_public_device_capabilities(profile_slugs)
     test_generated_web(profiles)
+    test_web_server_request_limits()
     test_zero_image_capacity_disables_all_image_card_pickers(profiles)
     test_constrained_s3_supports_one_cover_art_card(profiles)
     test_generated_yaml(profiles)


### PR DESCRIPTION
## Summary

- increase the ESP-IDF HTTP request-header limit from 1,024 to 4,096 bytes to prevent HTTP 431 responses from modern browsers
- keep form-encoded POST bodies independently limited to 1,024 bytes
- add a configuration contract check that guards both limits against regression

Relates to #1657. The issue should remain open until the reporter confirms the fix on their device.

## Practical impact

Header storage remains request-scoped, so this permits up to roughly 3 KB more transient internal-heap use per actively parsed request. It does not add a comparable permanent allocation or expand accepted form-body size.

## Automated checks

- `npm run check:config`
- `npm run check:device-profiles`
- `npm run check:firmware-parser`
- `npm run check:fast`
- ESPHome 2026.8.0 factory compile for all six supported profiles:
  - ESP32-P4-86
  - Guition JC1060P470
  - Guition JC4880P443
  - Guition JC8012P4A1 V2
  - Guition JC8012P4A1 V1
  - Guition ESP32-S3-4848S040
- verified every generated SDK configuration contains `CONFIG_HTTPD_MAX_REQ_HDR_LEN=4096`

## Physical device testing required

Not performed locally. Please verify on a P4 panel and the constrained S3 panel:

- a request containing approximately 3.5 KB of headers is accepted instead of returning 431
- Settings can be repeatedly opened and a harmless setting saved
- free internal heap and largest free block recover after long-header requests
- form-encoded bodies larger than 1,024 bytes remain rejected
- normal web loading, authentication, native saves, legacy POST fallback, and EventSource reconnects continue to work