### PR TITLE
Handle unpublished WebInstall firmware

### DIFF
--- a/docs/.vitepress/theme/components/EspInstallButton.vue
+++ b/docs/.vitepress/theme/components/EspInstallButton.vue
@@ -7,7 +7,8 @@
       Your browser does not support WebSerial. Use Chrome or Edge on desktop.
     </div>
     <div v-else-if="loadError" class="installer-status warning">
-      {{ loadError }}
+      <span>{{ loadError }}</span>
+      <button type="button" class="retry-button" @click="prepareInstaller">Try again</button>
     </div>
     <div v-else-if="checkingManifest" class="installer-status">
       Checking the latest firmware...
@@ -42,17 +43,21 @@ const manifestAvailable = ref(false)
 const ready = ref(false)
 const loadError = ref('')
 
-onMounted(async () => {
-  checked.value = true
-  supported.value = 'serial' in navigator
-  if (!supported.value) return
-
+async function prepareInstaller() {
   checkingManifest.value = true
+  manifestAvailable.value = false
+  ready.value = false
+  loadError.value = ''
+
   try {
     const response = await fetch(manifestUrl, { cache: 'no-store' })
     manifestAvailable.value = response.ok
+    if (!response.ok && response.status !== 404) {
+      loadError.value = `Could not check for WebInstall firmware (HTTP ${response.status}).`
+    }
   } catch {
     manifestAvailable.value = false
+    loadError.value = 'Could not check for WebInstall firmware. Check your connection.'
   } finally {
     checkingManifest.value = false
   }
@@ -65,6 +70,13 @@ onMounted(async () => {
   } catch (err) {
     loadError.value = `Failed to load the USB installer. ${err?.message || ''}`.trim()
   }
+}
+
+onMounted(() => {
+  checked.value = true
+  supported.value = 'serial' in navigator
+  if (!supported.value) return
+  prepareInstaller()
 })
 </script>
 
@@ -104,5 +116,16 @@ onMounted(async () => {
 .installer-status.warning {
   background-color: var(--vp-c-warning-soft);
   color: var(--vp-c-warning-1);
+}
+
+.retry-button {
+  margin-left: 10px;
+  border: 1px solid currentColor;
+  border-radius: 12px;
+  padding: 2px 10px;
+  color: inherit;
+  background: transparent;
+  font: inherit;
+  cursor: pointer;
 }
 </style>

--- a/docs/.vitepress/theme/components/EspInstallButton.vue
+++ b/docs/.vitepress/theme/components/EspInstallButton.vue
@@ -1,10 +1,23 @@
 <template>
   <div class="esp-install-wrapper">
-    <div v-if="!supported" class="unsupported">
+    <div v-if="!checked" class="installer-status">
+      Preparing installer...
+    </div>
+    <div v-else-if="!supported" class="installer-status warning">
       Your browser does not support WebSerial. Use Chrome or Edge on desktop.
     </div>
-    <div v-else-if="loadError" class="unsupported">
-      Failed to load installer. {{ loadError }}
+    <div v-else-if="loadError" class="installer-status warning">
+      {{ loadError }}
+    </div>
+    <div v-else-if="checkingManifest" class="installer-status">
+      Checking the latest firmware...
+    </div>
+    <div v-else-if="!manifestAvailable" class="installer-status warning">
+      WebInstall firmware for this panel has not been published yet. Use the manual ESPHome
+      setup below or check again after the next EspControl release.
+    </div>
+    <div v-else-if="!ready" class="installer-status">
+      Loading installer...
     </div>
     <div v-else class="install-button">
       <esp-web-install-button :manifest="manifestUrl">
@@ -22,16 +35,35 @@ const props = defineProps({
   slug: { type: String, default: 'guition-esp32-p4-jc1060p470' }
 })
 const manifestUrl = withBase(`/firmware/${props.slug}/manifest.json`)
+const checked = ref(false)
 const supported = ref(false)
-const loadError = ref(null)
+const checkingManifest = ref(false)
+const manifestAvailable = ref(false)
+const ready = ref(false)
+const loadError = ref('')
 
 onMounted(async () => {
+  checked.value = true
   supported.value = 'serial' in navigator
   if (!supported.value) return
+
+  checkingManifest.value = true
+  try {
+    const response = await fetch(manifestUrl, { cache: 'no-store' })
+    manifestAvailable.value = response.ok
+  } catch {
+    manifestAvailable.value = false
+  } finally {
+    checkingManifest.value = false
+  }
+
+  if (!manifestAvailable.value) return
+
   try {
     await import('https://unpkg.com/esp-web-tools@10/dist/web/install-button.js')
+    ready.value = true
   } catch (err) {
-    loadError.value = err?.message || 'Network or script load error.'
+    loadError.value = `Failed to load the USB installer. ${err?.message || ''}`.trim()
   }
 })
 </script>
@@ -61,11 +93,16 @@ onMounted(async () => {
   background-color: var(--vp-button-brand-hover-bg);
 }
 
-.unsupported {
+.installer-status {
   padding: 12px 16px;
   border-radius: 8px;
+  background-color: var(--vp-c-default-soft);
+  color: var(--vp-c-text-2);
+  font-size: 14px;
+}
+
+.installer-status.warning {
   background-color: var(--vp-c-warning-soft);
   color: var(--vp-c-warning-1);
-  font-size: 14px;
 }
 </style>

--- a/docs/.vitepress/theme/components/EspInstallSelector.vue
+++ b/docs/.vitepress/theme/components/EspInstallSelector.vue
@@ -46,7 +46,8 @@
         Your browser does not support WebSerial. Use Chrome or Edge on desktop.
       </div>
       <div v-else-if="loadError" class="installer-status warning">
-        {{ loadError }}
+        <span>{{ loadError }}</span>
+        <button type="button" class="retry-button" @click="prepareInstaller">Try again</button>
       </div>
       <div v-else-if="checkingManifest" class="installer-status">
         Checking the latest firmware...
@@ -189,9 +190,13 @@ async function prepareInstaller() {
     const response = await fetch(manifestUrl.value, { cache: 'no-store' })
     if (request !== manifestRequest) return
     manifestAvailable.value = response.ok
+    if (!response.ok && response.status !== 404) {
+      loadError.value = `Could not check for WebInstall firmware (HTTP ${response.status}).`
+    }
   } catch {
     if (request !== manifestRequest) return
     manifestAvailable.value = false
+    loadError.value = 'Could not check for WebInstall firmware. Check your connection.'
   } finally {
     if (request === manifestRequest) checkingManifest.value = false
   }
@@ -407,6 +412,17 @@ onMounted(() => {
 .installer-status.warning {
   background-color: var(--vp-c-warning-soft);
   color: var(--vp-c-warning-1);
+}
+
+.retry-button {
+  margin-left: 10px;
+  border: 1px solid currentColor;
+  border-radius: 12px;
+  padding: 2px 10px;
+  color: inherit;
+  background: transparent;
+  font: inherit;
+  cursor: pointer;
 }
 
 @media (max-width: 640px) {

--- a/docs/.vitepress/theme/components/EspInstallSelector.vue
+++ b/docs/.vitepress/theme/components/EspInstallSelector.vue
@@ -46,7 +46,14 @@
         Your browser does not support WebSerial. Use Chrome or Edge on desktop.
       </div>
       <div v-else-if="loadError" class="installer-status warning">
-        Failed to load installer. {{ loadError }}
+        {{ loadError }}
+      </div>
+      <div v-else-if="checkingManifest" class="installer-status">
+        Checking the latest firmware...
+      </div>
+      <div v-else-if="!manifestAvailable" class="installer-status warning">
+        WebInstall firmware for this panel has not been published yet. Use its manual ESPHome
+        setup or check again after the next EspControl release.
       </div>
       <div v-else-if="!ready" class="installer-status">
         Loading installer...
@@ -164,25 +171,53 @@ const selected = ref(devices[0])
 const checked = ref(false)
 const supported = ref(false)
 const ready = ref(false)
-const loadError = ref(null)
+const checkingManifest = ref(false)
+const manifestAvailable = ref(false)
+const loadError = ref('')
+let manifestRequest = 0
 
 const manifestUrl = computed(() => withBase(`/firmware/${selected.value.slug}/manifest.json`))
 
-function selectDevice(device) {
-  selected.value = device
-}
+async function prepareInstaller() {
+  const request = ++manifestRequest
+  checkingManifest.value = true
+  manifestAvailable.value = false
+  ready.value = false
+  loadError.value = ''
 
-onMounted(async () => {
-  checked.value = true
-  supported.value = 'serial' in navigator
-  if (!supported.value) return
+  try {
+    const response = await fetch(manifestUrl.value, { cache: 'no-store' })
+    if (request !== manifestRequest) return
+    manifestAvailable.value = response.ok
+  } catch {
+    if (request !== manifestRequest) return
+    manifestAvailable.value = false
+  } finally {
+    if (request === manifestRequest) checkingManifest.value = false
+  }
+
+  if (request !== manifestRequest || !manifestAvailable.value) return
 
   try {
     await import('https://unpkg.com/esp-web-tools@10/dist/web/install-button.js')
-    ready.value = true
+    if (request === manifestRequest) ready.value = true
   } catch (err) {
-    loadError.value = err?.message || 'Network or script load error.'
+    if (request === manifestRequest) {
+      loadError.value = `Failed to load the USB installer. ${err?.message || ''}`.trim()
+    }
   }
+}
+
+function selectDevice(device) {
+  selected.value = device
+  if (checked.value && supported.value) prepareInstaller()
+}
+
+onMounted(() => {
+  checked.value = true
+  supported.value = 'serial' in navigator
+  if (!supported.value) return
+  prepareInstaller()
 })
 </script>
 

--- a/scripts/check_firmware_release.py
+++ b/scripts/check_firmware_release.py
@@ -478,6 +478,22 @@ def test_recovery_sources_and_documentation_stay_complete() -> None:
     assert "guition-esp32-s3-4848s040" not in selector
 
 
+def test_installers_preflight_public_manifest() -> None:
+    install_button = (
+        ROOT / "docs/.vitepress/theme/components/EspInstallButton.vue"
+    ).read_text(encoding="utf-8")
+    install_selector = (
+        ROOT / "docs/.vitepress/theme/components/EspInstallSelector.vue"
+    ).read_text(encoding="utf-8")
+    for component in (install_button, install_selector):
+        assert "fetch(manifestUrl" in component
+        assert "cache: 'no-store'" in component
+        assert "manifestAvailable.value = response.ok" in component
+        assert "!manifestAvailable" in component
+        assert "has not been published yet" in component
+    assert "if (checked.value && supported.value) prepareInstaller()" in install_selector
+
+
 def test_valid_files_and_directory() -> None:
     with TemporaryDirectory() as tmp:
         base = Path(tmp)
@@ -775,6 +791,7 @@ def main() -> int:
     test_recovery_manifest_and_payload_verification()
     test_c6_dependency_preparation_is_verified_and_atomic()
     test_recovery_sources_and_documentation_stay_complete()
+    test_installers_preflight_public_manifest()
     test_draft_release_publishes_only_after_remote_asset_verification()
     test_published_or_mismatched_asset_release_stays_unpublished()
     test_wrong_slug_path_fails()

--- a/scripts/check_firmware_release.py
+++ b/scripts/check_firmware_release.py
@@ -489,8 +489,10 @@ def test_installers_preflight_public_manifest() -> None:
         assert "fetch(manifestUrl" in component
         assert "cache: 'no-store'" in component
         assert "manifestAvailable.value = response.ok" in component
+        assert "response.status !== 404" in component
         assert "!manifestAvailable" in component
         assert "has not been published yet" in component
+        assert '@click="prepareInstaller"' in component
     assert "if (checked.value && supported.value) prepareInstaller()" in install_selector
 
 


### PR DESCRIPTION
## Purpose

Prevent WebInstall from presenting a broken install action when a device profile exists on the documentation site but its firmware manifest has not been published in a stable release. This addresses the follow-up report on #1273 without closing the device-support issue.

## Root cause

The JC1060P470 V2 profile was added after the current stable release (`v2.8.1`). Its live manifest URL therefore returns HTTP 404, but both normal installer components still rendered an active WebInstall button. ESP Web Tools then reported “Failed to download manifest.”

## Practical impact

- Checks the selected public manifest before loading or rendering WebInstall.
- Rechecks availability whenever a user changes devices in the installer selector.
- Shows a clear “firmware has not been published yet” message when the manifest is absent.
- Automatically enables WebInstall once a later stable release publishes the manifest; no follow-up code change is needed.
- Adds contract coverage for manifest preflight, no-cache fetching, missing-manifest messaging, and device reselection.

A new stable release is still required to publish the first JC1060P470 V2 manifest and binaries.

## Automated checks

- `python3 scripts/check_firmware_release.py`
- `python3 scripts/check_dev_docs.py --check`
- `npm run docs:build`
- `git diff --check`

All passed locally.

## User testing

After Pages deploys this branch, select the JC1060P470 V2 installer in Chrome. Before a V2 release exists, confirm the page shows the unpublished-firmware explanation instead of an active button. After the next stable release, confirm the button appears and WebInstall downloads the V2 manifest. No physical display test is required for the missing-manifest state.