### PR TITLE
Update ESPHome references to 2026.8.1

### DIFF
--- a/docs/getting-started/manual-esphome-setup.md
+++ b/docs/getting-started/manual-esphome-setup.md
@@ -11,7 +11,7 @@ The normal [browser install](/getting-started/install) is the easiest route. Use
 ## What You Need
 
 - A supported ESP32 panel.
-- ESPHome 2026.7.4 or newer, using Device Builder in Home Assistant or the ESPHome command line on your computer.
+- ESPHome 2026.8.1 or newer, using Device Builder in Home Assistant or the ESPHome command line on your computer.
 - A USB-C data cable for the first install.
 - Your WiFi name and password, unless you are using an advanced wired Ethernet option.
 

--- a/scripts/check_firmware_release.py
+++ b/scripts/check_firmware_release.py
@@ -123,7 +123,7 @@ def validate_esphome_env(path: Path) -> None:
     assert len(lines) == 1, f"{path}: expected exactly one ESPHOME_VERSION line"
     assert ESPHOME_ENV_RE.fullmatch(lines[0]), (
         f"{path}: expected ESPHOME_VERSION to be a stable numeric ESPHome release, "
-        "for example ESPHOME_VERSION=2026.6.5"
+        "for example ESPHOME_VERSION=2026.8.1"
     )
 
 
@@ -132,16 +132,16 @@ def test_esphome_env_format() -> None:
     with TemporaryDirectory() as tmp:
         base = Path(tmp)
         valid = base / "valid.env"
-        valid.write_text("ESPHOME_VERSION=2026.6.5\n", encoding="utf-8")
+        valid.write_text("ESPHOME_VERSION=2026.8.1\n", encoding="utf-8")
         validate_esphome_env(valid)
 
         for value in (
             "",
-            "export ESPHOME_VERSION=2026.6.5\n",
-            "ESPHOME_VERSION=\"2026.6.5\"\n",
-            "ESPHOME_VERSION=2026.6.5-beta.1\n",
-            "OTHER_VERSION=2026.6.5\n",
-            "ESPHOME_VERSION=2026.6.5\nEXTRA=value\n",
+            "export ESPHOME_VERSION=2026.8.1\n",
+            "ESPHOME_VERSION=\"2026.8.1\"\n",
+            "ESPHOME_VERSION=2026.8.1-beta.1\n",
+            "OTHER_VERSION=2026.8.1\n",
+            "ESPHOME_VERSION=2026.8.1\nEXTRA=value\n",
         ):
             invalid = base / "invalid.env"
             invalid.write_text(value, encoding="utf-8")

--- a/scripts/local_esphome.py
+++ b/scripts/local_esphome.py
@@ -169,15 +169,15 @@ class LocalEsphomeTests(unittest.TestCase):
             run_mock.return_value = subprocess.CompletedProcess(
                 args=["esphome", "version"],
                 returncode=0,
-                stdout="Version: 2026.7.4\n",
+                stdout="Version: 2026.8.1\n",
                 stderr="",
             )
-            self.assertEqual(installed_esphome_version("esphome"), "2026.7.4")
+            self.assertEqual(installed_esphome_version("esphome"), "2026.8.1")
 
     def test_rejects_an_unpinned_esphome_version(self) -> None:
-        with mock.patch(__name__ + ".pinned_esphome_version", return_value="2026.7.4"), \
-            mock.patch(__name__ + ".installed_esphome_version", return_value="2026.7.0"):
-            with self.assertRaisesRegex(LocalEsphomeError, "2026.7.4.*2026.7.0"):
+        with mock.patch(__name__ + ".pinned_esphome_version", return_value="2026.8.1"), \
+            mock.patch(__name__ + ".installed_esphome_version", return_value="2026.8.0"):
+            with self.assertRaisesRegex(LocalEsphomeError, "2026.8.1.*2026.8.0"):
                 ensure_pinned_esphome("esphome")
 
     def test_uses_dev_firmware_version(self) -> None:


### PR DESCRIPTION
## Summary

- Align maintained ESPHome documentation and test examples with the repository's `2026.8.1` runtime pin.
- Keep historical build records, compatibility thresholds, and separately versioned dependencies unchanged.

## Practical impact

- Manual-install users are now told to use ESPHome 2026.8.1 or newer.
- ESPHome helper and release-validation tests use current version examples.

## Documentation decision

- [x] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [ ] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Updated the manual ESPHome setup prerequisite.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [ ] Device testing is required before merge.
- [x] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- None; this changes documentation and test fixtures only.

## Notes for testing

- `npm run check:firmware-release`
- `npm run check:local-esphome`
- `npm run docs:build`
- Physical device testing is not required because the firmware configuration and runtime code are unchanged.

<!-- espcontrol-pr-testing-guidance -->
## Automated testing guidance

No specific device could be inferred from the changed files.

Suggested checks:
- Confirm automated checks pass.
- If the change affects what appears on a display, test the relevant device before merge.

Suggested PR status: Needs human judgement on whether device testing is required.

Changed files considered:
- `docs/getting-started/manual-esphome-setup.md`
- `scripts/check_firmware_release.py`
- `scripts/local_esphome.py`

## PR status

- [x] Checks running or waiting.
- [ ] Needs automated fix.
- [ ] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.
