### PR TITLE
Stop repeated cover art refresh allocations

### DIFF
--- a/components/espcontrol/artwork_controller.h
+++ b/components/espcontrol/artwork_controller.h
@@ -191,6 +191,13 @@ constexpr bool artwork_pending_refresh_needs_reschedule(
   return refresh_pending && !timer_scheduled;
 }
 
+// If an ordinary replacement refresh has to be rescheduled after a forced
+// batch finishes, it must inherit that batch's explicit refresh requirement.
+constexpr bool artwork_rescheduled_refresh_forced(
+    bool completed_batch_forced, bool pending_trigger_forced) {
+  return completed_batch_forced || pending_trigger_forced;
+}
+
 constexpr bool artwork_timeout_retry_allowed(uint8_t attempts,
                                              uint8_t max_attempts) {
   return attempts < max_attempts;

--- a/components/espcontrol/artwork_controller.h
+++ b/components/espcontrol/artwork_controller.h
@@ -98,6 +98,7 @@ struct RefreshBatch {
     if (!this->active()) return false;
     this->expected_mask = 0;
     this->received_mask = 0;
+    this->forced = false;
     return true;
   }
 
@@ -217,6 +218,15 @@ constexpr bool artwork_refresh_forced(bool active_forced,
                                      bool pending_forced,
                                      bool requested_forced) {
   return active_forced || pending_forced || requested_forced;
+}
+
+// A timed-out batch that received no new source cannot justify replacing the
+// artwork already on screen. Retrying the retained attribute read is enough;
+// decoding the same cached URL again only creates avoidable allocator churn.
+constexpr bool artwork_timeout_preserves_displayed_image(bool response_window_expired,
+                                                          bool response_received,
+                                                          bool image_ready) {
+  return response_window_expired && !response_received && image_ready;
 }
 
 // A selected source only needs another download when it differs from the

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -2177,7 +2177,9 @@ inline void image_card_process_media_artwork(ImageCardCtx *ctx,
   if (espcontrol::artwork::artwork_pending_refresh_needs_reschedule(
         ctx->media_artwork_trigger.pending,
         ctx->media_artwork_trigger_timer != nullptr)) {
-    const bool force_refresh = ctx->media_artwork_trigger.forced;
+    const bool force_refresh =
+      espcontrol::artwork::artwork_rescheduled_refresh_forced(
+        refresh_forced, ctx->media_artwork_trigger.forced);
     ctx->media_artwork_retry_mask = 0;
     ctx->next_picture_retry_ms = 0;
     image_card_schedule_media_artwork_refresh(ctx, force_refresh);

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -2137,6 +2137,7 @@ inline void image_card_process_media_artwork(ImageCardCtx *ctx,
                                              bool response_window_expired = false) {
   if (!ctx || !ctx->active || !ctx->media_artwork) return;
   const bool batch_complete = ctx->media_artwork_refresh.complete();
+  const bool response_received = ctx->media_artwork_refresh.received_mask != 0;
   const bool refresh_forced = ctx->media_artwork_refresh.forced;
   const bool prefer_refreshed_remote =
     ctx->media_artwork_sources.remote_changed_in_refresh();
@@ -2206,6 +2207,11 @@ inline void image_card_process_media_artwork(ImageCardCtx *ctx,
       return;
     }
     image_card_clear_media_artwork(ctx);
+    return;
+  }
+  if (espcontrol::artwork::artwork_timeout_preserves_displayed_image(
+        response_window_expired, response_received, ctx->image_ready)) {
+    image_card_log_diagnostics(ctx, "media-artwork-timeout-current-preserved");
     return;
   }
   if (!espcontrol::artwork::artwork_selection_needs_download(

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -1118,8 +1118,9 @@ inline void media_playback_apply_state_to_now_playing_snapshot(
     std::strncpy(ctx->artist, state->artist.c_str(), sizeof(ctx->artist) - 1);
     ctx->artist[sizeof(ctx->artist) - 1] = '\0';
     media_apply_now_playing_artist_text(ctx);
-    if (!state->artist.empty() &&
-        (ctx->show_track_details || ctx->external_source_fallback)) {
+    if (espcontrol::cover_art::media_now_playing_artist_visible(
+          !state->artist.empty(), ctx->external_source,
+          ctx->show_track_details, ctx->external_source_fallback)) {
       lv_obj_clear_flag(ctx->artist_lbl, LV_OBJ_FLAG_HIDDEN);
     } else {
       lv_obj_add_flag(ctx->artist_lbl, LV_OBJ_FLAG_HIDDEN);

--- a/components/espcontrol/cover_art.h
+++ b/components/espcontrol/cover_art.h
@@ -45,6 +45,14 @@ inline bool media_card_artwork_suppressed(bool source_known,
   return source_known && external_source;
 }
 
+inline bool media_now_playing_artist_visible(bool artist_present,
+                                             bool external_source,
+                                             bool show_track_details,
+                                             bool external_source_fallback) {
+  return (show_track_details || external_source_fallback) &&
+         (artist_present || external_source);
+}
+
 inline bool media_external_source_stale_for_current_content(
     bool external_source, bool source_observed_for_state,
     bool current_content_present) {

--- a/tests/firmware/artwork_controller_test.cpp
+++ b/tests/firmware/artwork_controller_test.cpp
@@ -23,6 +23,7 @@ using espcontrol::artwork::artwork_timeout_retry_mask;
 using espcontrol::artwork::artwork_pending_refresh_needs_reschedule;
 using espcontrol::artwork::artwork_timeout_retry_allowed;
 using espcontrol::artwork::artwork_timeout_exhaustion_preserves_current;
+using espcontrol::artwork::artwork_timeout_preserves_displayed_image;
 using espcontrol::artwork::artwork_metadata_refresh_clears_retry;
 using espcontrol::artwork::artwork_refresh_forced;
 using espcontrol::artwork::artwork_response_needs_processing;
@@ -215,6 +216,10 @@ int main() {
   assert(artwork_refresh_forced(false, true, false));
   assert(artwork_refresh_forced(false, false, true));
   assert(!artwork_refresh_forced(false, false, false));
+  assert(artwork_timeout_preserves_displayed_image(true, false, true));
+  assert(!artwork_timeout_preserves_displayed_image(false, false, true));
+  assert(!artwork_timeout_preserves_displayed_image(true, true, true));
+  assert(!artwork_timeout_preserves_displayed_image(true, false, false));
 
   // A state update with the same selected local artwork does not download it
   // again. Reconnect and attribute-read retry use the forced path instead.
@@ -274,6 +279,7 @@ int main() {
   assert(batch.complete());
   assert(batch.finish());
   assert(!batch.active());
+  assert(!batch.forced);
 
   const uint32_t second_read = batch.begin(ARTWORK_SOURCE_BOTH, true);
   assert(second_read != first_read && batch.forced);
@@ -283,6 +289,7 @@ int main() {
   assert(batch.receive(second_read, false));
   assert(batch.complete());
   assert(batch.finish());
+  assert(!batch.forced);
 
   // Each paired read captures its own generation. A delayed response from the
   // previous track cannot be accepted into the newer track's batch.

--- a/tests/firmware/artwork_controller_test.cpp
+++ b/tests/firmware/artwork_controller_test.cpp
@@ -21,6 +21,7 @@ using espcontrol::artwork::artwork_empty_selection_preserves_retry;
 using espcontrol::artwork::artwork_entity_picture_present;
 using espcontrol::artwork::artwork_timeout_retry_mask;
 using espcontrol::artwork::artwork_pending_refresh_needs_reschedule;
+using espcontrol::artwork::artwork_rescheduled_refresh_forced;
 using espcontrol::artwork::artwork_timeout_retry_allowed;
 using espcontrol::artwork::artwork_timeout_exhaustion_preserves_current;
 using espcontrol::artwork::artwork_timeout_preserves_displayed_image;
@@ -32,6 +33,7 @@ using espcontrol::artwork::source_response_can_apply_immediately;
 using espcontrol::cover_art::RuntimeState;
 using espcontrol::cover_art::media_card_artwork_suppressed;
 using espcontrol::cover_art::media_external_source_stale_for_current_content;
+using espcontrol::cover_art::media_now_playing_artist_visible;
 
 int main() {
   RefreshTrigger trigger;
@@ -50,6 +52,14 @@ int main() {
   assert(!media_card_artwork_suppressed(false, true));
   assert(!media_card_artwork_suppressed(true, false));
   assert(media_card_artwork_suppressed(true, true));
+
+  // External inputs replace the artist with the localized "Source" caption,
+  // so the label remains visible even when no artist metadata is available.
+  assert(media_now_playing_artist_visible(false, true, false, true));
+  assert(media_now_playing_artist_visible(false, true, true, false));
+  assert(media_now_playing_artist_visible(true, false, true, false));
+  assert(!media_now_playing_artist_visible(false, false, true, false));
+  assert(!media_now_playing_artist_visible(true, false, false, false));
 
   // A source attribute omitted from the latest Home Assistant state must not
   // leave a retained TV route active once current music content arrives.
@@ -200,6 +210,10 @@ int main() {
   assert(artwork_pending_refresh_needs_reschedule(true, false));
   assert(!artwork_pending_refresh_needs_reschedule(true, true));
   assert(!artwork_pending_refresh_needs_reschedule(false, false));
+  assert(artwork_rescheduled_refresh_forced(true, false));
+  assert(artwork_rescheduled_refresh_forced(false, true));
+  assert(artwork_rescheduled_refresh_forced(true, true));
+  assert(!artwork_rescheduled_refresh_forced(false, false));
   assert(artwork_timeout_retry_allowed(0, 3));
   assert(artwork_timeout_retry_allowed(2, 3));
   assert(!artwork_timeout_retry_allowed(3, 3));


### PR DESCRIPTION
## Purpose

Fix the stepwise free-heap drops seen while a Cover Art card is active and tracks change. This branch deliberately includes the two commits from #1767 so the media source-transition fixes are part of the tested firmware.

## Diagnosis and practical impact

Live logging across S3 and P4 displays showed decoded artwork and compressed download buffers returning to their pre-download PSRAM baseline. The repeated allocation pressure instead came from refresh control state: a completed forced refresh stayed forced for later ordinary checks, and a timed-out local artwork read could decode the already displayed URL again despite receiving no new response.

This change clears the forced flag when its batch finishes and preserves the displayed image when a timed-out batch received no source response. Genuine track changes and explicit recovery refreshes still download fresh artwork.

## Automated validation

- All 28 native firmware tests pass, including new forced-batch and no-response timeout regressions
- Cover art contract check passes
- Firmware Home Assistant binding check and self-tests pass
- ESPHome 2026.8.1 factory compile passes for:
  - guition-esp32-p4-jc1060p470
  - guition-esp32-p4-jc4880p443
  - guition-esp32-s3-4848s040

## Live monitoring

Observed current dev firmware on the 10-inch P4, 7-inch P4, and 4-inch S3 during track changes. Artwork decode buffers were released, while redundant forced download cycles correlated with the internal-heap drops.

## Physical device testing

Not yet tested with this branch flashed. Please flash an affected display, leave a Cover Art card visible through several track changes, and confirm that Memory: Heap Free no longer falls in repeated steps and artwork still updates once per track.