### PR TITLE
Prevent API encryption lockouts during adoption

### DIFF
--- a/builds/esp32-p4-86.factory.yaml
+++ b/builds/esp32-p4-86.factory.yaml
@@ -13,6 +13,7 @@ substitutions:
 
 packages:
   core: !include esp32-p4-86.yaml
+  api_encryption: !include ../common/addon/api_encryption_dynamic.yaml
 
 esphome:
   project:

--- a/builds/guition-esp32-p4-jc1060p470-v2.factory.yaml
+++ b/builds/guition-esp32-p4-jc1060p470-v2.factory.yaml
@@ -16,6 +16,7 @@ substitutions:
 
 packages:
   core: !include guition-esp32-p4-jc1060p470-v2.yaml
+  api_encryption: !include ../common/addon/api_encryption_dynamic.yaml
 
 esphome:
   project:

--- a/builds/guition-esp32-p4-jc1060p470.factory.yaml
+++ b/builds/guition-esp32-p4-jc1060p470.factory.yaml
@@ -16,6 +16,7 @@ substitutions:
 
 packages:
   core: !include guition-esp32-p4-jc1060p470.yaml
+  api_encryption: !include ../common/addon/api_encryption_dynamic.yaml
 
 esphome:
   project:

--- a/builds/guition-esp32-p4-jc4880p443.factory.yaml
+++ b/builds/guition-esp32-p4-jc4880p443.factory.yaml
@@ -13,6 +13,7 @@ substitutions:
 
 packages:
   core: !include guition-esp32-p4-jc4880p443.yaml
+  api_encryption: !include ../common/addon/api_encryption_dynamic.yaml
 
 esphome:
   project:

--- a/builds/guition-esp32-p4-jc8012p4a1-v2.factory.yaml
+++ b/builds/guition-esp32-p4-jc8012p4a1-v2.factory.yaml
@@ -16,6 +16,7 @@ substitutions:
 
 packages:
   core: !include guition-esp32-p4-jc8012p4a1-v2.yaml
+  api_encryption: !include ../common/addon/api_encryption_dynamic.yaml
 
 esphome:
   project:

--- a/builds/guition-esp32-p4-jc8012p4a1.factory.yaml
+++ b/builds/guition-esp32-p4-jc8012p4a1.factory.yaml
@@ -16,6 +16,7 @@ substitutions:
 
 packages:
   core: !include guition-esp32-p4-jc8012p4a1.yaml
+  api_encryption: !include ../common/addon/api_encryption_dynamic.yaml
 
 esphome:
   project:

--- a/builds/guition-esp32-s3-4848s040.factory.yaml
+++ b/builds/guition-esp32-s3-4848s040.factory.yaml
@@ -18,6 +18,7 @@ esp32:
 
 packages:
   core: !include ../devices/guition-esp32-s3-4848s040/packages.yaml
+  api_encryption: !include ../common/addon/api_encryption_dynamic.yaml
 
 esphome:
   name_add_mac_suffix: true

--- a/common/addon/api_encryption_dynamic.yaml
+++ b/common/addon/api_encryption_dynamic.yaml
@@ -1,0 +1,2 @@
+api:
+  encryption: {}

--- a/devices/esp32-p4-86/esphome.yaml
+++ b/devices/esp32-p4-86/esphome.yaml
@@ -24,6 +24,10 @@ wifi:
 # Remote package (pulls full config from GitHub)
 # ---------------------------------------------------------------------------
 packages:
+  api_encryption:
+    url: https://github.com/jtenniswood/espcontrol/
+    file: common/addon/api_encryption_dynamic.yaml
+    refresh: 1s
   setup:
     url: https://github.com/jtenniswood/espcontrol/
     file: devices/esp32-p4-86/packages.yaml

--- a/devices/guition-esp32-p4-jc1060p470-v2/esphome.yaml
+++ b/devices/guition-esp32-p4-jc1060p470-v2/esphome.yaml
@@ -26,6 +26,10 @@ packages:
   # WiFi builds include credentials from secrets.yaml. Ethernet builds include
   # an empty placeholder so WiFi is not added alongside Ethernet.
   network_credentials: !include device/starter_network${starter_network_package_suffix}.yaml
