### PR TITLE
Fix 10-inch backup restoration

### DIFF
--- a/compatibility/fixtures/panel_config_migration_v1.json
+++ b/compatibility/fixtures/panel_config_migration_v1.json
@@ -77,6 +77,87 @@
         "settings": { "button_order": "1" }
       },
       "expected_result": "mirror-failed"
+    },
+    "ten_inch_legacy_restore": {
+      "backup": {
+        "version": 2,
+        "format": "espcontrol.backup",
+        "device": "guition-esp32-p4-jc8012p4a1",
+        "source": { "device": "guition-esp32-p4-jc8012p4a1", "slots": 20 },
+        "exported_at": "2026-08-09T00:00:00.000Z",
+        "button_order": "1,7,6p,,,8,2,,,,3,4,,,,9,5",
+        "button_on_color": "FF8C00",
+        "buttons": [
+          { "entity": "light.office", "label": "Features", "icon": "Lightbulb Outline", "icon_on": "Lightbulb", "sensor": "", "unit": "", "type": "", "precision": "", "options": "" },
+          { "entity": "climate.office", "label": "Aircon", "icon": "Thermostat", "icon_on": "Auto", "sensor": "", "unit": "", "type": "climate_control", "precision": "", "options": "" },
+          { "entity": "", "label": "Devices", "icon": "Power", "icon_on": "Auto", "sensor": "", "unit": "", "type": "subpage", "precision": "", "options": "" },
+          { "entity": "cover.office", "label": "Blind", "icon": "Blinds Open", "icon_on": "Blinds", "sensor": "", "unit": "", "type": "cover", "precision": "", "options": "" },
+          { "entity": "alarm_control_panel.home", "label": "", "icon": "Security", "icon_on": "Auto", "sensor": "", "unit": "", "type": "alarm", "precision": "", "options": "" },
+          { "entity": "media_player.office", "label": "Cover Art", "icon": "Auto", "icon_on": "Auto", "sensor": "cover_art", "unit": "", "type": "media", "precision": "", "options": "" },
+          { "entity": "switch.calls", "label": "Calls", "icon": "Auto", "icon_on": "Auto", "sensor": "", "unit": "", "type": "", "precision": "", "options": "" },
+          { "entity": "climate.heating", "label": "Heating", "icon": "Thermostat", "icon_on": "Auto", "sensor": "", "unit": "", "type": "climate_control", "precision": "", "options": "" },
+          { "entity": "switch.charger", "label": "Battery", "icon": "Battery 30%", "icon_on": "Battery Charging", "sensor": "", "unit": "", "type": "", "precision": "", "options": "" },
+          {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+        ],
+        "subpages": {},
+        "subpage_objects": {
+          "3": {
+            "order": ["B", "1", "2"],
+            "back_label": "Back",
+            "buttons": [
+              { "entity": "switch.printer", "label": "Printer", "icon": "Printer 3D", "icon_on": "Auto", "sensor": "sensor.printer_progress", "unit": "%", "type": "", "precision": "", "options": "confirm_off" },
+              { "entity": "switch.heater", "label": "Heater", "icon": "Radiator", "icon_on": "Auto", "sensor": "sensor.heater_humidity", "unit": "%", "type": "", "precision": "", "options": "" }
+            ]
+          }
+        },
+        "settings": {},
+        "screen": {}
+      },
+      "expected": {
+        "button_order": "1,7,6p,,,8,2,,,,3,4,,,,9,5",
+        "button_entities": ["light.office", "climate.office", "", "cover.office", "alarm_control_panel.home", "media_player.office", "switch.calls", "climate.heating", "switch.charger"],
+        "subpage_slot": "3",
+        "subpage_entities": ["switch.printer", "switch.heater"]
+      }
+    },
+    "ten_inch_native_restore": {
+      "backup": {
+        "version": 2,
+        "format": "espcontrol.backup",
+        "device": "guition-esp32-p4-jc8012p4a1",
+        "source": { "device": "guition-esp32-p4-jc8012p4a1", "slots": 20 },
+        "exported_at": "2026-08-22T00:00:00.000Z",
+        "button_order": "1,2,6p,,,7,8,,,,9,4,,,,5",
+        "button_on_color": "FF8C00",
+        "buttons": [
+          { "entity": "light.office", "label": "Features" },
+          { "entity": "climate.office", "label": "Aircon", "type": "climate_control" },
+          { "entity": "", "label": "Devices", "type": "subpage" },
+          { "entity": "cover.office", "label": "Blind", "type": "cover" },
+          { "entity": "alarm_control_panel.home", "type": "alarm" },
+          { "entity": "media_player.office", "label": "Cover Art", "sensor": "cover_art", "type": "media" },
+          { "entity": "switch.calls", "label": "Calls" },
+          { "entity": "climate.heating", "label": "Heating", "type": "climate_control" },
+          { "entity": "switch.charger", "label": "Battery" },
+          {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+        ],
+        "subpages": {},
+        "subpage_objects": {},
+        "settings": {},
+        "screen": {},
+        "native_config": {
+          "document_version": 1,
+          "device_profile": "guition-esp32-p4-jc8012p4a1",
+          "payload": "RVBDRgEAEADJAgAAFwAAAAEbAGd1aXRpb24tZXNwMzItcDQtamM4MDEycDRhMQIyAAFsaWdodC5vZmZpY2U7RmVhdHVyZXM7TGlnaHRidWxiIE91dGxpbmU7TGlnaHRidWxiAjgAAmNsaW1hdGUub2ZmaWNlO0FpcmNvbjtUaGVybW9zdGF0O0F1dG87OztjbGltYXRlX2NvbnRyb2wCHgADO0RldmljZXM7UG93ZXI7QXV0bzs7O3N1YnBhZ2UCLgAEY292ZXIub2ZmaWNlO0JsaW5kO0JsaW5kcyBPcGVuO0JsaW5kczs7O2NvdmVyAjAABWFsYXJtX2NvbnRyb2xfcGFuZWwuaG9tZTs7U2VjdXJpdHk7QXV0bzs7O2FsYXJtAjkABm1lZGlhX3BsYXllci5vZmZpY2U7Q292ZXIgQXJ0O0F1dG87QXV0bztjb3Zlcl9hcnQ7O21lZGlhAh0AB3N3aXRjaC5jYWxscztDYWxscztBdXRvO0F1dG8COgAIY2xpbWF0ZS5oZWF0aW5nO0hlYXRpbmc7VGhlcm1vc3RhdDtBdXRvOzs7Y2xpbWF0ZV9jb250cm9sAjQACXN3aXRjaC5jaGFyZ2VyO0JhdHRlcnk7QmF0dGVyeSAzMCU7QmF0dGVyeSBDaGFyZ2luZwIMAAo7O0F1dG87QXV0bwIMAAs7O0F1dG87QXV0bwIMAAw7O0F1dG87QXV0bwIMAA07O0F1dG87QXV0bwIMAA47O0F1dG87QXV0bwIMAA87O0F1dG87QXV0bwIMABA7O0F1dG87QXV0bwIMABE7O0F1dG87QXV0bwIMABI7O0F1dG87QXV0bwIMABM7O0F1dG87QXV0bwIMABQ7O0F1dG87QXV0bwQWAA9idXR0b25fb25fY29sb3JGRjhDMDAEJQAMYnV0dG9uX29yZGVyMSwyLDZwLCwsNyw4LCwsLDksNCwsLCw1"
+        }
+      },
+      "expected": {
+        "record_count": 20,
+        "slot_16": ";;Auto;Auto",
+        "slot_20": ";;Auto;Auto",
+        "button_order": "1,2,6p,,,7,8,,,,9,4,,,,5",
+        "subpage_slots": []
+      }
     }
   }
 }

