### PR TITLE
Clamp restored card layouts to display bounds

### DIFF
--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -1129,6 +1129,7 @@ inline bool grid_refresh_subpage_layouts(
     const std::string order = get_subpage_order(sp_cfg);
     SubpageOrder sp_order;
     parse_subpage_order(order, NS, sp_btns.size(), sp_order);
+    normalize_subpage_order_spans(sp_order, NS, COLS);
 
     // Binding a card to another entity/type requires new HA callbacks. Keep
     // the existing data-bound widgets intact and defer that structural edit to
@@ -1965,6 +1966,7 @@ inline void grid_phase2(
 
     SubpageOrder sp_ord;
     parse_subpage_order(sp_order_str, NS, sp_btns.size(), sp_ord);
+    normalize_subpage_order_spans(sp_ord, NS, COLS);
 
     lv_obj_t *sub_scr = lv_obj_create(NULL);
     int display_order = NS;

--- a/components/espcontrol/button_grid_layout.h
+++ b/components/espcontrol/button_grid_layout.h
@@ -199,6 +199,31 @@ inline void parse_order_string(const std::string &order_str, int num_slots, Orde
   }
 }
 
+// Saved layouts can originate on a larger display or an older web editor.
+// Downgrade any card that extends beyond the active grid before passing its
+// cell coordinates to LVGL.
+inline void normalize_grid_span_for_position(int position, int num_slots,
+                                             int cols, int &row_span,
+                                             int &col_span) {
+  int slot_limit = bounded_grid_slots(num_slots);
+  if (position < 0 || position >= slot_limit || cols <= 0) {
+    row_span = 1;
+    col_span = 1;
+    return;
+  }
+  if (row_span < 1) row_span = 1;
+  if (col_span < 1) col_span = 1;
+  int rows = (slot_limit + cols - 1) / cols;
+  int row = position / cols;
+  int col = position % cols;
+  int last_cell = position + (row_span - 1) * cols + col_span - 1;
+  if (row + row_span > rows || col + col_span > cols ||
+      last_cell >= slot_limit) {
+    row_span = 1;
+    col_span = 1;
+  }
+}
+
 // Zero out grid cells that are covered by a neighbouring multi-cell button
 inline void clear_spanned_cells(const OrderResult &order, int num_slots, int cols, OrderResult &result) {
   int slot_limit = bounded_grid_slots(num_slots);
@@ -212,6 +237,9 @@ inline void clear_spanned_cells(const OrderResult &order, int num_slots, int col
     int idx = result.positions[p] - 1;
     int row_span = result.row_span[idx] > 0 ? result.row_span[idx] : 1;
     int col_span = result.col_span[idx] > 0 ? result.col_span[idx] : 1;
+    normalize_grid_span_for_position(p, slot_limit, cols, row_span, col_span);
+    result.row_span[idx] = row_span;
+    result.col_span[idx] = col_span;
     int col = p % cols;
     for (int r = 0; r < row_span; r++) {
       for (int c = 0; c < col_span; c++) {

--- a/components/espcontrol/button_grid_subpages.h
+++ b/components/espcontrol/button_grid_subpages.h
@@ -579,10 +579,15 @@ inline void normalize_subpage_order_spans(SubpageOrder &order, int num_slots,
   for (int position = 0; position < slot_limit; position++) {
     int button_index = order.positions[position];
     if (button_index < 1 || button_index > MAX_GRID_SLOTS) continue;
+    int rendered_position = order.has_back_token ? position : position + 1;
+    if (rendered_position >= slot_limit) {
+      order.positions[position] = 0;
+      continue;
+    }
     int &row_span = order.row_span[button_index - 1];
     int &col_span = order.col_span[button_index - 1];
-    normalize_grid_span_for_position(position, slot_limit, cols, row_span,
-                                     col_span);
+    normalize_grid_span_for_position(rendered_position, slot_limit, cols,
+                                     row_span, col_span);
   }
 }
 

--- a/components/espcontrol/button_grid_subpages.h
+++ b/components/espcontrol/button_grid_subpages.h
@@ -568,4 +568,22 @@ inline void parse_subpage_order(const std::string &order_str, int num_slots, int
   }
 }
 
+inline void normalize_subpage_order_spans(SubpageOrder &order, int num_slots,
+                                          int cols) {
+  int slot_limit = bounded_grid_slots(num_slots);
+  if (order.has_back_token) {
+    normalize_grid_span_for_position(order.back_pos, slot_limit, cols,
+                                     order.back_row_span,
+                                     order.back_col_span);
+  }
+  for (int position = 0; position < slot_limit; position++) {
+    int button_index = order.positions[position];
+    if (button_index < 1 || button_index > MAX_GRID_SLOTS) continue;
+    int &row_span = order.row_span[button_index - 1];
+    int &col_span = order.col_span[button_index - 1];
+    normalize_grid_span_for_position(position, slot_limit, cols, row_span,
+                                     col_span);
+  }
+}
+
 #endif  // ESPCONTROL_SUBPAGE_PARSER_ONLY

--- a/scripts/check_firmware_parser.py
+++ b/scripts/check_firmware_parser.py
@@ -737,6 +737,15 @@ int main() {
   assert(fitting_span_safe.row_span[1] == 1);
   assert(fitting_span_safe.col_span[1] == 2);
 
+  // Legacy subpages reserve the first cell for Back. A wide card at source
+  // position 4 is rendered at position 5, where it fits a five-column grid.
+  int subpage_row_span = 1;
+  int subpage_col_span = 2;
+  normalize_grid_span_for_position(5, 15, 5, subpage_row_span,
+                                   subpage_col_span);
+  assert(subpage_row_span == 1);
+  assert(subpage_col_span == 2);
+
   return 0;
 }
 '''

--- a/scripts/check_firmware_parser.py
+++ b/scripts/check_firmware_parser.py
@@ -719,6 +719,24 @@ int main() {
   assert(cleared.positions[3] == 0);
   assert(cleared.positions[4] == 0);
 
+  // A 10-inch portrait-large tile must not retain its 4x3 span when restored
+  // onto the 7-inch 5x3 grid from the reported backup layout.
+  OrderResult cross_device;
+  parse_order_string("1,7,6p,,,8,2,,,,3,4,,,,9,5", 15, cross_device);
+  OrderResult cross_device_safe;
+  clear_spanned_cells(cross_device, 15, 5, cross_device_safe);
+  assert(cross_device_safe.positions[2] == 6);
+  assert(cross_device_safe.row_span[5] == 1);
+  assert(cross_device_safe.col_span[5] == 1);
+
+  // Spans that fit the target grid remain unchanged.
+  OrderResult fitting_span;
+  parse_order_string("1,2w", 6, fitting_span);
+  OrderResult fitting_span_safe;
+  clear_spanned_cells(fitting_span, 6, 3, fitting_span_safe);
+  assert(fitting_span_safe.row_span[1] == 1);
+  assert(fitting_span_safe.col_span[1] == 2);
+
   return 0;
 }
 '''


### PR DESCRIPTION
## Purpose

Prevent layouts restored from a larger display from passing oversized card spans into a smaller display grid during boot.

## Practical impact

The web editor already adapts normal cross-device restores. This adds a firmware-side safety boundary for older editors, interrupted fallback restores, or stale saved layouts. Cards that would extend beyond the active grid are reduced to normal single tiles before LVGL receives their coordinates. Valid multi-cell cards remain unchanged.

The safeguard covers both the home grid and subpages. The reported 10.1-inch backup shape, including its `6p` 4x3 card, is covered by a regression test against the 7-inch 5x3 grid.

## Automated checks

- `npm run check:fast`
- 26 compiled firmware unit tests passed
- 105 web tests passed
- Backup/model compatibility, TypeScript, generated outputs, and all device-profile checks passed

<!-- espcontrol-pr-testing-guidance -->
## Automated testing guidance

Device testing is expected before merge because this change affects firmware and the on-device experience.

Suggested devices to test:
- Guition JC1060P470 (7 inches, Landscape)
- Guition JC4880P443 (4.3 inches, Portrait)
- Guition 4848S040 (4 inches, Square)

Suggested checks:
- Restore the supplied 10.1-inch backup onto a smaller display and reboot it.
- Confirm the device boots normally and does not restart repeatedly.
- Confirm oversized cards appear as normal single tiles.
- Confirm the home screen and subpage navigation still work.
- Confirm there is no blank screen, clipping, or visual corruption.

Suggested PR status: Ready for device test once automated checks pass.

## Physical device testing

Not yet performed. A compile/build pass does not replace the restore-and-reboot test above.