+  api_encryption:
+    url: https://github.com/jtenniswood/espcontrol/
+    file: common/addon/api_encryption_dynamic.yaml
+    refresh: 1s
   setup:
     url: https://github.com/jtenniswood/espcontrol/
     file: devices/guition-esp32-p4-jc1060p470-v2/packages.yaml

--- a/devices/guition-esp32-p4-jc1060p470/esphome.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/esphome.yaml
@@ -26,6 +26,10 @@ packages:
   # WiFi builds include credentials from secrets.yaml. Ethernet builds include
   # an empty placeholder so WiFi is not added alongside Ethernet.
   network_credentials: !include device/starter_network${starter_network_package_suffix}.yaml
+  api_encryption:
+    url: https://github.com/jtenniswood/espcontrol/
+    file: common/addon/api_encryption_dynamic.yaml
+    refresh: 1s
   setup:
     url: https://github.com/jtenniswood/espcontrol/
     file: devices/guition-esp32-p4-jc1060p470/packages.yaml

--- a/devices/guition-esp32-p4-jc4880p443/esphome.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/esphome.yaml
@@ -24,6 +24,10 @@ wifi:
 # Remote package (pulls full config from GitHub)
 # ---------------------------------------------------------------------------
 packages:
+  api_encryption:
+    url: https://github.com/jtenniswood/espcontrol/
+    file: common/addon/api_encryption_dynamic.yaml
+    refresh: 1s
   setup:
     url: https://github.com/jtenniswood/espcontrol/
     file: devices/guition-esp32-p4-jc4880p443/packages.yaml

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/esphome.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/esphome.yaml
@@ -24,6 +24,10 @@ wifi:
 # Remote package (pulls full config from GitHub)
 # ---------------------------------------------------------------------------
 packages:
+  api_encryption:
+    url: https://github.com/jtenniswood/espcontrol/
+    file: common/addon/api_encryption_dynamic.yaml
+    refresh: 1s
   setup:
     url: https://github.com/jtenniswood/espcontrol/
     file: devices/guition-esp32-p4-jc8012p4a1-v2/packages.yaml

--- a/devices/guition-esp32-p4-jc8012p4a1/esphome.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/esphome.yaml
@@ -24,6 +24,10 @@ wifi:
 # Remote package (pulls full config from GitHub)
 # ---------------------------------------------------------------------------
 packages:
+  api_encryption:
+    url: https://github.com/jtenniswood/espcontrol/
+    file: common/addon/api_encryption_dynamic.yaml
+    refresh: 1s
   setup:
     url: https://github.com/jtenniswood/espcontrol/
     file: devices/guition-esp32-p4-jc8012p4a1/packages.yaml

--- a/devices/guition-esp32-s3-4848s040/esphome.yaml
+++ b/devices/guition-esp32-s3-4848s040/esphome.yaml
@@ -24,6 +24,10 @@ wifi:
 # Remote package (pulls full config from GitHub)
 # ---------------------------------------------------------------------------
 packages:
+  api_encryption:
+    url: https://github.com/jtenniswood/espcontrol/
+    file: common/addon/api_encryption_dynamic.yaml
+    refresh: 1s
   setup:
     url: https://github.com/jtenniswood/espcontrol/
     file: devices/guition-esp32-s3-4848s040/packages.yaml

--- a/docs/getting-started/manual-esphome-setup.md
+++ b/docs/getting-started/manual-esphome-setup.md
@@ -52,11 +52,19 @@ wifi:
   password: !secret wifi_password
 
 packages:
