### PR TITLE
Fix artwork endpoint review feedback

### DIFF
--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -1061,15 +1061,15 @@ script:
                   }
                 }
               }
+              if (url.empty() && id(cover_art_delayed_playback_stopped).is_running()) {
+                ESP_LOGD("cover_art", "Keeping cached artwork during brief playback transition");
+                return;
+              }
+
               if (local) {
                 id(cover_art_local_source_relative) = relative;
               } else {
                 id(cover_art_remote_source_relative) = relative;
-              }
-
-              if (url.empty() && id(cover_art_delayed_playback_stopped).is_running()) {
-                ESP_LOGD("cover_art", "Keeping cached artwork during brief playback transition");
-                return;
               }
 
               const bool source_changed = id(cover_art_runtime).sources.get(local) != url;

--- a/components/espcontrol/home_assistant_endpoint_policy.h
+++ b/components/espcontrol/home_assistant_endpoint_policy.h
@@ -111,8 +111,20 @@ inline std::string normalize_address(std::string value) {
   std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
     return static_cast<char>(std::tolower(c));
   });
-  if (value.rfind("::ffff:", 0) == 0) return value.substr(7);
-  if (value.find(':') != std::string::npos) value = canonical_ipv6(value);
+  if (value.rfind("::ffff:", 0) == 0 && value.find('.') != std::string::npos)
+    return value.substr(7);
+  if (value.find(':') != std::string::npos) {
+    std::array<uint16_t, 8> words{};
+    if (parse_ipv6_words(value, words) && words[0] == 0 && words[1] == 0 &&
+        words[2] == 0 && words[3] == 0 && words[4] == 0 &&
+        words[5] == 0xFFFF) {
+      return std::to_string(words[6] >> 8) + "." +
+             std::to_string(words[6] & 0xFF) + "." +
+             std::to_string(words[7] >> 8) + "." +
+             std::to_string(words[7] & 0xFF);
+    }
+    value = canonical_ipv6(value);
+  }
   return value;
 }
 

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -1138,6 +1138,18 @@ def firmware_cover_art_playback_grace_errors(path: Path, root: Path) -> list[str
         errors.append(f"{rel}: cancel a pending stop when playback resumes or pauses")
     if "url.empty() && id(cover_art_delayed_playback_stopped).is_running()" not in text:
         errors.append(f"{rel}: keep cached artwork when Home Assistant clears it during a brief playback transition")
+    else:
+        cached_guard = text.find(
+            "url.empty() && id(cover_art_delayed_playback_stopped).is_running()"
+        )
+        relative_markers = (
+            text.find("id(cover_art_local_source_relative) = relative;"),
+            text.find("id(cover_art_remote_source_relative) = relative;"),
+        )
+        if any(0 <= marker < cached_guard for marker in relative_markers):
+            errors.append(
+                f"{rel}: retain cached artwork's relative marker during a brief playback transition"
+            )
 
     stopped_body = yaml_script_body(text, "cover_art_playback_stopped")
     if not stopped_body or "script.stop: cover_art_delayed_playback_stopped" not in stopped_body:
@@ -5999,6 +6011,8 @@ def run_self_test() -> int:
         "          id(cover_art_delay_timer).stop();\n"
         "          id(cover_art_delayed_playback_stopped).execute();\n"
         "          if (url.empty() && id(cover_art_delayed_playback_stopped).is_running()) return;\n"
+        "          id(cover_art_local_source_relative) = relative;\n"
+        "          id(cover_art_remote_source_relative) = relative;\n"
         "  - id: cover_art_delayed_playback_stopped\n"
         "    mode: restart\n"
         "    then:\n"

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -1146,7 +1146,7 @@ def firmware_cover_art_playback_grace_errors(path: Path, root: Path) -> list[str
             text.find("id(cover_art_local_source_relative) = relative;"),
             text.find("id(cover_art_remote_source_relative) = relative;"),
         )
-        if any(0 <= marker < cached_guard for marker in relative_markers):
+        if any(marker < 0 or marker < cached_guard for marker in relative_markers):
             errors.append(
                 f"{rel}: retain cached artwork's relative marker during a brief playback transition"
             )
@@ -5996,8 +5996,7 @@ def run_self_test() -> int:
             "cancel pending playback grace during an immediate stop",
         ),
     )
