### PR TITLE
Fix S3 cover art heap allocation

### DIFF
--- a/components/artwork_image/s3_artwork_transfer.cpp
+++ b/components/artwork_image/s3_artwork_transfer.cpp
@@ -14,6 +14,7 @@
 #include "esp_heap_caps.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include "freertos/idf_additions.h"
 
 #include "image_pipeline_policy.h"
 
@@ -23,6 +24,11 @@ namespace artwork_image {
 static const char *const TAG = "artwork_image.s3_transfer";
 static constexpr size_t MAX_TRANSFER_SIZE = 2 * 1024 * 1024;
 static constexpr size_t INITIAL_TRANSFER_CAPACITY = 16 * 1024;
+// Keep the ESP-IDF HTTP client's internal RX buffer below the S3 panel's
+// narrow internal-heap margin. Artwork bytes themselves are accumulated in
+// PSRAM by http_event_().
+static constexpr size_t HTTP_CLIENT_BUFFER_SIZE = 4 * 1024;
+static constexpr uint32_t TRANSFER_TASK_STACK_SIZE = 8192;
 static constexpr size_t MAX_REDIRECT_URL_LENGTH = 2048;
 static constexpr int MAX_REDIRECTS = 3;
 
@@ -137,9 +143,21 @@ S3ArtworkTransferService &S3ArtworkTransferService::instance() {
 S3ArtworkTransferService::S3ArtworkTransferService() {
   this->mutex_ = xSemaphoreCreateMutex();
   if (!this->mutex_) return;
-  const BaseType_t created = xTaskCreate(
-      task_entry_, "s3_artwork_http", 8192, this, 2, &this->task_);
+  bool stack_in_psram = false;
+  BaseType_t created = xTaskCreateWithCaps(
+      task_entry_, "s3_artwork_http", TRANSFER_TASK_STACK_SIZE, this, 2,
+      &this->task_, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  stack_in_psram = created == pdPASS;
+  if (created != pdPASS) {
+    ESP_LOGW(TAG, "Could not allocate artwork task stack in PSRAM; falling back to internal RAM");
+    created = xTaskCreate(
+        task_entry_, "s3_artwork_http", TRANSFER_TASK_STACK_SIZE, this, 2,
+        &this->task_);
+  }
   this->ready_ = created == pdPASS && this->task_ != nullptr;
+  if (this->ready_) {
+    ESP_LOGI(TAG, "Artwork transfer task ready (stack=%s)", stack_in_psram ? "PSRAM" : "internal RAM");
+  }
   if (!this->ready_) {
     ESP_LOGE(TAG, "Could not start guarded ESP32-S3 artwork transfer task");
   }
@@ -409,7 +427,7 @@ S3ArtworkTransferResult *S3ArtworkTransferService::perform_(Job *job) {
     config.auth_type = HTTP_AUTH_TYPE_NONE;
     config.event_handler = http_event_;
     config.user_data = &transfer;
-    config.buffer_size = 8192;
+    config.buffer_size = HTTP_CLIENT_BUFFER_SIZE;
     if (tls_mode == BackgroundTransferTlsMode::VERIFIED_HTTPS) {
       config.crt_bundle_attach = esp_crt_bundle_attach;
     } else if (tls_mode ==

--- a/components/web_server_idf/web_server_idf.cpp
+++ b/components/web_server_idf/web_server_idf.cpp
@@ -216,12 +216,22 @@ void AsyncWebServer::begin() {
   // The ESPControl web UI exposes many internal configuration entities. Larger
   // P4 panels can overflow the ESP-IDF default while serving entity details.
   httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+#if defined(CONFIG_IDF_TARGET_ESP32S3)
+  // The S3 display has a much smaller internal-heap margin than P4 panels.
+  // Keep the configuration UI available while returning 4 KiB to the
+  // artwork/networking paths.
+  config.stack_size = 12288;
+  config.max_open_sockets = 3;
+#else
   config.stack_size = 16384;
   // Keep browser bursts from opening several web sessions at once. The config
   // UI fetches details sequentially, so two client sockets are enough and leave
   // more internal heap available for LVGL/display work on P4 panels.
   config.max_open_sockets = 5;
+#endif
   config.backlog_conn = 2;
+  ESP_LOGI(TAG, "HTTP server policy: stack=%u sockets=%u", (unsigned) config.stack_size,
+           (unsigned) config.max_open_sockets);
   config.server_port = this->port_;
   config.uri_match_fn = [](const char * /*unused*/, const char * /*unused*/, size_t /*unused*/) { return true; };
   // Always enable LRU purging to handle socket exhaustion gracefully.

--- a/devices/guition-esp32-s3-4848s040/device/device.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/device.yaml
@@ -35,6 +35,11 @@ esp32:
       # and LVGL buffers are initialized.
       CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM: "8"
       CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP: "y"
+      # Route ordinary allocations larger than 4 KiB to PSRAM while keeping
+      # a 32 KiB internal reserve for DMA and cache-disabled operations.
+      CONFIG_SPIRAM_USE_MALLOC: "y"
+      CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL: "4096"
+      CONFIG_SPIRAM_MALLOC_RESERVE_INTERNAL: "32768"
       # The RGB driver already restarts after a genuine DMA underflow. Restarting
       # on every VSYNC can instead shift the framebuffer by one bounce-buffer block.
       CONFIG_LCD_RGB_RESTART_IN_VSYNC: "n"

--- a/scripts/check_device_profiles.py
+++ b/scripts/check_device_profiles.py
@@ -22,6 +22,8 @@ BUTTON_GRID_WEATHER_DRIVER = ROOT / "components" / "espcontrol" / "button_grid_w
 BUTTON_GRID_WEATHER_FORECAST = ROOT / "components" / "espcontrol" / "button_grid_weather_forecast.h"
 WEB_SERVER_IDF_INIT = ROOT / "components" / "web_server_idf" / "__init__.py"
 WEB_SERVER_IDF_CPP = ROOT / "components" / "web_server_idf" / "web_server_idf.cpp"
+S3_DEVICE_YAML = ROOT / "devices" / "guition-esp32-s3-4848s040" / "device" / "device.yaml"
+S3_ARTWORK_TRANSFER_CPP = ROOT / "components" / "artwork_image" / "s3_artwork_transfer.cpp"
 PUBLIC_API_ENCRYPTION_PACKAGE = ROOT / "common" / "addon" / "api_encryption_dynamic.yaml"
 PUBLIC_API_ENCRYPTION_REFERENCE = "common/addon/api_encryption_dynamic.yaml"
 LEGACY_OTA_PARTITION_LAYOUTS = {
@@ -193,6 +195,37 @@ def test_web_server_request_limits() -> None:
     )
     assert "r->content_len > CONFIG_HTTPD_MAX_REQ_HDR_LEN" not in server, (
         "form-encoded POST bodies must not inherit the request-header limit"
+    )
+
+
+def test_s3_low_heap_policy() -> None:
+    """Keep the S3 artwork path and web server within its internal-heap budget."""
+    device = S3_DEVICE_YAML.read_text(encoding="utf-8")
+    artwork = S3_ARTWORK_TRANSFER_CPP.read_text(encoding="utf-8")
+    server = WEB_SERVER_IDF_CPP.read_text(encoding="utf-8")
+
+    for option in (
+        'CONFIG_SPIRAM_USE_MALLOC: "y"',
+        'CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL: "4096"',
+        'CONFIG_SPIRAM_MALLOC_RESERVE_INTERNAL: "32768"',
+    ):
+        assert option in device, f"S3 device profile is missing {option}"
+    assert "HTTP_CLIENT_BUFFER_SIZE = 4 * 1024" in artwork, (
+        "S3 artwork HTTP buffer must stay at 4 KiB"
+    )
+    assert "xTaskCreateWithCaps" in artwork and "MALLOC_CAP_SPIRAM" in artwork, (
+        "S3 artwork transfer task must prefer a PSRAM stack"
+    )
+    assert "falling back to internal RAM" in artwork and "config.buffer_size = HTTP_CLIENT_BUFFER_SIZE" in artwork, (
+        "S3 artwork transfer must retain an internal-stack fallback and bounded HTTP buffer"
+    )
+    conditional = server.split("#if defined(CONFIG_IDF_TARGET_ESP32S3)", 1)[1].split("#endif", 1)[0]
+    s3_server, p4_server = conditional.split("#else", 1)
+    assert "config.stack_size = 12288;" in s3_server and "config.max_open_sockets = 3;" in s3_server, (
+        "S3 web server policy must use the reduced stack and socket count"
+    )
+    assert "config.stack_size = 16384;" in p4_server and "config.max_open_sockets = 5;" in p4_server, (
+        "P4 web server policy must remain unchanged"
     )
 
 
@@ -793,6 +826,7 @@ def main() -> int:
     test_public_device_capabilities(profile_slugs)
     test_generated_web(profiles)
     test_web_server_request_limits()
+    test_s3_low_heap_policy()
     test_zero_image_capacity_disables_all_image_card_pickers(profiles)
     test_constrained_s3_supports_one_cover_art_card(profiles)
     test_generated_yaml(profiles)


### PR DESCRIPTION
## Purpose
The 4-inch ESP32-S3 could not load the configured Media Cover Art card because the HTTP client exhausted the fragmented internal heap.

## Changes
- Bound the S3 artwork HTTP buffer to 4 KiB.
- Allocate the guarded artwork worker stack in PSRAM with an internal-RAM fallback.
- Reduce only the S3 web server stack and socket limits; P4 remains unchanged.
- Route ordinary S3 allocations through PSRAM while retaining a 32 KiB internal reserve.
- Add a device-profile regression check for the S3 policy and P4 guardrails.

## Validation
- Stage 1, 2, 3, and 4 firmware compiled and flashed to 192.168.6.105.
- Final S3 logs show repeated `Artwork buffer ready` and successful JPEG decodes (162,633-byte artwork), with about 79–80 KiB internal heap available during transfers.
- `curl http://192.168.6.105/` returned HTTP 200.
- `python3 scripts/check_device_profiles.py` passed.
- Factory firmware compile passed for guition-esp32-p4-jc1060p470, guition-esp32-p4-jc4880p443, and guition-esp32-s3-4848s040.

Physical display/web UI testing should continue on the flashed S3 before merging.