### PR TITLE
Release cover art refresh memory

### DIFF
--- a/components/espcontrol/button_grid_ha.h
+++ b/components/espcontrol/button_grid_ha.h
@@ -301,9 +301,11 @@ inline bool ha_subscribe_attribute(const std::string &entity_id,
 
 inline bool ha_read_retained_attribute(const std::string &entity_id,
                                        const std::string &attribute,
-                                       HomeAssistantStateCallback callback) {
-  void *owner = ha_callback_owner();
-  if (owner != nullptr) {
+                                       HomeAssistantStateCallback callback,
+                                       void *request_owner = nullptr) {
+  void *ambient_owner = ha_callback_owner();
+  void *owner = request_owner != nullptr ? request_owner : ambient_owner;
+  if (ambient_owner != nullptr && request_owner == nullptr) {
     callback = [owner, callback = std::move(callback)](esphome::StringRef state) {
       if (!lv_obj_is_valid(static_cast<lv_obj_t *>(owner))) return;
       if (callback) callback(state);

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -835,6 +835,7 @@ inline void reset_image_card_pool(const GridConfig &cfg) {
   if (cfg.image_card_modal_image) cfg.image_card_modal_image->cancel_update();
   image_card_bind_modal_callbacks(cfg.image_card_modal_image);
   for (int i = 0; i < IMAGE_CARD_MAX_CONTEXTS; i++) {
+    ha_release_callbacks_for_owner(&contexts[i]);
     esphome::artwork_image::ArtworkImage *next_image =
         (i < count && cfg.image_card_images) ? cfg.image_card_images[i] : nullptr;
     if (contexts[i].image) contexts[i].image->cancel_update();
@@ -2333,7 +2334,8 @@ inline void image_card_request_media_artwork(ImageCardCtx *ctx, bool force_refre
         [ctx, entity_id, generation, request_generation](esphome::StringRef picture) {
           if (!image_card_context_current(ctx, entity_id, generation)) return;
           image_card_handle_media_artwork_picture(ctx, picture, false, request_generation);
-        })
+        }),
+      ctx
     );
   }
   bool local_queued = true;
@@ -2345,7 +2347,8 @@ inline void image_card_request_media_artwork(ImageCardCtx *ctx, bool force_refre
         [ctx, entity_id, generation, request_generation](esphome::StringRef picture) {
           if (!image_card_context_current(ctx, entity_id, generation)) return;
           image_card_handle_media_artwork_picture(ctx, picture, true, request_generation);
-        })
+        }),
+      ctx
     );
   }
   ctx->media_artwork_retry_mask = espcontrol::artwork::artwork_source_failed_mask(

--- a/components/espcontrol/ha_read_coordinator.h
+++ b/components/espcontrol/ha_read_coordinator.h
@@ -43,6 +43,12 @@ class HaReadCoordinator {
     for (const auto &request : deferred_) count += request.callbacks.size();
     return count;
   }
+  size_t transient_callback_capacity() const {
+    size_t capacity = deferred_.capacity();
+    for (const auto &request : deferred_) capacity += request.callbacks.capacity();
+    for (const auto &channel : subscription_channels_) capacity += channel.pending_reads.capacity();
+    return capacity;
+  }
 
   bool read_retained(const std::string &entity_id,
                      const std::string &attribute,
@@ -109,12 +115,11 @@ class HaReadCoordinator {
       dispatch_many(request.channel, std::move(request.callbacks));
       processed++;
     }
+    release_empty_deferred_storage();
   }
 
   void reset_deferred() {
-    // Keep the small high-water allocation so reentrant refreshes do not
-    // repeatedly release and regrow the same queue storage.
-    deferred_.clear();
+    std::vector<DeferredRequest>().swap(deferred_);
   }
 
   void invalidate_retained_state() {
@@ -122,9 +127,9 @@ class HaReadCoordinator {
     // particular, artwork URLs and access tokens may change while the panel is
     // offline, so reads after a reconnect must wait for a fresh announcement.
     for (auto &channel : subscription_channels_) {
-      channel.last_state.clear();
+      release_string_storage(channel.last_state);
       channel.has_last_state = false;
-      channel.cached_state.clear();
+      release_string_storage(channel.cached_state);
       channel.has_cached_state = false;
     }
   }
@@ -147,8 +152,8 @@ class HaReadCoordinator {
     if (generation_ == 0) generation_ = 1;
     reset_deferred();
     for (auto &channel : subscription_channels_) {
-      channel.pending_reads.clear();
-      channel.cached_state.clear();
+      release_callback_storage(channel.pending_reads);
+      release_string_storage(channel.cached_state);
       channel.has_cached_state = false;
     }
     reset_subscriptions(default_scope);
@@ -162,6 +167,7 @@ class HaReadCoordinator {
           std::remove_if(channel.pending_reads.begin(), channel.pending_reads.end(),
                          [owner](const CallbackRef &ref) { return ref.owner == owner; }),
           channel.pending_reads.end());
+      if (channel.pending_reads.empty()) release_callback_storage(channel.pending_reads);
     }
     if (callback_depth_ != 0) {
       // Grid rebuilds can release an old card and attach its replacement to
@@ -301,7 +307,7 @@ class HaReadCoordinator {
       }
     }
     if (callbacks.empty()) {
-      subscription.last_state.clear();
+      release_string_storage(subscription.last_state);
       subscription.has_last_state = false;
     } else {
       retain_replay_state(channel, state);
@@ -310,7 +316,7 @@ class HaReadCoordinator {
       subscription.cached_state.assign(state.c_str(), state.size());
       subscription.has_cached_state = true;
     } else {
-      subscription.cached_state.clear();
+      release_string_storage(subscription.cached_state);
       subscription.has_cached_state = false;
     }
     for (const auto &callback_ref : pending_reads) {
@@ -321,14 +327,6 @@ class HaReadCoordinator {
       // being dispatched. Skip callbacks marked by that reset, but keep the
       // currently executing std::function alive until it returns.
       if (subscription_callback_active(callback)) invoke(callback, state);
-    }
-    // Reentrant reads are deferred above, so this channel should still have an
-    // empty pending list. Reacquire it by index because a callback may have
-    // appended channels and reallocated subscription_channels_.
-    pending_reads.clear();
-    if (channel < subscription_channels_.size() &&
-        subscription_channels_[channel].pending_reads.empty()) {
-      pending_reads.swap(subscription_channels_[channel].pending_reads);
     }
   }
 
@@ -403,7 +401,7 @@ class HaReadCoordinator {
       if (retained >= MAX_REPLAY_STATES) {
         for (size_t candidate = 0; candidate < subscription_channels_.size(); candidate++) {
           if (candidate == channel || !subscription_channels_[candidate].has_last_state) continue;
-          subscription_channels_[candidate].last_state.clear();
+          release_string_storage(subscription_channels_[candidate].last_state);
           subscription_channels_[candidate].has_last_state = false;
           break;
         }
@@ -417,10 +415,23 @@ class HaReadCoordinator {
     for (size_t channel = 0; channel < subscription_channels_.size(); channel++) {
       if (channel_reuses_reads(channel)) continue;
       SubscriptionChannel &subscription = subscription_channels_[channel];
-      subscription.cached_state.clear();
-      subscription.pending_reads.clear();
+      release_string_storage(subscription.cached_state);
+      release_callback_storage(subscription.pending_reads);
       subscription.has_cached_state = false;
     }
+  }
+
+  static void release_callback_storage(std::vector<CallbackRef> &callbacks) {
+    std::vector<CallbackRef>().swap(callbacks);
+  }
+
+  static void release_string_storage(std::string &value) {
+    std::string().swap(value);
+  }
+
+  void release_empty_deferred_storage() {
+    if (!deferred_.empty() || deferred_.capacity() == 0) return;
+    std::vector<DeferredRequest>().swap(deferred_);
   }
 
   void release_subscriptions(uint32_t scope) {

--- a/tests/firmware/ha_read_coordinator_test.cpp
+++ b/tests/firmware/ha_read_coordinator_test.cpp
@@ -165,6 +165,8 @@ void reentrant_reads_on_one_channel_share_deferred_work() {
   coordinator.transport().publish(1, "inner");
   require(first == 1 && second == 1,
           "grouped same-channel reads did not fan out once");
+  require(coordinator.transient_callback_capacity() == 0,
+          "completed reentrant reads retained callback storage");
 }
 
 void resolved_deferred_channels_survive_channel_vector_growth() {
@@ -514,6 +516,8 @@ void a_full_pending_queue_rejects_new_work_without_evicting_accepted_callbacks()
   coordinator.transport().publish(0, "artwork");
   require(accepted_calls == 64 && rejected_calls == 0,
           "full queue silently evicted accepted work or delivered rejected work");
+  require(coordinator.transient_callback_capacity() == 0,
+          "delivered retained reads kept their high-water callback allocation");
 }
 
 void generation_change_discards_cached_and_pending_channel_reads() {
@@ -605,6 +609,9 @@ void stalled_reusable_channel_coalesces_reads_per_owner() {
   require(coordinator.read_retained("media_player.room", "entity_picture_local",
                           [&](std::string) { current_calls++; }, true, 10, 5, &owner),
           "replacement local artwork read should wait");
+  require(coordinator.pending_read_count() == 1 &&
+              coordinator.transient_callback_capacity() == 1,
+          "stalled artwork retries retained superseded callback storage");
   coordinator.transport().publish(0, "new");
   require(stale_calls == 0 && current_calls == 1,
           "stalled artwork retries retained superseded callbacks for one owner");
@@ -670,6 +677,9 @@ void released_owner_drops_pending_reads_even_if_its_address_is_reused() {
               "sensor.old", "", [&](std::string) { old_calls++; }, false, 10, 5, &owner),
           "old owned read should wait");
   coordinator.release_owner(&owner);
+  require(coordinator.pending_read_count() == 0 &&
+              coordinator.transient_callback_capacity() == 0,
+          "released owner retained pending callback storage");
   require(coordinator.subscribe("sensor.replacement", "", [](std::string) {}, 1u, &owner, true),
           "replacement retained subscription should register");
   require(coordinator.read_retained(


### PR DESCRIPTION
## Purpose

Fix the gradual free-heap decline seen when cover-art cards refresh across changing tracks.

Home Assistant can omit the optional local artwork attribute. Each retry was then retaining another ownerless callback in the reusable read channel, while transient callback and cached-string capacity also remained allocated after use. The cover-art pair now uses a stable card-specific owner so retries replace obsolete callbacks, and the coordinator releases transient storage after it is drained or invalidated.

## Practical impact

Repeated artwork changes no longer produce the previous downward heap stair-step. Existing artwork loading and rendering behavior is unchanged.

## Automated checks

- Firmware tests: 29/29 passed
- Home Assistant bindings: normal and self-test modes passed
- ESPHome builds passed for every device configuration during OTA validation
- Diff whitespace check passed

## Physical device testing

Flashed the development configuration and monitored live logs/free-heap sensors on:

- 4-inch S3 primary (192.168.6.105): five different artwork downloads; settled internal heap 93,851, 93,851, 93,851, 93,851, and 93,763 B (88 B range). Before the fix, comparable changes fell 90,299 -> 89,391 -> 88,987 -> 88,679 B.
- 4-inch S3 second (192.168.6.100): completed an 83 KB artwork download and resource cleanup; 93,423 B free heap.
- 7-inch P4 V1 (192.168.6.102): clean boot and smoke test; 126,348 B free heap.
- 10-inch P4 V1 (192.168.6.103): completed an artwork cycle and released a 1,135,484-byte retired image buffer; 101,640 B free heap.
- P4-86 (192.168.6.104): completed two artwork cycles with settled internal heap 177,036 and 176,976 B; 177,044 B exact sensor reading. A stored crash record belonged to the prior firmware build; the patched build booted and ran successfully.
- 4.3-inch P4 (192.168.6.101): clean boot and smoke test; 336,356 B free heap.

No new crash, reboot loop, allocation failure, or repeatable post-artwork heap decline was observed on the patched builds.

## User testing

Please leave this PR open until the cover-art card has been exercised on the preferred physical display over a longer normal-use period. The branch is ready to flash independently of main.