### PR TITLE
Add second S3 flash target

### DIFF
--- a/.agents/skills/flash-displays/SKILL.md
+++ b/.agents/skills/flash-displays/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flash-displays
-description: Flash EspControl display firmware from this repository using ESPHome. Use when the user invokes /flash-displays with no extra display name, or asks to flash, reflash, update, or upload firmware to all known displays in sequence, or to a specific display such as 7inch, 7-inch P4, 10inch, 10-inch V1, 10-inch V2, P4-86, 4.3-inch P4, 4-inch P4, or 4-inch S3, over an explicitly supplied OTA target or USB.
+description: Flash EspControl display firmware from this repository using ESPHome. Use when the user invokes /flash-displays with no extra display name, or asks to flash, reflash, update, or upload firmware to all known displays in sequence, or to a specific display such as 7inch, 7-inch P4, 10inch, 10-inch V1, 10-inch V2, P4-86, 4.3-inch P4, 4-inch P4, 4-inch S3, or S3 second, over an explicitly supplied OTA target or USB.
 ---
 
 # Flash Displays
@@ -20,6 +20,7 @@ Use the local development ESPHome configs to flash the known EspControl displays
 | `4inch P4`, `4-inch P4`, `P4-86`, `86 Panel`, `Waveshare P4-86`, `esp32-p4-86` | `devices/esp32-p4-86` | `192.168.6.104` |
 | `4.3inch P4`, `4.3-inch P4`, `P4 4.3inch`, `P4 4.3-inch`, `JC4880P443` | `devices/guition-esp32-p4-jc4880p443` | `192.168.6.101` |
 | `4inch S3`, `4-inch S3`, `4848S040` | `devices/guition-esp32-s3-4848s040` | `192.168.6.105` |
+| `S3 second`, `second S3`, `4inch S3 second`, `4-inch S3 second` | `devices/guition-esp32-s3-4848s040` | `192.168.6.100` |
 
 Treat the 7-inch panel at `192.168.6.102`, and an ambiguous or default `7inch` request, as V1 hardware. Always flash that panel with the V1 `JC1060P470` configuration in `devices/guition-esp32-p4-jc1060p470`; never substitute the V2 configuration because that firmware will not work on this panel. Select the V2 directory only when the user explicitly requests the 7-inch V2 panel and supplies a different OTA target or explicitly requests USB.
 
@@ -36,6 +37,7 @@ For `/flash-displays` with no extra target, or for `all`, flash in this sequence
 3. 4-inch P4 / P4-86.
 4. 4.3-inch P4.
 5. 4-inch S3.
+6. S3 second.
 
 ## YAML Selection
 
@@ -149,6 +151,14 @@ cd /Users/jtenniswood/Git/espcontrol/devices/guition-esp32-s3-4848s040
 python3 ../../scripts/local_esphome.py dev.yaml run --device 192.168.6.105 --no-logs
 
 # 4-inch S3 over USB, only when explicitly requested
+cd /Users/jtenniswood/Git/espcontrol/devices/guition-esp32-s3-4848s040
+python3 ../../scripts/local_esphome.py dev.yaml run --device /dev/cu.usbmodem201301 --no-logs
+
+# S3 second over OTA
+cd /Users/jtenniswood/Git/espcontrol/devices/guition-esp32-s3-4848s040
+python3 ../../scripts/local_esphome.py dev.yaml run --device 192.168.6.100 --no-logs
+
+# S3 second over USB, only when explicitly requested
 cd /Users/jtenniswood/Git/espcontrol/devices/guition-esp32-s3-4848s040
 python3 ../../scripts/local_esphome.py dev.yaml run --device /dev/cu.usbmodem201301 --no-logs
 ```


### PR DESCRIPTION
## Purpose

Teach the flash-displays skill about the second S3 screen.

## Practical impact

- Recognizes S3 second and natural name variants.
- Uses the existing 4-inch S3 configuration with OTA target 192.168.6.100.
- Includes the second S3 as the final screen in the default all-displays sequence.
- Documents OTA and USB command examples.

## Checks

- Skill metadata and structure validated with the skill-creator quick validator.
- Git diff whitespace check passed.
- No firmware was compiled or flashed; this change only updates skill instructions.

## User testing

Invoke /flash-displays S3 second and confirm it selects devices/guition-esp32-s3-4848s040 with OTA target 192.168.6.100.