-    expect_cover_art_playback_grace_errors(
-        "cover art playback grace present",
+    valid_cover_art_playback_grace = (
         "script:\n"
         "  - id: cover_art_resubscribe\n"
         "    then:\n"
@@ -6025,8 +6024,26 @@ def run_self_test() -> int:
         "            - script.execute: cover_art_playback_stopped\n"
         "  - id: cover_art_playback_stopped\n"
         "    then:\n"
-        "      - script.stop: cover_art_delayed_playback_stopped\n",
+        "      - script.stop: cover_art_delayed_playback_stopped\n"
+    )
+    expect_cover_art_playback_grace_errors(
+        "cover art playback grace present",
+        valid_cover_art_playback_grace,
         (),
+    )
+    expect_cover_art_playback_grace_errors(
+        "cover art playback grace missing local relative marker",
+        valid_cover_art_playback_grace.replace(
+            "          id(cover_art_local_source_relative) = relative;\n", ""
+        ),
+        ("retain cached artwork's relative marker",),
+    )
+    expect_cover_art_playback_grace_errors(
+        "cover art playback grace missing remote relative marker",
+        valid_cover_art_playback_grace.replace(
+            "          id(cover_art_remote_source_relative) = relative;\n", ""
+        ),
+        ("retain cached artwork's relative marker",),
     )
     expect_cover_art_disable_errors(
         "independent media sleep prevention when cover art is disabled",

--- a/tests/firmware/home_assistant_endpoint_policy_test.cpp
+++ b/tests/firmware/home_assistant_endpoint_policy_test.cpp
@@ -14,6 +14,8 @@ using espcontrol::home_assistant_endpoint::select_discovered_origin;
 int main() {
   assert(normalize_address(" 192.168.1.10:60532 ") == "192.168.1.10");
   assert(normalize_address("::ffff:192.168.1.10") == "192.168.1.10");
+  assert(normalize_address("::ffff:c0a8:10a") == "192.168.1.10");
+  assert(normalize_address("0:0:0:0:0:ffff:c0a8:010a") == "192.168.1.10");
   assert(normalize_address("[FE80::1234%wlan0]") ==
          "fe80:0:0:0:0:0:0:1234");
   assert(normalize_address("fe80:0000:0000:0000:0000:0000:0000:1234") ==
@@ -35,9 +37,12 @@ int main() {
                       "http://other.local:8123", false};
   ServiceRecord landing{{"192.168.1.10"}, 8123, "", true};
   assert(record_matches_client(matching, "192.168.1.10:60532"));
+  assert(record_matches_client(matching, "::ffff:c0a8:10a"));
   assert(!record_matches_client(other, "192.168.1.10"));
   assert(!record_matches_client(landing, "192.168.1.10"));
   assert(select_discovered_origin({other, matching}, "192.168.1.10", "http") ==
+         "http://192.168.1.10:80");
+  assert(select_discovered_origin({other, matching}, "::ffff:c0a8:10a", "http") ==
          "http://192.168.1.10:80");
   assert(select_discovered_origin({landing, other}, "192.168.1.10", "http").empty());
 


### PR DESCRIPTION
## Summary

- decode hexadecimal IPv4-mapped IPv6 client addresses before matching Home Assistant discovery records or building fallback artwork URLs
- retain cached artwork relative-path markers when Home Assistant briefly clears artwork between tracks
- add regression coverage for mapped-address matching and cached marker ordering

## Practical impact

Automatic artwork endpoint discovery now works when the native API reports an IPv4-mapped address in hexadecimal form. Cached relative artwork also follows endpoint changes correctly after brief playback transitions instead of remaining tied to the previous Home Assistant origin.

Follow-on to #1760.

## Automated checks

- npm run test:firmware — passed, 28/28 tests
- python3 scripts/check_firmware_ha_bindings.py — passed
- python3 scripts/check_firmware_ha_bindings.py --self-test — passed
- git diff --check — passed
- CI=true npm run check:parallel — relevant firmware tests passed; full local run was incomplete because this isolated worktree has no esbuild dependency and generated-file validation could not reach the pinned CDN

## Physical testing still required

- connect from an environment where the native API exposes a hexadecimal IPv4-mapped IPv6 address and confirm automatic artwork loads
- during playback, trigger a brief empty/unavailable artwork update followed by an endpoint change and confirm cached artwork refreshes from the new endpoint

Physical device testing has not been performed by the automated checks. Leave this PR open until these scenarios are confirmed.