### PR TITLE
Optimize retained Home Assistant reads

### DIFF
--- a/components/espcontrol/ha_read_coordinator.h
+++ b/components/espcontrol/ha_read_coordinator.h
@@ -57,9 +57,9 @@ class HaReadCoordinator {
     if (channel == subscription_channels_.size() || !channel_reuses_reads(channel)) return false;
     CallbackRef callback_ref{std::make_shared<Callback>(std::move(callback)), owner, owner_generation(owner)};
     if (callback_depth_ != 0) {
-      return queue(entity_id, attribute, std::move(callback_ref), has_attribute);
+      return queue(channel, std::move(callback_ref));
     }
-    return queue_on_subscription_channel(entity_id, attribute, std::move(callback_ref), has_attribute);
+    return queue_on_subscription_channel(channel, std::move(callback_ref));
   }
 
   bool subscribe(const std::string &entity_id,
@@ -70,20 +70,15 @@ class HaReadCoordinator {
                  bool retain_latest = false) {
     if (!available() || entity_id.empty() || !callback) return false;
     auto callback_ref = std::make_shared<Callback>(std::move(callback));
-    size_t channel = subscription_channels_.size();
-    for (size_t i = 0; i < subscription_channels_.size(); i++) {
-      if (subscription_channels_[i].entity_id == entity_id &&
-          subscription_channels_[i].attribute == attribute) {
-        channel = i;
-        break;
-      }
-    }
+    size_t channel = find_subscription_channel(entity_id, attribute, true);
     const bool new_channel = channel == subscription_channels_.size();
     if (new_channel) {
       SubscriptionChannel subscription_channel;
       subscription_channel.entity_id = entity_id;
       subscription_channel.attribute = attribute;
       subscription_channels_.push_back(std::move(subscription_channel));
+      // Transport callbacks retain this numeric index for the firmware
+      // lifetime, so channels are append-only and their indices stay stable.
       transport_.subscribe(
           entity_id, attribute,
           [this, channel](State state) { invoke_subscription_channel(channel, state); });
@@ -111,16 +106,15 @@ class HaReadCoordinator {
         deferred_.insert(deferred_.begin(), std::move(request));
         return;
       }
-      dispatch_many(
-          std::move(request.entity_id), std::move(request.attribute),
-          std::move(request.callbacks), request.has_attribute);
+      dispatch_many(request.channel, std::move(request.callbacks));
       processed++;
     }
-    release_empty_deferred_storage();
   }
 
   void reset_deferred() {
-    std::vector<DeferredRequest>().swap(deferred_);
+    // Keep the small high-water allocation so reentrant refreshes do not
+    // repeatedly release and regrow the same queue storage.
+    deferred_.clear();
   }
 
   void invalidate_retained_state() {
@@ -175,15 +169,15 @@ class HaReadCoordinator {
   struct CallbackRef {
     std::shared_ptr<Callback> callback;
     void *owner = nullptr;
+    // Only retained-read callbacks need this token. It prevents an old read
+    // from being delivered after its LVGL owner address has been reused.
     uint32_t owner_generation = 0;
   };
 
   struct DeferredRequest {
-    std::string entity_id;
-    std::string attribute;
+    size_t channel = 0;
     std::vector<CallbackRef> callbacks;
     uint32_t generation = 0;
-    bool has_attribute = false;
   };
 
   struct OwnerGeneration {
@@ -239,30 +233,21 @@ class HaReadCoordinator {
         owner_generations_.end());
   }
 
-  bool queue(const std::string &entity_id,
-             const std::string &attribute,
-             CallbackRef callback,
-             bool has_attribute) {
+  bool queue(size_t channel, CallbackRef callback) {
     for (auto &request : deferred_) {
       if (request.generation == generation_ &&
-          request.has_attribute == has_attribute &&
-          request.entity_id == entity_id &&
-          request.attribute == attribute) {
+          request.channel == channel) {
         return queue_callback_ref(request.callbacks, std::move(callback));
       }
     }
     if (deferred_.size() >= MAX_DEFERRED_REQUESTS ||
         pending_read_count() >= MAX_PENDING_READS) return false;
-    deferred_.push_back({entity_id, attribute, {std::move(callback)}, generation_, has_attribute});
+    deferred_.push_back({channel, {std::move(callback)}, generation_});
     return true;
   }
 
-  void dispatch_many(std::string entity_id,
-                     std::string attribute,
-                     std::vector<CallbackRef> callbacks,
-                     bool has_attribute) {
-    size_t channel = find_subscription_channel(entity_id, attribute, has_attribute);
-    if (channel != subscription_channels_.size() && channel_reuses_reads(channel)) {
+  void dispatch_many(size_t channel, std::vector<CallbackRef> callbacks) {
+    if (channel < subscription_channels_.size() && channel_reuses_reads(channel)) {
       auto &subscription = subscription_channels_[channel];
       if (subscription.has_cached_state) {
         State state(subscription.cached_state);
@@ -288,9 +273,8 @@ class HaReadCoordinator {
       release_subscriptions(mask == UINT32_MAX ? 0 : mask);
     }
     if (callback_depth_ == 0 && !pending_owner_releases_.empty()) {
-      std::vector<void *> owners;
-      owners.swap(pending_owner_releases_);
-      for (void *owner : owners) release_owner_subscriptions(owner);
+      for (void *owner : pending_owner_releases_) release_owner_subscriptions(owner);
+      pending_owner_releases_.clear();
     }
   }
 
@@ -325,6 +309,14 @@ class HaReadCoordinator {
       if (owner_generation_current(callback_ref)) invoke(callback_ref.callback, state);
     }
     for (const auto &callback : callbacks) invoke(callback, state);
+    // Reentrant reads are deferred above, so this channel should still have an
+    // empty pending list. Reacquire it by index because a callback may have
+    // appended channels and reallocated subscription_channels_.
+    pending_reads.clear();
+    if (channel < subscription_channels_.size() &&
+        subscription_channels_[channel].pending_reads.empty()) {
+      pending_reads.swap(subscription_channels_[channel].pending_reads);
+    }
   }
 
   size_t find_subscription_channel(const std::string &entity_id,
@@ -340,11 +332,7 @@ class HaReadCoordinator {
     return subscription_channels_.size();
   }
 
-  bool queue_on_subscription_channel(const std::string &entity_id,
-                                      const std::string &attribute,
-                                      CallbackRef callback_ref,
-                                      bool has_attribute) {
-    size_t channel = find_subscription_channel(entity_id, attribute, has_attribute);
+  bool queue_on_subscription_channel(size_t channel, CallbackRef callback_ref) {
     if (channel == subscription_channels_.size() || !channel_reuses_reads(channel)) return false;
     SubscriptionChannel &subscription = subscription_channels_[channel];
     if (subscription.has_cached_state) {
@@ -444,11 +432,6 @@ class HaReadCoordinator {
     subscriptions_.resize(write_index);
     if (subscriptions_.empty()) std::vector<SubscriptionRef>().swap(subscriptions_);
     release_inactive_channel_state();
-  }
-
-  void release_empty_deferred_storage() {
-    if (!deferred_.empty() || deferred_.capacity() == 0) return;
-    std::vector<DeferredRequest>().swap(deferred_);
   }
 
   Transport transport_;

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -254,7 +254,8 @@ def firmware_ha_boundary_errors(firmware_dir: Path, root: Path) -> list[str]:
     if (
         "if (callback_depth_ != 0)" not in coordinator_text
         or "queue_callback_ref(request.callbacks, std::move(callback))" not in coordinator_text
-        or "request.entity_id == entity_id" not in coordinator_text
+        or "request.channel == channel" not in coordinator_text
+        or "queue_on_subscription_channel(channel, std::move(callback_ref))" not in coordinator_text
         or "for (const auto &callback_ref : callbacks)" not in coordinator_text
     ):
         errors.append(f"{rel}: queue and fan out bounded reentrant retained reads")
@@ -265,8 +266,8 @@ def firmware_ha_boundary_errors(firmware_dir: Path, root: Path) -> list[str]:
     if (
         "subscription_channels_" not in coordinator_text
         or "invoke_subscription_channel" not in coordinator_text
-        or "subscription_channels_[i].entity_id == entity_id" not in coordinator_text
-        or "subscription_channels_[i].attribute == attribute" not in coordinator_text
+        or "size_t channel = find_subscription_channel(entity_id, attribute, true);" not in coordinator_text
+        or "transport_.subscribe(" not in coordinator_text
     ):
         errors.append(f"{rel}: reuse one Home Assistant transport subscription across grid rebuilds")
     if (

--- a/tests/firmware/ha_read_coordinator_test.cpp
+++ b/tests/firmware/ha_read_coordinator_test.cpp
@@ -137,6 +137,74 @@ void reentrant_reads_are_deferred() {
   require(nested == 1, "reentrant callback did not run");
 }
 
+void reentrant_reads_on_one_channel_share_deferred_work() {
+  Coordinator coordinator;
+  require(coordinator.subscribe("sensor.outer", "", [](std::string) {}, 1u, nullptr, true),
+          "outer retained subscription should register");
+  require(coordinator.subscribe("sensor.inner", "", [](std::string) {}, 1u, nullptr, true),
+          "inner retained subscription should register");
+  int first = 0;
+  int second = 0;
+  require(coordinator.read_retained(
+              "sensor.outer", "",
+              [&](std::string) {
+                require(coordinator.read_retained(
+                            "sensor.inner", "", [&](std::string) { first++; }, false, 10, 5),
+                        "first nested read should queue");
+                require(coordinator.read_retained(
+                            "sensor.inner", "", [&](std::string) { second++; }, false, 10, 5),
+                        "second nested read should queue");
+              },
+              false, 10, 5),
+          "outer read should wait");
+
+  coordinator.transport().publish(0, "outer");
+  require(coordinator.deferred_count() == 1 && coordinator.pending_read_count() == 2,
+          "same-channel nested reads were not grouped");
+  coordinator.flush(8, 10, 5);
+  coordinator.transport().publish(1, "inner");
+  require(first == 1 && second == 1,
+          "grouped same-channel reads did not fan out once");
+}
+
+void resolved_deferred_channels_survive_channel_vector_growth() {
+  Coordinator coordinator;
+  require(coordinator.subscribe("sensor.outer", "", [](std::string) {}, 1u, nullptr, true),
+          "outer retained subscription should register");
+  require(coordinator.subscribe("sensor.first", "", [](std::string) {}, 1u, nullptr, true),
+          "first retained subscription should register");
+  require(coordinator.subscribe("sensor.second", "", [](std::string) {}, 1u, nullptr, true),
+          "second retained subscription should register");
+  int first = 0;
+  int second = 0;
+  require(coordinator.read_retained(
+              "sensor.outer", "",
+              [&](std::string) {
+                require(coordinator.read_retained(
+                            "sensor.first", "", [&](std::string) { first++; }, false, 10, 5),
+                        "first resolved channel should queue");
+                require(coordinator.read_retained(
+                            "sensor.second", "", [&](std::string) { second++; }, false, 10, 5),
+                        "second resolved channel should queue");
+                for (size_t i = 0; i < 100; i++) {
+                  require(coordinator.subscribe(
+                              "sensor.extra_" + std::to_string(i), "", [](std::string) {}, 1u),
+                          "extra subscription should register");
+                }
+              },
+              false, 10, 5),
+          "outer read should wait");
+
+  coordinator.transport().publish(0, "outer");
+  require(coordinator.deferred_count() == 2,
+          "different resolved channels were incorrectly combined");
+  coordinator.flush(8, 10, 5);
+  coordinator.transport().publish(1, "first");
+  coordinator.transport().publish(2, "second");
+  require(first == 1 && second == 1,
+          "resolved channel index became stale after channel vector growth");
+}
+
 void cancellation_is_safe_during_callback() {
   Coordinator coordinator;
   constexpr uint32_t scope = 1u << 2;
@@ -350,6 +418,29 @@ void pending_unowned_reads_are_globally_capped() {
   coordinator.transport().publish(1, "local");
   require(calls == 64 && coordinator.pending_read_count() == 0,
           "globally capped pending retained reads were not released");
+}
+
+void a_full_pending_queue_rejects_new_work_without_evicting_accepted_callbacks() {
+  Coordinator coordinator;
+  require(coordinator.subscribe(
+              "media_player.room", "entity_picture", [](std::string) {}, 1u, nullptr, true),
+          "retained artwork subscription should register");
+  int accepted_calls = 0;
+  for (size_t i = 0; i < 64; i++) {
+    require(coordinator.read_retained(
+                "media_player.room", "entity_picture",
+                [&](std::string) { accepted_calls++; }, true, 10, 5),
+            "bounded read should be accepted");
+  }
+  int rejected_calls = 0;
+  require(!coordinator.read_retained(
+              "media_player.room", "entity_picture",
+              [&](std::string) { rejected_calls++; }, true, 10, 5),
+          "full queue should explicitly reject newest work");
+
+  coordinator.transport().publish(0, "artwork");
+  require(accepted_calls == 64 && rejected_calls == 0,
+          "full queue silently evicted accepted work or delivered rejected work");
 }
 
 void generation_change_discards_cached_and_pending_channel_reads() {
@@ -570,6 +661,8 @@ int main() {
   low_memory_rejects_retained_read_without_pending_work();
   duplicate_reads_fan_out_once();
   reentrant_reads_are_deferred();
+  reentrant_reads_on_one_channel_share_deferred_work();
+  resolved_deferred_channels_survive_channel_vector_growth();
   cancellation_is_safe_during_callback();
   rebuilt_subscriptions_share_one_transport_channel();
   rebuilt_subscription_replays_last_value();
@@ -580,6 +673,7 @@ int main() {
   retained_reads_never_accumulate_transport_callbacks();
   missing_retained_channel_fails_closed();
   pending_unowned_reads_are_globally_capped();
+  a_full_pending_queue_rejects_new_work_without_evicting_accepted_callbacks();
   generation_change_discards_cached_and_pending_channel_reads();
   reconnect_discards_retained_channel_state();
   ordinary_subscriptions_fail_closed_for_retained_reads();

--- a/tests/mutations/ha-duplicate-read-fanout.patch
+++ b/tests/mutations/ha-duplicate-read-fanout.patch
@@ -1,12 +1,11 @@
 diff --git a/components/espcontrol/ha_read_coordinator.h b/components/espcontrol/ha_read_coordinator.h
 --- a/components/espcontrol/ha_read_coordinator.h
 +++ b/components/espcontrol/ha_read_coordinator.h
-@@ -122,7 +122,7 @@ class HaReadCoordinator {
+@@ -237,6 +237,6 @@ class HaReadCoordinator {
      for (auto &request : deferred_) {
        if (request.generation == generation_ &&
-           request.has_attribute == has_attribute &&
--          request.entity_id == entity_id &&
-+          request.entity_id != entity_id &&
-           request.attribute == attribute) {
-         request.callbacks.push_back(std::move(callback));
-         return true;
+-          request.channel == channel) {
++          request.channel != channel) {
+         return queue_callback_ref(request.callbacks, std::move(callback));
+       }
+     }


### PR DESCRIPTION
## Summary

- Resolve Home Assistant subscription channels once at the public read/subscribe boundary and pass stable append-only channel indices through deferred work.
- Avoid copying entity and attribute strings into deferred requests, and retain small queue allocations across repeated grid refresh cycles.
- Add regression coverage for re-entrant same-channel fan-out, channel-vector growth, and explicit queue-cap behavior.

## Practical impact

- Repeated Home Assistant grid refreshes perform fewer string lookups, string copies, and short-lived vector allocations.
- Existing retry behavior remains intact: when the hard pending-read cap is reached, new work is explicitly rejected so callers can retry instead of silently losing an already-accepted callback.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Internal retained-read optimization only; no configuration or visible behavior changes.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.
- [ ] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- All displays use the shared Home Assistant read coordinator; S3 Second was used for device validation.

## Notes for testing

- Rebased onto main at 3c908407d. Main already contains the complete S3 cover-art heap fix from #1763, including the 4 KiB HTTP buffer, PSRAM transfer-task stack, allocator policy, web-server limits, and stronger device-profile regression checks. Redundant S3 implementation/test changes were removed from this PR.
- Host HA coordinator tests passed, including re-entrant fan-out, channel-vector growth, and queue-cap cases.
- Firmware HA binding checks, their self-test, cover-art contract checks, device-profile checks, mutation patch applicability, and diff checks passed.
- Factory firmware compiled successfully with ESPHome 2026.8.1 for the 7-inch P4, 4.3-inch P4, and 4-inch S3 targets after the rebase.
- The retained-read code in this final diff is the same coordinator implementation previously OTA-tested on S3 Second. That run successfully downloaded and applied cover art through the LVGL callback without an allocation failure. The direct S3 heap improvements are now correctly attributed to main/#1763 rather than this PR.

## PR status

- [ ] Checks running or waiting.
- [ ] Needs automated fix.
- [ ] Ready for device test.
- [ ] Device test failed; details below.
- [x] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.