--- a/components/espcontrol/panel_config_write_endpoint.h
+++ b/components/espcontrol/panel_config_write_endpoint.h
@@ -14,6 +14,7 @@
 #include "panel_config_document.h"
 #include "panel_config_http_etag.h"
 #include "panel_config_http_context.h"
+#include "panel_config_write_status.h"
 
 namespace espcontrol::configuration {
 
@@ -122,28 +123,33 @@ class PanelConfigWriteHandler final
     // buffers in handleRequest() so they remain valid through every send below.
     char generation_text[16]{};
     char etag[20]{};
-    if (saved.status == ServiceStatus::GENERATION_CONFLICT) {
+    const PanelConfigWriteResponse response =
+        panel_config_write_response(saved.status);
+    if (response == PanelConfigWriteResponse::GENERATION_CONFLICT) {
       set_generation_headers(raw_request, saved.generation, generation_text,
                              etag);
       send_status(raw_request, "409 Conflict",
                   "Panel configuration changed on the device");
       return;
     }
-    if (saved.status == ServiceStatus::INVALID_DOCUMENT ||
-        saved.status == ServiceStatus::UNSUPPORTED_VERSION ||
-        saved.status == ServiceStatus::INVALID_ARGUMENT) {
+    if (response == PanelConfigWriteResponse::BAD_REQUEST) {
       httpd_resp_send_err(raw_request, HTTPD_400_BAD_REQUEST,
                           "Invalid panel configuration document");
       return;
     }
-    if (!saved.durable()) {
+    if (response == PanelConfigWriteResponse::INTERNAL_ERROR) {
+      const char *const message =
+          saved.status == ServiceStatus::RUNTIME_APPLY_FAILED
+              ? "Panel configuration was saved but could not be applied"
+              : "Panel configuration could not be saved";
       httpd_resp_send_err(raw_request, HTTPD_500_INTERNAL_SERVER_ERROR,
-                          "Panel configuration could not be saved");
+                          message);
       return;
     }
     set_generation_headers(raw_request, saved.generation, generation_text,
                            etag);
-    if (saved.status == ServiceStatus::LEGACY_MIRROR_FAILED) {
+    if (response ==
+        PanelConfigWriteResponse::ACCEPTED_WITH_LEGACY_WARNING) {
       httpd_resp_set_hdr(raw_request, "X-Panel-Config-Legacy-Mirror", "failed");
       httpd_resp_set_status(raw_request, "202 Accepted");
     } else {

--- a/components/espcontrol/panel_config_write_status.h
+++ b/components/espcontrol/panel_config_write_status.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "configuration_service.h"
+
+namespace espcontrol::configuration {
+
+enum class PanelConfigWriteResponse : uint8_t {
+  NO_CONTENT,
+  ACCEPTED_WITH_LEGACY_WARNING,
+  BAD_REQUEST,
+  GENERATION_CONFLICT,
+  INTERNAL_ERROR,
+};
+
+inline PanelConfigWriteResponse panel_config_write_response(
+    ServiceStatus status) {
+  switch (status) {
+    case ServiceStatus::OK:
+      return PanelConfigWriteResponse::NO_CONTENT;
+    case ServiceStatus::LEGACY_MIRROR_FAILED:
+      return PanelConfigWriteResponse::ACCEPTED_WITH_LEGACY_WARNING;
+    case ServiceStatus::INVALID_DOCUMENT:
+    case ServiceStatus::UNSUPPORTED_VERSION:
+    case ServiceStatus::INVALID_ARGUMENT:
+      return PanelConfigWriteResponse::BAD_REQUEST;
+    case ServiceStatus::GENERATION_CONFLICT:
+      return PanelConfigWriteResponse::GENERATION_CONFLICT;
+    default:
+      return PanelConfigWriteResponse::INTERNAL_ERROR;
+  }
+}
+
+}  // namespace espcontrol::configuration

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -112,6 +112,16 @@ espcontrol:
         subpage_chunks: [subpage_14_config, subpage_14_config_ext, subpage_14_config_ext_2, subpage_14_config_ext_3, subpage_14_config_ext_4, subpage_14_config_ext_5, subpage_14_config_ext_6, subpage_14_config_ext_7]
       - config: button_15_config
         subpage_chunks: [subpage_15_config, subpage_15_config_ext, subpage_15_config_ext_2, subpage_15_config_ext_3, subpage_15_config_ext_4, subpage_15_config_ext_5, subpage_15_config_ext_6, subpage_15_config_ext_7]
+      - config: button_16_config
+        subpage_chunks: [subpage_16_config, subpage_16_config_ext, subpage_16_config_ext_2, subpage_16_config_ext_3, subpage_16_config_ext_4, subpage_16_config_ext_5, subpage_16_config_ext_6, subpage_16_config_ext_7]
+      - config: button_17_config
+        subpage_chunks: [subpage_17_config, subpage_17_config_ext, subpage_17_config_ext_2, subpage_17_config_ext_3, subpage_17_config_ext_4, subpage_17_config_ext_5, subpage_17_config_ext_6, subpage_17_config_ext_7]
+      - config: button_18_config
+        subpage_chunks: [subpage_18_config, subpage_18_config_ext, subpage_18_config_ext_2, subpage_18_config_ext_3, subpage_18_config_ext_4, subpage_18_config_ext_5, subpage_18_config_ext_6, subpage_18_config_ext_7]
+      - config: button_19_config
+        subpage_chunks: [subpage_19_config, subpage_19_config_ext, subpage_19_config_ext_2, subpage_19_config_ext_3, subpage_19_config_ext_4, subpage_19_config_ext_5, subpage_19_config_ext_6, subpage_19_config_ext_7]
+      - config: button_20_config
+        subpage_chunks: [subpage_20_config, subpage_20_config_ext, subpage_20_config_ext_2, subpage_20_config_ext_3, subpage_20_config_ext_4, subpage_20_config_ext_5, subpage_20_config_ext_6, subpage_20_config_ext_7]
 # ---------------------------------------------------------------------------
 # ESPHome core (device name from substitutions)
 # ---------------------------------------------------------------------------

--- a/scripts/check_device_profiles.py
+++ b/scripts/check_device_profiles.py
@@ -229,17 +229,49 @@ def test_s3_low_heap_policy() -> None:
     )
 
 
+def test_native_panel_config_bindings(slug: str, profile: dict, device: str) -> None:
+    espcontrol = re.search(r"(?ms)^espcontrol:\n(?P<body>(?:^  .*\n|^\s*$\n)*)", device)
+    assert espcontrol, f"{slug}: device.yaml is missing its espcontrol block"
+    body = espcontrol.group("body")
+    if "  panel_config:\n" not in body:
+        return
+
+    slots = int(profile["slots"])
+    bindings = [
+        int(slot)
+        for slot in re.findall(r"(?m)^      - config: button_(\d+)_config$", body)
+    ]
+    assert bindings == list(range(1, slots + 1)), (
+        f"{slug}: native panel config bindings must cover slots 1-{slots} exactly; "
+        f"found {bindings}"
+    )
+
+    chunk_rows = re.findall(r"(?m)^        subpage_chunks: \[([^\n]+)\]$", body)
+    assert len(chunk_rows) == slots, (
+        f"{slug}: native panel config must provide subpage chunks for all {slots} slots"
+    )
+    for slot, row in enumerate(chunk_rows, start=1):
+        expected = [f"subpage_{slot}_config", f"subpage_{slot}_config_ext"] + [
+            f"subpage_{slot}_config_ext_{suffix}" for suffix in range(2, 8)
+        ]
+        actual = [value.strip() for value in row.split(",")]
+        assert actual == expected, (
+            f"{slug}: slot {slot} native subpage bindings differ: {actual} != {expected}"
+        )
+
+
 def test_generated_yaml(profiles: dict[str, dict]) -> None:
     for slug, profile in profiles.items():
         package_path = ROOT / "devices" / slug / "packages.yaml"
         device_path = ROOT / "devices" / slug / "device" / "device.yaml"
         sensor_path = ROOT / "devices" / slug / "device" / "sensors.yaml"
         package = package_path.read_text(encoding="utf-8")
-        device_path.read_text(encoding="utf-8")
+        device = device_path.read_text(encoding="utf-8")
         sensors = sensor_path.read_text(encoding="utf-8")
         assert f'device_slug: "{slug}"' in package, f"{slug}: packages.yaml missing device slug"
         assert f'firmware_manifest_slug: "{slug}"' in package, f"{slug}: packages.yaml missing manifest slug"
         assert f"cfg.num_slots = {profile['slots']};" in sensors, f"{slug}: sensors.yaml missing slot count"
+        test_native_panel_config_bindings(slug, profile, device)
         label_lines = profile["web"]["btn"]["labelLines"]
         label_lines_tall = profile["web"]["btn"]["labelLinesDouble"]
         assert f"cfg.label_lines = {label_lines};" in sensors, (

--- a/tests/firmware/CMakeLists.txt
+++ b/tests/firmware/CMakeLists.txt
@@ -126,6 +126,12 @@ target_compile_options(panel_config_http_etag_test PRIVATE -Wall -Wextra -Werror
 target_include_directories(panel_config_http_etag_test PRIVATE ../../components/espcontrol)
 add_test(NAME panel_config_http_etag_test COMMAND panel_config_http_etag_test)
 
+add_executable(panel_config_write_status_test panel_config_write_status_test.cpp)
+target_compile_features(panel_config_write_status_test PRIVATE cxx_std_17)
+target_compile_options(panel_config_write_status_test PRIVATE -Wall -Wextra -Werror)
+target_include_directories(panel_config_write_status_test PRIVATE ../../components/espcontrol)
+add_test(NAME panel_config_write_status_test COMMAND panel_config_write_status_test)
+
 add_executable(panel_config_storage_backend_test
   panel_config_storage_backend_test.cpp
   ../../components/espcontrol/configuration_store.cpp

--- a/tests/firmware/panel_config_legacy_adapter_test.cpp
+++ b/tests/firmware/panel_config_legacy_adapter_test.cpp
@@ -31,7 +31,8 @@ static_assert(std::is_base_of_v<
 
 class FakeText final : public PanelConfigTextValue {
  public:
-  explicit FakeText(std::string state = {}) : state_(std::move(state)) {}
+  FakeText() = default;
+  explicit FakeText(std::string state) : state_(std::move(state)) {}
   const std::string &value() const override { return state_; }
   bool set_value(const char *value, size_t value_size) override {
     if (value == nullptr && value_size > 0) return false;
@@ -193,12 +194,91 @@ bool native_document_updates_live_grid_without_writing_legacy_preferences() {
          button.runtime_publishes == 1 && order.runtime_publishes == 1;
 }
 
+bool twenty_slot_document_reaches_order_and_subpage_settings() {
+  constexpr size_t SLOT_COUNT = 20;
+  FakeText order("old-order");
+  FakeText on_color("old-color");
+  std::array<FakeText, SLOT_COUNT> buttons{};
+  FakeText subpage;
+  std::array<std::array<PanelConfigTextValue *,
+                        PanelConfigTextBindings::MAX_SUBPAGE_CHUNKS>,
+             SLOT_COUNT>
+      chunks{};
+  chunks[2][0] = &subpage;
+
+  PanelConfigTextBindings bindings;
+  PanelConfigLegacyAdapter legacy(bindings);
+  PanelConfigRuntimeAdapter runtime(bindings);
+  bindings.set_device_profile("guition-esp32-p4-jc8012p4a1");
+  bindings.set_button_order(&order);
+  bindings.set_button_on_color(&on_color);
+  for (size_t index = 0; index < SLOT_COUNT; ++index) {
+    bindings.set_button(static_cast<uint8_t>(index + 1), &buttons[index],
+                        chunks[index]);
+  }
+
+  std::array<std::string, SLOT_COUNT> values{};
+  for (size_t index = 0; index < SLOT_COUNT; ++index) {
+    values[index] = index < 9 ? "card-" + std::to_string(index + 1)
+                              : ";;Auto;Auto";
+  }
+  constexpr char DEVICE_PROFILE[] = "guition-esp32-p4-jc8012p4a1";
+  constexpr char SUBPAGE[] = "~B,1,2|card-a|card-b";
+  constexpr char BUTTON_ORDER[] = "1,2,6p,,,7,8,,,,9,4,,,,5";
+  constexpr char BUTTON_ON_COLOR[] = "FF8C00";
+  std::array<uint8_t, 4096> document{};
+  PanelConfigWriter writer(document.data(), document.size());
+  size_t document_size = 0;
+  if (writer.begin() != PanelConfigStatus::OK ||
+      writer.append_device_profile(
+          reinterpret_cast<const uint8_t *>(DEVICE_PROFILE),
+          sizeof(DEVICE_PROFILE) - 1) != PanelConfigStatus::OK) {
+    return false;
+  }
+  for (size_t index = 0; index < SLOT_COUNT; ++index) {
+    if (writer.append_button(
+            static_cast<uint8_t>(index + 1),
+            reinterpret_cast<const uint8_t *>(values[index].data()),
+            values[index].size()) != PanelConfigStatus::OK) {
+      return false;
+    }
+  }
+  if (writer.append_subpage(3, reinterpret_cast<const uint8_t *>(SUBPAGE),
+                            sizeof(SUBPAGE) - 1) != PanelConfigStatus::OK ||
+      writer.append_setting(
+          reinterpret_cast<const uint8_t *>("button_on_color"), 15,
+          reinterpret_cast<const uint8_t *>(BUTTON_ON_COLOR),
+          sizeof(BUTTON_ON_COLOR) - 1) != PanelConfigStatus::OK ||
+      writer.append_setting(
+          reinterpret_cast<const uint8_t *>("button_order"), 12,
+          reinterpret_cast<const uint8_t *>(BUTTON_ORDER),
+          sizeof(BUTTON_ORDER) - 1) != PanelConfigStatus::OK ||
+      writer.finish(&document_size) != PanelConfigStatus::OK) {
+    return false;
+  }
+
+  if (!legacy.mirror(1, document.data(), document_size) ||
+      !runtime.apply(1, document.data(), document_size)) {
+    return false;
+  }
+  for (size_t index = 0; index < SLOT_COUNT; ++index) {
+    if (buttons[index].value() != values[index] ||
+        buttons[index].persistent_writes != 1) {
+      return false;
+    }
+  }
+  return subpage.value() == SUBPAGE && order.value() == BUTTON_ORDER &&
+         on_color.value() == BUTTON_ON_COLOR &&
+         order.persistent_writes == 1 && on_color.persistent_writes == 1;
+}
+
 }  // namespace
 
 int main() {
   return imports_legacy_button_subpage_and_order() &&
                  native_document_mirrors_back_to_legacy_entities_for_downgrade() &&
-                 native_document_updates_live_grid_without_writing_legacy_preferences()
+                 native_document_updates_live_grid_without_writing_legacy_preferences() &&
+                 twenty_slot_document_reaches_order_and_subpage_settings()
              ? 0
              : 1;
 }

--- a/tests/firmware/panel_config_write_status_test.cpp
+++ b/tests/firmware/panel_config_write_status_test.cpp
@@ -1,0 +1,26 @@
+#include "panel_config_write_status.h"
+
+int main() {
+  using espcontrol::configuration::PanelConfigWriteResponse;
+  using espcontrol::configuration::ServiceStatus;
+  using espcontrol::configuration::panel_config_write_response;
+
+  return panel_config_write_response(ServiceStatus::OK) ==
+                 PanelConfigWriteResponse::NO_CONTENT &&
+         panel_config_write_response(ServiceStatus::LEGACY_MIRROR_FAILED) ==
+                 PanelConfigWriteResponse::ACCEPTED_WITH_LEGACY_WARNING &&
+         panel_config_write_response(ServiceStatus::INVALID_DOCUMENT) ==
+                 PanelConfigWriteResponse::BAD_REQUEST &&
+         panel_config_write_response(ServiceStatus::UNSUPPORTED_VERSION) ==
+                 PanelConfigWriteResponse::BAD_REQUEST &&
+         panel_config_write_response(ServiceStatus::INVALID_ARGUMENT) ==
+                 PanelConfigWriteResponse::BAD_REQUEST &&
+         panel_config_write_response(ServiceStatus::GENERATION_CONFLICT) ==
+                 PanelConfigWriteResponse::GENERATION_CONFLICT &&
+         panel_config_write_response(ServiceStatus::STORE_FAILED) ==
+                 PanelConfigWriteResponse::INTERNAL_ERROR &&
+         panel_config_write_response(ServiceStatus::RUNTIME_APPLY_FAILED) ==
+                 PanelConfigWriteResponse::INTERNAL_ERROR
+             ? 0
+             : 1;
+}

--- a/tests/web/backup_feature.test.ts
+++ b/tests/web/backup_feature.test.ts
@@ -25,6 +25,25 @@ interface MigrationFixture {
         readonly subpage_slots: readonly string[];
       };
     };
+    readonly ten_inch_legacy_restore: {
+      readonly backup: Record<string, unknown>;
+      readonly expected: {
+        readonly button_order: string;
+        readonly button_entities: readonly string[];
+        readonly subpage_slot: string;
+        readonly subpage_entities: readonly string[];
+      };
+    };
+    readonly ten_inch_native_restore: {
+      readonly backup: Record<string, unknown>;
+      readonly expected: {
+        readonly record_count: number;
+        readonly slot_16: string;
+        readonly slot_20: string;
+        readonly button_order: string;
+        readonly subpage_slots: readonly string[];
+      };
+    };
   };
 }
 
@@ -65,6 +84,20 @@ const feature = createBackupFeature({
   serializeSubpageConfig: serializeSubpage,
   buildSubpageGrid(subpage) {
     const result = buildSubpageGrid(subpage, 6, 3);
+    subpage.sizes = result.sizes;
+    return result.grid;
+  },
+});
+
+const tenInchFeature = createBackupFeature({
+  deviceId: "guition-esp32-p4-jc8012p4a1",
+  gridCols: 5,
+  numSlots: 20,
+  normalizeButtonConfig: (button: CardConfig) => cloneCardConfig(button),
+  parseSubpageConfig: parseLegacySubpageConfig,
+  serializeSubpageConfig: serializeSubpage,
+  buildSubpageGrid(subpage) {
+    const result = buildSubpageGrid(subpage, 20, 5);
     subpage.sizes = result.sizes;
     return result.grid;
   },
@@ -158,4 +191,39 @@ export function runBackupFeatureTests(migrationFixture?: MigrationFixture): void
     scenario.expected.button_entities, "backup restore preserves button records");
   deepEqual(Object.keys(restored.subpages), scenario.expected.subpage_slots,
     "backup restore preserves structured subpages");
+
+  const legacyTenInch = migrationFixture.scenarios.ten_inch_legacy_restore;
+  const legacyPlan = tenInchFeature.planBackupImport(legacyTenInch.backup, {
+    device: "guition-esp32-p4-jc8012p4a1",
+    slots: 20,
+  });
+  equal(legacyPlan.buttons.length, 20, "legacy 10-inch restore retains all twenty slots");
+  equal(legacyPlan.button_order, legacyTenInch.expected.button_order,
+    "legacy 10-inch restore retains its card order");
+  deepEqual(
+    legacyPlan.buttons.slice(0, legacyTenInch.expected.button_entities.length)
+      .map((button) => button.entity),
+    legacyTenInch.expected.button_entities,
+    "legacy 10-inch restore retains its configured cards",
+  );
+  const restoredSubpage = legacyPlan.subpages[legacyTenInch.expected.subpage_slot];
+  deepEqual(restoredSubpage?.buttons.map((button) => button.entity),
+    legacyTenInch.expected.subpage_entities,
+    "legacy 10-inch restore retains the Devices subpage contents");
+
+  const nativeTenInch = migrationFixture.scenarios.ten_inch_native_restore;
+  const normalizedNativeTenInch = tenInchFeature.normalizeBackupConfig(nativeTenInch.backup);
+  const nativeTenInchDocument = decodePanelConfig(
+    decodePanelConfigBackupPayload(normalizedNativeTenInch.native_config),
+  );
+  equal(Object.keys(nativeTenInchDocument.buttons).length, nativeTenInch.expected.record_count,
+    "native 10-inch restore retains all twenty button records");
+  equal(nativeTenInchDocument.buttons[16], nativeTenInch.expected.slot_16,
+    "native 10-inch restore retains the slot 16 placeholder");
+  equal(nativeTenInchDocument.buttons[20], nativeTenInch.expected.slot_20,
+    "native 10-inch restore retains the slot 20 placeholder");
+  equal(nativeTenInchDocument.settings.button_order, nativeTenInch.expected.button_order,
+    "native 10-inch restore retains its card order");
+  deepEqual(Object.keys(nativeTenInchDocument.subpages), nativeTenInch.expected.subpage_slots,
+    "newer 10-inch backup remains empty when its source omitted subpages");
 }

--- a/tests/web/native_panel_config.test.ts
+++ b/tests/web/native_panel_config.test.ts
@@ -103,6 +103,14 @@ export async function runNativePanelConfigTests(migrationFixture?: MigrationFixt
   });
   equal(await mirrorFailureClient.save((current) => current), "mirror-failed", "a failed legacy mirror is reported");
 
+  const runtimeFailureClient = createNativePanelConfigClient(async (path, request) => {
+    if (path === "/api/v1/capabilities") return response(200);
+    if (request?.method === "PUT") return response(500);
+    return response(200, document, "\"1\"");
+  });
+  equal(await runtimeFailureClient.save((current) => current), "failed",
+    "a runtime application failure is not reported as a successful restore");
+
   const legacyClient = createNativePanelConfigClient(async () => ({
     ...response(200),
     json: async () => ({ configuration: { read: false, write: false, document_versions: [] } }),


### PR DESCRIPTION
## Purpose

Fix backup restoration on the original 10-inch JC8012P4A1 so all 20 card slots participate in native persistence and a document that cannot be applied at runtime is no longer reported as a successful restore.

## Practical impact

- Adds native persistence bindings for card slots 16–20, including all eight subpage chunks per slot.
- Returns HTTP 500 when a configuration is durably saved but cannot be applied to the running display. Successful writes remain 204, while a legacy mirror warning remains 202.
- Validates every native-config device profile against its manifest slot count, sequential slot bindings, and matching subpage chunk numbers.
- Adds sanitized regression fixtures matching the important shapes of the supplied 9 August and 22 August backups without retaining private Home Assistant entity names.
- Preserves the existing backup schema, compact card format, device slug, and version-1/version-2 compatibility behavior.

## Automated checks

- `npm run check:device-profiles`
- `npm run check:device-matrix`
- `npm run check:backup-contract`
- Native panel-config and restore web tests
- All host firmware tests: 29/29 passed
- `npm run check:product`
- ESPHome 2026.8.1 compile: `guition-esp32-p4-jc8012p4a1.factory.yaml`
- ESPHome 2026.8.1 compile: `guition-esp32-p4-jc1060p470.factory.yaml`
- ESPHome 2026.8.1 compile: `guition-esp32-p4-jc1060p470-v2.factory.yaml`

These are automated build and test results; physical device testing is still pending.

## Physical test instructions

Affected display: original `guition-esp32-p4-jc8012p4a1`.

1. Flash this PR firmware to the original JC8012P4A1.
2. Import the supplied 9 August backup.
3. Confirm all nine cards appear in the expected layout.
4. Open Devices and confirm Printer and Heater are present.
5. Reload the web configurator, then power-cycle the panel.
6. Confirm the display and web configurator retain the same cards, order, and subpage.
7. Export a new backup and verify it contains the restored native configuration and subpage.
8. Import the supplied 22 August backup separately and confirm its top-level cards persist while its subpage remains empty, as dictated by that backup.

The 9 August backup is the complete recovery source; the 22 August backup does not contain the missing subpage contents.
