### PR TITLE
Clear stale media cover art when playback stops

### DIFF
--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -2163,6 +2163,7 @@ script:
               subscribe_secondary_content_probe(std::string("entity_picture"), 2u);
               subscribe_secondary_content_probe(std::string("entity_picture_local"), 4u);
               subscribe_secondary_content_probe(std::string("media_content_id"), 8u);
+              subscribe_secondary_content_probe(std::string("media_artist"), 16u);
             }
           }
 

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -461,7 +461,8 @@ inline void subscribe_media_cover_art(MediaNowPlayingCtx *ctx,
           if (present) playback->artwork_content_mask |= 1u;
           else playback->artwork_content_mask &= static_cast<uint8_t>(~1u);
           clear_stale_artwork = espcontrol::cover_art::media_card_artwork_should_clear(
-            playback->has_state, playback->available, playback->state_text);
+            playback->has_state, playback->available, playback->state_text,
+            media_playback_has_current_content(playback));
           media_playback_apply_state_to_now_playing(playback);
         }
         if (!image_card_context_current(art, entity_id, generation)) return;
@@ -491,7 +492,8 @@ inline void subscribe_media_cover_art(MediaNowPlayingCtx *ctx,
           if (present) playback->artwork_content_mask |= 2u;
           else playback->artwork_content_mask &= static_cast<uint8_t>(~2u);
           clear_stale_artwork = espcontrol::cover_art::media_card_artwork_should_clear(
-            playback->has_state, playback->available, playback->state_text);
+            playback->has_state, playback->available, playback->state_text,
+            media_playback_has_current_content(playback));
           media_playback_apply_state_to_now_playing(playback);
         }
         if (!image_card_context_current(art, entity_id, generation)) return;

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -452,6 +452,7 @@ inline void subscribe_media_cover_art(MediaNowPlayingCtx *ctx,
     std::string("entity_picture"),
     std::function<void(esphome::StringRef)>(
       [art, playback, entity_id, generation](esphome::StringRef picture) {
+        bool clear_stale_artwork = false;
         if (media_playback_generation_valid(playback, generation)) {
           const std::string value = string_ref_limited(
             picture, espcontrol::cover_art::MAX_ARTWORK_URL_LENGTH);
@@ -459,9 +460,15 @@ inline void subscribe_media_cover_art(MediaNowPlayingCtx *ctx,
                                value != "unavailable";
           if (present) playback->artwork_content_mask |= 1u;
           else playback->artwork_content_mask &= static_cast<uint8_t>(~1u);
+          clear_stale_artwork = espcontrol::cover_art::media_card_artwork_should_clear(
+            playback->has_state, playback->available, playback->state_text);
           media_playback_apply_state_to_now_playing(playback);
         }
         if (!image_card_context_current(art, entity_id, generation)) return;
+        if (clear_stale_artwork) {
+          image_card_clear_media_artwork(art);
+          return;
+        }
         // Attribute subscriptions are independent. Ask the artwork coordinator
         // to obtain a matching remote/local pair instead of downloading from
         // this individual notification.
@@ -475,6 +482,7 @@ inline void subscribe_media_cover_art(MediaNowPlayingCtx *ctx,
     std::string("entity_picture_local"),
     std::function<void(esphome::StringRef)>(
       [art, playback, entity_id, generation](esphome::StringRef picture) {
+        bool clear_stale_artwork = false;
         if (media_playback_generation_valid(playback, generation)) {
           const std::string value = string_ref_limited(
             picture, espcontrol::cover_art::MAX_ARTWORK_URL_LENGTH);
@@ -482,9 +490,15 @@ inline void subscribe_media_cover_art(MediaNowPlayingCtx *ctx,
                                value != "unavailable";
           if (present) playback->artwork_content_mask |= 2u;
           else playback->artwork_content_mask &= static_cast<uint8_t>(~2u);
+          clear_stale_artwork = espcontrol::cover_art::media_card_artwork_should_clear(
+            playback->has_state, playback->available, playback->state_text);
           media_playback_apply_state_to_now_playing(playback);
         }
         if (!image_card_context_current(art, entity_id, generation)) return;
+        if (clear_stale_artwork) {
+          image_card_clear_media_artwork(art);
+          return;
+        }
         // See the remote callback above: one notification starts one paired
         // refresh, which prevents either attribute winning by arrival order.
         image_card_schedule_media_artwork_refresh(art);

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -458,7 +458,9 @@ inline void subscribe_media_cover_art(MediaNowPlayingCtx *ctx,
             picture, espcontrol::cover_art::MAX_ARTWORK_URL_LENGTH);
           const bool present = !value.empty() && value != "unknown" &&
                                value != "unavailable";
-          if (present) playback->artwork_content_mask |= 1u;
+          const bool current = espcontrol::cover_art::media_artwork_content_current(
+            playback->has_state, playback->available, playback->state_text, present);
+          if (current) playback->artwork_content_mask |= 1u;
           else playback->artwork_content_mask &= static_cast<uint8_t>(~1u);
           clear_stale_artwork = espcontrol::cover_art::media_card_artwork_should_clear(
             playback->has_state, playback->available, playback->state_text,
@@ -489,7 +491,9 @@ inline void subscribe_media_cover_art(MediaNowPlayingCtx *ctx,
             picture, espcontrol::cover_art::MAX_ARTWORK_URL_LENGTH);
           const bool present = !value.empty() && value != "unknown" &&
                                value != "unavailable";
-          if (present) playback->artwork_content_mask |= 2u;
+          const bool current = espcontrol::cover_art::media_artwork_content_current(
+            playback->has_state, playback->available, playback->state_text, present);
+          if (current) playback->artwork_content_mask |= 2u;
           else playback->artwork_content_mask &= static_cast<uint8_t>(~2u);
           clear_stale_artwork = espcontrol::cover_art::media_card_artwork_should_clear(
             playback->has_state, playback->available, playback->state_text,

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -954,11 +954,21 @@ inline std::string media_playback_artwork_refresh_signature(
   return state->has_state ? std::string("state:") + state->state_text : std::string();
 }
 
+inline bool media_playback_has_current_content(const MediaPlaybackState *state) {
+  if (!state) return false;
+  const bool has_content = !state->title.empty() || !state->artist.empty() ||
+                           state->has_current_content_id ||
+                           state->artwork_content_mask != 0;
+  return espcontrol::cover_art::media_entity_content_available(
+    state->has_state, state->available, has_content);
+}
+
 inline void media_playback_refresh_stable_artwork(MediaPlaybackState *state,
                                                   MediaNowPlayingCtx *ctx) {
   if (!state || !ctx || !ctx->cover_art) return;
+  const bool has_content = media_playback_has_current_content(state);
   if (espcontrol::cover_art::media_card_artwork_should_clear(
-        state->has_state, state->available, state->state_text)) {
+        state->has_state, state->available, state->state_text, has_content)) {
     ctx->artwork_refresh_signature.clear();
     image_card_clear_media_artwork(ctx->cover_art);
     return;
@@ -975,8 +985,9 @@ inline void media_playback_apply_state_to_now_playing_snapshot(
   ctx->source_known = state->source_known;
   ctx->external_source = state->external_source;
   if (ctx->cover_art) {
+    const bool has_content = media_playback_has_current_content(state);
     if (espcontrol::cover_art::media_card_artwork_should_clear(
-          state->has_state, state->available, state->state_text)) {
+          state->has_state, state->available, state->state_text, has_content)) {
       image_card_clear_media_artwork(ctx->cover_art);
     } else {
       image_card_set_media_artwork_suppressed(
@@ -1023,14 +1034,6 @@ inline void media_playback_apply_state_to_now_playing(MediaPlaybackState *state,
   }
   media_playback_refresh_stable_artwork(state, ctx);
   media_playback_apply_state_to_now_playing_snapshot(state, ctx);
-}
-
-inline bool media_playback_has_current_content(const MediaPlaybackState *state) {
-  if (!state || !state->has_state || !state->available ||
-      !espcontrol::cover_art::media_entity_state_usable(state->state_text)) return false;
-  return !state->title.empty() || !state->artist.empty() ||
-         state->has_current_content_id || state->has_current_content_type ||
-         state->artwork_content_mask != 0;
 }
 
 inline void media_playback_apply_state_to_now_playing(MediaPlaybackState *state) {

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -777,6 +777,19 @@ inline void media_playback_reset_state(MediaPlaybackState *state,
   std::vector<MediaPlaybackButtonRef>().swap(state->buttons);
 }
 
+inline void media_playback_invalidate_retained_content(MediaPlaybackState *state) {
+  if (!state) return;
+  state->title.clear();
+  state->artist.clear();
+  state->current_content_id.clear();
+  state->current_content_fingerprint = 0;
+  state->current_content_type.clear();
+  state->current_content_kind = espcontrol::media::MediaItemKind::UNKNOWN;
+  state->has_current_content_id = false;
+  state->has_current_content_type = false;
+  state->artwork_content_mask = 0;
+}
+
 inline MediaPlaybackState *media_playback_find_state(const std::string &entity_id) {
   if (entity_id.empty()) return nullptr;
   std::vector<MediaPlaybackState *> &states = media_playback_states();
@@ -1422,6 +1435,9 @@ inline void media_playback_subscribe_playback_state(MediaPlaybackState *state) {
       [state, generation](esphome::StringRef state_ref) {
         if (!media_playback_generation_valid(state, generation)) return;
         std::string state_text = string_ref_limited(state_ref, HA_SHORT_STATE_MAX_LEN);
+        const bool invalidate_retained_content =
+          espcontrol::cover_art::media_state_change_invalidates_retained_content(
+            state->has_state, state->state_text, state_text);
         bool was_playing = state->playing;
         float paused_position_seconds = was_playing
           ? media_playback_current_position_seconds(state)
@@ -1430,6 +1446,9 @@ inline void media_playback_subscribe_playback_state(MediaPlaybackState *state) {
         state->state_text = state_text;
         state->available = !ha_state_unavailable_ref(state_ref);
         state->playing = state_text == "playing";
+        if (invalidate_retained_content) {
+          media_playback_invalidate_retained_content(state);
+        }
         if (was_playing && !state->playing) {
           state->position_seconds = paused_position_seconds;
           state->position_updated_ms = esphome::millis();

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -957,6 +957,12 @@ inline std::string media_playback_artwork_refresh_signature(
 inline void media_playback_refresh_stable_artwork(MediaPlaybackState *state,
                                                   MediaNowPlayingCtx *ctx) {
   if (!state || !ctx || !ctx->cover_art) return;
+  if (espcontrol::cover_art::media_card_artwork_should_clear(
+        state->has_state, state->available, state->state_text)) {
+    ctx->artwork_refresh_signature.clear();
+    image_card_clear_media_artwork(ctx->cover_art);
+    return;
+  }
   const std::string signature = media_playback_artwork_refresh_signature(state);
   if (signature.empty() || signature == ctx->artwork_refresh_signature) return;
   ctx->artwork_refresh_signature = signature;
@@ -969,9 +975,14 @@ inline void media_playback_apply_state_to_now_playing_snapshot(
   ctx->source_known = state->source_known;
   ctx->external_source = state->external_source;
   if (ctx->cover_art) {
-    image_card_set_media_artwork_suppressed(
-      ctx->cover_art, espcontrol::cover_art::media_card_artwork_suppressed(
-        ctx->source_known, ctx->external_source));
+    if (espcontrol::cover_art::media_card_artwork_should_clear(
+          state->has_state, state->available, state->state_text)) {
+      image_card_clear_media_artwork(ctx->cover_art);
+    } else {
+      image_card_set_media_artwork_suppressed(
+        ctx->cover_art, espcontrol::cover_art::media_card_artwork_suppressed(
+          ctx->source_known, ctx->external_source));
+    }
   }
   if (ctx->title_lbl) {
     const std::string title =

--- a/components/espcontrol/button_grid_sliders.h
+++ b/components/espcontrol/button_grid_sliders.h
@@ -9,6 +9,7 @@ struct ImageCardCtx;
 inline void image_card_set_media_artwork_suppressed(ImageCardCtx *ctx,
                                                      bool suppressed);
 inline void image_card_refresh_media_artwork_on_metadata_change(ImageCardCtx *ctx);
+inline void image_card_clear_media_artwork(ImageCardCtx *ctx);
 
 struct CardPadding {
   lv_coord_t left = 0;

--- a/components/espcontrol/cover_art.h
+++ b/components/espcontrol/cover_art.h
@@ -51,6 +51,11 @@ inline bool media_entity_state_usable(const std::string &state) {
          normalized == "buffering";
 }
 
+inline bool media_card_artwork_should_clear(bool state_known, bool available,
+                                            const std::string &state) {
+  return state_known && (!available || !media_entity_state_usable(state));
+}
+
 inline bool use_secondary_media_entity(bool primary_external,
                                        bool secondary_configured,
                                        bool secondary_available,

--- a/components/espcontrol/cover_art.h
+++ b/components/espcontrol/cover_art.h
@@ -51,6 +51,13 @@ inline bool media_entity_state_usable(const std::string &state) {
          normalized == "buffering";
 }
 
+inline bool media_artwork_content_current(bool state_known, bool available,
+                                          const std::string &state,
+                                          bool artwork_present) {
+  return artwork_present && state_known && available &&
+         media_entity_state_usable(state);
+}
+
 inline bool media_state_change_invalidates_retained_content(
     bool previous_state_known, const std::string &previous_state,
     const std::string &next_state) {

--- a/components/espcontrol/cover_art.h
+++ b/components/espcontrol/cover_art.h
@@ -51,6 +51,15 @@ inline bool media_entity_state_usable(const std::string &state) {
          normalized == "buffering";
 }
 
+inline bool media_state_change_invalidates_retained_content(
+    bool previous_state_known, const std::string &previous_state,
+    const std::string &next_state) {
+  const std::string normalized_next = normalized_media_source(next_state);
+  if (media_entity_state_usable(normalized_next)) return false;
+  return !previous_state_known ||
+         normalized_media_source(previous_state) != normalized_next;
+}
+
 inline bool media_card_artwork_should_clear(bool state_known, bool available,
                                             const std::string &state,
                                             bool has_content) {

--- a/components/espcontrol/cover_art.h
+++ b/components/espcontrol/cover_art.h
@@ -52,8 +52,15 @@ inline bool media_entity_state_usable(const std::string &state) {
 }
 
 inline bool media_card_artwork_should_clear(bool state_known, bool available,
-                                            const std::string &state) {
-  return state_known && (!available || !media_entity_state_usable(state));
+                                            const std::string &state,
+                                            bool has_content) {
+  return state_known &&
+         (!available || (!media_entity_state_usable(state) && !has_content));
+}
+
+inline bool media_entity_content_available(bool state_known, bool available,
+                                           bool has_content) {
+  return state_known && available && has_content;
 }
 
 inline bool use_secondary_media_entity(bool primary_external,

--- a/scripts/check_cover_art_contract.py
+++ b/scripts/check_cover_art_contract.py
@@ -23,6 +23,13 @@ int main() {
   assert(!media_entity_state_usable("idle"));
   assert(!media_entity_state_usable("off"));
   assert(!media_entity_state_usable(" unavailable "));
+  assert(!media_card_artwork_should_clear(false, true, "unknown"));
+  assert(!media_card_artwork_should_clear(true, true, "playing"));
+  assert(!media_card_artwork_should_clear(true, true, "paused"));
+  assert(!media_card_artwork_should_clear(true, true, "buffering"));
+  assert(media_card_artwork_should_clear(true, true, "idle"));
+  assert(media_card_artwork_should_clear(true, true, "off"));
+  assert(media_card_artwork_should_clear(true, false, "playing"));
   assert(!use_secondary_media_entity(false, true, true, true));
   assert(!use_secondary_media_entity(true, false, true, true));
   assert(!use_secondary_media_entity(true, true, false, true));
@@ -521,6 +528,8 @@ for required in (
     'std::string("entity_picture")',
     'std::string("entity_picture_local")',
     "image_card_schedule_media_artwork_refresh(art)",
+    "media_card_artwork_should_clear(",
+    "image_card_clear_media_artwork(art)",
 ):
     if required not in media_art:
         raise SystemExit(f"Media card cover art subscription contract missing: {required}")
@@ -529,4 +538,23 @@ if "subscribe_image_card_entity_state" in media_art:
         "Media card cover art must not add a general entity-state subscription "
         "on top of its picture subscriptions"
     )
+now_playing_refresh_start = media.find(
+    "inline void media_playback_refresh_stable_artwork("
+)
+now_playing_refresh_end = media.find(
+    "inline void media_playback_apply_state_to_now_playing_snapshot(",
+    now_playing_refresh_start,
+)
+if now_playing_refresh_start < 0 or now_playing_refresh_end < 0:
+    raise SystemExit("Media cover-art playback-state contract missing")
+now_playing_refresh = media[now_playing_refresh_start:now_playing_refresh_end]
+for required in (
+    "media_card_artwork_should_clear(",
+    "ctx->artwork_refresh_signature.clear();",
+    "image_card_clear_media_artwork(ctx->cover_art);",
+):
+    if required not in now_playing_refresh:
+        raise SystemExit(
+            f"Stopped media must clear stale card artwork: {required}"
+        )
 print("Cover art policy, layout, and state contract checks passed.")

--- a/scripts/check_cover_art_contract.py
+++ b/scripts/check_cover_art_contract.py
@@ -23,6 +23,14 @@ int main() {
   assert(!media_entity_state_usable("idle"));
   assert(!media_entity_state_usable("off"));
   assert(!media_entity_state_usable(" unavailable "));
+  assert(media_artwork_content_current(true, true, "playing", true));
+  assert(media_artwork_content_current(true, true, "paused", true));
+  assert(media_artwork_content_current(true, true, "buffering", true));
+  assert(!media_artwork_content_current(true, true, "idle", true));
+  assert(!media_artwork_content_current(true, true, "off", true));
+  assert(!media_artwork_content_current(true, false, "playing", true));
+  assert(!media_artwork_content_current(false, true, "playing", true));
+  assert(!media_artwork_content_current(true, true, "playing", false));
   assert(media_state_change_invalidates_retained_content(false, "unknown", "idle"));
   assert(media_state_change_invalidates_retained_content(true, "playing", "idle"));
   assert(media_state_change_invalidates_retained_content(true, "paused", "off"));
@@ -540,6 +548,7 @@ for required in (
     'std::string("entity_picture")',
     'std::string("entity_picture_local")',
     "image_card_schedule_media_artwork_refresh(art)",
+    "media_artwork_content_current(",
     "media_card_artwork_should_clear(",
     "image_card_clear_media_artwork(art)",
 ):

--- a/scripts/check_cover_art_contract.py
+++ b/scripts/check_cover_art_contract.py
@@ -23,6 +23,13 @@ int main() {
   assert(!media_entity_state_usable("idle"));
   assert(!media_entity_state_usable("off"));
   assert(!media_entity_state_usable(" unavailable "));
+  assert(media_state_change_invalidates_retained_content(false, "unknown", "idle"));
+  assert(media_state_change_invalidates_retained_content(true, "playing", "idle"));
+  assert(media_state_change_invalidates_retained_content(true, "paused", "off"));
+  assert(media_state_change_invalidates_retained_content(true, "idle", "off"));
+  assert(!media_state_change_invalidates_retained_content(true, "idle", "idle"));
+  assert(!media_state_change_invalidates_retained_content(true, "idle", "playing"));
+  assert(!media_state_change_invalidates_retained_content(true, "paused", "buffering"));
   assert(!media_card_artwork_should_clear(false, true, "unknown", false));
   assert(!media_card_artwork_should_clear(true, true, "playing", false));
   assert(!media_card_artwork_should_clear(true, true, "paused", false));
@@ -587,6 +594,23 @@ for stale_gate in (
     if stale_gate in current_content:
         raise SystemExit(
             f"Secondary routing must follow actual metadata, not {stale_gate}"
+        )
+state_subscription_start = media.find(
+    "inline void media_playback_subscribe_playback_state(MediaPlaybackState *state) {"
+)
+state_subscription_end = media.find(
+    "inline void media_playback_subscribe_metadata(", state_subscription_start
+)
+if state_subscription_start < 0 or state_subscription_end < 0:
+    raise SystemExit("Playback-state retained metadata contract missing")
+state_subscription = media[state_subscription_start:state_subscription_end]
+for required in (
+    "media_state_change_invalidates_retained_content(",
+    "media_playback_invalidate_retained_content(state);",
+):
+    if required not in state_subscription:
+        raise SystemExit(
+            f"Stopped playback must invalidate retained metadata: {required}"
         )
 for required in (
     "espcontrol::cover_art::media_entity_state_usable(next)",

--- a/scripts/check_cover_art_contract.py
+++ b/scripts/check_cover_art_contract.py
@@ -23,13 +23,18 @@ int main() {
   assert(!media_entity_state_usable("idle"));
   assert(!media_entity_state_usable("off"));
   assert(!media_entity_state_usable(" unavailable "));
-  assert(!media_card_artwork_should_clear(false, true, "unknown"));
-  assert(!media_card_artwork_should_clear(true, true, "playing"));
-  assert(!media_card_artwork_should_clear(true, true, "paused"));
-  assert(!media_card_artwork_should_clear(true, true, "buffering"));
-  assert(media_card_artwork_should_clear(true, true, "idle"));
-  assert(media_card_artwork_should_clear(true, true, "off"));
-  assert(media_card_artwork_should_clear(true, false, "playing"));
+  assert(!media_card_artwork_should_clear(false, true, "unknown", false));
+  assert(!media_card_artwork_should_clear(true, true, "playing", false));
+  assert(!media_card_artwork_should_clear(true, true, "paused", false));
+  assert(!media_card_artwork_should_clear(true, true, "buffering", false));
+  assert(media_card_artwork_should_clear(true, true, "idle", false));
+  assert(!media_card_artwork_should_clear(true, true, "idle", true));
+  assert(media_card_artwork_should_clear(true, true, "off", false));
+  assert(media_card_artwork_should_clear(true, false, "playing", true));
+  assert(media_entity_content_available(true, true, true));
+  assert(!media_entity_content_available(true, true, false));
+  assert(!media_entity_content_available(true, false, true));
+  assert(!media_entity_content_available(false, true, true));
   assert(!use_secondary_media_entity(false, true, true, true));
   assert(!use_secondary_media_entity(true, false, true, true));
   assert(!use_secondary_media_entity(true, true, false, true));
@@ -556,5 +561,39 @@ for required in (
     if required not in now_playing_refresh:
         raise SystemExit(
             f"Stopped media must clear stale card artwork: {required}"
+        )
+current_content_start = media.find(
+    "inline bool media_playback_has_current_content("
+)
+current_content_end = media.find("\n}", current_content_start)
+if current_content_start < 0 or current_content_end < 0:
+    raise SystemExit("Secondary media content routing contract missing")
+current_content = media[current_content_start:current_content_end]
+for required in (
+    "media_entity_content_available(",
+    "!state->title.empty()",
+    "!state->artist.empty()",
+    "state->has_current_content_id",
+    "state->artwork_content_mask != 0",
+):
+    if required not in current_content:
+        raise SystemExit(
+            f"Secondary media content routing contract missing: {required}"
+        )
+for stale_gate in (
+    "media_entity_state_usable(",
+    "state->has_current_content_type",
+):
+    if stale_gate in current_content:
+        raise SystemExit(
+            f"Secondary routing must follow actual metadata, not {stale_gate}"
+        )
+for required in (
+    "espcontrol::cover_art::media_entity_state_usable(next)",
+    'subscribe_secondary_content_probe(std::string("media_artist"), 16u)',
+):
+    if required not in resubscribe:
+        raise SystemExit(
+            f"Full-screen secondary media routing contract missing: {required}"
         )
 print("Cover art policy, layout, and state contract checks passed.")


### PR DESCRIPTION
## Purpose

Clear stale media cover art after playback stops and make primary Sonos / external media routing follow whichever entity currently has meaningful media data.

## Practical impact

- Stopped, idle, off, and unavailable players now cancel pending artwork work and release the previous decoded cover image.
- Late artwork callbacks cannot restore the stale image after playback stops.
- Paused and buffering players continue to retain their current artwork.
- A later playback start clears the old refresh signature so current artwork is requested again.
- When the configured external media entity has no title, artist, content ID, or artwork, the card returns to the primary Sonos entity and shows its source fallback, such as `TV` and `Source`.
- Fresh external metadata selects the external entity again, even if its playback state update lags behind the metadata.
- A generic media content type by itself no longer keeps an empty external entity selected.

## Automated checks

- `python3 scripts/check_tasks.py run fast --no-cache --jobs 4` — all 47 tasks passed, including 26 compiled firmware host tests.
- Cover-art policy/state, Home Assistant binding, modal allocation, generated device-slot, web, and generated-output checks passed within the fast profile.

## Device testing

Automated checks are complete; physical display testing is still required.

On any display configured with a Media card in Cover Art mode:

1. Configure a primary Sonos player and an External Source Media Entity on a Cover Art card.
2. Start media on the external entity and confirm its artwork and track details appear.
3. Stop playback so Home Assistant clears the external artwork and metadata.
4. Confirm the previous cover image disappears and the card returns to the Sonos source labels, typically `TV` and `Source`.
5. Make new metadata appear on the external entity and confirm the card switches back to it automatically.
6. Pause instead of stopping and confirm valid artwork remains visible.

This is shared media-card firmware behavior and can affect all supported displays using cover-art cards.
