### PR TITLE
Prepare web assets for v2.8.3

### DIFF
--- a/docs/public/webserver/web-assets.json
+++ b/docs/public/webserver/web-assets.json
@@ -16,11 +16,11 @@
       ],
       "firmwareVersions": [
         "dev",
+        "v2.8.3",
         "v2.8.2",
         "v2.8.1",
         "v2.8.0",
-        "v2.7.1",
-        "v2.7.0"
+        "v2.7.1"
       ],
       "webAssetVersion": 1
     }

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -48,11 +48,11 @@ WEB_SOURCE_DIR = ROOT / "src" / "webserver"
 # list aligned with the GitHub Pages release catalogue in pages.yml.
 WEB_ASSET_SUPPORTED_FIRMWARE_VERSIONS = (
     "dev",
+    "v2.8.3",
     "v2.8.2",
     "v2.8.1",
     "v2.8.0",
     "v2.7.1",
-    "v2.7.0",
 )
 
 # Fixed editor controls use a few MDI glyphs that are not selectable Product


### PR DESCRIPTION
## Purpose
Adds v2.8.3 to the declared immutable web bundle compatibility list before the release tag is created.

## Practical impact
The hosted bridge will select the declared web bundle for v2.8.3 firmware. The helper retains dev and the five most recent stable releases, so v2.7.0 is removed from the list.

## Automated checks
- python3 scripts/build.py
- python3 scripts/build.py --check
- npm run check:release-preflight

All release-preflight tasks passed, including firmware tests, web tests, browser smoke checks for seven layouts, release contract checks, and the docs build.

## Physical testing
Not required for this compatibility-list-only change.