### PR TITLE
Prepare web assets for v2.8.2

### DIFF
--- a/docs/public/webserver/web-assets.json
+++ b/docs/public/webserver/web-assets.json
@@ -16,11 +16,11 @@
       ],
       "firmwareVersions": [
         "dev",
+        "v2.8.2",
         "v2.8.1",
         "v2.8.0",
         "v2.7.1",
-        "v2.7.0",
-        "v2.6.3"
+        "v2.7.0"
       ],
       "webAssetVersion": 1
     }

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -48,11 +48,11 @@ WEB_SOURCE_DIR = ROOT / "src" / "webserver"
 # list aligned with the GitHub Pages release catalogue in pages.yml.
 WEB_ASSET_SUPPORTED_FIRMWARE_VERSIONS = (
     "dev",
+    "v2.8.2",
     "v2.8.1",
     "v2.8.0",
     "v2.7.1",
     "v2.7.0",
-    "v2.6.3",
 )
 
 # Fixed editor controls use a few MDI glyphs that are not selectable Product


### PR DESCRIPTION
Adds `v2.8.2` to the declared immutable web bundle compatibility list before the release tag is created.

## Checks

- `python3 scripts/build.py --check`
- `npm run check:release-preflight`
- `git diff --check`

The full release preflight passed locally, including firmware tests, web tests, browser smoke checks for seven layouts, release contracts, and the documentation build.

No physical device testing is required for this mechanical compatibility declaration.