### PR TITLE
Fix ESPHome web server iterator warning

### DIFF
--- a/components/web_server_idf/web_server_idf.cpp
+++ b/components/web_server_idf/web_server_idf.cpp
@@ -1160,7 +1160,7 @@ void AsyncEventSourceResponse::loop() {
   process_buffer_();
   process_deferred_queue_();
   if (!this->entities_iterator_.completed())
-    this->entities_iterator_.advance();
+    this->entities_iterator_.try_advance(1);
 }
 
 bool AsyncEventSourceResponse::try_send_nodefer(const char *message, size_t message_len, const char *event, uint32_t id,


### PR DESCRIPTION
## Purpose

Update the custom ESP-IDF web server component to use ESPHome 2026.8.1's supported component iterator API.

## Practical impact

Manual and release firmware builds no longer emit the deprecation warning for `ComponentIterator::advance()`, and the component remains compatible when ESPHome removes that method in 2027.3.0. Runtime behavior is unchanged because `advance()` currently delegates directly to `try_advance(1)`.

## Checks

- Automated: compiled `builds/guition-esp32-s3-4848s040.yaml` with ESPHome 2026.8.1
- Automated: confirmed `web_server_idf.cpp` rebuilt without the deprecated iterator warning
- Automated: `git diff --check`
- Physical device testing: not required for this API-only compatibility update