### PR TITLE
Fix media source transitions and stale cover art

### DIFF
--- a/components/espcontrol/artwork_controller.h
+++ b/components/espcontrol/artwork_controller.h
@@ -22,6 +22,10 @@ constexpr uint8_t ARTWORK_SOURCE_REMOTE = 1u << 0;
 constexpr uint8_t ARTWORK_SOURCE_LOCAL = 1u << 1;
 constexpr uint8_t ARTWORK_SOURCE_BOTH = ARTWORK_SOURCE_REMOTE | ARTWORK_SOURCE_LOCAL;
 
+inline bool artwork_entity_picture_present(const std::string &value) {
+  return !value.empty() && value != "unknown" && value != "unavailable";
+}
+
 // Coalesces adjacent refresh triggers before a paired Home Assistant read.
 // A forced trigger must survive later ordinary triggers in the same window.
 struct RefreshTrigger {
@@ -261,6 +265,10 @@ struct SourceCandidates {
   SourceSelection select(const std::string &current_url,
                          bool refresh_needed) const {
     SourceSelection selection;
+    // entity_picture is the authoritative indication that the entity has
+    // artwork. entity_picture_local is only a transport-friendly version of
+    // that image and must never keep stale artwork alive by itself.
+    if (remote_url.empty()) return selection;
     selection.primary = local_url.empty() ? remote_url : local_url;
     if (!local_url.empty() && !remote_url.empty() &&
         remote_url != selection.primary) {

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -453,11 +453,12 @@ inline void subscribe_media_cover_art(MediaNowPlayingCtx *ctx,
     std::function<void(esphome::StringRef)>(
       [art, playback, entity_id, generation](esphome::StringRef picture) {
         bool clear_stale_artwork = false;
+        const std::string value = string_ref_limited(
+          picture, espcontrol::cover_art::MAX_ARTWORK_URL_LENGTH);
+        const bool present =
+          espcontrol::artwork::artwork_entity_picture_present(value);
         if (media_playback_generation_valid(playback, generation)) {
-          const std::string value = string_ref_limited(
-            picture, espcontrol::cover_art::MAX_ARTWORK_URL_LENGTH);
-          const bool present = !value.empty() && value != "unknown" &&
-                               value != "unavailable";
+          media_playback_clear_stale_external_source(playback, present);
           const bool current = espcontrol::cover_art::media_artwork_content_current(
             playback->has_state, playback->available, playback->state_text, present);
           if (current) playback->artwork_content_mask |= 1u;
@@ -468,7 +469,7 @@ inline void subscribe_media_cover_art(MediaNowPlayingCtx *ctx,
           media_playback_apply_state_to_now_playing(playback);
         }
         if (!image_card_context_current(art, entity_id, generation)) return;
-        if (clear_stale_artwork) {
+        if (!present || clear_stale_artwork) {
           image_card_clear_media_artwork(art);
           return;
         }
@@ -489,8 +490,8 @@ inline void subscribe_media_cover_art(MediaNowPlayingCtx *ctx,
         if (media_playback_generation_valid(playback, generation)) {
           const std::string value = string_ref_limited(
             picture, espcontrol::cover_art::MAX_ARTWORK_URL_LENGTH);
-          const bool present = !value.empty() && value != "unknown" &&
-                               value != "unavailable";
+          const bool present =
+            espcontrol::artwork::artwork_entity_picture_present(value);
           const bool current = espcontrol::cover_art::media_artwork_content_current(
             playback->has_state, playback->available, playback->state_text, present);
           if (current) playback->artwork_content_mask |= 2u;

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -2243,6 +2243,13 @@ inline void image_card_handle_media_artwork_picture(ImageCardCtx *ctx,
   ctx->media_artwork_retry_mask = espcontrol::artwork::artwork_source_mark_received(
     ctx->media_artwork_retry_mask, local);
   std::string raw = string_ref_limited(picture, 4096);
+  if (!local &&
+      !espcontrol::artwork::artwork_entity_picture_present(raw)) {
+    ESP_LOGD("image_card", "Clearing artwork for %s because entity_picture is empty",
+             ctx->entity_id.c_str());
+    image_card_clear_media_artwork(ctx);
+    return;
+  }
   std::string url = image_card_join_url(image_card_base_url(ctx), raw);
   ESP_LOGD("image_card", "Artwork %s response for %s: value=%s base_url=%s",
            local ? "local" : "remote", ctx->entity_id.c_str(),

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -1825,14 +1825,19 @@ inline void media_playback_subscribe_content(MediaPlaybackState *state) {
         if (!media_playback_generation_valid(state, generation)) return;
         const std::string next_content_id = media_playback_metadata_value(
           value, HA_STATE_TEXT_MAX_LEN);
-        const bool external_content =
-          espcontrol::media::media_content_id_external_input(next_content_id);
+        const char *external_source =
+          espcontrol::media::media_content_id_external_source(next_content_id);
+        const bool external_content = external_source[0] != '\0';
         if (external_content) {
           const bool changed = !state->external_source;
+          const bool replace_retained_source =
+            espcontrol::media::media_content_id_should_replace_external_source(
+              state->source_observed_for_state, state->external_source,
+              !state->source.empty());
           state->source_known = true;
           state->external_source = true;
           state->source_observed_for_state = true;
-          if (state->source.empty()) state->source = "TV";
+          if (replace_retained_source) state->source = external_source;
           if (changed) {
             media_playback_invalidate_external_input_metadata(state);
             media_playback_apply_progress_consumers(state);

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -615,6 +615,7 @@ struct MediaPlaybackState {
   bool playing = false;
   bool source_known = false;
   bool external_source = false;
+  bool source_observed_for_state = false;
   bool has_duration = false;
   bool has_position = false;
   float duration = 0.0f;
@@ -782,6 +783,7 @@ inline void media_playback_reset_state(MediaPlaybackState *state,
   state->playing = false;
   state->source_known = false;
   state->external_source = false;
+  state->source_observed_for_state = false;
   state->has_duration = false;
   state->has_position = false;
   state->duration = 0.0f;
@@ -820,6 +822,36 @@ inline void media_playback_invalidate_retained_content(MediaPlaybackState *state
   state->has_current_content_id = false;
   state->has_current_content_type = false;
   state->artwork_content_mask = 0;
+}
+
+inline void media_playback_invalidate_external_input_metadata(
+    MediaPlaybackState *state) {
+  if (!state) return;
+  bool primary_cover_source = false;
+  for (MediaNowPlayingCtx *ctx : state->now_playing) {
+    if (ctx && ctx->primary_entity == state->entity_id) {
+      primary_cover_source = true;
+      break;
+    }
+  }
+  // A secondary media entity can expose TV/HDMI as its own source while still
+  // supplying the programme metadata that should replace the Sonos details.
+  // Only the card's primary source owns the external-input fallback.
+  if (!primary_cover_source) return;
+  // Home Assistant omits attributes that do not apply to TV and line-in
+  // snapshots. Treat the source transition itself as authoritative so song
+  // metadata cannot survive just because there is no empty attribute callback.
+  state->title.clear();
+  state->artist.clear();
+  state->artwork_content_mask = 0;
+  state->duration = 0.0f;
+  state->has_duration = false;
+  state->last_duration_callback_ms = 0;
+  state->position_seconds = 0.0f;
+  state->position_updated_ms = 0;
+  state->position_updated_at_known = false;
+  state->position_updated_at_ms = 0;
+  state->has_position = false;
 }
 
 inline MediaPlaybackState *media_playback_find_state(const std::string &entity_id) {
@@ -892,6 +924,15 @@ inline void media_playback_set_artist(MediaPlaybackState *state,
   if (!media_playback_generation_valid(state, generation)) return;
   state->artist = media_playback_metadata_value(value, HA_STATE_TEXT_MAX_LEN);
   media_playback_apply_metadata_consumers(state);
+}
+
+inline void media_playback_clear_video_artist(MediaPlaybackState *state,
+                                               const std::string &content_type) {
+  if (state &&
+      espcontrol::media::media_item_kind({}, content_type) ==
+        espcontrol::media::MediaItemKind::VIDEO) {
+    state->artist.clear();
+  }
 }
 
 inline void media_playback_set_playing_hint(MediaPlaybackState *state, bool playing) {
@@ -999,6 +1040,23 @@ inline std::string media_playback_artwork_refresh_signature(
   return state->has_state ? std::string("state:") + state->state_text : std::string();
 }
 
+inline bool media_playback_clear_stale_external_source(
+    MediaPlaybackState *state, bool current_content_present) {
+  if (!state ||
+      !espcontrol::cover_art::media_external_source_stale_for_current_content(
+        state->external_source, state->source_observed_for_state,
+        current_content_present)) {
+    return false;
+  }
+  ESP_LOGI("media_card",
+           "Clearing retained external source for %s; current state omitted source",
+           state->entity_id.c_str());
+  state->source.clear();
+  state->source_known = false;
+  state->external_source = false;
+  return true;
+}
+
 inline bool media_playback_has_current_content(const MediaPlaybackState *state) {
   if (!state) return false;
   const bool has_content = !state->title.empty() || !state->artist.empty() ||
@@ -1056,7 +1114,8 @@ inline void media_playback_apply_state_to_now_playing_snapshot(
     std::strncpy(ctx->artist, state->artist.c_str(), sizeof(ctx->artist) - 1);
     ctx->artist[sizeof(ctx->artist) - 1] = '\0';
     media_apply_now_playing_artist_text(ctx);
-    if (ctx->show_track_details || ctx->external_source_fallback) {
+    if (!state->artist.empty() &&
+        (ctx->show_track_details || ctx->external_source_fallback)) {
       lv_obj_clear_flag(ctx->artist_lbl, LV_OBJ_FLAG_HIDDEN);
     } else {
       lv_obj_add_flag(ctx->artist_lbl, LV_OBJ_FLAG_HIDDEN);
@@ -1493,6 +1552,7 @@ inline void media_playback_subscribe_playback_state(MediaPlaybackState *state) {
         state->state_text = state_text;
         state->available = !ha_state_unavailable_ref(state_ref);
         state->playing = state_text == "playing";
+        state->source_observed_for_state = false;
         if (invalidate_retained_content) {
           media_playback_invalidate_retained_content(state);
         }
@@ -1513,12 +1573,26 @@ inline void media_playback_subscribe_metadata(MediaPlaybackState *state) {
   state->metadata_subscribed = true;
   const std::string entity_id = state->entity_id;
   const uint32_t generation = state->generation;
+  // Subscribe to source before the metadata attributes. Home Assistant omits
+  // an attribute callback when source is absent, so later title/artwork
+  // callbacks can distinguish that from a source value belonging to this
+  // same entity-state snapshot.
+  media_playback_subscribe_source(state);
   ha_subscribe_attribute(
     entity_id, std::string("media_title"),
     std::function<void(esphome::StringRef)>(
       [state, generation](esphome::StringRef value) {
         if (!media_playback_generation_valid(state, generation)) return;
-        state->title = media_playback_metadata_value(value, HA_STATE_TEXT_MAX_LEN);
+        const std::string next_title = media_playback_metadata_value(
+          value, HA_STATE_TEXT_MAX_LEN);
+        media_playback_clear_stale_external_source(
+          state, !next_title.empty());
+        if (next_title != state->title) {
+          // Video entities commonly omit media_artist entirely. Clear the
+          // previous audio item's grouping as soon as the film title changes.
+          media_playback_clear_video_artist(state, state->current_content_type);
+        }
+        state->title = next_title;
         media_playback_apply_metadata_consumers(state);
       })
   );
@@ -1533,7 +1607,6 @@ inline void media_playback_subscribe_metadata(MediaPlaybackState *state) {
     true
   );
 
-  media_playback_subscribe_source(state);
 }
 
 inline void media_playback_subscribe_source(MediaPlaybackState *state) {
@@ -1550,6 +1623,11 @@ inline void media_playback_subscribe_source(MediaPlaybackState *state) {
     state->source = next;
     state->source_known = true;
     state->external_source = external;
+    state->source_observed_for_state = true;
+    if (changed && external) {
+      media_playback_invalidate_external_input_metadata(state);
+      media_playback_apply_progress_consumers(state);
+    }
     if (changed) media_playback_apply_metadata_consumers(state);
   };
   ha_subscribe_attribute(
@@ -1734,6 +1812,7 @@ inline void media_playback_subscribe_content(MediaPlaybackState *state) {
         state->current_content_type = media_playback_metadata_value(
           value, HA_SHORT_STATE_MAX_LEN);
         state->has_current_content_type = !state->current_content_type.empty();
+        media_playback_clear_video_artist(state, state->current_content_type);
         media_playback_apply_state_to_playlists(state);
         media_playback_apply_state_to_now_playing(state);
       })
@@ -1746,6 +1825,24 @@ inline void media_playback_subscribe_content(MediaPlaybackState *state) {
         if (!media_playback_generation_valid(state, generation)) return;
         const std::string next_content_id = media_playback_metadata_value(
           value, HA_STATE_TEXT_MAX_LEN);
+        const bool external_content =
+          espcontrol::media::media_content_id_external_input(next_content_id);
+        if (external_content) {
+          const bool changed = !state->external_source;
+          state->source_known = true;
+          state->external_source = true;
+          state->source_observed_for_state = true;
+          if (state->source.empty()) state->source = "TV";
+          if (changed) {
+            media_playback_invalidate_external_input_metadata(state);
+            media_playback_apply_progress_consumers(state);
+            ESP_LOGI("media_card", "Detected external input for %s from media_content_id",
+                     state->entity_id.c_str());
+          }
+        } else {
+          media_playback_clear_stale_external_source(
+            state, !next_content_id.empty());
+        }
         const uint64_t next_content_fingerprint = next_content_id.empty()
           ? 0
           : espcontrol::media::media_content_identity_fingerprint(

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -1854,6 +1854,17 @@ inline void media_playback_subscribe_content(MediaPlaybackState *state) {
             ESP_LOGI("media_card", "Detected external input for %s from media_content_id",
                      state->entity_id.c_str());
           }
+        } else if (
+          espcontrol::media::media_content_id_should_clear_external_source(
+            next_content_id, state->external_source)) {
+          ESP_LOGI(
+            "media_card",
+            "Clearing conflicting external source for %s from media_content_id",
+            state->entity_id.c_str());
+          state->source.clear();
+          state->source_known = false;
+          state->external_source = false;
+          state->source_observed_for_state = false;
         } else {
           media_playback_clear_stale_external_source(
             state, !next_content_id.empty());

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -616,6 +616,7 @@ struct MediaPlaybackState {
   bool source_known = false;
   bool external_source = false;
   bool source_observed_for_state = false;
+  bool content_id_observed_for_state = false;
   bool has_duration = false;
   bool has_position = false;
   float duration = 0.0f;
@@ -784,6 +785,7 @@ inline void media_playback_reset_state(MediaPlaybackState *state,
   state->source_known = false;
   state->external_source = false;
   state->source_observed_for_state = false;
+  state->content_id_observed_for_state = false;
   state->has_duration = false;
   state->has_position = false;
   state->duration = 0.0f;
@@ -802,6 +804,7 @@ inline void media_playback_reset_state(MediaPlaybackState *state,
   state->volume_control_mode = espcontrol::media::VolumeControlMode::ABSOLUTE;
   state->has_current_content_id = false;
   state->has_current_content_type = false;
+  state->content_id_observed_for_state = false;
   state->artwork_content_mask = 0;
   std::vector<SliderCtx *>().swap(state->sliders);
   std::vector<MediaControlCtx *>().swap(state->controls);
@@ -821,6 +824,7 @@ inline void media_playback_invalidate_retained_content(MediaPlaybackState *state
   state->current_content_kind = espcontrol::media::MediaItemKind::UNKNOWN;
   state->has_current_content_id = false;
   state->has_current_content_type = false;
+  state->content_id_observed_for_state = false;
   state->artwork_content_mask = 0;
 }
 
@@ -1553,6 +1557,7 @@ inline void media_playback_subscribe_playback_state(MediaPlaybackState *state) {
         state->available = !ha_state_unavailable_ref(state_ref);
         state->playing = state_text == "playing";
         state->source_observed_for_state = false;
+        state->content_id_observed_for_state = false;
         if (invalidate_retained_content) {
           media_playback_invalidate_retained_content(state);
         }
@@ -1620,7 +1625,7 @@ inline void media_playback_subscribe_source(MediaPlaybackState *state) {
     const bool source_external = media_external_source_input(next);
     const bool content_id_overrides_source =
       espcontrol::media::media_content_id_should_override_source_update(
-        state->current_content_id, next);
+        state->content_id_observed_for_state, state->current_content_id, next);
     const char *content_id_source = content_id_overrides_source
       ? espcontrol::media::media_content_id_external_source(
           state->current_content_id)
@@ -1835,6 +1840,7 @@ inline void media_playback_subscribe_content(MediaPlaybackState *state) {
         if (!media_playback_generation_valid(state, generation)) return;
         const std::string next_content_id = media_playback_metadata_value(
           value, HA_STATE_TEXT_MAX_LEN);
+        state->content_id_observed_for_state = !next_content_id.empty();
         const char *external_source =
           espcontrol::media::media_content_id_external_source(next_content_id);
         const bool external_content = external_source[0] != '\0';

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -1620,7 +1620,7 @@ inline void media_playback_subscribe_source(MediaPlaybackState *state) {
     const bool source_external = media_external_source_input(next);
     const bool content_id_overrides_source =
       espcontrol::media::media_content_id_should_override_source_update(
-        state->current_content_id, source_external);
+        state->current_content_id, next);
     const char *content_id_source = content_id_overrides_source
       ? espcontrol::media::media_content_id_external_source(
           state->current_content_id)

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -1617,10 +1617,20 @@ inline void media_playback_subscribe_source(MediaPlaybackState *state) {
   auto handle_media_source = [state, generation](esphome::StringRef source) {
     if (!media_playback_generation_valid(state, generation)) return;
     const std::string next = media_playback_metadata_value(source, HA_STATE_TEXT_MAX_LEN);
-    bool external = media_external_source_input(next);
-    bool changed = !state->source_known || next != state->source ||
+    const bool source_external = media_external_source_input(next);
+    const bool content_id_overrides_source =
+      espcontrol::media::media_content_id_should_override_source_update(
+        state->current_content_id, source_external);
+    const char *content_id_source = content_id_overrides_source
+      ? espcontrol::media::media_content_id_external_source(
+          state->current_content_id)
+      : "";
+    const std::string reconciled_source = content_id_overrides_source
+      ? content_id_source : next;
+    const bool external = source_external || content_id_overrides_source;
+    bool changed = !state->source_known || reconciled_source != state->source ||
                    external != state->external_source;
-    state->source = next;
+    state->source = reconciled_source;
     state->source_known = true;
     state->external_source = external;
     state->source_observed_for_state = true;

--- a/components/espcontrol/button_grid_media_driver.h
+++ b/components/espcontrol/button_grid_media_driver.h
@@ -227,11 +227,34 @@ inline void media_driver_bind_cover_art_route(
     const bool secondary_configured =
       !now_playing->secondary_entity.empty() &&
       now_playing->secondary_entity != now_playing->primary_entity;
+    const bool secondary_playback_active =
+      secondary_state && secondary_state->has_state &&
+      secondary_state->available &&
+      espcontrol::cover_art::media_entity_state_usable(
+        secondary_state->state_text);
+    const bool secondary_has_content =
+      media_playback_has_current_content(secondary_state);
     const bool use_secondary = espcontrol::cover_art::use_secondary_media_entity(
       primary_state && primary_state->external_source,
       secondary_configured,
-      secondary_state && secondary_state->available,
-      media_playback_has_current_content(secondary_state));
+      secondary_playback_active,
+      secondary_has_content);
+    if (primary_state && primary_state->external_source) {
+      ESP_LOGD(
+        "media_card",
+        "Secondary route entity=%s configured=%d state=%s active=%d content=%d title=%d artist=%d artwork=%u selected=%d",
+        now_playing->secondary_entity.empty()
+          ? "<none>" : now_playing->secondary_entity.c_str(),
+        secondary_configured,
+        secondary_state && secondary_state->has_state
+          ? secondary_state->state_text.c_str() : "<unknown>",
+        secondary_playback_active,
+        secondary_has_content,
+        secondary_state && !secondary_state->title.empty(),
+        secondary_state && !secondary_state->artist.empty(),
+        secondary_state ? static_cast<unsigned>(secondary_state->artwork_content_mask) : 0u,
+        use_secondary);
+    }
     const bool external_source_fallback =
       primary_state && primary_state->external_source && !use_secondary;
     const std::string next_entity = use_secondary

--- a/components/espcontrol/cover_art.h
+++ b/components/espcontrol/cover_art.h
@@ -45,6 +45,13 @@ inline bool media_card_artwork_suppressed(bool source_known,
   return source_known && external_source;
 }
 
+inline bool media_external_source_stale_for_current_content(
+    bool external_source, bool source_observed_for_state,
+    bool current_content_present) {
+  return external_source && !source_observed_for_state &&
+         current_content_present;
+}
+
 inline bool media_entity_state_usable(const std::string &state) {
   const std::string normalized = normalized_media_source(state);
   return normalized == "playing" || normalized == "paused" ||
@@ -81,9 +88,9 @@ inline bool media_entity_content_available(bool state_known, bool available,
 
 inline bool use_secondary_media_entity(bool primary_external,
                                        bool secondary_configured,
-                                       bool secondary_available,
+                                       bool secondary_playback_active,
                                        bool secondary_has_content) {
-  return primary_external && secondary_configured && secondary_available &&
+  return primary_external && secondary_configured && secondary_playback_active &&
          secondary_has_content;
 }
 

--- a/components/espcontrol/ha_read_coordinator.h
+++ b/components/espcontrol/ha_read_coordinator.h
@@ -131,7 +131,12 @@ class HaReadCoordinator {
 
   void reset_subscriptions(uint32_t scope = 0) {
     if (callback_depth_ != 0) {
-      pending_reset_mask_ = scope == 0 ? UINT32_MAX : (pending_reset_mask_ | scope);
+      // A callback can rebuild a card immediately after requesting its old
+      // subscriptions be reset. Mark only the callbacks that exist now so the
+      // replacements survive the deferred vector compaction.
+      mark_subscriptions_for_release(scope);
+      pending_subscription_compaction_ = true;
+      release_inactive_channel_state();
       return;
     }
     release_subscriptions(scope);
@@ -159,7 +164,13 @@ class HaReadCoordinator {
           channel.pending_reads.end());
     }
     if (callback_depth_ != 0) {
-      pending_owner_releases_.push_back(owner);
+      // Grid rebuilds can release an old card and attach its replacement to
+      // the same persistent LVGL owner before this callback returns. Mark the
+      // subscriptions that exist now; resolving by owner later would also
+      // delete the replacement card's newly registered callbacks.
+      mark_owner_subscriptions_for_release(owner);
+      pending_subscription_compaction_ = true;
+      release_inactive_channel_state();
       return;
     }
     release_owner_subscriptions(owner);
@@ -191,6 +202,7 @@ class HaReadCoordinator {
     void *owner = nullptr;
     size_t channel = 0;
     bool retain_latest = false;
+    bool pending_release = false;
   };
 
   struct SubscriptionChannel {
@@ -267,14 +279,9 @@ class HaReadCoordinator {
     callback_depth_++;
     (*callback)(state);
     callback_depth_--;
-    if (callback_depth_ == 0 && pending_reset_mask_ != 0) {
-      uint32_t mask = pending_reset_mask_;
-      pending_reset_mask_ = 0;
-      release_subscriptions(mask == UINT32_MAX ? 0 : mask);
-    }
-    if (callback_depth_ == 0 && !pending_owner_releases_.empty()) {
-      for (void *owner : pending_owner_releases_) release_owner_subscriptions(owner);
-      pending_owner_releases_.clear();
+    if (callback_depth_ == 0 && pending_subscription_compaction_) {
+      pending_subscription_compaction_ = false;
+      compact_released_subscriptions();
     }
   }
 
@@ -287,7 +294,8 @@ class HaReadCoordinator {
     callbacks.reserve(subscriptions_.size());
     bool retain_latest = false;
     for (const auto &ref : subscriptions_) {
-      if (ref.channel == channel && ref.callback && *ref.callback) {
+      if (!ref.pending_release && ref.channel == channel &&
+          ref.callback && *ref.callback) {
         callbacks.push_back(ref.callback);
         retain_latest = retain_latest || ref.retain_latest;
       }
@@ -308,7 +316,12 @@ class HaReadCoordinator {
     for (const auto &callback_ref : pending_reads) {
       if (owner_generation_current(callback_ref)) invoke(callback_ref.callback, state);
     }
-    for (const auto &callback : callbacks) invoke(callback, state);
+    for (const auto &callback : callbacks) {
+      // An earlier callback can reset this scope while the channel snapshot is
+      // being dispatched. Skip callbacks marked by that reset, but keep the
+      // currently executing std::function alive until it returns.
+      if (subscription_callback_active(callback)) invoke(callback, state);
+    }
     // Reentrant reads are deferred above, so this channel should still have an
     // empty pending list. Reacquire it by index because a callback may have
     // appended channels and reallocated subscription_channels_.
@@ -367,7 +380,15 @@ class HaReadCoordinator {
 
   bool channel_reuses_reads(size_t channel) const {
     for (const auto &ref : subscriptions_) {
-      if (ref.channel == channel && ref.retain_latest && ref.callback && *ref.callback) return true;
+      if (!ref.pending_release && ref.channel == channel && ref.retain_latest &&
+          ref.callback && *ref.callback) return true;
+    }
+    return false;
+  }
+
+  bool subscription_callback_active(const std::shared_ptr<Callback> &callback) const {
+    for (const auto &ref : subscriptions_) {
+      if (!ref.pending_release && ref.callback == callback && ref.callback && *ref.callback) return true;
     }
     return false;
   }
@@ -403,26 +424,25 @@ class HaReadCoordinator {
   }
 
   void release_subscriptions(uint32_t scope) {
-    size_t write_index = 0;
-    for (size_t read_index = 0; read_index < subscriptions_.size(); read_index++) {
-      SubscriptionRef &ref = subscriptions_[read_index];
-      if (scope == 0 || (ref.scope & scope) != 0) {
-        if (ref.callback && *ref.callback) *ref.callback = nullptr;
-        continue;
-      }
-      if (write_index != read_index) subscriptions_[write_index] = std::move(ref);
-      write_index++;
-    }
-    subscriptions_.resize(write_index);
-    if (subscriptions_.empty()) std::vector<SubscriptionRef>().swap(subscriptions_);
+    mark_subscriptions_for_release(scope);
+    compact_released_subscriptions();
     release_inactive_channel_state();
   }
 
-  void release_owner_subscriptions(void *owner) {
+  void mark_subscriptions_for_release(uint32_t scope) {
+    for (SubscriptionRef &ref : subscriptions_) {
+      if (scope != 0 && (ref.scope & scope) == 0) continue;
+      ref.pending_release = true;
+    }
+  }
+
+  void compact_released_subscriptions() {
     size_t write_index = 0;
     for (size_t read_index = 0; read_index < subscriptions_.size(); read_index++) {
       SubscriptionRef &ref = subscriptions_[read_index];
-      if (ref.owner == owner) {
+      if (ref.pending_release) {
+        // Compaction only runs outside a callback body, so it is now safe to
+        // release the std::function target as well as its tracking entry.
         if (ref.callback && *ref.callback) *ref.callback = nullptr;
         continue;
       }
@@ -431,7 +451,19 @@ class HaReadCoordinator {
     }
     subscriptions_.resize(write_index);
     if (subscriptions_.empty()) std::vector<SubscriptionRef>().swap(subscriptions_);
+  }
+
+  void release_owner_subscriptions(void *owner) {
+    mark_owner_subscriptions_for_release(owner);
+    compact_released_subscriptions();
     release_inactive_channel_state();
+  }
+
+  void mark_owner_subscriptions_for_release(void *owner) {
+    if (!owner) return;
+    for (SubscriptionRef &ref : subscriptions_) {
+      if (ref.owner == owner) ref.pending_release = true;
+    }
   }
 
   Transport transport_;
@@ -442,7 +474,6 @@ class HaReadCoordinator {
   std::vector<OwnerGeneration> owner_generations_;
   uint32_t generation_ = 1;
   uint32_t next_owner_generation_ = 1;
-  uint32_t pending_reset_mask_ = 0;
-  std::vector<void *> pending_owner_releases_;
+  bool pending_subscription_compaction_ = false;
   uint8_t callback_depth_ = 0;
 };

--- a/components/espcontrol/media_metadata_policy.h
+++ b/components/espcontrol/media_metadata_policy.h
@@ -49,6 +49,13 @@ inline bool media_content_id_external_input(const std::string &content_id) {
   return media_content_id_external_source(content_id)[0] != '\0';
 }
 
+inline const char *media_source_external_label(std::string source) {
+  source = normalize_media_kind_token(std::move(source));
+  if (source == "line_in") return "Line-in";
+  if (source == "tv" || source.rfind("hdmi", 0) == 0) return "TV";
+  return "";
+}
+
 inline bool media_content_id_should_replace_external_source(
     bool source_observed_for_state, bool retained_source_external,
     bool retained_source_present) {
@@ -57,8 +64,10 @@ inline bool media_content_id_should_replace_external_source(
 }
 
 inline bool media_content_id_should_override_source_update(
-    const std::string &content_id, bool source_update_external) {
-  return !source_update_external && media_content_id_external_input(content_id);
+    const std::string &content_id, const std::string &source_update) {
+  const char *content_label = media_content_id_external_source(content_id);
+  return content_label[0] != '\0' &&
+         std::string(content_label) != media_source_external_label(source_update);
 }
 
 inline bool media_content_id_should_clear_external_source(

--- a/components/espcontrol/media_metadata_policy.h
+++ b/components/espcontrol/media_metadata_policy.h
@@ -61,6 +61,12 @@ inline bool media_content_id_should_override_source_update(
   return !source_update_external && media_content_id_external_input(content_id);
 }
 
+inline bool media_content_id_should_clear_external_source(
+    const std::string &content_id, bool current_source_external) {
+  return current_source_external && !content_id.empty() &&
+         !media_content_id_external_input(content_id);
+}
+
 inline MediaItemKind media_item_kind_from_token(std::string token) {
   token = normalize_media_kind_token(std::move(token));
   if (token == "track") return MediaItemKind::TRACK;

--- a/components/espcontrol/media_metadata_policy.h
+++ b/components/espcontrol/media_metadata_policy.h
@@ -64,7 +64,9 @@ inline bool media_content_id_should_replace_external_source(
 }
 
 inline bool media_content_id_should_override_source_update(
-    const std::string &content_id, const std::string &source_update) {
+    bool content_id_observed_for_state, const std::string &content_id,
+    const std::string &source_update) {
+  if (!content_id_observed_for_state) return false;
   const char *content_label = media_content_id_external_source(content_id);
   return content_label[0] != '\0' &&
          std::string(content_label) != media_source_external_label(source_update);

--- a/components/espcontrol/media_metadata_policy.h
+++ b/components/espcontrol/media_metadata_policy.h
@@ -34,6 +34,14 @@ inline std::string normalize_media_kind_token(std::string value) {
   return value;
 }
 
+inline bool media_content_id_external_input(std::string content_id) {
+  content_id = normalize_media_kind_token(std::move(content_id));
+  return content_id.rfind("x_sonos_htastream:", 0) == 0 ||
+         content_id.rfind("x_rincon_htastream:", 0) == 0 ||
+         content_id.rfind("x_rincon_stream:", 0) == 0 ||
+         content_id.find(":spdif") != std::string::npos;
+}
+
 inline MediaItemKind media_item_kind_from_token(std::string token) {
   token = normalize_media_kind_token(std::move(token));
   if (token == "track") return MediaItemKind::TRACK;

--- a/components/espcontrol/media_metadata_policy.h
+++ b/components/espcontrol/media_metadata_policy.h
@@ -56,6 +56,11 @@ inline bool media_content_id_should_replace_external_source(
          !retained_source_present;
 }
 
+inline bool media_content_id_should_override_source_update(
+    const std::string &content_id, bool source_update_external) {
+  return !source_update_external && media_content_id_external_input(content_id);
+}
+
 inline MediaItemKind media_item_kind_from_token(std::string token) {
   token = normalize_media_kind_token(std::move(token));
   if (token == "track") return MediaItemKind::TRACK;

--- a/components/espcontrol/media_metadata_policy.h
+++ b/components/espcontrol/media_metadata_policy.h
@@ -34,12 +34,26 @@ inline std::string normalize_media_kind_token(std::string value) {
   return value;
 }
 
-inline bool media_content_id_external_input(std::string content_id) {
+inline const char *media_content_id_external_source(std::string content_id) {
   content_id = normalize_media_kind_token(std::move(content_id));
-  return content_id.rfind("x_sonos_htastream:", 0) == 0 ||
-         content_id.rfind("x_rincon_htastream:", 0) == 0 ||
-         content_id.rfind("x_rincon_stream:", 0) == 0 ||
-         content_id.find(":spdif") != std::string::npos;
+  if (content_id.rfind("x_rincon_stream:", 0) == 0) return "Line-in";
+  if (content_id.rfind("x_sonos_htastream:", 0) == 0 ||
+      content_id.rfind("x_rincon_htastream:", 0) == 0 ||
+      content_id.find(":spdif") != std::string::npos) {
+    return "TV";
+  }
+  return "";
+}
+
+inline bool media_content_id_external_input(const std::string &content_id) {
+  return media_content_id_external_source(content_id)[0] != '\0';
+}
+
+inline bool media_content_id_should_replace_external_source(
+    bool source_observed_for_state, bool retained_source_external,
+    bool retained_source_present) {
+  return !source_observed_for_state || !retained_source_external ||
+         !retained_source_present;
 }
 
 inline MediaItemKind media_item_kind_from_token(std::string token) {

--- a/tests/firmware/artwork_controller_test.cpp
+++ b/tests/firmware/artwork_controller_test.cpp
@@ -18,6 +18,7 @@ using espcontrol::artwork::artwork_batch_waits_for_companion;
 using espcontrol::artwork::artwork_batch_needs_response_timer;
 using espcontrol::artwork::artwork_empty_selection_preserves_pending_refresh;
 using espcontrol::artwork::artwork_empty_selection_preserves_retry;
+using espcontrol::artwork::artwork_entity_picture_present;
 using espcontrol::artwork::artwork_timeout_retry_mask;
 using espcontrol::artwork::artwork_pending_refresh_needs_reschedule;
 using espcontrol::artwork::artwork_timeout_retry_allowed;
@@ -29,6 +30,7 @@ using espcontrol::artwork::artwork_selection_needs_download;
 using espcontrol::artwork::source_response_can_apply_immediately;
 using espcontrol::cover_art::RuntimeState;
 using espcontrol::cover_art::media_card_artwork_suppressed;
+using espcontrol::cover_art::media_external_source_stale_for_current_content;
 
 int main() {
   RefreshTrigger trigger;
@@ -48,8 +50,19 @@ int main() {
   assert(!media_card_artwork_suppressed(true, false));
   assert(media_card_artwork_suppressed(true, true));
 
+  // A source attribute omitted from the latest Home Assistant state must not
+  // leave a retained TV route active once current music content arrives.
+  assert(media_external_source_stale_for_current_content(true, false, true));
+  assert(!media_external_source_stale_for_current_content(true, true, true));
+  assert(!media_external_source_stale_for_current_content(true, false, false));
+  assert(!media_external_source_stale_for_current_content(false, false, true));
+
   SourceCandidates sources;
   assert(sources.empty());
+  assert(!artwork_entity_picture_present(""));
+  assert(!artwork_entity_picture_present("unknown"));
+  assert(!artwork_entity_picture_present("unavailable"));
+  assert(artwork_entity_picture_present("/api/media_player_proxy/player"));
 
   // Home Assistant normally publishes the remote value first. It is usable
   // immediately, then the matching local value takes priority when it arrives.
@@ -72,7 +85,7 @@ int main() {
   sources.finish_refresh();
 
   // Repeated events are idempotent and an empty local result retains the
-  // current remote fallback.
+  // current remote source.
   assert(!sources.update(false, "remote-b"));
   assert(sources.update(true, ""));
   assert(sources.select("remote-b", false).primary == "remote-b");
@@ -222,9 +235,12 @@ int main() {
   assert(selected.primary == "local-stable");
   assert(selected.fallback == "remote-stable");
 
-  // Empty responses are a real artwork update. Once both sources are empty,
-  // the caller must clear/cancel the currently displayed artwork.
+  // entity_picture is authoritative. An empty remote response immediately
+  // suppresses even a retained local proxy, so it cannot restore stale art.
   assert(sources.update(false, "", RemoteUpdatePolicy::PRESERVE_LOCAL));
+  selected = sources.select("local-stable", false);
+  assert(selected.primary.empty());
+  assert(sources.local_url == "local-stable");
   assert(sources.update(true, ""));
   selected = sources.select("local-stable", false);
   assert(selected.primary.empty());

--- a/tests/firmware/ha_read_coordinator_test.cpp
+++ b/tests/firmware/ha_read_coordinator_test.cpp
@@ -223,6 +223,79 @@ void cancellation_is_safe_during_callback() {
           "callback cancellation was not deferred safely");
 }
 
+void subscription_reset_during_callback_preserves_rebuilt_subscriptions() {
+  Coordinator coordinator;
+  constexpr uint32_t scope = 1u << 1;
+  int artwork_calls = 0;
+  int secondary_idle_calls = 0;
+  require(coordinator.subscribe(
+              "media_player.primary", "source",
+              [&](std::string) {
+                coordinator.reset_subscriptions(scope);
+                require(coordinator.subscribe(
+                            "media_player.music", "entity_picture",
+                            [&](std::string) { artwork_calls++; }, scope, nullptr, true),
+                        "rebuilt artwork subscription should register");
+                require(coordinator.subscribe(
+                            "media_player.secondary", "",
+                            [&](std::string state) {
+                              if (state == "idle") secondary_idle_calls++;
+                            }, scope),
+                        "rebuilt secondary playback subscription should register");
+              },
+              scope),
+          "source subscription should register");
+
+  coordinator.transport().publish(0, "Music");
+  require(coordinator.subscription_count() == 2,
+          "deferred reset removed rebuilt media subscriptions");
+  require(coordinator.read_retained(
+              "media_player.music", "entity_picture",
+              [](std::string) {}, true, 10, 5),
+          "rebuilt artwork subscription should support retained reads");
+  coordinator.transport().publish(1, "/api/media_player_proxy/music");
+  coordinator.transport().publish(2, "idle");
+  require(artwork_calls == 1,
+          "rebuilt artwork subscription did not receive its first update");
+  require(secondary_idle_calls == 1,
+          "rebuilt secondary playback subscription missed its stopped state");
+}
+
+void owner_release_during_callback_preserves_rebuilt_subscriptions() {
+  Coordinator coordinator;
+  int card_owner = 0;
+  int source_calls = 0;
+  int stopped_calls = 0;
+  require(coordinator.subscribe(
+              "text.button_config", "",
+              [&](std::string) {
+                coordinator.release_owner(&card_owner);
+                require(coordinator.subscribe(
+                            "media_player.primary", "source",
+                            [&](std::string) { source_calls++; }, 1u,
+                            &card_owner, true),
+                        "rebuilt source subscription should register");
+                require(coordinator.subscribe(
+                            "media_player.secondary", "",
+                            [&](std::string state) {
+                              if (state == "idle") stopped_calls++;
+                            }, 1u, &card_owner),
+                        "rebuilt secondary subscription should register");
+              },
+              1u, &card_owner),
+          "card configuration subscription should register");
+
+  coordinator.transport().publish(0, "rebuilt");
+  require(coordinator.subscription_count() == 2,
+          "deferred owner release removed rebuilt card subscriptions");
+  coordinator.transport().publish(1, "Music");
+  coordinator.transport().publish(2, "idle");
+  require(source_calls == 1,
+          "rebuilt source subscription missed its first update");
+  require(stopped_calls == 1,
+          "rebuilt secondary subscription missed its stopped state");
+}
+
 void rebuilt_subscriptions_share_one_transport_channel() {
   Coordinator coordinator;
   constexpr uint32_t scope = 1u;
@@ -664,6 +737,8 @@ int main() {
   reentrant_reads_on_one_channel_share_deferred_work();
   resolved_deferred_channels_survive_channel_vector_growth();
   cancellation_is_safe_during_callback();
+  subscription_reset_during_callback_preserves_rebuilt_subscriptions();
+  owner_release_during_callback_preserves_rebuilt_subscriptions();
   rebuilt_subscriptions_share_one_transport_channel();
   rebuilt_subscription_replays_last_value();
   reconnect_does_not_replay_previous_connection_state();

--- a/tests/firmware/media_metadata_policy_test.cpp
+++ b/tests/firmware/media_metadata_policy_test.cpp
@@ -7,6 +7,7 @@ int main() {
   using espcontrol::media::media_content_identity_fingerprint;
   using espcontrol::media::media_content_id_external_input;
   using espcontrol::media::media_content_id_external_source;
+  using espcontrol::media::media_content_id_should_clear_external_source;
   using espcontrol::media::media_content_id_should_override_source_update;
   using espcontrol::media::media_content_id_should_replace_external_source;
   using espcontrol::media::media_item_kind;
@@ -60,6 +61,13 @@ int main() {
   assert(!media_content_id_should_override_source_update(
     "x-sonos-htastream:RINCON_48A6B8B84F0901400:spdif", true));
   assert(!media_content_id_should_override_source_update(
+    "x-sonos-spotify:spotify%3atrack%3a0KIhLAkHfL9fvgn0yy1qsU", false));
+  assert(media_content_id_should_clear_external_source(
+    "x-sonos-spotify:spotify%3atrack%3a0KIhLAkHfL9fvgn0yy1qsU", true));
+  assert(!media_content_id_should_clear_external_source("", true));
+  assert(!media_content_id_should_clear_external_source(
+    "x-sonos-htastream:RINCON_48A6B8B84F0901400:spdif", true));
+  assert(!media_content_id_should_clear_external_source(
     "x-sonos-spotify:spotify%3atrack%3a0KIhLAkHfL9fvgn0yy1qsU", false));
   assert(!media_content_id_external_input(
     "x-sonos-spotify:spotify%3atrack%3a0KIhLAkHfL9fvgn0yy1qsU"));

--- a/tests/firmware/media_metadata_policy_test.cpp
+++ b/tests/firmware/media_metadata_policy_test.cpp
@@ -5,6 +5,7 @@
 int main() {
   using espcontrol::media::MediaItemKind;
   using espcontrol::media::media_content_identity_fingerprint;
+  using espcontrol::media::media_content_id_external_input;
   using espcontrol::media::media_item_kind;
   using espcontrol::media::media_metadata_clear_decision;
   using espcontrol::media::should_replace_media_metadata_identity;
@@ -16,6 +17,8 @@ int main() {
          MediaItemKind::PODCAST);
   assert(media_item_kind("library://radio/1") == MediaItemKind::RADIO);
   assert(media_item_kind("library://movie/1") == MediaItemKind::VIDEO);
+  assert(media_item_kind("", "movie") == MediaItemKind::VIDEO);
+  assert(media_item_kind("", "tv_show") == MediaItemKind::VIDEO);
   assert(media_item_kind("library://playlist/1") == MediaItemKind::COLLECTION);
   assert(media_item_kind("spotify:track:456") == MediaItemKind::TRACK);
   assert(media_item_kind("provider:audiobook:book-id", "music") ==
@@ -26,6 +29,22 @@ int main() {
          MediaItemKind::AUDIOBOOK);
   assert(media_item_kind("opaque-content-id", "music") ==
          MediaItemKind::UNKNOWN);
+
+  // Sonos exposes TV audio as a home-theatre SPDIF stream. Music services use
+  // ordinary provider IDs and must not inherit a retained TV classification.
+  assert(media_content_id_external_input(
+    "x-sonos-htastream:RINCON_48A6B8B84F0901400:spdif"));
+  assert(media_content_id_external_input(
+    "x-rincon-htastream:RINCON_48A6B8B84F0901400:SPDIF"));
+  assert(media_content_id_external_input(
+    "x-rincon-stream:RINCON_804AF2CAFA8001400"));
+  assert(media_content_id_external_input(
+    "x-rincon-stream:RINCON_804AF2CAFA8001400:0"));
+  assert(!media_content_id_external_input(
+    "x-sonos-spotify:spotify%3atrack%3a0KIhLAkHfL9fvgn0yy1qsU"));
+  assert(!media_content_id_external_input(
+    "x-rincon-queue:RINCON_804AF2CAFA8001400#0"));
+  assert(!media_content_id_external_input("spotify:track:456"));
 
   const auto same_artist_track = media_metadata_clear_decision(
     media_content_identity_fingerprint("library://track/1"),

--- a/tests/firmware/media_metadata_policy_test.cpp
+++ b/tests/firmware/media_metadata_policy_test.cpp
@@ -55,19 +55,22 @@ int main() {
   assert(media_content_id_should_replace_external_source(true, true, false));
   assert(!media_content_id_should_replace_external_source(true, true, true));
   assert(media_content_id_should_override_source_update(
-    "x-sonos-htastream:RINCON_48A6B8B84F0901400:spdif", "Spotify"));
+    true, "x-sonos-htastream:RINCON_48A6B8B84F0901400:spdif", "Spotify"));
   assert(media_content_id_should_override_source_update(
-    "x-rincon-stream:RINCON_804AF2CAFA8001400", "Spotify"));
+    true, "x-rincon-stream:RINCON_804AF2CAFA8001400", "Spotify"));
   assert(!media_content_id_should_override_source_update(
-    "x-sonos-htastream:RINCON_48A6B8B84F0901400:spdif", "TV"));
+    true, "x-sonos-htastream:RINCON_48A6B8B84F0901400:spdif", "TV"));
   assert(!media_content_id_should_override_source_update(
-    "x-sonos-htastream:RINCON_48A6B8B84F0901400:spdif", "HDMI 1"));
+    true, "x-sonos-htastream:RINCON_48A6B8B84F0901400:spdif", "HDMI 1"));
   assert(media_content_id_should_override_source_update(
-    "x-rincon-stream:RINCON_804AF2CAFA8001400", "TV"));
+    true, "x-rincon-stream:RINCON_804AF2CAFA8001400", "TV"));
   assert(!media_content_id_should_override_source_update(
-    "x-rincon-stream:RINCON_804AF2CAFA8001400", "Line in"));
+    true, "x-rincon-stream:RINCON_804AF2CAFA8001400", "Line in"));
   assert(!media_content_id_should_override_source_update(
+    true,
     "x-sonos-spotify:spotify%3atrack%3a0KIhLAkHfL9fvgn0yy1qsU", "TV"));
+  assert(!media_content_id_should_override_source_update(
+    false, "x-sonos-htastream:RINCON_48A6B8B84F0901400:spdif", "Spotify"));
   assert(media_content_id_should_clear_external_source(
     "x-sonos-spotify:spotify%3atrack%3a0KIhLAkHfL9fvgn0yy1qsU", true));
   assert(!media_content_id_should_clear_external_source("", true));

--- a/tests/firmware/media_metadata_policy_test.cpp
+++ b/tests/firmware/media_metadata_policy_test.cpp
@@ -6,6 +6,8 @@ int main() {
   using espcontrol::media::MediaItemKind;
   using espcontrol::media::media_content_identity_fingerprint;
   using espcontrol::media::media_content_id_external_input;
+  using espcontrol::media::media_content_id_external_source;
+  using espcontrol::media::media_content_id_should_replace_external_source;
   using espcontrol::media::media_item_kind;
   using espcontrol::media::media_metadata_clear_decision;
   using espcontrol::media::should_replace_media_metadata_identity;
@@ -40,6 +42,16 @@ int main() {
     "x-rincon-stream:RINCON_804AF2CAFA8001400"));
   assert(media_content_id_external_input(
     "x-rincon-stream:RINCON_804AF2CAFA8001400:0"));
+  assert(std::string(media_content_id_external_source(
+    "x-sonos-htastream:RINCON_48A6B8B84F0901400:spdif")) == "TV");
+  assert(std::string(media_content_id_external_source(
+    "x-rincon-stream:RINCON_804AF2CAFA8001400")) == "Line-in");
+  assert(std::string(media_content_id_external_source(
+    "x-sonos-spotify:spotify%3atrack%3a0KIhLAkHfL9fvgn0yy1qsU")).empty());
+  assert(media_content_id_should_replace_external_source(false, false, true));
+  assert(media_content_id_should_replace_external_source(true, false, true));
+  assert(media_content_id_should_replace_external_source(true, true, false));
+  assert(!media_content_id_should_replace_external_source(true, true, true));
   assert(!media_content_id_external_input(
     "x-sonos-spotify:spotify%3atrack%3a0KIhLAkHfL9fvgn0yy1qsU"));
   assert(!media_content_id_external_input(

--- a/tests/firmware/media_metadata_policy_test.cpp
+++ b/tests/firmware/media_metadata_policy_test.cpp
@@ -55,13 +55,19 @@ int main() {
   assert(media_content_id_should_replace_external_source(true, true, false));
   assert(!media_content_id_should_replace_external_source(true, true, true));
   assert(media_content_id_should_override_source_update(
-    "x-sonos-htastream:RINCON_48A6B8B84F0901400:spdif", false));
+    "x-sonos-htastream:RINCON_48A6B8B84F0901400:spdif", "Spotify"));
   assert(media_content_id_should_override_source_update(
-    "x-rincon-stream:RINCON_804AF2CAFA8001400", false));
+    "x-rincon-stream:RINCON_804AF2CAFA8001400", "Spotify"));
   assert(!media_content_id_should_override_source_update(
-    "x-sonos-htastream:RINCON_48A6B8B84F0901400:spdif", true));
+    "x-sonos-htastream:RINCON_48A6B8B84F0901400:spdif", "TV"));
   assert(!media_content_id_should_override_source_update(
-    "x-sonos-spotify:spotify%3atrack%3a0KIhLAkHfL9fvgn0yy1qsU", false));
+    "x-sonos-htastream:RINCON_48A6B8B84F0901400:spdif", "HDMI 1"));
+  assert(media_content_id_should_override_source_update(
+    "x-rincon-stream:RINCON_804AF2CAFA8001400", "TV"));
+  assert(!media_content_id_should_override_source_update(
+    "x-rincon-stream:RINCON_804AF2CAFA8001400", "Line in"));
+  assert(!media_content_id_should_override_source_update(
+    "x-sonos-spotify:spotify%3atrack%3a0KIhLAkHfL9fvgn0yy1qsU", "TV"));
   assert(media_content_id_should_clear_external_source(
     "x-sonos-spotify:spotify%3atrack%3a0KIhLAkHfL9fvgn0yy1qsU", true));
   assert(!media_content_id_should_clear_external_source("", true));

--- a/tests/firmware/media_metadata_policy_test.cpp
+++ b/tests/firmware/media_metadata_policy_test.cpp
@@ -7,6 +7,7 @@ int main() {
   using espcontrol::media::media_content_identity_fingerprint;
   using espcontrol::media::media_content_id_external_input;
   using espcontrol::media::media_content_id_external_source;
+  using espcontrol::media::media_content_id_should_override_source_update;
   using espcontrol::media::media_content_id_should_replace_external_source;
   using espcontrol::media::media_item_kind;
   using espcontrol::media::media_metadata_clear_decision;
@@ -52,6 +53,14 @@ int main() {
   assert(media_content_id_should_replace_external_source(true, false, true));
   assert(media_content_id_should_replace_external_source(true, true, false));
   assert(!media_content_id_should_replace_external_source(true, true, true));
+  assert(media_content_id_should_override_source_update(
+    "x-sonos-htastream:RINCON_48A6B8B84F0901400:spdif", false));
+  assert(media_content_id_should_override_source_update(
+    "x-rincon-stream:RINCON_804AF2CAFA8001400", false));
+  assert(!media_content_id_should_override_source_update(
+    "x-sonos-htastream:RINCON_48A6B8B84F0901400:spdif", true));
+  assert(!media_content_id_should_override_source_update(
+    "x-sonos-spotify:spotify%3atrack%3a0KIhLAkHfL9fvgn0yy1qsU", false));
   assert(!media_content_id_external_input(
     "x-sonos-spotify:spotify%3atrack%3a0KIhLAkHfL9fvgn0yy1qsU"));
   assert(!media_content_id_external_input(


### PR DESCRIPTION
## Purpose

Fix cover-art cards retaining stale media data or selecting the wrong entity when Sonos changes between music, TV, and line-in sources.

## Practical impact

- Detects Sonos TV and line-in streams even when Home Assistant source attributes are absent or delayed.
- Returns the display to primary music metadata when the external source disappears.
- Clears omitted artist, artwork, and progress data instead of retaining the previous item.
- Clears secondary artwork when entity_picture is absent or playback stops.
- Keeps configured secondary media metadata available while the primary Sonos entity is on TV.
- Makes Home Assistant subscription rebuilds safe when callbacks reset or re-register subscriptions.

## Automated checks

- All 28 native firmware tests passed.
- Cover-art contract checks passed.
- Firmware Home Assistant binding checks passed.
- ESPHome 2026.8.1 S3 development firmware compiled successfully.

## Physical device testing

- Flashed the 4-inch S3 display over OTA.
- User confirmed music-to-TV switching now clears stale primary metadata.
- User confirmed the configured secondary media entity is displayed after Home Assistant publishes its metadata.
- Sonos line-in URI detection is covered by automated tests but has not been physically verified.