+  api_encryption:
+    url: https://github.com/jtenniswood/espcontrol/
+    file: common/addon/api_encryption_dynamic.yaml
+    refresh: 1sec
   setup:
     url: https://github.com/jtenniswood/espcontrol/
     file: devices/guition-esp32-p4-jc1060p470/packages.yaml
     refresh: 1sec
 ```
+
+The `api_encryption` package lets Home Assistant create a unique encryption key for the display the first time it connects. Home Assistant stores that key and, with Home Assistant and ESPHome Device Builder 2026.8 or newer, passes the same key to Device Builder when you adopt or rebuild the display. You do not need to create or share a key yourself.
+
+Wireless OTA updates preserve the key stored on the display. A full USB erase can remove it, so Home Assistant may ask you to pair the display again afterward. For the underlying behavior, see the [ESPHome native API documentation](https://esphome.io/components/api/), the [Home Assistant key-handoff fix](https://github.com/home-assistant/core/pull/178039), and the [Device Builder adoption fix](https://github.com/esphome/device-builder/pull/2496).
 
 If you do not use ESPHome secrets, replace the two `!secret` lines with your WiFi details:
 
@@ -85,6 +93,10 @@ substitutions:
   espcontrol_web_password: !secret espcontrol_web_password
 
 packages:
+  api_encryption:
+    url: https://github.com/jtenniswood/espcontrol/
+    file: common/addon/api_encryption_dynamic.yaml
+    refresh: 1sec
   setup:
     url: https://github.com/jtenniswood/espcontrol/
     file: devices/guition-esp32-p4-jc1060p470/packages.yaml
@@ -129,6 +141,10 @@ substitutions:
   disable_updates: "true"
 
 packages:
+  api_encryption:
+    url: https://github.com/jtenniswood/espcontrol/
+    file: common/addon/api_encryption_dynamic.yaml
+    refresh: 1sec
   setup:
     url: https://github.com/jtenniswood/espcontrol/
     file: devices/guition-esp32-p4-jc1060p470/packages.yaml

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -29,6 +29,13 @@ description:
 - Make sure the display and Home Assistant are on the **same WiFi network** (not a guest network or a different VLAN).
 - In Home Assistant, go to **Settings > Devices & Services > Add Integration** and search for **ESPHome**. Enter the device's IP address manually.
 
+## Home Assistant Says "Connection Requires Encryption"
+
+- Update both Home Assistant and ESPHome Device Builder to 2026.8 or newer. These versions pass a display's unique API encryption key between Home Assistant and Device Builder when the display is adopted or rebuilt.
+- If you already rebuilt the display and Home Assistant asks for a key, open its YAML in ESPHome Device Builder and use the existing `api.encryption.key` value in Home Assistant's reauthentication prompt. Do not generate a different key.
+- Normal OTA updates retain the key stored on the display. Erasing the whole display during a USB install can remove it and may require pairing the display with Home Assistant again.
+- See [Manual Setup](/getting-started/manual-esphome-setup) for more about automatic API encryption.
+
 ## A P4 Panel Has Unreliable WiFi
 
 - P4 panels use a separate ESP32-C6 WiFi processor. Mismatched or outdated C6

--- a/scripts/check_device_profiles.py
+++ b/scripts/check_device_profiles.py
@@ -22,6 +22,8 @@ BUTTON_GRID_WEATHER_DRIVER = ROOT / "components" / "espcontrol" / "button_grid_w
 BUTTON_GRID_WEATHER_FORECAST = ROOT / "components" / "espcontrol" / "button_grid_weather_forecast.h"
 WEB_SERVER_IDF_INIT = ROOT / "components" / "web_server_idf" / "__init__.py"
 WEB_SERVER_IDF_CPP = ROOT / "components" / "web_server_idf" / "web_server_idf.cpp"
+PUBLIC_API_ENCRYPTION_PACKAGE = ROOT / "common" / "addon" / "api_encryption_dynamic.yaml"
+PUBLIC_API_ENCRYPTION_REFERENCE = "common/addon/api_encryption_dynamic.yaml"
 LEGACY_OTA_PARTITION_LAYOUTS = {
     "esp32-p4-86": "partitions_32mb_card_images.csv",
     "guition-esp32-p4-jc1060p470": "partitions_16mb_card_images.csv",
@@ -233,6 +235,35 @@ def test_generated_yaml(profiles: dict[str, dict]) -> None:
             )
         if profile["firmware"].get("display", {}).get("infoOnly"):
             assert "cfg.info_only = true;" in sensors, f"{slug}: sensors.yaml missing info-only grid flag"
+
+
+def test_public_api_encryption_policy(profile_slugs: list[str]) -> None:
+    policy = PUBLIC_API_ENCRYPTION_PACKAGE.read_text(encoding="utf-8")
+    assert policy == "api:\n  encryption: {}\n", (
+        "public API encryption package must remain keyless and dynamically provisionable"
+    )
+    assert "key:" not in policy, "public firmware must not embed a shared API encryption key"
+    assert "provisioning:" not in policy, "public firmware must not add a timed provisioning lockout"
+
+    local_reference = f"api_encryption: !include ../{PUBLIC_API_ENCRYPTION_REFERENCE}"
+    remote_reference = f"file: {PUBLIC_API_ENCRYPTION_REFERENCE}"
+    for slug in profile_slugs:
+        factory = (ROOT / "builds" / f"{slug}.factory.yaml").read_text(encoding="utf-8")
+        public_config = (ROOT / "devices" / slug / "esphome.yaml").read_text(encoding="utf-8")
+        dev = (ROOT / "devices" / slug / "dev.yaml").read_text(encoding="utf-8")
+        local_build = (ROOT / "builds" / f"{slug}.yaml").read_text(encoding="utf-8")
+        assert local_reference in factory, f"{slug}: factory firmware must support dynamic API encryption"
+        assert remote_reference in public_config, f"{slug}: public config must support dynamic API encryption"
+        assert PUBLIC_API_ENCRYPTION_REFERENCE not in dev, f"{slug}: dev firmware must remain plaintext"
+        assert PUBLIC_API_ENCRYPTION_REFERENCE not in local_build, f"{slug}: local build must remain plaintext"
+
+    core = (ROOT / "common" / "device" / "core_infra.yaml").read_text(encoding="utf-8")
+    assert PUBLIC_API_ENCRYPTION_REFERENCE not in core, "shared core firmware must remain plaintext"
+
+    manual_setup = (ROOT / "docs" / "getting-started" / "manual-esphome-setup.md").read_text(encoding="utf-8")
+    assert manual_setup.count(remote_reference) == 3, (
+        "manual WiFi, authenticated web, and Ethernet examples must include dynamic API encryption"
+    )
 
 
 def test_ota_preserves_deployed_partition_layouts() -> None:
@@ -764,6 +795,7 @@ def main() -> int:
     test_zero_image_capacity_disables_all_image_card_pickers(profiles)
     test_constrained_s3_supports_one_cover_art_card(profiles)
     test_generated_yaml(profiles)
+    test_public_api_encryption_policy(profile_slugs)
     test_ota_preserves_deployed_partition_layouts()
     test_upgrades_do_not_reset_saved_panel_config()
     test_local_voice_generation_uses_capability()


### PR DESCRIPTION
## Summary

- Add a keyless public-firmware API encryption package so Home Assistant provisions a unique key per display.
- Include it in all six factory profiles and all six public device entrypoints while keeping shared core, dev, and local build profiles plaintext.
- Add the package to every manual WiFi and Ethernet setup example.
- Enforce the public/local split and the absence of a fixed key or timed provisioning window in device-profile checks.
- Document Home Assistant/ESPHome Device Builder 2026.8+ key handoff and recovery guidance.

## Practical impact

Public firmware accepts the initial plaintext provisioning connection and supports Noise encryption after Home Assistant supplies a key. No project-wide key is embedded. A user's explicit `api.encryption.key` still overrides the dynamic default.

Related to #1736. This PR intentionally does not close the issue; it should remain open until the physical device sequence below is confirmed.

## Automated checks

- `npm run check:fast` — passed
- `npm run docs:build` — passed
- All six factory profiles compiled with ESPHome 2026.8.0
- Generated source for all six builds contains `USE_API_NOISE` and `USE_API_PLAINTEXT`, with no generated `set_noise_psk` call or YAML-baked PSK
- A temporary configuration with an explicit literal API encryption key passed ESPHome 2026.8 validation and resolved to the supplied key

## Physical testing required

Test one P4 display and the S3 display:

1. Install clean factory firmware.
2. Add it to Home Assistant and confirm a key is provisioned.
3. Take control in ESPHome Device Builder 2026.8+.
4. Flash the first adopted build over OTA.
5. Confirm Home Assistant reconnects without requesting the key.
6. Flash a second build and confirm the key remains stable.

Automated compile/configuration checks are complete; no physical displays were flashed as part of this PR.