### PR TITLE
Remove Noto Sans fallback fonts

### DIFF
--- a/common/addon/connectivity.yaml
+++ b/common/addon/connectivity.yaml
@@ -132,7 +132,7 @@ script:
                             " '" + hotspot_ssid + "' " +
                             espcontrol_i18n_key("to_configure_your_network_settings");
           lv_label_set_text(id(wifi_setup_title), espcontrol_i18n("Configure your WiFi"));
-          lv_label_set_text(id(wifi_setup_instructions), msg.c_str());
+          lv_label_set_display_text(id(wifi_setup_instructions), msg.c_str());
       - lvgl.page.show: wifi_setup_page
       - script.execute:
           id: backlight_note_internal_brightness

--- a/common/assets/latin_extended_additional_glyphs.yaml
+++ b/common/assets/latin_extended_additional_glyphs.yaml
@@ -1,3 +1,0 @@
-# Latin Extended Additional letters missing from the Google Fonts Roboto file.
-# Noto Sans supplies these as fallback glyphs for names and media metadata.
-- "Ṣṣ"

--- a/common/device/screen_cover_art.yaml
+++ b/common/device/screen_cover_art.yaml
@@ -1359,10 +1359,11 @@ script:
           id: cover_art_title_label
           text: !lambda |-
             if (id(cover_art_external_input_active) && !id(cover_art_media_source).empty()) {
-              return id(cover_art_media_source);
+              return normalize_display_text(
+                decode_html_entities(id(cover_art_media_source)));
             }
             if (id(cover_art_title).empty()) return std::string("—");
-            return id(cover_art_title);
+            return normalize_display_text(id(cover_art_title));
       - if:
           condition:
             lambda: 'return id(cover_art_external_input_active) || !id(cover_art_artist).empty();'
@@ -1370,7 +1371,9 @@ script:
             - lvgl.label.update:
                 id: cover_art_artist_label
                 text: !lambda |-
-                  if (!id(cover_art_artist).empty()) return id(cover_art_artist);
+                  if (!id(cover_art_artist).empty()) {
+                    return normalize_display_text(id(cover_art_artist));
+                  }
                   return espcontrol_i18n(std::string("Source"));
             - lvgl.widget.show: cover_art_artist_label
           else:

--- a/common/device/screen_loading.yaml
+++ b/common/device/screen_loading.yaml
@@ -97,7 +97,7 @@ esphome:
                   std::string msg = std::string(espcontrol_i18n_key("connect_to")) +
                                     " '" + hotspot_ssid + "' " +
                                     espcontrol_i18n_key("to_configure_your_network_settings");
-                  lv_label_set_text(id(loading_status_label), msg.c_str());
+                  lv_label_set_display_text(id(loading_status_label), msg.c_str());
         - if:
             condition:
               lambda: |-

--- a/common/device/screen_wifi_setup.yaml
+++ b/common/device/screen_wifi_setup.yaml
@@ -77,4 +77,4 @@ script:
           std::string msg = std::string(espcontrol_i18n_key("connect_to")) +
                             " '" + hotspot_ssid + "' " +
                             espcontrol_i18n_key("to_configure_your_network_settings");
-          lv_label_set_text(id(wifi_setup_instructions), msg.c_str());
+          lv_label_set_display_text(id(wifi_setup_instructions), msg.c_str());

--- a/components/espcontrol/battery_status.h
+++ b/components/espcontrol/battery_status.h
@@ -5,6 +5,8 @@
 
 #include <cmath>
 
+#include "display_text.h"
+
 constexpr const char *BATTERY_ICON_UNKNOWN = "\U000F0091";  // Battery Unknown
 constexpr const char *BATTERY_ICON_ALERT = "\U000F0083";    // Battery Alert
 
@@ -37,5 +39,5 @@ inline const char *battery_status_icon(float pct) {
 
 inline void battery_status_set_icon(lv_obj_t *label, float pct) {
   if (!label) return;
-  lv_label_set_text(label, battery_status_icon(pct));
+  lv_label_set_display_text(label, battery_status_icon(pct));
 }

--- a/components/espcontrol/button_grid.h
+++ b/components/espcontrol/button_grid.h
@@ -34,6 +34,8 @@
 // implementation is split into focused headers below for easier review.
 #include "button_grid_limits.h"
 #include "button_grid_string.h"
+#include "display_text.h"
+
 #include "button_grid_ha.h"
 #include "button_grid_config.h"
 #include "button_grid_style.h"

--- a/components/espcontrol/button_grid_access_cards.h
+++ b/components/espcontrol/button_grid_access_cards.h
@@ -147,7 +147,7 @@ inline void transient_status_label_revert_cb(lv_timer_t *timer) {
   TransientStatusLabel *ctx = static_cast<TransientStatusLabel *>(lv_timer_get_user_data(timer));
   if (!ctx) return;
   ctx->showing_status = false;
-  if (ctx->label) lv_label_set_text(ctx->label, ctx->steady_text.c_str());
+  if (ctx->label) lv_label_set_display_text(ctx->label, ctx->steady_text.c_str());
   lv_timer_pause(timer);
 }
 
@@ -158,7 +158,7 @@ inline TransientStatusLabel *create_transient_status_label(
   TransientStatusLabel *ctx = new TransientStatusLabel();
   ctx->label = label;
   ctx->steady_text = steady_text;
-  if (ctx->label) lv_label_set_text(ctx->label, ctx->steady_text.c_str());
+  if (ctx->label) lv_label_set_display_text(ctx->label, ctx->steady_text.c_str());
   ctx->revert_timer = lv_timer_create(transient_status_label_revert_cb, stable_ms, ctx);
   if (ctx->revert_timer) lv_timer_pause(ctx->revert_timer);
   return ctx;
@@ -169,7 +169,7 @@ inline void transient_status_label_set_steady(TransientStatusLabel *ctx,
   if (!ctx) return;
   ctx->steady_text = steady_text;
   if (!ctx->showing_status && ctx->label) {
-    lv_label_set_text(ctx->label, ctx->steady_text.c_str());
+    lv_label_set_display_text(ctx->label, ctx->steady_text.c_str());
   }
 }
 
@@ -182,7 +182,7 @@ inline void transient_status_label_show_if_changed(TransientStatusLabel *ctx,
     ctx->has_status = true;
     if (!release_to_steady) {
       ctx->showing_status = true;
-      if (ctx->label) lv_label_set_text(ctx->label, status_text.c_str());
+      if (ctx->label) lv_label_set_display_text(ctx->label, status_text.c_str());
       if (ctx->revert_timer) lv_timer_pause(ctx->revert_timer);
     }
     return;
@@ -190,7 +190,7 @@ inline void transient_status_label_show_if_changed(TransientStatusLabel *ctx,
   if (ctx->last_status_text == status_text) return;
   ctx->last_status_text = status_text;
   ctx->showing_status = true;
-  if (ctx->label) lv_label_set_text(ctx->label, status_text.c_str());
+  if (ctx->label) lv_label_set_display_text(ctx->label, status_text.c_str());
   if (ctx->revert_timer) {
     if (release_to_steady) {
       lv_timer_reset(ctx->revert_timer);

--- a/components/espcontrol/button_grid_alarm.h
+++ b/components/espcontrol/button_grid_alarm.h
@@ -341,8 +341,8 @@ inline const char *alarm_card_icon(const ParsedCfg &p) {
 }
 
 inline void setup_alarm_card(BtnSlot &s, const ParsedCfg &p) {
-  lv_label_set_text(s.icon_lbl, alarm_card_icon(p));
-  lv_label_set_text(s.text_lbl, p.label.empty() ? espcontrol_i18n("Alarm") : p.label.c_str());
+  lv_label_set_display_text(s.icon_lbl, alarm_card_icon(p));
+  lv_label_set_display_text(s.text_lbl, p.label.empty() ? espcontrol_i18n("Alarm") : p.label.c_str());
 }
 
 inline bool alarm_pin_arm_required(const std::string &options) {
@@ -419,11 +419,11 @@ inline const char *alarm_action_icon(const std::string &mode) {
 }
 
 inline void setup_alarm_action_card(BtnSlot &s, const ParsedCfg &p) {
-  lv_label_set_text(s.icon_lbl, alarm_action_icon(p.sensor));
+  lv_label_set_display_text(s.icon_lbl, alarm_action_icon(p.sensor));
   if (!p.icon.empty() && p.icon != "Auto") {
-    lv_label_set_text(s.icon_lbl, find_icon(p.icon.c_str()));
+    lv_label_set_display_text(s.icon_lbl, find_icon(p.icon.c_str()));
   }
-  lv_label_set_text(s.text_lbl,
+  lv_label_set_display_text(s.text_lbl,
     p.label.empty() ? alarm_action_label(p.sensor) : p.label.c_str());
 }
 
@@ -527,7 +527,7 @@ inline bool alarm_state_releases_label(const std::string &state) {
 
 inline void alarm_apply_card_status_icon(AlarmCardCtx *ctx) {
   if (!ctx || !ctx->icon_lbl || !ctx->show_status_icon) return;
-  lv_label_set_text(ctx->icon_lbl, alarm_state_icon(ctx->state, ctx->arm_mode));
+  lv_label_set_display_text(ctx->icon_lbl, alarm_state_icon(ctx->state, ctx->arm_mode));
 }
 
 inline std::string alarm_state_control_mode(const std::string &state) {
@@ -949,7 +949,7 @@ inline void alarm_show_failure(AlarmCardCtx *ctx, const std::string &message) {
   ui.box = shell.box;
 
   lv_obj_t *label = lv_label_create(ui.box);
-  lv_label_set_text(label, message.empty() ? espcontrol_i18n("Alarm action failed") : espcontrol_i18n(message).c_str());
+  lv_label_set_display_text(label, message.empty() ? espcontrol_i18n("Alarm action failed") : espcontrol_i18n(message).c_str());
   if (ctx && ctx->label_font) lv_obj_set_style_text_font(label, ctx->label_font, LV_PART_MAIN);
   lv_obj_set_style_text_color(label, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
@@ -1073,13 +1073,13 @@ inline void alarm_control_update_modal(AlarmCardCtx *ctx) {
   alarm_control_set_hidden(ui.rail, show_arming);
   alarm_control_set_hidden(ui.arming_view, !show_arming);
   if (ui.arming_view) {
-    if (ui.arming_title) lv_label_set_text(ui.arming_title, alarm_state_label(ctx->state).c_str());
+    if (ui.arming_title) lv_label_set_display_text(ui.arming_title, alarm_state_label(ctx->state).c_str());
     int remaining = show_arming ? alarm_remaining_delay_seconds(ctx) : -1;
     if (ui.arming_countdown) {
       alarm_control_set_hidden(ui.arming_countdown, remaining < 0);
       if (remaining >= 0) {
         std::string countdown = alarm_delay_label(remaining);
-        lv_label_set_text(ui.arming_countdown, countdown.c_str());
+        lv_label_set_display_text(ui.arming_countdown, countdown.c_str());
       }
     }
     alarm_control_update_delay_progress(ui, ctx, remaining);
@@ -1106,7 +1106,7 @@ inline void alarm_control_update_modal(AlarmCardCtx *ctx) {
       std::string label = selected
         ? alarm_control_button_label_for_state(mode, ctx->state, ctx->arm_mode)
         : alarm_control_button_label(mode);
-      lv_label_set_text(ui.mode_label[i], label.c_str());
+      lv_label_set_display_text(ui.mode_label[i], label.c_str());
     }
   }
 }
@@ -1173,11 +1173,11 @@ inline void alarm_pin_update_display() {
   AlarmPinModalUi &ui = alarm_pin_modal_ui();
   if (!ui.pin_lbl) return;
   if (ui.pin.empty()) {
-    lv_label_set_text(ui.pin_lbl, espcontrol_i18n("Enter Pin"));
+    lv_label_set_display_text(ui.pin_lbl, espcontrol_i18n("Enter Pin"));
     return;
   }
   std::string masked(ui.pin.size(), '*');
-  lv_label_set_text(ui.pin_lbl, masked.c_str());
+  lv_label_set_display_text(ui.pin_lbl, masked.c_str());
 }
 
 inline void alarm_pin_submit() {
@@ -1407,7 +1407,7 @@ inline lv_obj_t *alarm_control_create_mode_button(
   lv_obj_clear_flag(content, LV_OBJ_FLAG_SCROLLABLE);
 
   lv_obj_t *icon = lv_label_create(content);
-  lv_label_set_text(icon, alarm_action_icon(mode ? std::string(mode) : ""));
+  lv_label_set_display_text(icon, alarm_action_icon(mode ? std::string(mode) : ""));
   lv_obj_set_style_text_color(icon, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_align(icon, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (icon_font) lv_obj_set_style_text_font(icon, icon_font, LV_PART_MAIN);
@@ -1416,7 +1416,7 @@ inline lv_obj_t *alarm_control_create_mode_button(
   lv_obj_align(icon, LV_ALIGN_CENTER, 0, -height / 7);
 
   lv_obj_t *label = lv_label_create(content);
-  lv_label_set_text(label, alarm_control_button_label(mode ? std::string(mode) : ""));
+  lv_label_set_display_text(label, alarm_control_button_label(mode ? std::string(mode) : ""));
   lv_obj_set_style_text_color(label, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (label_font) lv_obj_set_style_text_font(label, label_font, LV_PART_MAIN);
@@ -1457,7 +1457,7 @@ inline void alarm_control_create_arming_view(AlarmControlModalUi &ui,
   }
 
   ui.arming_title = lv_label_create(ui.arming_view);
-  lv_label_set_text(ui.arming_title, espcontrol_i18n("Arming"));
+  lv_label_set_display_text(ui.arming_title, espcontrol_i18n("Arming"));
   lv_obj_set_style_text_color(ui.arming_title, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_align(ui.arming_title, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (title_font) lv_obj_set_style_text_font(ui.arming_title, title_font, LV_PART_MAIN);
@@ -1468,7 +1468,7 @@ inline void alarm_control_create_arming_view(AlarmControlModalUi &ui,
   lv_coord_t countdown_y = status_center_y + lv_obj_get_height(ui.arming_title) / 2 + countdown_gap;
 
   ui.arming_countdown = lv_label_create(ui.arming_view);
-  lv_label_set_text(ui.arming_countdown, "");
+  lv_label_set_display_text(ui.arming_countdown, "");
   lv_obj_set_style_text_color(ui.arming_countdown, lv_color_hex(DARK_TEXT_MUTED), LV_PART_MAIN);
   lv_obj_set_style_text_align(ui.arming_countdown, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (countdown_font) lv_obj_set_style_text_font(ui.arming_countdown, countdown_font, LV_PART_MAIN);
@@ -1720,8 +1720,8 @@ inline AlarmCardCtx *create_alarm_card_context(
   BtnSlot back_slot = create_dynamic_card_slot(back_btn, icon_font, value_font, label_font, text_color);
   apply_width_compensation(back_slot.icon_lbl, width_compensation_percent);
   apply_slot_text_width_compensation(back_slot, width_compensation_percent);
-  lv_label_set_text(back_slot.icon_lbl, "\U000F0141");
-  lv_label_set_text(back_slot.text_lbl, espcontrol_i18n("Back"));
+  lv_label_set_display_text(back_slot.icon_lbl, "\U000F0141");
+  lv_label_set_display_text(back_slot.text_lbl, espcontrol_i18n("Back"));
   lv_obj_add_event_cb(back_btn, [](lv_event_t *e) {
     lv_obj_t *target = static_cast<lv_obj_t *>(lv_event_get_user_data(e));
     if (target) lv_scr_load_anim(target, LV_SCR_LOAD_ANIM_NONE, 0, 0, false);
@@ -1741,8 +1741,8 @@ inline AlarmCardCtx *create_alarm_card_context(
     BtnSlot action_slot = create_dynamic_card_slot(action_btn, icon_font, value_font, label_font, text_color);
     apply_width_compensation(action_slot.icon_lbl, width_compensation_percent);
     apply_slot_text_width_compensation(action_slot, width_compensation_percent);
-    lv_label_set_text(action_slot.icon_lbl, alarm_action_icon(mode));
-    lv_label_set_text(action_slot.text_lbl, alarm_action_label(mode));
+    lv_label_set_display_text(action_slot.icon_lbl, alarm_action_icon(mode));
+    lv_label_set_display_text(action_slot.text_lbl, alarm_action_label(mode));
     apply_push_button_transition(action_btn);
 
     AlarmActionCtx *action_ctx = new AlarmActionCtx();

--- a/components/espcontrol/button_grid_cards.h
+++ b/components/espcontrol/button_grid_cards.h
@@ -9,35 +9,35 @@ inline void clear_push_button_transition(lv_obj_t *btn);
 
 inline void setup_garage_card(BtnSlot &s, const ParsedCfg &p) {
   if (garage_command_mode(p.sensor)) {
-    lv_label_set_text(s.icon_lbl, garage_command_icon(p));
-    lv_label_set_text(s.text_lbl, garage_card_show_status(p) ? "--" : garage_card_label(p));
+    lv_label_set_display_text(s.icon_lbl, garage_command_icon(p));
+    lv_label_set_display_text(s.text_lbl, garage_card_show_status(p) ? "--" : garage_card_label(p));
     apply_push_button_transition(s.btn);
     return;
   }
-  lv_label_set_text(s.icon_lbl, garage_closed_icon(p.icon));
-  lv_label_set_text(s.text_lbl, garage_card_show_status(p) ? "--" : garage_card_label(p));
+  lv_label_set_display_text(s.icon_lbl, garage_closed_icon(p.icon));
+  lv_label_set_display_text(s.text_lbl, garage_card_show_status(p) ? "--" : garage_card_label(p));
 }
 
 inline void setup_gate_card(BtnSlot &s, const ParsedCfg &p) {
   if (gate_command_mode(p.sensor)) {
-    lv_label_set_text(s.icon_lbl, gate_command_icon(p));
-    lv_label_set_text(s.text_lbl, gate_card_show_status(p) ? "--" : gate_card_label(p));
+    lv_label_set_display_text(s.icon_lbl, gate_command_icon(p));
+    lv_label_set_display_text(s.text_lbl, gate_card_show_status(p) ? "--" : gate_card_label(p));
     apply_push_button_transition(s.btn);
     return;
   }
-  lv_label_set_text(s.icon_lbl, gate_closed_icon(p.icon));
-  lv_label_set_text(s.text_lbl, gate_card_show_status(p) ? "--" : gate_card_label(p));
+  lv_label_set_display_text(s.icon_lbl, gate_closed_icon(p.icon));
+  lv_label_set_display_text(s.text_lbl, gate_card_show_status(p) ? "--" : gate_card_label(p));
 }
 
 inline void setup_lock_card(BtnSlot &s, const ParsedCfg &p) {
   if (lock_command_mode(p.sensor)) {
-    lv_label_set_text(s.icon_lbl, lock_command_icon(p));
-    lv_label_set_text(s.text_lbl, lock_card_label(p));
+    lv_label_set_display_text(s.icon_lbl, lock_command_icon(p));
+    lv_label_set_display_text(s.text_lbl, lock_card_label(p));
     apply_push_button_transition(s.btn);
     return;
   }
-  lv_label_set_text(s.icon_lbl, lock_locked_icon(p.icon));
-  lv_label_set_text(s.text_lbl, lock_card_label(p));
+  lv_label_set_display_text(s.icon_lbl, lock_locked_icon(p.icon));
+  lv_label_set_display_text(s.text_lbl, lock_card_label(p));
 }
 
 inline const char *screen_lock_locked_icon(const ParsedCfg &p) {
@@ -68,10 +68,10 @@ inline void screen_lock_register_card(const BtnSlot &s, const ParsedCfg &p) {
 }
 
 inline void setup_screen_lock_card(BtnSlot &s, const ParsedCfg &p) {
-  lv_label_set_text(s.icon_lbl,
+  lv_label_set_display_text(s.icon_lbl,
     screen_lock_enabled() ? screen_lock_locked_icon(p) : screen_lock_unlocked_icon(p));
   std::string label = screen_lock_card_label();
-  lv_label_set_text(s.text_lbl, label.c_str());
+  lv_label_set_display_text(s.text_lbl, label.c_str());
   screen_lock_register_card(s, p);
   apply_push_button_transition(s.btn);
 }
@@ -98,9 +98,9 @@ inline void clear_push_button_transition(lv_obj_t *btn) {
 inline void setup_internal_relay_card(BtnSlot &s, const ParsedCfg &p) {
   bool push_mode = internal_relay_push_mode(p);
   std::string label = internal_relay_label(p);
-  lv_label_set_text(s.text_lbl, label.c_str());
+  lv_label_set_display_text(s.text_lbl, label.c_str());
   const char *icon_off = internal_relay_icon(p, push_mode);
-  lv_label_set_text(s.icon_lbl, icon_off);
+  lv_label_set_display_text(s.icon_lbl, icon_off);
   if (push_mode) {
     apply_push_button_transition(s.btn);
     return;
@@ -115,7 +115,7 @@ inline void setup_internal_relay_card(BtnSlot &s, const ParsedCfg &p) {
 inline void setup_toggle_visual(BtnSlot &s, const ParsedCfg &p) {
   if (!p.entity.empty()) {
     if (!p.label.empty()) {
-      lv_label_set_text(s.text_lbl, p.label.c_str());
+      lv_label_set_display_text(s.text_lbl, p.label.c_str());
     }
     const char* icon_cp = "\U000F0493";
     if (p.icon.empty() || p.icon == "Auto") {
@@ -124,26 +124,26 @@ inline void setup_toggle_visual(BtnSlot &s, const ParsedCfg &p) {
     } else {
       icon_cp = find_icon(p.icon.c_str());
     }
-    lv_label_set_text(s.icon_lbl, icon_cp);
+    lv_label_set_display_text(s.icon_lbl, icon_cp);
 
     if (!p.sensor.empty()) {
       if (!p.unit.empty()) {
         std::string unit = trim_display_unit(p.unit);
-        lv_label_set_text(s.unit_lbl, unit.c_str());
+        lv_label_set_display_text(s.unit_lbl, unit.c_str());
       }
     }
   } else {
     if (!p.label.empty()) {
-      lv_label_set_text(s.text_lbl, p.label.c_str());
+      lv_label_set_display_text(s.text_lbl, p.label.c_str());
     }
     if (!p.icon.empty() && p.icon != "Auto") {
-      lv_label_set_text(s.icon_lbl, find_icon(p.icon.c_str()));
+      lv_label_set_display_text(s.icon_lbl, find_icon(p.icon.c_str()));
     } else if (p.type == "push") {
-      lv_label_set_text(s.icon_lbl, "\U000F0741");
+      lv_label_set_display_text(s.icon_lbl, "\U000F0741");
       apply_push_button_transition(s.btn);
     }
     if (p.type == "push" && p.label.empty()) {
-      lv_label_set_text(s.text_lbl, espcontrol_i18n("Push"));
+      lv_label_set_display_text(s.text_lbl, espcontrol_i18n("Push"));
     }
   }
 }
@@ -158,27 +158,27 @@ inline void setup_action_card(BtnSlot &s, const ParsedCfg &p) {
   std::string action_label = p.label.empty()
     ? (p.entity.empty() ? espcontrol_i18n(std::string("Action")) : p.entity)
     : p.label;
-  lv_label_set_text(s.text_lbl, action_label.c_str());
+  lv_label_set_display_text(s.text_lbl, action_label.c_str());
   const char *icon_cp = (p.icon.empty() || p.icon == "Auto") ? find_icon("Flash") : find_icon(p.icon.c_str());
-  lv_label_set_text(s.icon_lbl, icon_cp);
+  lv_label_set_display_text(s.icon_lbl, icon_cp);
   if (action_card_state_icon_mode(p) || action_card_state_text_mode(p)) {
     lv_obj_clear_flag(s.icon_lbl, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_flag(s.sensor_container, LV_OBJ_FLAG_HIDDEN);
   } else if (action_card_state_numeric_mode(p)) {
     lv_obj_add_flag(s.icon_lbl, LV_OBJ_FLAG_HIDDEN);
     lv_obj_clear_flag(s.sensor_container, LV_OBJ_FLAG_HIDDEN);
-    lv_label_set_text(s.sensor_lbl, "--");
+    lv_label_set_display_text(s.sensor_lbl, "--");
     std::string unit = trim_display_unit(action_card_state_unit(p));
-    lv_label_set_text(s.unit_lbl, unit.c_str());
+    lv_label_set_display_text(s.unit_lbl, unit.c_str());
   }
   apply_push_button_transition(s.btn);
 }
 
 inline void setup_local_action_card(BtnSlot &s, const ParsedCfg &p) {
   std::string label = p.label.empty() ? (p.entity.empty() ? "Local Action" : sentence_cap_text(p.entity)) : p.label;
-  lv_label_set_text(s.text_lbl, label.c_str());
+  lv_label_set_display_text(s.text_lbl, label.c_str());
   const char *icon_cp = (p.icon.empty() || p.icon == "Auto") ? find_icon("Gesture Tap") : find_icon(p.icon.c_str());
-  lv_label_set_text(s.icon_lbl, icon_cp);
+  lv_label_set_display_text(s.icon_lbl, icon_cp);
   apply_push_button_transition(s.btn);
 }
 
@@ -234,11 +234,11 @@ inline void setup_subpage_parent_state_card(BtnSlot &s, const ParsedCfg &p,
   lv_obj_add_flag(s.icon_lbl, LV_OBJ_FLAG_HIDDEN);
   lv_obj_clear_flag(s.sensor_container, LV_OBJ_FLAG_HIDDEN);
   if (value_font) lv_obj_set_style_text_font(s.sensor_lbl, value_font, LV_PART_MAIN);
-  lv_label_set_text(s.sensor_lbl, "--");
+  lv_label_set_display_text(s.sensor_lbl, "--");
   std::string unit = trim_display_unit(p.unit);
-  lv_label_set_text(s.unit_lbl, unit.c_str());
+  lv_label_set_display_text(s.unit_lbl, unit.c_str());
   std::string subpage_label = p.label.empty() ? espcontrol_i18n(std::string("Subpage")) : p.label;
-  lv_label_set_text(s.text_lbl, subpage_label.c_str());
+  lv_label_set_display_text(s.text_lbl, subpage_label.c_str());
   set_subpage_chevron_visible(
     s, subpage_chevron_enabled, subpage_chevron_x, subpage_chevron_y,
     subpage_chevron_text_width_percent);

--- a/components/espcontrol/button_grid_climate.h
+++ b/components/espcontrol/button_grid_climate.h
@@ -1083,7 +1083,7 @@ inline void climate_update_card(ClimateControlCtx *ctx) {
     if (show_icon) {
       if (ctx->icon_font)
         lv_obj_set_style_text_font(ctx->icon_lbl, ctx->icon_font, LV_PART_MAIN);
-      lv_label_set_text(ctx->icon_lbl,
+      lv_label_set_display_text(ctx->icon_lbl,
         climate_temperature_controls_enabled(ctx) ? ctx->icon_on_glyph : ctx->icon_off_glyph);
       climate_layout_card_icon(ctx->icon_lbl);
       lv_obj_clear_flag(ctx->icon_lbl, LV_OBJ_FLAG_HIDDEN);
@@ -1098,10 +1098,10 @@ inline void climate_update_card(ClimateControlCtx *ctx) {
       climate_layout_card_sensor(ctx->sensor_container);
     }
   }
-  if (!show_icon && ctx->value_lbl) lv_label_set_text(ctx->value_lbl, value.c_str());
-  if (!show_icon && ctx->unit_lbl) lv_label_set_text(ctx->unit_lbl, (value.empty() || value == "--") ? "" : display_temperature_unit_symbol());
+  if (!show_icon && ctx->value_lbl) lv_label_set_display_text(ctx->value_lbl, value.c_str());
+  if (!show_icon && ctx->unit_lbl) lv_label_set_display_text(ctx->unit_lbl, (value.empty() || value == "--") ? "" : display_temperature_unit_symbol());
   if (ctx->label_lbl) {
-    lv_label_set_text(ctx->label_lbl, climate_card_label(ctx).c_str());
+    lv_label_set_display_text(ctx->label_lbl, climate_card_label(ctx).c_str());
     climate_layout_card_label(ctx->label_lbl);
   }
   if (ctx->btn) {
@@ -1185,15 +1185,15 @@ inline void climate_update_drag_preview(ClimateControlCtx *ctx) {
   if (climate_dual_target(ctx)) {
     if (ctx->edit_high) {
       if (ui.high_target_lbl && ctx->has_high)
-        lv_label_set_text(ui.high_target_lbl, climate_format_tenths(
+        lv_label_set_display_text(ui.high_target_lbl, climate_format_tenths(
           climate_display_high_target(ctx), climate_target_display_precision(ctx)).c_str());
     } else {
       if (ui.low_target_lbl && ctx->has_low)
-        lv_label_set_text(ui.low_target_lbl, climate_format_tenths(
+        lv_label_set_display_text(ui.low_target_lbl, climate_format_tenths(
           climate_display_low_target(ctx), climate_target_display_precision(ctx)).c_str());
     }
   } else if (ui.target_lbl) {
-    lv_label_set_text(ui.target_lbl, climate_format_tenths(
+    lv_label_set_display_text(ui.target_lbl, climate_format_tenths(
       target, climate_target_display_precision(ctx)).c_str());
   }
   if (ui.panel && !climate_dual_target(ctx))
@@ -1295,7 +1295,7 @@ inline void climate_update_chip(lv_obj_t *chip, const char *title, const std::st
   if (!label) return;
   std::string text = espcontrol_i18n(title);
   if (show_value) text += " " + (value.empty() ? espcontrol_i18n(std::string("None")) : climate_option_label(value));
-  lv_label_set_text(label, text.c_str());
+  lv_label_set_display_text(label, text.c_str());
 }
 
 inline void climate_update_option_chip(lv_obj_t *chip, const char *title,
@@ -1310,10 +1310,10 @@ inline void climate_update_option_chip(lv_obj_t *chip, const char *title,
   if (!text_col) return;
   lv_obj_t *title_lbl = lv_obj_get_child(text_col, 0);
   lv_obj_t *value_lbl = lv_obj_get_child(text_col, 1);
-  if (title_lbl) lv_label_set_text(title_lbl, espcontrol_i18n(title));
+  if (title_lbl) lv_label_set_display_text(title_lbl, espcontrol_i18n(title));
   if (value_lbl) {
     std::string text = value.empty() ? espcontrol_i18n(std::string("None")) : climate_option_label(value);
-    lv_label_set_text(value_lbl, text.c_str());
+    lv_label_set_display_text(value_lbl, text.c_str());
   }
 }
 
@@ -1434,7 +1434,7 @@ inline lv_obj_t *climate_create_option_chip(lv_obj_t *parent, const char *icon,
 
   lv_obj_t *icon_lbl = lv_label_create(btn);
   lv_obj_add_flag(icon_lbl, LV_OBJ_FLAG_SCROLL_CHAIN_HOR);
-  lv_label_set_text(icon_lbl, icon);
+  lv_label_set_display_text(icon_lbl, icon);
   lv_obj_set_style_text_color(icon_lbl, lv_color_hex(DARK_TEXT_SOFT), LV_PART_MAIN);
   lv_obj_set_style_text_align(icon_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (icon_font) lv_obj_set_style_text_font(icon_lbl, icon_font, LV_PART_MAIN);
@@ -1457,7 +1457,7 @@ inline lv_obj_t *climate_create_option_chip(lv_obj_t *parent, const char *icon,
   lv_obj_t *title_lbl = lv_label_create(text_col);
   lv_obj_add_flag(title_lbl, LV_OBJ_FLAG_SCROLL_CHAIN_HOR);
   lv_obj_set_width(title_lbl, lv_pct(100));
-  lv_label_set_text(title_lbl, espcontrol_i18n(title));
+  lv_label_set_display_text(title_lbl, espcontrol_i18n(title));
   lv_label_set_long_mode(title_lbl, LV_LABEL_LONG_CLIP);
   lv_obj_set_style_text_color(title_lbl, lv_color_hex(DARK_TEXT_MUTED), LV_PART_MAIN);
   lv_obj_set_style_text_align(title_lbl, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN);
@@ -1466,7 +1466,7 @@ inline lv_obj_t *climate_create_option_chip(lv_obj_t *parent, const char *icon,
   lv_obj_t *value_lbl = lv_label_create(text_col);
   lv_obj_add_flag(value_lbl, LV_OBJ_FLAG_SCROLL_CHAIN_HOR);
   lv_obj_set_width(value_lbl, lv_pct(100));
-  lv_label_set_text(value_lbl, espcontrol_i18n("None"));
+  lv_label_set_display_text(value_lbl, espcontrol_i18n("None"));
   lv_label_set_long_mode(value_lbl, LV_LABEL_LONG_CLIP);
   lv_obj_set_style_text_color(value_lbl, lv_color_hex(DARK_TEXT_SOFT), LV_PART_MAIN);
   lv_obj_set_style_text_align(value_lbl, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN);
@@ -1598,7 +1598,7 @@ inline lv_obj_t *climate_control_create_tab_button(lv_obj_t *parent, const char 
   lv_obj_clear_flag(btn, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_t *label = lv_label_create(btn);
   if (label) {
-    lv_label_set_text(label, icon);
+    lv_label_set_display_text(label, icon);
     lv_obj_set_style_text_color(label, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
     lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
     if (font) lv_obj_set_style_text_font(label, font, LV_PART_MAIN);
@@ -1728,7 +1728,7 @@ inline void climate_open_inline_option_list(ClimateControlCtx *ctx, const std::s
       }
 
       lv_obj_t *icon_lbl = lv_label_create(content_parent);
-      lv_label_set_text(icon_lbl, climate_option_icon(section_kind, option));
+      lv_label_set_display_text(icon_lbl, climate_option_icon(section_kind, option));
       lv_obj_set_style_text_color(icon_lbl, lv_color_hex(text_color), LV_PART_MAIN);
       lv_obj_set_style_text_align(icon_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
       if (compact_portrait_layout && ctx->card_icon_font) {
@@ -1740,7 +1740,7 @@ inline void climate_open_inline_option_list(ClimateControlCtx *ctx, const std::s
         icon_lbl, CLIMATE_MODAL_COMPACT_PORTRAIT_OPTION_ICON_ZOOM, LV_PART_MAIN);
 
       lv_obj_t *label = lv_label_create(content_parent);
-      lv_label_set_text(label, climate_option_label(option).c_str());
+      lv_label_set_display_text(label, climate_option_label(option).c_str());
       lv_label_set_long_mode(label, compact_portrait_layout ? LV_LABEL_LONG_CLIP : LV_LABEL_LONG_WRAP);
       lv_obj_set_width(label, compact_portrait_layout ? LV_SIZE_CONTENT : lv_pct(100));
       lv_obj_set_style_text_color(label, lv_color_hex(text_color), LV_PART_MAIN);
@@ -1861,7 +1861,7 @@ inline void climate_open_option_menu(ClimateControlCtx *ctx, const std::string &
     lv_obj_set_style_pad_left(btn, 12, LV_PART_MAIN);
     lv_obj_set_style_pad_right(btn, 12, LV_PART_MAIN);
     lv_obj_t *label = lv_label_create(btn);
-    lv_label_set_text(label, climate_option_label(option).c_str());
+    lv_label_set_display_text(label, climate_option_label(option).c_str());
     lv_label_set_long_mode(label, LV_LABEL_LONG_CLIP);
     lv_obj_set_style_text_color(label, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
     lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN);
@@ -1917,8 +1917,8 @@ inline void climate_control_set_modal_value(ClimateControlCtx *ctx) {
   if (ui.target_lbl) {
     climate_set_obj_visible(ui.target_lbl, !dual);
     if (!ctx->available || !climate_selected_target_available(ctx))
-      lv_label_set_text(ui.target_lbl, "--");
-    else lv_label_set_text(ui.target_lbl, climate_format_tenths(
+      lv_label_set_display_text(ui.target_lbl, "--");
+    else lv_label_set_display_text(ui.target_lbl, climate_format_tenths(
       target, climate_target_display_precision(ctx)).c_str());
     lv_obj_clear_flag(ui.target_lbl, LV_OBJ_FLAG_CLICKABLE);
   }
@@ -1926,7 +1926,7 @@ inline void climate_control_set_modal_value(ClimateControlCtx *ctx) {
   climate_set_obj_visible(ui.target_separator_lbl, dual);
   climate_set_obj_visible(ui.high_target_lbl, dual);
   if (ui.low_target_lbl) {
-    lv_label_set_text(ui.low_target_lbl, ctx->has_low
+    lv_label_set_display_text(ui.low_target_lbl, ctx->has_low
       ? climate_format_tenths(climate_display_low_target(ctx),
           climate_target_display_precision(ctx)).c_str()
       : "--");
@@ -1935,7 +1935,7 @@ inline void climate_control_set_modal_value(ClimateControlCtx *ctx) {
     lv_obj_set_style_text_opa(ui.low_target_lbl, LV_OPA_COVER, LV_PART_MAIN);
   }
   if (ui.high_target_lbl) {
-    lv_label_set_text(ui.high_target_lbl, ctx->has_high
+    lv_label_set_display_text(ui.high_target_lbl, ctx->has_high
       ? climate_format_tenths(climate_display_high_target(ctx),
           climate_target_display_precision(ctx)).c_str()
       : "--");
@@ -1944,11 +1944,11 @@ inline void climate_control_set_modal_value(ClimateControlCtx *ctx) {
     lv_obj_set_style_text_opa(ui.high_target_lbl, LV_OPA_COVER, LV_PART_MAIN);
   }
   if (ui.unit_lbl) {
-    lv_label_set_text(ui.unit_lbl, show_dial ? display_temperature_unit_symbol() : "");
+    lv_label_set_display_text(ui.unit_lbl, show_dial ? display_temperature_unit_symbol() : "");
     climate_set_obj_visible(ui.unit_lbl, show_dial);
   }
   if (ui.status_lbl) {
-    lv_label_set_text(ui.status_lbl, climate_action_label(ctx).c_str());
+    lv_label_set_display_text(ui.status_lbl, climate_action_label(ctx).c_str());
   }
   climate_update_target_chip(ui.target_chip, ctx, false);
   climate_update_option_chip(ui.mode_chip, "Mode", ctx->hvac_mode, false);
@@ -2383,7 +2383,7 @@ inline void climate_control_open_modal(ClimateControlCtx *ctx) {
   ui.low_target_lbl = create_range_target_label();
 
   ui.target_separator_lbl = lv_label_create(ui.target_row);
-  lv_label_set_text(ui.target_separator_lbl, "-");
+  lv_label_set_display_text(ui.target_separator_lbl, "-");
   lv_obj_set_style_text_color(ui.target_separator_lbl,
                               lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_align(ui.target_separator_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
@@ -2447,7 +2447,7 @@ inline void climate_control_open_modal(ClimateControlCtx *ctx) {
     lv_obj_clear_flag(btn, LV_OBJ_FLAG_SCROLLABLE);
     control_modal_apply_pressed_fill(btn);
     lv_obj_t *label = lv_label_create(btn);
-    lv_label_set_text(label, icon);
+    lv_label_set_display_text(label, icon);
     lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
     const lv_font_t *toggle_icon_font = ctx->card_icon_font
       ? ctx->card_icon_font : ctx->icon_font;
@@ -2543,7 +2543,7 @@ inline void setup_climate_control_button(lv_obj_t *btn, lv_obj_t *icon_lbl,
   if (icon_lbl) {
     if (show_icon && icon_font)
       lv_obj_set_style_text_font(icon_lbl, icon_font, LV_PART_MAIN);
-    lv_label_set_text(icon_lbl, (p.icon.empty() || p.icon == "Auto") ? find_icon("Thermostat") : find_icon(p.icon.c_str()));
+    lv_label_set_display_text(icon_lbl, (p.icon.empty() || p.icon == "Auto") ? find_icon("Thermostat") : find_icon(p.icon.c_str()));
     if (show_icon) {
       climate_layout_card_icon(icon_lbl);
       lv_obj_clear_flag(icon_lbl, LV_OBJ_FLAG_HIDDEN);
@@ -2556,10 +2556,10 @@ inline void setup_climate_control_button(lv_obj_t *btn, lv_obj_t *icon_lbl,
     else lv_obj_clear_flag(sensor_container, LV_OBJ_FLAG_HIDDEN);
     climate_layout_card_sensor(sensor_container);
   }
-  if (sensor_lbl) lv_label_set_text(sensor_lbl, "--");
-  if (unit_lbl) lv_label_set_text(unit_lbl, "");
+  if (sensor_lbl) lv_label_set_display_text(sensor_lbl, "--");
+  if (unit_lbl) lv_label_set_display_text(unit_lbl, "");
   if (text_lbl) {
-    lv_label_set_text(text_lbl, p.label.empty() ? espcontrol_i18n("Climate") : p.label.c_str());
+    lv_label_set_display_text(text_lbl, p.label.empty() ? espcontrol_i18n("Climate") : p.label.c_str());
     climate_layout_card_label(text_lbl);
   }
   apply_push_button_transition(btn);

--- a/components/espcontrol/button_grid_config_parser.h
+++ b/components/espcontrol/button_grid_config_parser.h
@@ -1799,7 +1799,7 @@ inline std::string sensor_state_display_text(const ParsedCfg &p,
 }
 
 inline void lv_label_set_text_limited(lv_obj_t *label, esphome::StringRef value, size_t max_len) {
-  std::string text = string_ref_limited(value, max_len);
+  std::string text = normalize_display_text(string_ref_limited(value, max_len));
   lv_label_set_text(label, text.c_str());
 }
 

--- a/components/espcontrol/button_grid_confirm.h
+++ b/components/espcontrol/button_grid_confirm.h
@@ -106,7 +106,7 @@ inline void switch_confirmation_open_modal(const ParsedCfg &p, lv_obj_t *btn_obj
 
   ui.message_lbl = lv_label_create(ui.panel);
   std::string message = switch_confirmation_message(p);
-  lv_label_set_text(ui.message_lbl, message.c_str());
+  lv_label_set_display_text(ui.message_lbl, message.c_str());
   lv_label_set_long_mode(ui.message_lbl, LV_LABEL_LONG_WRAP);
   lv_obj_set_width(ui.message_lbl, content_w);
   lv_obj_set_style_text_color(ui.message_lbl, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);

--- a/components/espcontrol/button_grid_date_time_driver.h
+++ b/components/espcontrol/button_grid_date_time_driver.h
@@ -29,11 +29,11 @@ inline bool date_time_driver_setup_visual(
   lv_obj_clear_flag(slot.sensor_container, LV_OBJ_FLAG_HIDDEN);
   const bool calendar =
     context.runtime.type == card_runtime::CardTypeId::CALENDAR;
-  lv_label_set_text(slot.sensor_lbl, calendar ? "--" : "--:--");
-  lv_label_set_text(slot.unit_lbl, "");
+  lv_label_set_display_text(slot.sensor_lbl, calendar ? "--" : "--:--");
+  lv_label_set_display_text(slot.unit_lbl, "");
 
   if (calendar) {
-    lv_label_set_text(slot.text_lbl, espcontrol_i18n("Date"));
+    lv_label_set_display_text(slot.text_lbl, espcontrol_i18n("Date"));
     register_calendar_card(
       slot.sensor_lbl, slot.unit_lbl, slot.text_lbl,
       calendar_card_shows_time(config));
@@ -41,12 +41,12 @@ inline bool date_time_driver_setup_visual(
     const std::string label = config.label.empty()
       ? timezone_city_label(config.entity)
       : config.label;
-    lv_label_set_text(slot.text_lbl, label.c_str());
+    lv_label_set_display_text(slot.text_lbl, label.c_str());
     register_timezone_card(
       slot.sensor_lbl, slot.unit_lbl, slot.text_lbl,
       config.entity, config.label);
   } else {
-    lv_label_set_text(slot.text_lbl, "");
+    lv_label_set_display_text(slot.text_lbl, "");
     register_timezone_card(
       slot.sensor_lbl, slot.unit_lbl, slot.text_lbl,
       config.entity, "", false);

--- a/components/espcontrol/button_grid_datetime_cards.h
+++ b/components/espcontrol/button_grid_datetime_cards.h
@@ -117,9 +117,9 @@ inline void apply_calendar_card_text(const CalendarCardRef &ref,
     value_text = value_buf;
     label_text = calendar_month_name(state.month);
   }
-  if (ref.value_lbl) lv_label_set_text(ref.value_lbl, value_text);
-  if (ref.unit_lbl) lv_label_set_text(ref.unit_lbl, unit_text);
-  if (ref.label_lbl) lv_label_set_text(ref.label_lbl, label_text);
+  if (ref.value_lbl) lv_label_set_display_text(ref.value_lbl, value_text);
+  if (ref.unit_lbl) lv_label_set_display_text(ref.unit_lbl, unit_text);
+  if (ref.label_lbl) lv_label_set_display_text(ref.label_lbl, label_text);
 }
 
 inline void refresh_calendar_cards() {
@@ -310,9 +310,9 @@ inline void apply_timezone_card_text(const TimezoneCardRef &ref,
     }
   }
 
-  if (ref.value_lbl) lv_label_set_text(ref.value_lbl, value_text);
-  if (ref.unit_lbl) lv_label_set_text(ref.unit_lbl, unit_text);
-  if (ref.label_lbl) lv_label_set_text(ref.label_lbl, label.c_str());
+  if (ref.value_lbl) lv_label_set_display_text(ref.value_lbl, value_text);
+  if (ref.unit_lbl) lv_label_set_display_text(ref.unit_lbl, unit_text);
+  if (ref.label_lbl) lv_label_set_display_text(ref.label_lbl, label.c_str());
 }
 
 inline bool timezone_card_ref_ready(const TimezoneCardRef &ref) {

--- a/components/espcontrol/button_grid_fan.h
+++ b/components/espcontrol/button_grid_fan.h
@@ -317,14 +317,14 @@ inline std::string fan_card_label(const ParsedCfg &p) {
 }
 
 inline void setup_fan_card(BtnSlot &s, const ParsedCfg &p) {
-  lv_label_set_text(s.icon_lbl, find_icon(fan_card_icon_name(p)));
-  lv_label_set_text(s.text_lbl, fan_card_label(p).c_str());
+  lv_label_set_display_text(s.icon_lbl, find_icon(fan_card_icon_name(p)));
+  lv_label_set_display_text(s.text_lbl, fan_card_label(p).c_str());
   if (p.type != "fan_switch") apply_push_button_transition(s.btn);
 }
 
 inline void setup_fan_control_card(BtnSlot &s, const ParsedCfg &p) {
-  lv_label_set_text(s.icon_lbl, find_icon(fan_card_icon_name(p)));
-  lv_label_set_text(s.text_lbl, fan_card_label(p).c_str());
+  lv_label_set_display_text(s.icon_lbl, find_icon(fan_card_icon_name(p)));
+  lv_label_set_display_text(s.text_lbl, fan_card_label(p).c_str());
   apply_push_button_transition(s.btn);
 }
 
@@ -447,9 +447,9 @@ inline void fan_apply_card_visual(FanCardCtx *ctx) {
 
   if (ctx->icon_lbl) {
     if ((ctx->type == "fan_switch" || ctx->type == "fan_control") && active && ctx->icon_on_glyph) {
-      lv_label_set_text(ctx->icon_lbl, ctx->icon_on_glyph);
+      lv_label_set_display_text(ctx->icon_lbl, ctx->icon_on_glyph);
     } else if (ctx->icon_off_glyph) {
-      lv_label_set_text(ctx->icon_lbl, ctx->icon_off_glyph);
+      lv_label_set_display_text(ctx->icon_lbl, ctx->icon_off_glyph);
     }
   }
 }
@@ -571,7 +571,7 @@ inline lv_obj_t *fan_control_create_tab_button(lv_obj_t *parent, const char *ico
   lv_obj_clear_flag(btn, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_t *label = lv_label_create(btn);
   if (label) {
-    lv_label_set_text(label, icon);
+    lv_label_set_display_text(label, icon);
     lv_obj_set_style_text_color(label, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
     lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
     if (font) lv_obj_set_style_text_font(label, font, LV_PART_MAIN);
@@ -603,7 +603,7 @@ inline lv_obj_t *fan_control_create_icon_button(lv_obj_t *parent, const char *ic
   lv_obj_clear_flag(btn, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_t *label = lv_label_create(btn);
   if (label) {
-    lv_label_set_text(label, icon);
+    lv_label_set_display_text(label, icon);
     lv_obj_set_style_text_color(label, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
     lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
     if (font) lv_obj_set_style_text_font(label, font, LV_PART_MAIN);
@@ -675,7 +675,7 @@ inline void fan_control_set_speed_value(FanCardCtx *ctx, int pct) {
   if (ui.speed_value_lbl) {
     char buf[8];
     snprintf(buf, sizeof(buf), "%d%%", pct);
-    lv_label_set_text(ui.speed_value_lbl, buf);
+    lv_label_set_display_text(ui.speed_value_lbl, buf);
   }
 }
 
@@ -960,7 +960,7 @@ inline void fan_control_rebuild_preset_list(FanCardCtx *ctx) {
   }
   if (count == 0) {
     lv_obj_t *empty = lv_label_create(ui.preset_list);
-    lv_label_set_text(empty, espcontrol_i18n("No presets"));
+    lv_label_set_display_text(empty, espcontrol_i18n("No presets"));
     lv_label_set_long_mode(empty, LV_LABEL_LONG_WRAP);
     lv_obj_set_width(empty, lv_pct(100));
     lv_obj_set_style_text_color(empty, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
@@ -1070,7 +1070,7 @@ inline void fan_control_open_modal(FanCardCtx *ctx) {
     if (ui.speed_value_lbl) {
       char buf[8];
       snprintf(buf, sizeof(buf), "%d%%", pct);
-      lv_label_set_text(ui.speed_value_lbl, buf);
+      lv_label_set_display_text(ui.speed_value_lbl, buf);
     }
     fan_control_refresh_card(ui.active);
   }, LV_EVENT_VALUE_CHANGED, nullptr);
@@ -1176,7 +1176,7 @@ inline void fan_preset_open(FanCardCtx *ctx) {
 
   if (count == 0) {
     ui.empty_lbl = lv_label_create(ui.list);
-    lv_label_set_text(ui.empty_lbl, espcontrol_i18n("No presets"));
+    lv_label_set_display_text(ui.empty_lbl, espcontrol_i18n("No presets"));
     lv_label_set_long_mode(ui.empty_lbl, LV_LABEL_LONG_WRAP);
     lv_obj_set_width(ui.empty_lbl, lv_pct(100));
     lv_obj_set_style_text_color(ui.empty_lbl, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -311,10 +311,10 @@ inline void reset_card_slot_dynamic_children(BtnSlot &s) {
 inline void clear_unsupported_card_slot_visuals(BtnSlot &s) {
   // Slot widgets persist across dashboard reloads. An unsupported replacement
   // must not keep showing the icon, label, or value from the previous card.
-  if (s.icon_lbl) lv_label_set_text(s.icon_lbl, "");
-  if (s.text_lbl) lv_label_set_text(s.text_lbl, "");
-  if (s.sensor_lbl) lv_label_set_text(s.sensor_lbl, "");
-  if (s.unit_lbl) lv_label_set_text(s.unit_lbl, "");
+  if (s.icon_lbl) lv_label_set_display_text(s.icon_lbl, "");
+  if (s.text_lbl) lv_label_set_display_text(s.text_lbl, "");
+  if (s.sensor_lbl) lv_label_set_display_text(s.sensor_lbl, "");
+  if (s.unit_lbl) lv_label_set_display_text(s.unit_lbl, "");
 }
 
 inline bool info_only_hidden_card_type(const espcontrol::cards::Context &context) {
@@ -757,7 +757,7 @@ inline void refresh_media_card_layout(BtnSlot &s, const ParsedCfg &p,
     if (!ctx) return;
     if (s.icon_lbl) lv_obj_add_flag(s.icon_lbl, LV_OBJ_FLAG_HIDDEN);
     if (s.text_lbl) {
-      lv_label_set_text(s.text_lbl, "");
+      lv_label_set_display_text(s.text_lbl, "");
       lv_obj_add_flag(s.text_lbl, LV_OBJ_FLAG_HIDDEN);
     }
     if (ctx->title_lbl && ctx->artist_lbl) {
@@ -1177,7 +1177,7 @@ inline bool grid_refresh_subpage_layouts(
     lv_obj_set_grid_dsc_array(entry->screen, subpage_cols, subpage_rows);
     const std::string back_label = get_subpage_back_label(order);
     if (entry->back_slot.text_lbl != nullptr) {
-      lv_label_set_text(entry->back_slot.text_lbl, back_label.c_str());
+      lv_label_set_display_text(entry->back_slot.text_lbl, back_label.c_str());
     }
     set_grid_card_cell(
       entry->back_button, entry->screen,
@@ -2027,8 +2027,8 @@ inline void grid_phase2(
       cfg.subpage_chevron_font);
     display_apply_main_width(back_slot.icon_lbl, display);
     display_apply_slot_text_width(back_slot, display);
-    lv_label_set_text(back_slot.icon_lbl, "\U000F0141");
-    lv_label_set_text(back_slot.text_lbl, sp_back_label.c_str());
+    lv_label_set_display_text(back_slot.icon_lbl, "\U000F0141");
+    lv_label_set_display_text(back_slot.text_lbl, sp_back_label.c_str());
     apply_card_label_line_clamp(back_slot.text_lbl, cfg, sp_ord.back_row_span);
     configure_button_label_wrap(back_slot.text_lbl);
 

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -453,9 +453,9 @@ inline void image_card_set_loading_state(lv_obj_t *loading_widget, const char *t
   lv_obj_t *btn = lv_obj_get_parent(loading_widget);
   image_card_position_widget(btn, loading_widget, nullptr, nullptr);
   lv_obj_t *icon = image_card_loading_icon(loading_widget);
-  if (icon) lv_label_set_text(icon, IMAGE_CARD_LOADING_ICON);
+  if (icon) lv_label_set_display_text(icon, IMAGE_CARD_LOADING_ICON);
   lv_obj_t *label = image_card_loading_label(loading_widget);
-  if (label) lv_label_set_text(label, espcontrol_i18n(text));
+  if (label) lv_label_set_display_text(label, espcontrol_i18n(text));
   image_card_refresh_loading_layout(loading_widget);
   lv_obj_clear_flag(loading_widget, LV_OBJ_FLAG_HIDDEN);
   lv_obj_move_foreground(loading_widget);
@@ -574,8 +574,8 @@ inline void image_card_show_modal_loading(ImageCardCtx *ctx, const char *text) {
   if (lv_obj_get_child_cnt(ui.loading_widget) >= 2) {
     lv_obj_t *icon = lv_obj_get_child(ui.loading_widget, 0);
     lv_obj_t *label = lv_obj_get_child(ui.loading_widget, 1);
-    lv_label_set_text(icon, IMAGE_CARD_LOADING_ICON);
-    lv_label_set_text(label, espcontrol_i18n(text));
+    lv_label_set_display_text(icon, IMAGE_CARD_LOADING_ICON);
+    lv_label_set_display_text(label, espcontrol_i18n(text));
   }
   lv_obj_clear_flag(ui.loading_widget, LV_OBJ_FLAG_HIDDEN);
   lv_obj_move_foreground(ui.loading_widget);
@@ -1181,14 +1181,14 @@ inline void setup_image_card(BtnSlot &s) {
   image_card_apply_loading_fonts(loading, loading_icon_font, loading_label_font);
   lv_obj_set_style_text_color(loading_icon, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_opa(loading_icon, LV_OPA_COVER, LV_PART_MAIN);
-  lv_label_set_text(loading_icon, IMAGE_CARD_LOADING_ICON);
+  lv_label_set_display_text(loading_icon, IMAGE_CARD_LOADING_ICON);
 
   lv_obj_t *loading_label = lv_label_create(loading);
   image_card_apply_loading_fonts(loading, loading_icon_font, loading_label_font);
   lv_obj_set_style_text_color(loading_label, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_opa(loading_label, LV_OPA_COVER, LV_PART_MAIN);
   lv_obj_set_style_text_align(loading_label, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN);
-  lv_label_set_text(loading_label, espcontrol_i18n("Loading"));
+  lv_label_set_display_text(loading_label, espcontrol_i18n("Loading"));
 
   lv_obj_set_user_data(img, loading);
   lv_obj_set_user_data(loading, s.text_lbl);
@@ -1300,11 +1300,11 @@ inline void image_card_set_label_text(lv_obj_t *label, lv_obj_t *btn,
   if (!label) return;
   const char *safe_text = text ? text : "";
   lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
-  lv_label_set_text(label, safe_text);
+  lv_label_set_display_text(label, safe_text);
   lv_obj_t *shadow = image_card_label_shadow(label, btn);
   if (shadow) {
     lv_label_set_long_mode(shadow, LV_LABEL_LONG_WRAP);
-    lv_label_set_text(shadow, safe_text);
+    lv_label_set_display_text(shadow, safe_text);
   }
   image_card_align_label_stack(label, btn, icon);
 }
@@ -1361,7 +1361,7 @@ inline void image_card_configure_icon(BtnSlot &s, const ParsedCfg &p) {
     lv_obj_add_flag(s.icon_lbl, LV_OBJ_FLAG_HIDDEN);
     return;
   }
-  lv_label_set_text(s.icon_lbl, find_icon(
+  lv_label_set_display_text(s.icon_lbl, find_icon(
     p.icon.empty() || p.icon == "Auto" ? "Camera" : p.icon.c_str()));
   lv_obj_clear_flag(s.icon_lbl, LV_OBJ_FLAG_HIDDEN);
   image_card_align_icon(s.icon_lbl, s.btn);
@@ -1996,7 +1996,7 @@ inline void image_card_open_modal(ImageCardCtx *ctx) {
   if (ctx->icon_font) lv_obj_set_style_text_font(loading_icon, ctx->icon_font, LV_PART_MAIN);
   lv_obj_set_style_text_color(loading_icon, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_opa(loading_icon, LV_OPA_COVER, LV_PART_MAIN);
-  lv_label_set_text(loading_icon, IMAGE_CARD_LOADING_ICON);
+  lv_label_set_display_text(loading_icon, IMAGE_CARD_LOADING_ICON);
 
   lv_obj_t *loading_label = lv_label_create(ui.loading_widget);
   if (!loading_label) {
@@ -2008,7 +2008,7 @@ inline void image_card_open_modal(ImageCardCtx *ctx) {
   lv_obj_set_style_text_opa(loading_label, LV_OPA_COVER, LV_PART_MAIN);
   lv_obj_set_style_text_align(loading_label, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN);
   lv_label_set_long_mode(loading_label, LV_LABEL_LONG_DOT);
-  lv_label_set_text(loading_label, espcontrol_i18n("Loading"));
+  lv_label_set_display_text(loading_label, espcontrol_i18n("Loading"));
 
   ImageCardModalCache &modal_cache = image_card_modal_cache();
   if (image_card_modal_cache_matches(ctx)) {

--- a/components/espcontrol/button_grid_lawn_mower.h
+++ b/components/espcontrol/button_grid_lawn_mower.h
@@ -72,8 +72,8 @@ inline void setup_lawn_mower_card(BtnSlot &s, const ParsedCfg &p) {
   std::string label = p.label.empty()
     ? espcontrol_i18n(std::string(lawn_mower_card_mode_label(p.sensor)))
     : p.label;
-  lv_label_set_text(s.text_lbl, label.c_str());
-  lv_label_set_text(s.icon_lbl, lawn_mower_card_icon(p));
+  lv_label_set_display_text(s.text_lbl, label.c_str());
+  lv_label_set_display_text(s.icon_lbl, lawn_mower_card_icon(p));
   if (lawn_mower_card_read_only(p)) {
     lv_obj_clear_flag(s.icon_lbl, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_flag(s.sensor_container, LV_OBJ_FLAG_HIDDEN);
@@ -104,7 +104,7 @@ inline void apply_lawn_mower_card_state(LawnMowerCardCtx *ctx,
   if (!ctx) return;
   ctx->state = unavailable ? "unavailable" : std::string(state.c_str(), state.size());
   if (ctx->icon_lbl) {
-    lv_label_set_text(ctx->icon_lbl, find_icon(lawn_mower_state_icon_name(ctx->state)));
+    lv_label_set_display_text(ctx->icon_lbl, find_icon(lawn_mower_state_icon_name(ctx->state)));
   }
   if (ctx->text_lbl) {
     std::string label = ctx->status_card

--- a/components/espcontrol/button_grid_layout.h
+++ b/components/espcontrol/button_grid_layout.h
@@ -398,7 +398,7 @@ inline void configure_button_label_wrap(lv_obj_t *label) {
 inline void set_wrapped_button_label_text(lv_obj_t *label, const std::string &text) {
   if (!label) return;
   configure_button_label_wrap(label);
-  lv_label_set_text(label, text.c_str());
+  lv_label_set_display_text(label, text.c_str());
   lv_obj_align(label, LV_ALIGN_BOTTOM_LEFT, 0, 0);
 }
 

--- a/components/espcontrol/button_grid_local_controls.h
+++ b/components/espcontrol/button_grid_local_controls.h
@@ -132,7 +132,7 @@ inline bool local_sensor_apply_value(const std::string &key, float value) {
     if (control.precision == 1) snprintf(buffer, sizeof(buffer), "%.1f", value);
     else if (control.precision == 2) snprintf(buffer, sizeof(buffer), "%.2f", value);
     else snprintf(buffer, sizeof(buffer), "%.0f", value);
-    lv_label_set_text(control.sensor_lbl, buffer);
+    lv_label_set_display_text(control.sensor_lbl, buffer);
     applied = true;
   }
   return applied;
@@ -352,7 +352,7 @@ inline void apply_internal_relay_state(lv_obj_t *btn, lv_obj_t *icon_lbl,
     set_card_checked_state(btn, on);
   }
   if (icon_lbl && has_icon_on)
-    lv_label_set_text(icon_lbl, on ? icon_on : icon_off);
+    lv_label_set_display_text(icon_lbl, on ? icon_on : icon_off);
 }
 
 inline void apply_internal_relay_parent_indicator(InternalRelayWatcher &w, bool on) {
@@ -367,11 +367,11 @@ inline void apply_internal_relay_parent_indicator(InternalRelayWatcher &w, bool 
   if (w.sp_on_count[w.parent_idx] > 0) {
     set_card_checked_state(w.parent_btn, true);
     if (w.parent_has_alt_icon && w.parent_icon)
-      lv_label_set_text(w.parent_icon, w.parent_on_glyph);
+      lv_label_set_display_text(w.parent_icon, w.parent_on_glyph);
   } else {
     set_card_checked_state(w.parent_btn, false);
     if (w.parent_has_alt_icon && w.parent_icon)
-      lv_label_set_text(w.parent_icon, w.parent_off_glyph);
+      lv_label_set_display_text(w.parent_icon, w.parent_off_glyph);
   }
 }
 

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -257,7 +257,7 @@ inline void media_set_metadata_text(lv_obj_t *label, esphome::StringRef value,
                                     const char *fallback) {
   if (!label) return;
   std::string text = media_metadata_text(value, fallback);
-  lv_label_set_text(label, text.c_str());
+  lv_label_set_display_text(label, text.c_str());
 }
 
 inline bool media_external_source_input(std::string source) {
@@ -269,7 +269,7 @@ inline void media_apply_now_playing_artist_text(MediaNowPlayingCtx *ctx) {
   const char *text = ctx->external_source
     ? espcontrol_i18n("Source")
     : ctx->artist;
-  lv_label_set_text(ctx->artist_lbl, text);
+  lv_label_set_display_text(ctx->artist_lbl, text);
 }
 
 inline void media_position_now_playing_artist(MediaNowPlayingCtx *ctx) {
@@ -377,7 +377,7 @@ inline void media_control_refresh_parent_card(MediaControlCtx *ctx) {
     std::string label = ctx->label_shows_status
       ? media_status_text(ctx->state_text)
       : ctx->label;
-    lv_label_set_text(ctx->label_lbl, label.c_str());
+    lv_label_set_display_text(ctx->label_lbl, label.c_str());
   }
   if (ctx->top_shows_volume && ctx->volume_value_lbl) {
     if (ctx->volume_known) {
@@ -387,11 +387,11 @@ inline void media_control_refresh_parent_card(MediaControlCtx *ctx) {
         espcontrol::media::volume_display_value(
           ctx->volume_control_mode, ctx->current_pct,
           media_control_volume_max_pct(ctx)));
-      lv_label_set_text(ctx->volume_value_lbl, buf);
+      lv_label_set_display_text(ctx->volume_value_lbl, buf);
     } else {
-      lv_label_set_text(ctx->volume_value_lbl, "--");
+      lv_label_set_display_text(ctx->volume_value_lbl, "--");
     }
-    if (ctx->volume_unit_lbl) lv_label_set_text(ctx->volume_unit_lbl, "");
+    if (ctx->volume_unit_lbl) lv_label_set_display_text(ctx->volume_unit_lbl, "");
   }
 }
 
@@ -514,7 +514,7 @@ inline void media_apply_position(SliderCtx *ctx) {
   if (ctx->media_value_lbl) {
     char time_buf[16];
     media_format_time(seconds, time_buf, sizeof(time_buf));
-    lv_label_set_text(ctx->media_value_lbl, time_buf);
+    lv_label_set_display_text(ctx->media_value_lbl, time_buf);
   }
 
   int pct = 0;
@@ -984,7 +984,7 @@ inline void media_playback_apply_state_to_slider(MediaPlaybackState *state,
   ctx->media_playing = state->playing;
   if (ctx->media_status_lbl) {
     std::string label = media_status_text(state->available ? state->state_text : std::string("unavailable"));
-    lv_label_set_text(ctx->media_status_lbl, label.c_str());
+    lv_label_set_display_text(ctx->media_status_lbl, label.c_str());
   }
   if (!ctx->media_position) return;
 
@@ -1021,7 +1021,7 @@ inline void media_playback_apply_state_to_button(MediaPlaybackState *state,
   if (button.status_lbl && state->has_state) {
     std::string label = media_status_text(
       state->available ? state->state_text : std::string("unavailable"));
-    lv_label_set_text(button.status_lbl, label.c_str());
+    lv_label_set_display_text(button.status_lbl, label.c_str());
   }
 }
 
@@ -1107,7 +1107,7 @@ inline void media_playback_apply_state_to_now_playing_snapshot(
       ctx->external_source_fallback && state->external_source && !state->source.empty()
         ? state->source
         : state->title.empty() ? std::string("--") : state->title;
-    lv_label_set_text(ctx->title_lbl, title.c_str());
+    lv_label_set_display_text(ctx->title_lbl, title.c_str());
     if (ctx->show_track_details || ctx->external_source_fallback) {
       lv_obj_clear_flag(ctx->title_lbl, LV_OBJ_FLAG_HIDDEN);
     } else {
@@ -1187,8 +1187,8 @@ inline void media_playback_apply_state_to_volume(MediaPlaybackState *state,
   media_volume_refresh_controls(ctx);
   if (!ctx->available) media_volume_hide_modal();
   if (!state->volume_known) {
-    if (ctx->pct_lbl) lv_label_set_text(ctx->pct_lbl, "--");
-    if (ctx->unit_lbl) lv_label_set_text(ctx->unit_lbl, "");
+    if (ctx->pct_lbl) lv_label_set_display_text(ctx->pct_lbl, "--");
+    if (ctx->unit_lbl) lv_label_set_display_text(ctx->unit_lbl, "");
     return;
   }
 
@@ -2067,14 +2067,14 @@ inline void setup_media_action_layout(lv_obj_t *btn, lv_obj_t *icon_lbl,
   std::string mode = media_card_mode(p.sensor);
   if (icon_lbl) {
     lv_obj_clear_flag(icon_lbl, LV_OBJ_FLAG_HIDDEN);
-    lv_label_set_text(icon_lbl, media_default_icon(mode, p.icon));
+    lv_label_set_display_text(icon_lbl, media_default_icon(mode, p.icon));
     lv_obj_align(icon_lbl, LV_ALIGN_TOP_LEFT, 0, 0);
   }
   if (text_lbl) {
     std::string label = media_play_pause_show_state(p)
       ? espcontrol_i18n(std::string("Paused"))
       : media_action_label(p, mode);
-    lv_label_set_text(text_lbl, label.c_str());
+    lv_label_set_display_text(text_lbl, label.c_str());
     lv_obj_align(text_lbl, LV_ALIGN_BOTTOM_LEFT, 0, 0);
     configure_button_label_wrap(text_lbl);
   }
@@ -2127,12 +2127,12 @@ inline void setup_media_now_playing_layout(lv_obj_t *btn, lv_obj_t *icon_lbl,
       lv_obj_set_height(title_lbl, LV_SIZE_CONTENT);
     }
     lv_obj_align(title_lbl, LV_ALIGN_TOP_LEFT, padding.left, padding.top);
-    if (reset_text) lv_label_set_text(title_lbl, "--");
+    if (reset_text) lv_label_set_display_text(title_lbl, "--");
     lv_obj_move_foreground(title_lbl);
   }
   if (artist_lbl) {
     const lv_font_t *font = lv_obj_get_style_text_font(artist_lbl, LV_PART_MAIN);
-    if (reset_text) lv_label_set_text(artist_lbl, "");
+    if (reset_text) lv_label_set_display_text(artist_lbl, "");
     lv_label_set_long_mode(artist_lbl, LV_LABEL_LONG_DOT);
     if (font && font->line_height > 0) lv_obj_set_size(artist_lbl, text_width, font->line_height);
     else lv_obj_set_width(artist_lbl, text_width);
@@ -2209,13 +2209,13 @@ inline void setup_media_volume_button(lv_obj_t *btn, lv_obj_t *icon_lbl,
     lv_obj_move_foreground(sensor_container);
   }
   if (sensor_lbl) {
-    lv_label_set_text(sensor_lbl, "--");
+    lv_label_set_display_text(sensor_lbl, "--");
   }
   if (unit_lbl) {
-    lv_label_set_text(unit_lbl, "");
+    lv_label_set_display_text(unit_lbl, "");
   }
   if (text_lbl) {
-    lv_label_set_text(text_lbl, media_label(p).c_str());
+    lv_label_set_display_text(text_lbl, media_label(p).c_str());
     lv_obj_align(text_lbl, LV_ALIGN_BOTTOM_LEFT, 0, 0);
     configure_button_label_wrap(text_lbl);
     lv_obj_move_foreground(text_lbl);
@@ -2236,12 +2236,12 @@ inline lv_obj_t *setup_media_slider_layout(lv_obj_t *btn, lv_obj_t *icon_lbl,
   if (position) {
     if (icon_lbl) lv_obj_add_flag(icon_lbl, LV_OBJ_FLAG_HIDDEN);
     if (value_lbl) {
-      lv_label_set_text(value_lbl, "0:00");
+      lv_label_set_display_text(value_lbl, "0:00");
       lv_obj_move_foreground(value_lbl);
     }
     if (text_lbl) {
       lv_obj_clear_flag(text_lbl, LV_OBJ_FLAG_HIDDEN);
-      lv_label_set_text(text_lbl, media_position_show_state(p) ? espcontrol_i18n("Paused") : media_action_label(p, mode).c_str());
+      lv_label_set_display_text(text_lbl, media_position_show_state(p) ? espcontrol_i18n("Paused") : media_action_label(p, mode).c_str());
       lv_obj_align(text_lbl, LV_ALIGN_BOTTOM_LEFT, padding.left, -padding.bottom);
       configure_button_label_wrap(text_lbl);
       lv_obj_move_foreground(text_lbl);
@@ -2249,12 +2249,12 @@ inline lv_obj_t *setup_media_slider_layout(lv_obj_t *btn, lv_obj_t *icon_lbl,
   } else {
     if (icon_lbl) {
       lv_obj_clear_flag(icon_lbl, LV_OBJ_FLAG_HIDDEN);
-      lv_label_set_text(icon_lbl, media_default_icon(mode, p.icon));
+      lv_label_set_display_text(icon_lbl, media_default_icon(mode, p.icon));
       lv_obj_align(icon_lbl, LV_ALIGN_TOP_LEFT, padding.left, padding.top);
       lv_obj_move_foreground(icon_lbl);
     }
     if (text_lbl) {
-      lv_label_set_text(text_lbl, media_label(p).c_str());
+      lv_label_set_display_text(text_lbl, media_label(p).c_str());
       lv_obj_align(text_lbl, LV_ALIGN_BOTTOM_LEFT, padding.left, -padding.bottom);
       configure_button_label_wrap(text_lbl);
       lv_obj_move_foreground(text_lbl);
@@ -2305,7 +2305,7 @@ inline lv_obj_t *setup_media_slider_layout(lv_obj_t *btn, lv_obj_t *icon_lbl,
     if (ctx->media_position && ctx->media_duration > 0.0f && ctx->media_value_lbl) {
       char time_buf[16];
       media_format_time(ctx->media_duration * val / 100.0f, time_buf, sizeof(time_buf));
-      lv_label_set_text(ctx->media_value_lbl, time_buf);
+      lv_label_set_display_text(ctx->media_value_lbl, time_buf);
     }
   }, LV_EVENT_VALUE_CHANGED, nullptr);
 
@@ -2337,7 +2337,7 @@ inline lv_obj_t *setup_media_position_layout(lv_obj_t *btn, lv_obj_t *icon_lbl,
   if (value_font) lv_obj_set_style_text_font(value_lbl, value_font, LV_PART_MAIN);
   lv_obj_set_style_text_color(value_lbl, text_color, LV_PART_MAIN);
   apply_width_compensation(value_lbl, width_compensation_percent);
-  lv_label_set_text(value_lbl, "0:00");
+  lv_label_set_display_text(value_lbl, "0:00");
   lv_obj_align(value_lbl, LV_ALIGN_TOP_LEFT, padding.left, padding.top);
   lv_obj_set_style_bg_color(btn, lv_color_hex(background_color), LV_PART_MAIN);
   lv_obj_set_style_bg_color(
@@ -2369,11 +2369,11 @@ inline void setup_media_control_button(lv_obj_t *btn, lv_obj_t *icon_lbl,
       lv_obj_align(sensor_container, LV_ALIGN_TOP_LEFT, 0, 0);
       lv_obj_move_foreground(sensor_container);
     }
-    if (sensor_lbl) lv_label_set_text(sensor_lbl, "--");
-    if (unit_lbl) lv_label_set_text(unit_lbl, "");
+    if (sensor_lbl) lv_label_set_display_text(sensor_lbl, "--");
+    if (unit_lbl) lv_label_set_display_text(unit_lbl, "");
   } else if (icon_lbl) {
     lv_obj_clear_flag(icon_lbl, LV_OBJ_FLAG_HIDDEN);
-    lv_label_set_text(icon_lbl, media_default_icon(media_card_mode(p.sensor), p.icon));
+    lv_label_set_display_text(icon_lbl, media_default_icon(media_card_mode(p.sensor), p.icon));
     lv_obj_align(icon_lbl, LV_ALIGN_TOP_LEFT, 0, 0);
     if (sensor_container) lv_obj_add_flag(sensor_container, LV_OBJ_FLAG_HIDDEN);
   }
@@ -2381,7 +2381,7 @@ inline void setup_media_control_button(lv_obj_t *btn, lv_obj_t *icon_lbl,
     std::string label = media_control_card_show_status_label(p)
       ? media_status_text("unknown")
       : media_control_card_label(p);
-    lv_label_set_text(text_lbl, label.c_str());
+    lv_label_set_display_text(text_lbl, label.c_str());
     lv_obj_align(text_lbl, LV_ALIGN_BOTTOM_LEFT, 0, 0);
     configure_button_label_wrap(text_lbl);
   }
@@ -2455,7 +2455,7 @@ inline void media_control_reset_track_position(MediaControlCtx *ctx) {
 inline void media_control_refresh_play_icon(MediaControlCtx *ctx) {
   MediaControlModalUi &ui = media_control_modal_ui();
   if (!ctx || ui.active != ctx || !ui.play_icon_lbl) return;
-  lv_label_set_text(ui.play_icon_lbl, ctx->playing ? find_icon("Pause") : find_icon("Play"));
+  lv_label_set_display_text(ui.play_icon_lbl, ctx->playing ? find_icon("Pause") : find_icon("Play"));
 }
 
 inline void media_control_refresh_progress_time_label(MediaControlCtx *ctx, float seconds) {
@@ -2463,7 +2463,7 @@ inline void media_control_refresh_progress_time_label(MediaControlCtx *ctx, floa
   if (!ctx || ui.active != ctx || !ui.progress_time_lbl) return;
   char position_buf[16];
   media_format_time(seconds, position_buf, sizeof(position_buf));
-  lv_label_set_text(ui.progress_time_lbl, position_buf);
+  lv_label_set_display_text(ui.progress_time_lbl, position_buf);
 }
 
 inline lv_obj_t *media_control_create_progress_fill(lv_obj_t *slider, lv_color_t fill_color) {
@@ -2640,7 +2640,7 @@ inline void media_control_refresh_volume(MediaControlCtx *ctx) {
               : media_clamp_percent(ctx->current_pct));
   if (ui.volume_group_lbl) {
     if (grouped) {
-      lv_label_set_text(ui.volume_group_lbl, espcontrol_i18n("Group"));
+      lv_label_set_display_text(ui.volume_group_lbl, espcontrol_i18n("Group"));
       lv_obj_clear_flag(ui.volume_group_lbl, LV_OBJ_FLAG_HIDDEN);
     } else {
       lv_obj_add_flag(ui.volume_group_lbl, LV_OBJ_FLAG_HIDDEN);
@@ -2649,7 +2649,7 @@ inline void media_control_refresh_volume(MediaControlCtx *ctx) {
   if (ui.volume_pct_lbl) {
     char buf[8];
     snprintf(buf, sizeof(buf), "%d", pct);
-    lv_label_set_text(ui.volume_pct_lbl, buf);
+    lv_label_set_display_text(ui.volume_pct_lbl, buf);
   }
   if (ui.volume_arc && !ctx->dragging_volume) {
     ui.updating_volume = true;
@@ -2673,7 +2673,7 @@ inline void media_control_refresh_power(MediaControlCtx *ctx) {
     lv_color_hex(on ? ctx->accent_color : SECONDARY_GREY), LV_PART_MAIN);
   lv_obj_set_style_bg_opa(ui.power_btn, LV_OPA_COVER, LV_PART_MAIN);
   if (ui.power_icon_lbl) {
-    lv_label_set_text(ui.power_icon_lbl, find_icon("Power"));
+    lv_label_set_display_text(ui.power_icon_lbl, find_icon("Power"));
     lv_obj_set_style_text_color(
       ui.power_icon_lbl, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   }
@@ -2682,7 +2682,7 @@ inline void media_control_refresh_power(MediaControlCtx *ctx) {
       ? espcontrol_i18n(std::string("Unknown"))
       : (on ? espcontrol_i18n(std::string("On"))
             : espcontrol_i18n(std::string("Off")));
-    lv_label_set_text(ui.power_status_lbl, status.c_str());
+    lv_label_set_display_text(ui.power_status_lbl, status.c_str());
   }
   media_control_apply_availability(ui.power_btn, ui.power_btn, interactive);
 }
@@ -2721,7 +2721,7 @@ inline void media_control_refresh_playback_modes(MediaControlCtx *ctx) {
     const bool interactive = ctx->available && known &&
       media_control_repeat_supported(ctx);
     if (ui.repeat_icon_lbl) {
-      lv_label_set_text(
+      lv_label_set_display_text(
         ui.repeat_icon_lbl,
         find_icon(ctx->repeat_mode == espcontrol::media::RepeatMode::ONE
           ? "Repeat Once" : "Repeat"));
@@ -2736,8 +2736,8 @@ inline void media_control_refresh_modal(MediaControlCtx *ctx) {
   if (!ctx || ui.active != ctx) return;
   std::string title = media_control_title_text(ctx);
   std::string artist = media_control_artist_text(ctx);
-  if (ui.title_lbl) lv_label_set_text(ui.title_lbl, title.c_str());
-  if (ui.artist_lbl) lv_label_set_text(ui.artist_lbl, artist.c_str());
+  if (ui.title_lbl) lv_label_set_display_text(ui.title_lbl, title.c_str());
+  if (ui.artist_lbl) lv_label_set_display_text(ui.artist_lbl, artist.c_str());
   media_control_refresh_play_icon(ctx);
   media_control_refresh_progress(ctx);
   media_control_refresh_volume(ctx);
@@ -3060,7 +3060,7 @@ inline void media_control_create_progress_tab_content(MediaControlCtx *ctx) {
   ui.progress_time_lbl = lv_label_create(ui.content_box);
   if (ui.progress_time_lbl) {
     lv_obj_add_flag(ui.progress_time_lbl, LV_OBJ_FLAG_HIDDEN);
-    lv_label_set_text(ui.progress_time_lbl, "0:00");
+    lv_label_set_display_text(ui.progress_time_lbl, "0:00");
     lv_obj_set_style_text_color(ui.progress_time_lbl, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
     lv_obj_set_style_text_align(ui.progress_time_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
     if (ctx->title_font) lv_obj_set_style_text_font(ui.progress_time_lbl, ctx->title_font, LV_PART_MAIN);
@@ -3179,7 +3179,7 @@ inline void media_control_create_volume_tab_content(MediaControlCtx *ctx) {
 
   ui.volume_group_lbl = lv_label_create(ui.content_box);
   if (ui.volume_group_lbl) {
-    lv_label_set_text(ui.volume_group_lbl, espcontrol_i18n("Group"));
+    lv_label_set_display_text(ui.volume_group_lbl, espcontrol_i18n("Group"));
     lv_obj_set_style_text_color(ui.volume_group_lbl, lv_color_hex(DARK_TEXT_MUTED), LV_PART_MAIN);
     lv_obj_set_style_text_align(ui.volume_group_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
     if (ctx->label_font) lv_obj_set_style_text_font(ui.volume_group_lbl, ctx->label_font, LV_PART_MAIN);
@@ -3189,7 +3189,7 @@ inline void media_control_create_volume_tab_content(MediaControlCtx *ctx) {
 
   ui.volume_pct_lbl = lv_label_create(ui.content_box);
   if (ui.volume_pct_lbl) {
-    lv_label_set_text(ui.volume_pct_lbl, "0");
+    lv_label_set_display_text(ui.volume_pct_lbl, "0");
     lv_obj_set_style_text_color(ui.volume_pct_lbl, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
     lv_obj_set_style_text_align(ui.volume_pct_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
     if (ctx->number_font) lv_obj_set_style_text_font(ui.volume_pct_lbl, ctx->number_font, LV_PART_MAIN);
@@ -3267,7 +3267,7 @@ inline void media_control_set_speaker_status(const char *text, bool error = fals
     return;
   }
   lv_obj_clear_flag(ui.speakers_status_lbl, LV_OBJ_FLAG_HIDDEN);
-  lv_label_set_text(ui.speakers_status_lbl, text ? text : "");
+  lv_label_set_display_text(ui.speakers_status_lbl, text ? text : "");
   lv_obj_set_style_text_color(
     ui.speakers_status_lbl,
     lv_color_hex(error ? 0xFF6B6B : DARK_TEXT_MUTED), LV_PART_MAIN);
@@ -3334,7 +3334,7 @@ inline void media_control_refresh_speaker_row(MediaControlCtx *ctx,
   if (row->name_label) {
     std::string name = row->friendly_name.empty()
       ? media_control_speaker_fallback_name(row->entity_id) : row->friendly_name;
-    lv_label_set_text(row->name_label, name.c_str());
+    lv_label_set_display_text(row->name_label, name.c_str());
     lv_obj_set_style_text_color(row->name_label, lv_color_hex(text_color), LV_PART_MAIN);
 #ifdef ESPCONTROL_LOW_HEAP_MEDIA_CONTROL
     lv_obj_set_style_translate_y(
@@ -3344,7 +3344,7 @@ inline void media_control_refresh_speaker_row(MediaControlCtx *ctx,
 #endif
   }
   if (row->speaker_icon) {
-    lv_label_set_text(
+    lv_label_set_display_text(
       row->speaker_icon,
       find_icon(row->selected ? "Speaker Wireless" : "Speaker Off"));
     lv_obj_clear_flag(row->speaker_icon, LV_OBJ_FLAG_HIDDEN);
@@ -3381,7 +3381,7 @@ inline void media_control_refresh_speaker_row(MediaControlCtx *ctx,
     if (row->volume_known) snprintf(value, sizeof(value), "%d%%", row->volume_pct);
     else std::strncpy(value, "--", sizeof(value));
     value[sizeof(value) - 1] = '\0';
-    lv_label_set_text(row->volume_label, value);
+    lv_label_set_display_text(row->volume_label, value);
 #ifdef ESPCONTROL_LOW_HEAP_MEDIA_CONTROL
     lv_obj_set_style_translate_y(
       row->volume_label, lv_obj_get_height(row->volume_label) / 2, LV_PART_MAIN);
@@ -3480,7 +3480,7 @@ inline void media_control_apply_group_volume_percent(MediaControlCtx *ctx, int p
     if (ui.active == ctx && ui.volume_pct_lbl) {
       char value[8];
       snprintf(value, sizeof(value), "%d", media_control_clamp_volume(ctx, pct));
-      lv_label_set_text(ui.volume_pct_lbl, value);
+      lv_label_set_display_text(ui.volume_pct_lbl, value);
     }
     return;
   }
@@ -3598,7 +3598,7 @@ inline lv_obj_t *media_control_create_speaker_volume_button(
   lv_obj_set_style_pad_all(btn, 0, LV_PART_MAIN);
   control_modal_apply_pressed_fill(btn);
   lv_obj_t *label = lv_label_create(btn);
-  lv_label_set_text(label, icon);
+  lv_label_set_display_text(label, icon);
   if (ctx->icon_font) lv_obj_set_style_text_font(label, ctx->icon_font, LV_PART_MAIN);
   lv_obj_set_style_text_color(label, lv_color_hex(ctx->accent_color), LV_PART_MAIN);
   lv_obj_center(label);
@@ -3710,7 +3710,7 @@ inline void media_control_add_speaker_candidate(MediaControlCtx *ctx,
   lv_coord_t icon_column_w = control_modal_scaled_px(32, speaker_layout.short_side);
   if (icon_column_w < 32) icon_column_w = 32;
   lv_obj_set_width(row->speaker_icon, icon_column_w);
-  lv_label_set_text(row->speaker_icon, find_icon("Speaker"));
+  lv_label_set_display_text(row->speaker_icon, find_icon("Speaker"));
   lv_obj_set_style_text_align(row->speaker_icon, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (ctx->icon_font) lv_obj_set_style_text_font(row->speaker_icon, ctx->icon_font, LV_PART_MAIN);
   lv_obj_set_style_transform_zoom(
@@ -3777,7 +3777,7 @@ inline void media_control_add_speaker_candidate(MediaControlCtx *ctx,
   lv_coord_t icon_column_w = control_modal_scaled_px(36, speaker_layout.short_side);
   if (icon_column_w < 36) icon_column_w = 36;
   lv_obj_set_width(row->speaker_icon, icon_column_w);
-  lv_label_set_text(row->speaker_icon, find_icon("Speaker"));
+  lv_label_set_display_text(row->speaker_icon, find_icon("Speaker"));
   lv_obj_set_style_text_align(row->speaker_icon, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (ctx->icon_font) lv_obj_set_style_text_font(row->speaker_icon, ctx->icon_font, LV_PART_MAIN);
   lv_obj_set_style_transform_zoom(
@@ -3969,7 +3969,7 @@ inline void media_control_create_power_tab_content(MediaControlCtx *ctx) {
 
   ui.power_status_lbl = lv_label_create(ui.content_box);
   if (ui.power_status_lbl) {
-    lv_label_set_text(ui.power_status_lbl, espcontrol_i18n("Unknown"));
+    lv_label_set_display_text(ui.power_status_lbl, espcontrol_i18n("Unknown"));
     lv_obj_set_style_text_color(
       ui.power_status_lbl, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
     lv_obj_set_style_text_align(ui.power_status_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
@@ -4149,11 +4149,11 @@ inline void media_control_layout_modal(MediaControlCtx *ctx) {
   }
   if (ui.title_lbl) {
     std::string title = media_control_title_text(ctx);
-    lv_label_set_text(ui.title_lbl, title.c_str());
+    lv_label_set_display_text(ui.title_lbl, title.c_str());
   }
   if (ui.artist_lbl) {
     std::string artist = media_control_artist_text(ctx);
-    lv_label_set_text(ui.artist_lbl, artist.c_str());
+    lv_label_set_display_text(ui.artist_lbl, artist.c_str());
   }
   const lv_font_t *title_font = ctx->title_font
     ? ctx->title_font
@@ -4534,7 +4534,7 @@ inline void setup_media_card(BtnSlot &s, const ParsedCfg &p, uint32_t on_color,
       }
       apply_width_compensation(artist_lbl, width_compensation_percent);
       if (s.text_lbl) {
-        lv_label_set_text(s.text_lbl, "");
+        lv_label_set_display_text(s.text_lbl, "");
         lv_obj_add_flag(s.text_lbl, LV_OBJ_FLAG_HIDDEN);
       }
       ctx->title_lbl = title_lbl;

--- a/components/espcontrol/button_grid_modal.h
+++ b/components/espcontrol/button_grid_modal.h
@@ -675,7 +675,7 @@ inline lv_obj_t *control_modal_create_flat_icon_button(
 
   lv_obj_t *label = lv_label_create(btn);
   if (label) {
-    lv_label_set_text(label, icon);
+    lv_label_set_display_text(label, icon);
     lv_obj_set_style_text_color(label, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
     lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
     if (font) lv_obj_set_style_text_font(label, font, LV_PART_MAIN);
@@ -707,7 +707,7 @@ inline lv_obj_t *control_modal_create_round_button(lv_obj_t *parent, lv_coord_t 
     lv_obj_del(btn);
     return nullptr;
   }
-  lv_label_set_text(label, text);
+  lv_label_set_display_text(label, text);
   lv_obj_set_style_text_color(label, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (font) lv_obj_set_style_text_font(label, font, LV_PART_MAIN);
@@ -868,7 +868,7 @@ inline lv_obj_t *control_modal_create_title(lv_obj_t *parent,
                                             const lv_font_t *font,
                                             int width_compensation_percent) {
   lv_obj_t *title = lv_label_create(parent);
-  lv_label_set_text(title, text.c_str());
+  lv_label_set_display_text(title, text.c_str());
   lv_label_set_long_mode(title, LV_LABEL_LONG_DOT);
   lv_obj_set_width(title, width);
   lv_obj_set_style_text_color(title, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
@@ -916,7 +916,7 @@ inline lv_obj_t *control_modal_create_list_row(lv_obj_t *parent,
   control_modal_apply_pressed_fill(btn);
 
   lv_obj_t *value = lv_label_create(btn);
-  lv_label_set_text(value, label.c_str());
+  lv_label_set_display_text(value, label.c_str());
   lv_label_set_long_mode(value, LV_LABEL_LONG_DOT);
   lv_obj_set_width(value, lv_pct(100));
   lv_obj_set_style_text_color(value, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
@@ -947,7 +947,7 @@ inline lv_obj_t *control_modal_create_text_button(
   control_modal_apply_pressed_fill(btn);
 
   lv_obj_t *label = lv_label_create(btn);
-  lv_label_set_text(label, text.c_str());
+  lv_label_set_display_text(label, text.c_str());
   lv_label_set_long_mode(label, LV_LABEL_LONG_CLIP);
   lv_obj_set_style_text_color(label, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);

--- a/components/espcontrol/button_grid_option_select.h
+++ b/components/espcontrol/button_grid_option_select.h
@@ -79,12 +79,12 @@ inline void option_select_apply_card_text(OptionSelectCtx *ctx) {
   if (!ctx) return;
   if (ctx->value_lbl) {
     std::string text = option_select_display_value(ctx->current_option);
-    lv_label_set_text(ctx->value_lbl, text.c_str());
+    lv_label_set_display_text(ctx->value_lbl, text.c_str());
   }
-  if (ctx->unit_lbl) lv_label_set_text(ctx->unit_lbl, "");
+  if (ctx->unit_lbl) lv_label_set_display_text(ctx->unit_lbl, "");
   if (ctx->label_lbl) {
     std::string label = option_select_label(ctx);
-    lv_label_set_text(ctx->label_lbl, label.c_str());
+    lv_label_set_display_text(ctx->label_lbl, label.c_str());
   }
 }
 
@@ -104,12 +104,12 @@ inline void setup_option_select_card(BtnSlot &s, const ParsedCfg &p,
     ? value_font
     : s.text_lbl ? lv_obj_get_style_text_font(s.text_lbl, LV_PART_MAIN) : nullptr;
   if (text_value_font) lv_obj_set_style_text_font(s.sensor_lbl, text_value_font, LV_PART_MAIN);
-  lv_label_set_text(s.sensor_lbl, "--");
-  lv_label_set_text(s.unit_lbl, "");
+  lv_label_set_display_text(s.sensor_lbl, "--");
+  lv_label_set_display_text(s.unit_lbl, "");
   std::string label = p.label.empty()
     ? (p.entity.empty() ? espcontrol_i18n(std::string("Option")) : p.entity)
     : p.label;
-  lv_label_set_text(s.text_lbl, label.c_str());
+  lv_label_set_display_text(s.text_lbl, label.c_str());
   apply_push_button_transition(s.btn);
 }
 
@@ -280,7 +280,7 @@ inline void option_select_open_modal(OptionSelectCtx *ctx) {
 
   if (count == 0) {
     ui.empty_lbl = lv_label_create(ui.list);
-    lv_label_set_text(ui.empty_lbl, espcontrol_i18n("No options"));
+    lv_label_set_display_text(ui.empty_lbl, espcontrol_i18n("No options"));
     lv_label_set_long_mode(ui.empty_lbl, LV_LABEL_LONG_WRAP);
     lv_obj_set_width(ui.empty_lbl, lv_pct(100));
     lv_obj_set_style_text_color(ui.empty_lbl, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);

--- a/components/espcontrol/button_grid_sensor_driver.h
+++ b/components/espcontrol/button_grid_sensor_driver.h
@@ -59,20 +59,20 @@ inline bool sensor_driver_setup_visual(
     const char *icon = (config.icon.empty() || config.icon == "Auto")
       ? find_icon("Auto")
       : find_icon(config.icon.c_str());
-    lv_label_set_text(slot.icon_lbl, icon);
-    if (!config.label.empty()) lv_label_set_text(slot.text_lbl, config.label.c_str());
+    lv_label_set_display_text(slot.icon_lbl, icon);
+    if (!config.label.empty()) lv_label_set_display_text(slot.text_lbl, config.label.c_str());
     return true;
   }
 
   lv_obj_add_flag(slot.icon_lbl, LV_OBJ_FLAG_HIDDEN);
   lv_obj_clear_flag(slot.sensor_container, LV_OBJ_FLAG_HIDDEN);
-  if (local) lv_label_set_text(slot.sensor_lbl, "--");
-  if (config.precision == "time") lv_label_set_text(slot.unit_lbl, "");
+  if (local) lv_label_set_display_text(slot.sensor_lbl, "--");
+  if (config.precision == "time") lv_label_set_display_text(slot.unit_lbl, "");
   if (!config.unit.empty()) {
     const std::string unit = trim_display_unit(config.unit);
-    lv_label_set_text(slot.unit_lbl, unit.c_str());
+    lv_label_set_display_text(slot.unit_lbl, unit.c_str());
   }
-  if (!config.label.empty()) lv_label_set_text(slot.text_lbl, config.label.c_str());
+  if (!config.label.empty()) lv_label_set_display_text(slot.text_lbl, config.label.c_str());
   return true;
 }
 
@@ -158,7 +158,7 @@ inline void sensor_driver_register_local_value(
         if (control.precision == 1) snprintf(buffer, sizeof(buffer), "%.1f", esp_sensor->state);
         else if (control.precision == 2) snprintf(buffer, sizeof(buffer), "%.2f", esp_sensor->state);
         else snprintf(buffer, sizeof(buffer), "%.0f", esp_sensor->state);
-        lv_label_set_text(control.sensor_lbl, buffer);
+        lv_label_set_display_text(control.sensor_lbl, buffer);
       }
       break;
     }

--- a/components/espcontrol/button_grid_sliders.h
+++ b/components/espcontrol/button_grid_sliders.h
@@ -402,11 +402,11 @@ inline void light_control_apply_card_visual(LightControlCtx *ctx) {
   set_card_checked_state(ctx->btn, ctx->on);
   if (ctx->icon_lbl) {
     const char *glyph = ctx->on && ctx->icon_on_glyph ? ctx->icon_on_glyph : ctx->icon_off_glyph;
-    if (glyph) lv_label_set_text(ctx->icon_lbl, glyph);
+    if (glyph) lv_label_set_display_text(ctx->icon_lbl, glyph);
   }
   if (ctx->label_lbl) {
     std::string title = light_control_title(ctx);
-    lv_label_set_text(ctx->label_lbl, title.c_str());
+    lv_label_set_display_text(ctx->label_lbl, title.c_str());
   }
 }
 
@@ -595,7 +595,7 @@ inline lv_obj_t *light_control_create_tab_button(lv_obj_t *parent, const char *i
   lv_obj_clear_flag(btn, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_t *label = lv_label_create(btn);
   if (label) {
-    lv_label_set_text(label, icon);
+    lv_label_set_display_text(label, icon);
     lv_obj_set_style_text_color(label, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
     lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
     if (font) lv_obj_set_style_text_font(label, font, LV_PART_MAIN);
@@ -774,7 +774,7 @@ inline lv_obj_t *light_control_create_power_button(lv_obj_t *parent, const lv_fo
   lv_obj_clear_flag(btn, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_t *label = lv_label_create(btn);
   if (label) {
-    lv_label_set_text(label, find_icon(turn_on ? "Power" : "Circle Outline"));
+    lv_label_set_display_text(label, find_icon(turn_on ? "Power" : "Circle Outline"));
     lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
     if (font) lv_obj_set_style_text_font(label, font, LV_PART_MAIN);
     lv_obj_set_style_transform_zoom(label, turn_on ? 230 : 180, LV_PART_MAIN);
@@ -1130,8 +1130,8 @@ inline void light_control_rebuild_color_grid(LightControlCtx *ctx) {
 }
 
 inline void setup_light_control_card(BtnSlot &s, const ParsedCfg &p) {
-  lv_label_set_text(s.icon_lbl, light_control_icon_off(p));
-  lv_label_set_text(s.text_lbl, p.label.empty() ? espcontrol_i18n("Light") : p.label.c_str());
+  lv_label_set_display_text(s.icon_lbl, light_control_icon_off(p));
+  lv_label_set_display_text(s.text_lbl, p.label.empty() ? espcontrol_i18n("Light") : p.label.c_str());
   apply_push_button_transition(s.btn);
 }
 
@@ -1764,11 +1764,11 @@ inline void cover_control_apply_card_visual(CoverControlCtx *ctx,
     bool open_icon = ctx->current_position_known
       ? slider_clamp_pct(ctx->current_position) > 0
       : (!state_text.empty() ? garage_state_uses_open_icon(state_text) : ctx->current_position > 0);
-    lv_label_set_text(ctx->icon_lbl, open_icon ? ctx->icon_open_glyph : ctx->icon_closed_glyph);
+    lv_label_set_display_text(ctx->icon_lbl, open_icon ? ctx->icon_open_glyph : ctx->icon_closed_glyph);
   }
   if (ctx->label_lbl) {
     std::string title = cover_control_title(ctx);
-    lv_label_set_text(ctx->label_lbl, title.c_str());
+    lv_label_set_display_text(ctx->label_lbl, title.c_str());
   }
 }
 
@@ -1871,7 +1871,7 @@ inline lv_obj_t *cover_control_create_tab_button(lv_obj_t *parent, const char *i
   lv_obj_clear_flag(btn, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_t *label = lv_label_create(btn);
   if (label) {
-    lv_label_set_text(label, icon);
+    lv_label_set_display_text(label, icon);
     lv_obj_set_style_text_color(label, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
     lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
     if (font) lv_obj_set_style_text_font(label, font, LV_PART_MAIN);
@@ -1902,7 +1902,7 @@ inline lv_obj_t *cover_control_create_wide_icon_button(lv_obj_t *parent, const c
   lv_obj_clear_flag(btn, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_t *label = lv_label_create(btn);
   if (label) {
-    lv_label_set_text(label, icon);
+    lv_label_set_display_text(label, icon);
     lv_obj_set_style_text_color(label, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
     lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
     if (font) lv_obj_set_style_text_font(label, font, LV_PART_MAIN);
@@ -1938,7 +1938,7 @@ inline lv_obj_t *cover_control_create_preset_button(lv_obj_t *parent, int pct,
 
   lv_obj_t *icon = lv_label_create(btn);
   if (icon) {
-    lv_label_set_text(icon, pct <= 50 ? find_icon("Blinds") : find_icon("Blinds Open"));
+    lv_label_set_display_text(icon, pct <= 50 ? find_icon("Blinds") : find_icon("Blinds Open"));
     lv_obj_set_style_text_color(icon, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
     lv_obj_set_style_text_align(icon, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
     if (icon_font) lv_obj_set_style_text_font(icon, icon_font, LV_PART_MAIN);
@@ -1949,7 +1949,7 @@ inline lv_obj_t *cover_control_create_preset_button(lv_obj_t *parent, int pct,
   if (label) {
     char buf[8];
     snprintf(buf, sizeof(buf), "%d%%", pct);
-    lv_label_set_text(label, buf);
+    lv_label_set_display_text(label, buf);
     lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
     lv_obj_set_width(label, lv_pct(100));
     lv_obj_set_style_text_color(label, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
@@ -2704,13 +2704,13 @@ inline void subscribe_cover_control_state(CoverControlCtx *ctx) {
 }
 
 inline void setup_cover_toggle_card(BtnSlot &s, const ParsedCfg &p) {
-  lv_label_set_text(s.icon_lbl, slider_icon_off(p.type, p.entity, p.icon));
-  lv_label_set_text(s.text_lbl, p.label.empty() ? espcontrol_i18n("Cover") : p.label.c_str());
+  lv_label_set_display_text(s.icon_lbl, slider_icon_off(p.type, p.entity, p.icon));
+  lv_label_set_display_text(s.text_lbl, p.label.empty() ? espcontrol_i18n("Cover") : p.label.c_str());
 }
 
 inline void setup_cover_command_card(BtnSlot &s, const ParsedCfg &p) {
-  lv_label_set_text(s.icon_lbl, slider_icon_off(p.type, p.entity, p.icon));
-  lv_label_set_text(s.text_lbl, p.label.empty() ? espcontrol_i18n("Cover") : p.label.c_str());
+  lv_label_set_display_text(s.icon_lbl, slider_icon_off(p.type, p.entity, p.icon));
+  lv_label_set_display_text(s.text_lbl, p.label.empty() ? espcontrol_i18n("Cover") : p.label.c_str());
   apply_push_button_transition(s.btn);
 }
 
@@ -2721,7 +2721,7 @@ inline void setup_slider_visual(BtnSlot &s, const ParsedCfg &p, uint32_t on_colo
     p.entity.c_str(), p.type.c_str());
   setup_toggle_visual(s, p);
   if (p.type == "cover")
-    lv_label_set_text(s.icon_lbl, slider_icon_off(p.type, p.entity, p.icon));
+    lv_label_set_display_text(s.icon_lbl, slider_icon_off(p.type, p.entity, p.icon));
 
   const CardPadding padding = capture_card_padding(s.btn);
 
@@ -2836,7 +2836,7 @@ inline void slider_set_value_safe(lv_obj_t *slider, int pct) {
 }
 
 inline void slider_set_icon_safe(lv_obj_t *icon_lbl, const char *icon) {
-  if (icon_lbl && icon) lv_label_set_text(icon_lbl, icon);
+  if (icon_lbl && icon) lv_label_set_display_text(icon_lbl, icon);
 }
 
 // Subscribe to HA state for a slider entity (light brightness, fan percentage, or cover position/tilt)
@@ -2949,12 +2949,12 @@ inline void light_temp_show_drag_kelvin(SliderCtx *ctx, int kelvin) {
   if (!ctx || !ctx->text_lbl) return;
   char buf[16];
   snprintf(buf, sizeof(buf), "%dK", light_temp_rounded_kelvin(ctx, kelvin));
-  lv_label_set_text(ctx->text_lbl, buf);
+  lv_label_set_display_text(ctx->text_lbl, buf);
 }
 
 inline void light_temp_restore_label(SliderCtx *ctx) {
   if (!ctx || !ctx->text_lbl) return;
-  lv_label_set_text(ctx->text_lbl, ctx->cached_label.c_str());
+  lv_label_set_display_text(ctx->text_lbl, ctx->cached_label.c_str());
 }
 
 // Subscribe to friendly_name and keep the SliderCtx cached_label in sync;
@@ -3044,7 +3044,7 @@ inline void subscribe_light_temp_state(lv_obj_t *btn_ptr, lv_obj_t *slider,
 // Build the visual for a light temperature slider card.
 inline void setup_light_temp_visual(BtnSlot &s, const ParsedCfg &p, uint32_t on_color) {
   setup_toggle_visual(s, p);
-  lv_label_set_text(s.icon_lbl, light_temp_icon(p.icon));
+  lv_label_set_display_text(s.icon_lbl, light_temp_icon(p.icon));
   int min_k = 2000, max_k = 6500;
   parse_kelvin_range(p.unit, min_k, max_k);
   bool kcolor = (p.precision == "color");
@@ -3277,7 +3277,7 @@ inline void media_volume_apply_mic_button_state(MediaVolumeCtx *ctx) {
   MediaVolumeModalUi &ui = media_volume_modal_ui();
   if (!ctx || !ui.mic_btn || !ui.mic_lbl || !media_volume_has_mic_control(ctx)) return;
   bool muted = ctx->mic_muted();
-  lv_label_set_text(ui.mic_lbl, muted ? "\U000F036D" : "\U000F036C");
+  lv_label_set_display_text(ui.mic_lbl, muted ? "\U000F036D" : "\U000F036C");
   lv_obj_set_style_text_color(ui.mic_lbl,
     lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
 }
@@ -3292,8 +3292,8 @@ inline void media_volume_set_card_value(MediaVolumeCtx *ctx, int pct) {
   pct = media_clamp_percent(pct);
   char buf[8];
   snprintf(buf, sizeof(buf), "%d", pct);
-  lv_label_set_text(ctx->pct_lbl, buf);
-  if (ctx->unit_lbl) lv_label_set_text(ctx->unit_lbl, "");
+  lv_label_set_display_text(ctx->pct_lbl, buf);
+  if (ctx->unit_lbl) lv_label_set_display_text(ctx->unit_lbl, "");
 }
 
 inline void media_volume_apply_percent(MediaVolumeCtx *ctx, int pct,
@@ -3436,9 +3436,9 @@ inline void media_volume_set_modal_value(MediaVolumeCtx *ctx, int pct) {
   if (ui.pct_lbl) {
     char buf[8];
     snprintf(buf, sizeof(buf), "%d", pct);
-    lv_label_set_text(ui.pct_lbl, buf);
+    lv_label_set_display_text(ui.pct_lbl, buf);
   }
-  if (ui.pct_unit_lbl) lv_label_set_text(ui.pct_unit_lbl, "");
+  if (ui.pct_unit_lbl) lv_label_set_display_text(ui.pct_unit_lbl, "");
 }
 
 inline void media_volume_open_modal(MediaVolumeCtx *ctx) {
@@ -3481,7 +3481,7 @@ inline void media_volume_open_modal(MediaVolumeCtx *ctx) {
   }, LV_EVENT_VALUE_CHANGED, nullptr);
 
   ui.title_lbl = lv_label_create(ui.panel);
-  lv_label_set_text(ui.title_lbl, espcontrol_i18n("Volume"));
+  lv_label_set_display_text(ui.title_lbl, espcontrol_i18n("Volume"));
   lv_obj_set_style_text_color(ui.title_lbl, lv_color_hex(DARK_TEXT_MUTED), LV_PART_MAIN);
   lv_obj_set_style_text_align(ui.title_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (ctx->label_font) lv_obj_set_style_text_font(ui.title_lbl, ctx->label_font, LV_PART_MAIN);
@@ -3507,7 +3507,7 @@ inline void media_volume_open_modal(MediaVolumeCtx *ctx) {
   apply_width_compensation(ui.pct_lbl, ctx->width_compensation_percent);
 
   ui.pct_unit_lbl = lv_label_create(ui.pct_row);
-  lv_label_set_text(ui.pct_unit_lbl, "");
+  lv_label_set_display_text(ui.pct_unit_lbl, "");
   lv_obj_set_style_text_color(ui.pct_unit_lbl, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_align(ui.pct_unit_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (ctx->unit_font) lv_obj_set_style_text_font(ui.pct_unit_lbl, ctx->unit_font, LV_PART_MAIN);

--- a/components/espcontrol/button_grid_status_entity_driver.h
+++ b/components/espcontrol/button_grid_status_entity_driver.h
@@ -79,12 +79,12 @@ inline bool status_entity_driver_setup_visual(
   }
   lv_obj_clear_flag(slot.icon_lbl, LV_OBJ_FLAG_HIDDEN);
   lv_obj_add_flag(slot.sensor_container, LV_OBJ_FLAG_HIDDEN);
-  lv_label_set_text(
+  lv_label_set_display_text(
     slot.icon_lbl, status_entity_driver_inactive_icon(config, context));
   const std::string label = config.label.empty()
     ? status_entity_driver_default_label(config, context)
     : config.label;
-  lv_label_set_text(slot.text_lbl, label.c_str());
+  lv_label_set_display_text(slot.text_lbl, label.c_str());
   return true;
 }
 
@@ -131,7 +131,7 @@ inline bool status_entity_driver_bind_data(
         const bool unavailable = ha_state_unavailable_ref(state);
         const bool active = !unavailable &&
           status_entity_driver_state_active(type, state);
-        lv_label_set_text(icon, active ? active_icon : inactive_icon);
+        lv_label_set_display_text(icon, active ? active_icon : inactive_icon);
         if (btn && active_color) {
           lv_obj_set_style_bg_color(
             btn, lv_color_hex(active ? on_color : sensor_color),

--- a/components/espcontrol/button_grid_string.h
+++ b/components/espcontrol/button_grid_string.h
@@ -15,6 +15,34 @@ inline std::string string_ref_limited(esphome::StringRef value, size_t max_len) 
   return std::string(value.c_str(), len);
 }
 
+// Roboto does not provide the precomposed Latin S-with-dot-below glyphs used
+// by some user-supplied names and media metadata. Keep protocol/configuration
+// values untouched and apply this compact ASCII fallback only at display time.
+inline std::string normalize_display_text(const std::string &text) {
+  static constexpr char UPPER_S_DOT_BELOW[] = "\xE1\xB9\xA2";  // U+1E62
+  static constexpr char LOWER_S_DOT_BELOW[] = "\xE1\xB9\xA3";  // U+1E63
+
+  if (text.find(UPPER_S_DOT_BELOW) == std::string::npos &&
+      text.find(LOWER_S_DOT_BELOW) == std::string::npos) {
+    return text;
+  }
+
+  std::string normalized;
+  normalized.reserve(text.size());
+  for (size_t index = 0; index < text.size();) {
+    if (text.compare(index, 3, UPPER_S_DOT_BELOW) == 0) {
+      normalized.push_back('S');
+      index += 3;
+    } else if (text.compare(index, 3, LOWER_S_DOT_BELOW) == 0) {
+      normalized.push_back('s');
+      index += 3;
+    } else {
+      normalized.push_back(text[index++]);
+    }
+  }
+  return normalized;
+}
+
 inline bool append_html_code_point(std::string &output, uint32_t code_point) {
   if (code_point == 0 || code_point > 0x10FFFF ||
       (code_point >= 0xD800 && code_point <= 0xDFFF)) {

--- a/components/espcontrol/button_grid_subpages.h
+++ b/components/espcontrol/button_grid_subpages.h
@@ -335,13 +335,13 @@ inline lv_obj_t *create_card_sensor_container(lv_obj_t *parent,
   lv_obj_t *value = lv_label_create(container);
   if (value_font) lv_obj_set_style_text_font(value, value_font, LV_PART_MAIN);
   lv_obj_set_style_text_color(value, text_color, LV_PART_MAIN);
-  lv_label_set_text(value, "--");
+  lv_label_set_display_text(value, "--");
 
   lv_obj_t *unit = lv_label_create(container);
   if (unit_font) lv_obj_set_style_text_font(unit, unit_font, LV_PART_MAIN);
   lv_obj_set_style_text_color(unit, text_color, LV_PART_MAIN);
   lv_obj_set_style_pad_bottom(unit, 6, LV_PART_MAIN);
-  lv_label_set_text(unit, "");
+  lv_label_set_display_text(unit, "");
 
   if (value_lbl) *value_lbl = value;
   if (unit_lbl) *unit_lbl = unit;
@@ -360,7 +360,7 @@ inline BtnSlot create_dynamic_card_slot(lv_obj_t *btn,
   slot.icon_lbl = lv_label_create(btn);
   if (icon_font) lv_obj_set_style_text_font(slot.icon_lbl, icon_font, LV_PART_MAIN);
   lv_obj_set_style_text_color(slot.icon_lbl, text_color, LV_PART_MAIN);
-  lv_label_set_text(slot.icon_lbl, "\U000F0493");
+  lv_label_set_display_text(slot.icon_lbl, "\U000F0493");
   lv_obj_align(slot.icon_lbl, LV_ALIGN_TOP_LEFT, 0, 0);
 
   slot.sensor_container = create_card_sensor_container(
@@ -369,7 +369,7 @@ inline BtnSlot create_dynamic_card_slot(lv_obj_t *btn,
   slot.text_lbl = lv_label_create(btn);
   if (label_font) lv_obj_set_style_text_font(slot.text_lbl, label_font, LV_PART_MAIN);
   lv_obj_set_style_text_color(slot.text_lbl, text_color, LV_PART_MAIN);
-  lv_label_set_text(slot.text_lbl, espcontrol_i18n("Configure"));
+  lv_label_set_display_text(slot.text_lbl, espcontrol_i18n("Configure"));
   lv_obj_align(slot.text_lbl, LV_ALIGN_BOTTOM_LEFT, 0, 0);
   configure_button_label_wrap(slot.text_lbl);
 
@@ -378,7 +378,7 @@ inline BtnSlot create_dynamic_card_slot(lv_obj_t *btn,
   if (chevron_font) lv_obj_set_style_text_font(slot.subpage_lbl, chevron_font, LV_PART_MAIN);
   lv_obj_set_style_text_color(slot.subpage_lbl, text_color, LV_PART_MAIN);
   lv_obj_set_style_text_opa(slot.subpage_lbl, LV_OPA_50, LV_PART_MAIN);
-  lv_label_set_text(slot.subpage_lbl, "\U000F0142");
+  lv_label_set_display_text(slot.subpage_lbl, "\U000F0142");
   lv_obj_align(slot.subpage_lbl, LV_ALIGN_BOTTOM_RIGHT, 0, 2);
   lv_obj_add_flag(slot.subpage_lbl, LV_OBJ_FLAG_HIDDEN);
   return slot;
@@ -464,10 +464,10 @@ inline void subscribe_subpage_parent_indicator(
         }
         if (sp_on_count[parent_idx] > 0) {
           set_card_checked_state(parent_btn, true);
-          if (has_alt_icon) lv_label_set_text(parent_icon, on_glyph);
+          if (has_alt_icon) lv_label_set_display_text(parent_icon, on_glyph);
         } else {
           set_card_checked_state(parent_btn, false);
-          if (has_alt_icon) lv_label_set_text(parent_icon, off_glyph);
+          if (has_alt_icon) lv_label_set_display_text(parent_icon, off_glyph);
         }
       })
   );
@@ -489,7 +489,7 @@ inline void apply_climate_subpage_parent_indicator(ClimateSubpageParentIndicator
   bool working = ctx->available && climate_action_is_working(ctx->hvac_action);
   set_card_checked_state(ctx->parent_btn, working);
   if (ctx->has_alt_icon && ctx->parent_icon)
-    lv_label_set_text(ctx->parent_icon, working ? ctx->on_glyph : ctx->off_glyph);
+    lv_label_set_display_text(ctx->parent_icon, working ? ctx->on_glyph : ctx->off_glyph);
 }
 
 inline void subscribe_climate_subpage_parent_indicator(

--- a/components/espcontrol/button_grid_subscriptions.h
+++ b/components/espcontrol/button_grid_subscriptions.h
@@ -105,11 +105,11 @@ inline void subscribe_sensor_value(lv_obj_t *sensor_lbl, const std::string &sens
       if (!unavailable && parse_float_ref(state, val) && std::isfinite(val)) {
         char buf[16];
         format_fixed_decimal(buf, sizeof(buf), val, precision);
-        lv_label_set_text(sensor_lbl, buf);
-        if (unit_lbl) lv_label_set_text(unit_lbl, display_unit.c_str());
+        lv_label_set_display_text(sensor_lbl, buf);
+        if (unit_lbl) lv_label_set_display_text(unit_lbl, display_unit.c_str());
       } else {
-        lv_label_set_text(sensor_lbl, "");
-        if (unit_lbl) lv_label_set_text(unit_lbl, "");
+        lv_label_set_display_text(sensor_lbl, "");
+        if (unit_lbl) lv_label_set_display_text(unit_lbl, "");
       }
     })
   );
@@ -117,16 +117,16 @@ inline void subscribe_sensor_value(lv_obj_t *sensor_lbl, const std::string &sens
 
 inline void apply_time_sensor_value(TimeSensorCtx *ctx) {
   if (!ctx || !ctx->sensor_lbl) return;
-  if (ctx->unit_lbl) lv_label_set_text(ctx->unit_lbl, "");
+  if (ctx->unit_lbl) lv_label_set_display_text(ctx->unit_lbl, "");
   if (!ctx->has_state || (ctx->manual_unit.empty() && !ctx->has_auto_unit)) {
-    lv_label_set_text(ctx->sensor_lbl, "");
+    lv_label_set_display_text(ctx->sensor_lbl, "");
     return;
   }
 
   const std::string &input_unit = ctx->manual_unit.empty() ? ctx->auto_unit : ctx->manual_unit;
   double multiplier = 0.0;
   if (!duration_unit_seconds_multiplier(input_unit, multiplier)) {
-    lv_label_set_text(ctx->sensor_lbl, "");
+    lv_label_set_display_text(ctx->sensor_lbl, "");
     if (ctx->manual_unit.empty() &&
         (!ctx->warned_unit_set || ctx->warned_unit != input_unit)) {
       ESP_LOGW("sensors", "Time sensor %s has unsupported or missing unit_of_measurement '%s'",
@@ -144,10 +144,10 @@ inline void apply_time_sensor_value(TimeSensorCtx *ctx) {
                                     ctx->state, ctx->has_state,
                                     ctx->auto_unit, ctx->has_auto_unit,
                                     ctx->manual_unit, ctx->max_components)) {
-    lv_label_set_text(ctx->sensor_lbl, "");
+    lv_label_set_display_text(ctx->sensor_lbl, "");
     return;
   }
-  lv_label_set_text(ctx->sensor_lbl, output);
+  lv_label_set_display_text(ctx->sensor_lbl, output);
 }
 
 inline void subscribe_time_sensor_value(TimeSensorCtx *ctx, const std::string &sensor_id,
@@ -157,7 +157,7 @@ inline void subscribe_time_sensor_value(TimeSensorCtx *ctx, const std::string &s
   ctx->entity_id = sensor_id;
   ctx->manual_unit = manual_unit;
   ctx->max_components = max_components;
-  if (ctx->unit_lbl) lv_label_set_text(ctx->unit_lbl, "");
+  if (ctx->unit_lbl) lv_label_set_display_text(ctx->unit_lbl, "");
   ha_subscribe_state(
     sensor_id,
     std::function<void(esphome::StringRef)>([ctx](esphome::StringRef state) {
@@ -224,7 +224,7 @@ inline void subscribe_sensor_icon_state(lv_obj_t *btn_ptr, lv_obj_t *icon_lbl,
         set_card_checked_state(
           btn_ptr, active_color && !unavailable && is_entity_on_ref(state));
       }
-      lv_label_set_text(icon_lbl, (!unavailable && is_entity_on_ref(state)) ? icon_on : icon_off);
+      lv_label_set_display_text(icon_lbl, (!unavailable && is_entity_on_ref(state)) ? icon_on : icon_off);
     })
   );
 }
@@ -256,8 +256,8 @@ inline void subscribe_weather_state(lv_obj_t *icon_lbl, lv_obj_t *text_lbl, cons
       if (generation != ha_subscription_generation()) return;
       std::string state_text = string_ref_limited(state, HA_SHORT_STATE_MAX_LEN);
       ESP_LOGI("weather", "Current weather state for %s: %s", entity_id.c_str(), state_text.c_str());
-      lv_label_set_text(icon_lbl, weather_icon_for_state(state_text));
-      lv_label_set_text(text_lbl, weather_label_for_state(state_text).c_str());
+      lv_label_set_display_text(icon_lbl, weather_icon_for_state(state_text));
+      lv_label_set_display_text(text_lbl, weather_label_for_state(state_text).c_str());
       notify_dashboard_content_changed();
     })
   );
@@ -275,7 +275,7 @@ inline void subscribe_garage_state(lv_obj_t *btn_ptr, lv_obj_t *icon_lbl,
         std::string state_text = string_ref_limited(state, HA_SHORT_STATE_MAX_LEN);
         bool active = garage_state_is_active(state_text);
         set_card_checked_state(btn_ptr, active);
-        lv_label_set_text(icon_lbl, garage_state_uses_open_icon(state_text) ? open_icon : closed_icon);
+        lv_label_set_display_text(icon_lbl, garage_state_uses_open_icon(state_text) ? open_icon : closed_icon);
         transient_status_label_show_if_changed(
           status_label, garage_state_label(state_text),
           persistent_status ? false : garage_state_releases_label(state_text));
@@ -298,7 +298,7 @@ inline void subscribe_gate_state(lv_obj_t *btn_ptr, lv_obj_t *icon_lbl,
         apply_control_availability(btn_ptr, btn_ptr, !unavailable);
         bool active = garage_state_is_active(state_text);
         set_card_checked_state(btn_ptr, active);
-        lv_label_set_text(icon_lbl, garage_state_uses_open_icon(state_text) ? open_icon : closed_icon);
+        lv_label_set_display_text(icon_lbl, garage_state_uses_open_icon(state_text) ? open_icon : closed_icon);
         transient_status_label_show_if_changed(
           status_label, garage_state_label(state_text),
           persistent_status ? false : garage_state_releases_label(state_text));
@@ -317,7 +317,7 @@ inline void subscribe_cover_toggle_state(lv_obj_t *btn_ptr, lv_obj_t *icon_lbl,
         std::string state_text = string_ref_limited(state, HA_SHORT_STATE_MAX_LEN);
         bool active = cover_toggle_state_is_active(state_text);
         set_card_checked_state(btn_ptr, active);
-        lv_label_set_text(icon_lbl, garage_state_uses_open_icon(state_text) ? open_icon : closed_icon);
+        lv_label_set_display_text(icon_lbl, garage_state_uses_open_icon(state_text) ? open_icon : closed_icon);
         transient_status_label_show_if_changed(
           status_label, garage_state_label(state_text), garage_state_releases_label(state_text));
       })
@@ -337,7 +337,7 @@ inline void subscribe_lock_state(lv_obj_t *btn_ptr, lv_obj_t *icon_lbl,
         ctx->state = state_text;
         bool active = lock_state_is_active(state_text);
         set_card_checked_state(btn_ptr, active);
-        lv_label_set_text(icon_lbl,
+        lv_label_set_display_text(icon_lbl,
           lock_state_uses_unlocked_icon(state_text) ? unlocked_icon : locked_icon);
         transient_status_label_show_if_changed(
           status_label, lock_state_label(state_text), lock_state_releases_label(state_text));
@@ -414,7 +414,7 @@ inline void subscribe_toggle_state(lv_obj_t *btn_ptr, lv_obj_t *icon_lbl,
           if (icon_lbl) lv_obj_clear_flag(icon_lbl, LV_OBJ_FLAG_HIDDEN);
           if (sensor_ctr) lv_obj_add_flag(sensor_ctr, LV_OBJ_FLAG_HIDDEN);
           if (*slot_has_icon_on)
-            lv_label_set_text(icon_lbl, on ? *slot_icon_on : *slot_icon_off);
+            lv_label_set_display_text(icon_lbl, on ? *slot_icon_on : *slot_icon_off);
         }
         configure_button_label_wrap(text_lbl);
       })
@@ -461,7 +461,7 @@ inline void apply_action_card_display_value(ActionCardStateCtx *ctx,
                                             bool unavailable) {
   if (!ctx) return;
   if (ctx->show_icon_state && ctx->icon_lbl) {
-    lv_label_set_text(ctx->icon_lbl, (!unavailable && is_entity_on_ref(state)) ? ctx->icon_on : ctx->icon_off);
+    lv_label_set_display_text(ctx->icon_lbl, (!unavailable && is_entity_on_ref(state)) ? ctx->icon_on : ctx->icon_off);
     return;
   }
   if (ctx->show_text_state && ctx->text_lbl) {
@@ -474,11 +474,11 @@ inline void apply_action_card_display_value(ActionCardStateCtx *ctx,
   if (!unavailable && parse_float_ref(state, val) && std::isfinite(val)) {
     char buf[16];
     format_fixed_decimal(buf, sizeof(buf), val, ctx->precision);
-    lv_label_set_text(ctx->sensor_lbl, buf);
-    if (ctx->unit_lbl) lv_label_set_text(ctx->unit_lbl, ctx->unit.c_str());
+    lv_label_set_display_text(ctx->sensor_lbl, buf);
+    if (ctx->unit_lbl) lv_label_set_display_text(ctx->unit_lbl, ctx->unit.c_str());
   } else {
-    lv_label_set_text(ctx->sensor_lbl, "");
-    if (ctx->unit_lbl) lv_label_set_text(ctx->unit_lbl, "");
+    lv_label_set_display_text(ctx->sensor_lbl, "");
+    if (ctx->unit_lbl) lv_label_set_display_text(ctx->unit_lbl, "");
   }
 }
 

--- a/components/espcontrol/button_grid_todo.h
+++ b/components/espcontrol/button_grid_todo.h
@@ -24,9 +24,9 @@ inline void setup_todo_card(BtnSlot &s, const ParsedCfg &p, uint32_t secondary_c
     static_cast<lv_style_selector_t>(LV_PART_MAIN) | static_cast<lv_style_selector_t>(LV_STATE_DEFAULT));
   lv_obj_clear_flag(s.icon_lbl, LV_OBJ_FLAG_HIDDEN);
   lv_obj_add_flag(s.sensor_container, LV_OBJ_FLAG_HIDDEN);
-  lv_label_set_text(s.icon_lbl,
+  lv_label_set_display_text(s.icon_lbl,
     (!p.icon.empty() && p.icon != "Auto") ? find_icon(p.icon.c_str()) : find_icon("Check"));
-  lv_label_set_text(s.text_lbl, p.label.empty() ? espcontrol_i18n("Todo") : p.label.c_str());
+  lv_label_set_display_text(s.text_lbl, p.label.empty() ? espcontrol_i18n("Todo") : p.label.c_str());
 }
 
 inline void todo_cancel_pending_request(const char *reason, bool keep_modal_waiting = true) {
@@ -175,12 +175,12 @@ inline std::string todo_lite_card_label(TodoCardCtx *ctx) {
 
 inline void todo_lite_apply_card_text(TodoCardCtx *ctx) {
   if (!ctx) return;
-  if (ctx->label_lbl) lv_label_set_text(ctx->label_lbl, todo_lite_card_label(ctx).c_str());
+  if (ctx->label_lbl) lv_label_set_display_text(ctx->label_lbl, todo_lite_card_label(ctx).c_str());
   if (ctx->value_lbl) {
     if (ctx->value_font) lv_obj_set_style_text_font(ctx->value_lbl, ctx->value_font, LV_PART_MAIN);
-    lv_label_set_text(ctx->value_lbl, ctx->available ? ctx->count_text : "--");
+    lv_label_set_display_text(ctx->value_lbl, ctx->available ? ctx->count_text : "--");
   }
-  if (ctx->unit_lbl) lv_label_set_text(ctx->unit_lbl, "");
+  if (ctx->unit_lbl) lv_label_set_display_text(ctx->unit_lbl, "");
 }
 
 inline void setup_todo_card(BtnSlot &s, const ParsedCfg &p, uint32_t secondary_color) {
@@ -194,11 +194,11 @@ inline void setup_todo_card(BtnSlot &s, const ParsedCfg &p, uint32_t secondary_c
     lv_obj_clear_flag(s.icon_lbl, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_flag(s.sensor_container, LV_OBJ_FLAG_HIDDEN);
   }
-  lv_label_set_text(s.icon_lbl,
+  lv_label_set_display_text(s.icon_lbl,
     (!p.icon.empty() && p.icon != "Auto") ? find_icon(p.icon.c_str()) : find_icon("Check"));
-  lv_label_set_text(s.sensor_lbl, "--");
-  lv_label_set_text(s.unit_lbl, "");
-  lv_label_set_text(s.text_lbl, p.label.empty() ? espcontrol_i18n("Todo") : p.label.c_str());
+  lv_label_set_display_text(s.sensor_lbl, "--");
+  lv_label_set_display_text(s.unit_lbl, "");
+  lv_label_set_display_text(s.text_lbl, p.label.empty() ? espcontrol_i18n("Todo") : p.label.c_str());
   apply_push_button_transition(s.btn);
 }
 
@@ -264,7 +264,7 @@ inline void todo_lite_modal_set_status(const char *text) {
       lv_obj_set_style_text_font(ui.status_lbl, ui.active->label_font, LV_PART_MAIN);
   }
   if (!ui.status_lbl) return;
-  lv_label_set_text(ui.status_lbl, text ? espcontrol_i18n(text) : "");
+  lv_label_set_display_text(ui.status_lbl, text ? espcontrol_i18n(text) : "");
   if (wants_visible) lv_obj_clear_flag(ui.status_lbl, LV_OBJ_FLAG_HIDDEN);
   else lv_obj_add_flag(ui.status_lbl, LV_OBJ_FLAG_HIDDEN);
 }
@@ -309,7 +309,7 @@ inline lv_obj_t *todo_lite_create_row(TodoCardCtx *ctx, TodoLiteItem *item,
   lv_coord_t label_x = checkbox_size + gap;
   lv_coord_t label_w = content_w > label_x ? content_w - label_x : lv_pct(100);
   lv_obj_t *label = lv_label_create(row);
-  lv_label_set_text(label, item && item->summary[0] ? item->summary : espcontrol_i18n("(untitled)"));
+  lv_label_set_display_text(label, item && item->summary[0] ? item->summary : espcontrol_i18n("(untitled)"));
   lv_label_set_long_mode(label, LV_LABEL_LONG_DOT);
   lv_obj_set_width(label, label_w);
   lv_obj_set_style_text_color(label, lv_color_hex(DARK_TEXT_SOFT), LV_PART_MAIN);
@@ -334,7 +334,7 @@ inline lv_obj_t *todo_lite_create_note_row(TodoCardCtx *ctx, const char *text,
   lv_obj_clear_flag(row, LV_OBJ_FLAG_SCROLLABLE);
 
   lv_obj_t *label = lv_label_create(row);
-  lv_label_set_text(label, text ? text : "");
+  lv_label_set_display_text(label, text ? text : "");
   lv_label_set_long_mode(label, LV_LABEL_LONG_DOT);
   lv_obj_set_width(label, content_w);
   lv_obj_set_style_text_color(label, lv_color_hex(DARK_TEXT_MUTED), LV_PART_MAIN);
@@ -681,7 +681,7 @@ inline void subscribe_todo_friendly_name(TodoCardCtx *ctx) {
       ctx->friendly_name = string_ref_limited(name, HA_FRIENDLY_NAME_MAX_LEN);
       todo_lite_apply_card_text(ctx);
       TodoLiteModalUi &ui = todo_lite_modal_ui();
-      if (ui.active == ctx && ui.title_lbl) lv_label_set_text(ui.title_lbl, todo_lite_card_label(ctx).c_str());
+      if (ui.active == ctx && ui.title_lbl) lv_label_set_display_text(ui.title_lbl, todo_lite_card_label(ctx).c_str());
     })
   );
 }
@@ -820,12 +820,12 @@ inline void todo_apply_value_font(TodoCardCtx *ctx) {
 
 inline void todo_apply_card_text(TodoCardCtx *ctx) {
   if (!ctx) return;
-  if (ctx->label_lbl) lv_label_set_text(ctx->label_lbl, todo_card_label(ctx).c_str());
+  if (ctx->label_lbl) lv_label_set_display_text(ctx->label_lbl, todo_card_label(ctx).c_str());
   if (ctx->value_lbl) {
     todo_apply_value_font(ctx);
-    lv_label_set_text(ctx->value_lbl, ctx->available ? ctx->count_text.c_str() : "--");
+    lv_label_set_display_text(ctx->value_lbl, ctx->available ? ctx->count_text.c_str() : "--");
   }
-  if (ctx->unit_lbl) lv_label_set_text(ctx->unit_lbl, "");
+  if (ctx->unit_lbl) lv_label_set_display_text(ctx->unit_lbl, "");
 }
 
 inline void setup_todo_card(BtnSlot &s, const ParsedCfg &p, uint32_t secondary_color) {
@@ -839,11 +839,11 @@ inline void setup_todo_card(BtnSlot &s, const ParsedCfg &p, uint32_t secondary_c
     lv_obj_clear_flag(s.icon_lbl, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_flag(s.sensor_container, LV_OBJ_FLAG_HIDDEN);
   }
-  lv_label_set_text(s.icon_lbl,
+  lv_label_set_display_text(s.icon_lbl,
     (!p.icon.empty() && p.icon != "Auto") ? find_icon(p.icon.c_str()) : find_icon("Check"));
-  lv_label_set_text(s.sensor_lbl, "--");
-  lv_label_set_text(s.unit_lbl, "");
-  lv_label_set_text(s.text_lbl, p.label.empty() ? espcontrol_i18n("Todo") : p.label.c_str());
+  lv_label_set_display_text(s.sensor_lbl, "--");
+  lv_label_set_display_text(s.unit_lbl, "");
+  lv_label_set_display_text(s.text_lbl, p.label.empty() ? espcontrol_i18n("Todo") : p.label.c_str());
   apply_push_button_transition(s.btn);
 }
 
@@ -953,7 +953,7 @@ inline void todo_modal_set_status(const char *text) {
       lv_obj_set_style_text_font(ui.status_lbl, ui.active->label_font, LV_PART_MAIN);
   }
   if (!ui.status_lbl) return;
-  lv_label_set_text(ui.status_lbl, text ? espcontrol_i18n(text) : "");
+  lv_label_set_display_text(ui.status_lbl, text ? espcontrol_i18n(text) : "");
   if (wants_visible) lv_obj_clear_flag(ui.status_lbl, LV_OBJ_FLAG_HIDDEN);
   else lv_obj_add_flag(ui.status_lbl, LV_OBJ_FLAG_HIDDEN);
 }
@@ -1037,7 +1037,7 @@ inline lv_obj_t *todo_modal_create_list_item_row(
     lv_obj_align(box, LV_ALIGN_LEFT_MID, 0, 0);
     if (checked) {
       lv_obj_t *check = lv_label_create(box);
-      lv_label_set_text(check, find_icon("Check"));
+      lv_label_set_display_text(check, find_icon("Check"));
       lv_obj_set_style_text_color(check, lv_color_hex(checkbox_color), LV_PART_MAIN);
       lv_obj_set_style_text_align(check, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
       if (icon_font) lv_obj_set_style_text_font(check, icon_font, LV_PART_MAIN);
@@ -1059,7 +1059,7 @@ inline lv_obj_t *todo_modal_create_list_item_row(
   }
 
   lv_obj_t *value = lv_label_create(row);
-  lv_label_set_text(value, label.c_str());
+  lv_label_set_display_text(value, label.c_str());
   lv_label_set_long_mode(value, LV_LABEL_LONG_DOT);
   lv_obj_set_width(value, label_w);
   lv_obj_set_style_text_color(value,
@@ -1396,7 +1396,7 @@ inline void subscribe_todo_friendly_name(TodoCardCtx *ctx) {
       ctx->friendly_name = string_ref_limited(name, HA_FRIENDLY_NAME_MAX_LEN);
       todo_apply_card_text(ctx);
       TodoModalUi &ui = todo_modal_ui();
-      if (ui.active == ctx && ui.title_lbl) lv_label_set_text(ui.title_lbl, todo_card_label(ctx).c_str());
+      if (ui.active == ctx && ui.title_lbl) lv_label_set_display_text(ui.title_lbl, todo_card_label(ctx).c_str());
     })
   );
 }

--- a/components/espcontrol/button_grid_vacuum.h
+++ b/components/espcontrol/button_grid_vacuum.h
@@ -86,8 +86,8 @@ inline void setup_vacuum_card(BtnSlot &s, const ParsedCfg &p) {
   std::string label = p.label.empty()
     ? espcontrol_i18n(std::string(vacuum_card_mode_label(p.sensor)))
     : p.label;
-  lv_label_set_text(s.text_lbl, label.c_str());
-  lv_label_set_text(s.icon_lbl, vacuum_card_icon(p));
+  lv_label_set_display_text(s.text_lbl, label.c_str());
+  lv_label_set_display_text(s.icon_lbl, vacuum_card_icon(p));
   if (vacuum_card_read_only(p)) {
     lv_obj_clear_flag(s.icon_lbl, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_flag(s.sensor_container, LV_OBJ_FLAG_HIDDEN);
@@ -119,7 +119,7 @@ inline void apply_vacuum_card_state(VacuumCardCtx *ctx,
   if (!ctx) return;
   ctx->state = unavailable ? "unavailable" : std::string(state.c_str(), state.size());
   if (ctx->icon_lbl) {
-    lv_label_set_text(ctx->icon_lbl, find_icon(vacuum_state_icon_name(ctx->state)));
+    lv_label_set_display_text(ctx->icon_lbl, find_icon(vacuum_state_icon_name(ctx->state)));
   }
   if (ctx->text_lbl) {
     std::string label = ctx->status_card

--- a/components/espcontrol/button_grid_weather_driver.h
+++ b/components/espcontrol/button_grid_weather_driver.h
@@ -40,15 +40,15 @@ inline bool weather_driver_setup_visual(
   if (weather_driver_shows_forecast(config)) {
     lv_obj_add_flag(slot.icon_lbl, LV_OBJ_FLAG_HIDDEN);
     lv_obj_clear_flag(slot.sensor_container, LV_OBJ_FLAG_HIDDEN);
-    lv_label_set_text(slot.sensor_lbl, "--/--");
-    lv_label_set_text(slot.unit_lbl, display_temperature_unit_symbol());
+    lv_label_set_display_text(slot.sensor_lbl, "--/--");
+    lv_label_set_display_text(slot.unit_lbl, display_temperature_unit_symbol());
     const std::string day = weather_driver_forecast_day(config);
     const std::string label = config.label.empty()
       ? (day == "today"
           ? espcontrol_i18n(std::string("Today"))
           : espcontrol_i18n(std::string("Tomorrow")))
       : config.label;
-    lv_label_set_text(slot.text_lbl, label.c_str());
+    lv_label_set_display_text(slot.text_lbl, label.c_str());
     apply_width_compensation(
       slot.sensor_container, display_main_width_percent(display));
     apply_width_compensation(
@@ -61,10 +61,10 @@ inline bool weather_driver_setup_visual(
 
   lv_obj_clear_flag(slot.icon_lbl, LV_OBJ_FLAG_HIDDEN);
   lv_obj_add_flag(slot.sensor_container, LV_OBJ_FLAG_HIDDEN);
-  lv_label_set_text(slot.icon_lbl, find_icon("Weather Cloudy"));
-  lv_label_set_text(slot.sensor_lbl, "");
-  lv_label_set_text(slot.unit_lbl, "");
-  lv_label_set_text(slot.text_lbl, espcontrol_i18n("Cloudy"));
+  lv_label_set_display_text(slot.icon_lbl, find_icon("Weather Cloudy"));
+  lv_label_set_display_text(slot.sensor_lbl, "");
+  lv_label_set_display_text(slot.unit_lbl, "");
+  lv_label_set_display_text(slot.text_lbl, espcontrol_i18n("Cloudy"));
   return true;
 }
 

--- a/components/espcontrol/button_grid_weather_forecast.h
+++ b/components/espcontrol/button_grid_weather_forecast.h
@@ -230,13 +230,13 @@ inline void apply_weather_forecast_card_text(const WeatherForecastCardRef &ref,
       : (ref.label.empty()
           ? (ref.day == "today" ? espcontrol_i18n(std::string("Today")) : espcontrol_i18n(std::string("Tomorrow")))
           : ref.label);
-    lv_label_set_text(ref.label_lbl, label.c_str());
+    lv_label_set_display_text(ref.label_lbl, label.c_str());
   }
   if (!ref.value_lbl || !ref.unit_lbl) return;
   if (!valid) {
-    lv_label_set_text(ref.value_lbl, "--/--");
+    lv_label_set_display_text(ref.value_lbl, "--/--");
     std::string normalized_unit = weather_forecast_unit_symbol(unit);
-    lv_label_set_text(ref.unit_lbl, normalized_unit.c_str());
+    lv_label_set_display_text(ref.unit_lbl, normalized_unit.c_str());
     return;
   }
   char buf[24];
@@ -247,9 +247,9 @@ inline void apply_weather_forecast_card_text(const WeatherForecastCardRef &ref,
   if (low == WEATHER_FORECAST_TEMP_MISSING) snprintf(low_buf, sizeof(low_buf), "--");
   else snprintf(low_buf, sizeof(low_buf), "%d", weather_forecast_display_temp(low, unit));
   snprintf(buf, sizeof(buf), "%s/%s", high_buf, low_buf);
-  lv_label_set_text(ref.value_lbl, buf);
+  lv_label_set_display_text(ref.value_lbl, buf);
   std::string normalized_unit = weather_forecast_unit_symbol(unit);
-  lv_label_set_text(ref.unit_lbl, normalized_unit.c_str());
+  lv_label_set_display_text(ref.unit_lbl, normalized_unit.c_str());
 }
 
 inline bool weather_forecast_card_ref_ready(const WeatherForecastCardRef &ref) {

--- a/components/espcontrol/clock_bar.h
+++ b/components/espcontrol/clock_bar.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "esphome/components/lvgl/lvgl_esphome.h"
+#include "display_text.h"
 #include "display_mode_controller.h"
 #include "temperature_unit.h"
 
@@ -446,7 +447,7 @@ inline void refresh_clock_bar_temperature_label_values(
       else format_fixed_decimal(value_buf, sizeof(value_buf), value, 0);
       char buf[24];
       format_clock_bar_temperature_single(buf, sizeof(buf), value_buf);
-      lv_label_set_text(label, buf);
+      lv_label_set_display_text(label, buf);
       clock_bar_set_widget_hidden(label, !show_on_screen);
     };
     if (outdoor_enabled) set_legacy_temperature(outdoor);
@@ -475,7 +476,7 @@ inline void refresh_clock_bar_temperature_label_values(
     else format_fixed_decimal(value_buf, sizeof(value_buf), values[i], 0);
     char buf[24];
     format_clock_bar_temperature_single(buf, sizeof(buf), value_buf);
-    lv_label_set_text(label, buf);
+    lv_label_set_display_text(label, buf);
     clock_bar_set_widget_hidden(label, false);
   }
 }

--- a/components/espcontrol/display_text.h
+++ b/components/espcontrol/display_text.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstring>
+#include <string>
+
+#include "esphome/components/lvgl/lvgl_esphome.h"
+#include "button_grid_string.h"
+
+// LVGL copies label text, so a normalized temporary remains valid for the
+// duration of this call. Avoid allocating for the overwhelmingly common case.
+inline void lv_label_set_display_text(lv_obj_t *label, const char *text) {
+  if (text == nullptr ||
+      (std::strstr(text, "\xE1\xB9\xA2") == nullptr &&
+       std::strstr(text, "\xE1\xB9\xA3") == nullptr)) {
+    lv_label_set_text(label, text);
+    return;
+  }
+  const std::string normalized = normalize_display_text(text);
+  lv_label_set_text(label, normalized.c_str());
+}

--- a/components/espcontrol/network_status.h
+++ b/components/espcontrol/network_status.h
@@ -3,6 +3,8 @@
 // =============================================================================
 #pragma once
 
+#include "display_text.h"
+
 #include <cmath>
 #include <cstdlib>
 #include <string>
@@ -44,15 +46,15 @@ inline const char *network_status_wifi_icon(float pct) {
 inline void network_status_set_wifi_icon(lv_obj_t *label, float pct, bool connected) {
   if (!label) return;
   if (!connected) {
-    lv_label_set_text(label, NETWORK_ICON_WIFI_OFF_OUTLINE);
+    lv_label_set_display_text(label, NETWORK_ICON_WIFI_OFF_OUTLINE);
     return;
   }
-  lv_label_set_text(label, network_status_wifi_icon(pct));
+  lv_label_set_display_text(label, network_status_wifi_icon(pct));
 }
 
 inline void network_status_set_ethernet_icon(lv_obj_t *label) {
   if (!label) return;
-  lv_label_set_text(label, NETWORK_ICON_ETHERNET);
+  lv_label_set_display_text(label, NETWORK_ICON_ETHERNET);
 }
 
 inline void network_status_update_visibility(lv_obj_t *button, lv_obj_t *main_page_obj,
@@ -150,7 +152,7 @@ inline lv_obj_t *network_status_add_center_label(lv_obj_t *parent,
                                                  lv_coord_t width,
                                                  uint32_t color) {
   lv_obj_t *label = lv_label_create(parent);
-  lv_label_set_text(label, text ? text : "");
+  lv_label_set_display_text(label, text ? text : "");
   lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
   lv_obj_set_width(label, width);
   lv_obj_set_style_text_color(label, lv_color_hex(color), LV_PART_MAIN);

--- a/components/espcontrol/screen_lock_state.h
+++ b/components/espcontrol/screen_lock_state.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "display_text.h"
+
 // Internal implementation detail for button_grid.h. Include button_grid.h from device YAML.
 
 #include <algorithm>
@@ -126,10 +128,10 @@ inline void screen_lock_apply() {
     lv_obj_add_flag(ref.btn, LV_OBJ_FLAG_CLICKABLE);
     if (ref.icon_lbl) {
       const char *icon = locked ? ref.locked_icon : ref.unlocked_icon;
-      lv_label_set_text(ref.icon_lbl, icon ? icon : "");
+      lv_label_set_display_text(ref.icon_lbl, icon ? icon : "");
     }
     if (ref.text_lbl) {
-      lv_label_set_text(ref.text_lbl,
+      lv_label_set_display_text(ref.text_lbl,
         locked ? espcontrol_i18n("Screen Locked") : espcontrol_i18n("Screen Unlocked"));
     }
   }

--- a/dev-docs/font-guidelines.md
+++ b/dev-docs/font-guidelines.md
@@ -107,8 +107,10 @@ When adding or changing card UI, prefer one of these existing pointers.
 Fonts only include the glyphs explicitly listed for that font.
 
 - Text fonts usually include `common/assets/text_glyphs.yaml`.
-- Text characters that Roboto does not provide use a small Noto Sans fallback
-  set from `common/assets/latin_extended_additional_glyphs.yaml`.
+- User-supplied `Ṣ` and `ṣ` characters that Roboto does not provide are
+  normalized to plain `S` and `s` only when text is rendered. Keep this
+  substitution at the display boundary so Home Assistant values and service
+  data remain unchanged.
 - Icon fonts use Material Design Icon glyph sets such as
   `common/assets/icon_glyphs.yaml`.
 - Number fonts intentionally include only digits and a few symbols such as

--- a/devices/esp32-p4-86/device/fonts.yaml
+++ b/devices/esp32-p4-86/device/fonts.yaml
@@ -34,8 +34,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -46,8 +44,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -58,8 +54,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -70,8 +64,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -82,8 +74,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -94,8 +84,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 

--- a/devices/guition-esp32-p4-jc1060p470-v2/device/fonts.yaml
+++ b/devices/guition-esp32-p4-jc1060p470-v2/device/fonts.yaml
@@ -34,8 +34,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -46,8 +44,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -58,8 +54,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -70,8 +64,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -82,8 +74,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -101,8 +91,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 

--- a/devices/guition-esp32-p4-jc1060p470/device/fonts.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/device/fonts.yaml
@@ -34,8 +34,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -46,8 +44,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -58,8 +54,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -70,8 +64,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -82,8 +74,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -101,8 +91,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 

--- a/devices/guition-esp32-p4-jc4880p443/device/fonts.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/device/fonts.yaml
@@ -34,8 +34,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -46,8 +44,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -58,8 +54,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -70,8 +64,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -82,8 +74,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/device/fonts.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/device/fonts.yaml
@@ -34,8 +34,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -46,8 +44,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -58,8 +54,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -70,8 +64,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -82,8 +74,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -101,8 +91,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 

--- a/devices/guition-esp32-p4-jc8012p4a1/device/fonts.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/fonts.yaml
@@ -34,8 +34,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -46,8 +44,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -58,8 +54,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -70,8 +64,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -82,8 +74,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -101,8 +91,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 

--- a/devices/guition-esp32-s3-4848s040/device/fonts.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/fonts.yaml
@@ -34,8 +34,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -46,8 +44,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -58,8 +54,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -70,8 +64,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -82,8 +74,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 
@@ -94,8 +84,6 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
-      - file: "gfonts://Noto+Sans@Light"
-        glyphs: !include ../../../common/assets/latin_extended_additional_glyphs.yaml
       - file: "gfonts://Heebo@Light"
         glyphs: !include ../../../common/assets/hebrew_glyphs.yaml
 

--- a/scripts/check_device_profiles.py
+++ b/scripts/check_device_profiles.py
@@ -595,7 +595,7 @@ def test_weather_card_visual_matches_preview() -> None:
     assert 'set_weather_card_badge(s, "Weather Cloudy")' not in weather_visuals, (
         "current weather device card should not render a visible weather badge"
     )
-    assert 'lv_label_set_text(slot.text_lbl, espcontrol_i18n("Cloudy"))' in weather_driver, (
+    assert 'lv_label_set_display_text(slot.text_lbl, espcontrol_i18n("Cloudy"))' in weather_driver, (
         "current weather device card should render the same label as the web preview"
     )
     assert 'set_weather_card_badge(s, "Weather Partly Cloudy")' not in weather_visuals, (
@@ -604,10 +604,10 @@ def test_weather_card_visual_matches_preview() -> None:
     assert '"HA Actions"' not in weather_forecast, (
         "forecast weather errors should keep the configured/default label like the web preview"
     )
-    assert 'lv_label_set_text(slot.unit_lbl, display_temperature_unit_symbol())' in weather_driver, (
+    assert 'lv_label_set_display_text(slot.unit_lbl, display_temperature_unit_symbol())' in weather_driver, (
         "forecast weather placeholder should show the configured unit like the web preview"
     )
-    assert 'lv_label_set_text(ref.unit_lbl, normalized_unit.c_str())' in weather_forecast, (
+    assert 'lv_label_set_display_text(ref.unit_lbl, normalized_unit.c_str())' in weather_forecast, (
         "forecast weather unavailable state should keep showing the configured unit"
     )
     grid = (ROOT / "components" / "espcontrol" / "button_grid_grid.h").read_text(encoding="utf-8")

--- a/scripts/check_firmware_card_runtime.py
+++ b/scripts/check_firmware_card_runtime.py
@@ -185,7 +185,7 @@ def check_root(root: Path) -> list[str]:
                 )
         unsupported_clear_body = function_body(text, "clear_unsupported_card_slot_visuals")
         if unsupported_clear_body is None or any(
-            f"lv_label_set_text(s.{label}, \"\");" not in unsupported_clear_body
+            f"lv_label_set_display_text(s.{label}, \"\");" not in unsupported_clear_body
             for label in ("icon_lbl", "text_lbl", "sensor_lbl", "unit_lbl")
         ):
             failures.append(

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -14,6 +14,7 @@ ROOT = Path(__file__).resolve().parents[1]
 FIRMWARE_DIR = ROOT / "components" / "espcontrol"
 CORE_INFRA_PATH = ROOT / "common" / "device" / "core_infra.yaml"
 SCREEN_LOADING_PATH = ROOT / "common" / "device" / "screen_loading.yaml"
+SCREEN_WIFI_SETUP_PATH = ROOT / "common" / "device" / "screen_wifi_setup.yaml"
 API_NAVIGATE_PATH = ROOT / "common" / "device" / "api_navigate.yaml"
 C6_FIRMWARE_UPDATE_PATH = ROOT / "common" / "device" / "esp32_c6_firmware_update.yaml"
 COVER_ART_PATH = ROOT / "common" / "device" / "screen_cover_art.yaml"
@@ -3489,7 +3490,10 @@ def firmware_connectivity_api_errors(paths: tuple[Path, ...], root: Path) -> lis
 
 
 def firmware_wifi_setup_display_text_errors(
-    loading_path: Path, connectivity_path: Path, root: Path
+    loading_path: Path,
+    wifi_setup_path: Path,
+    connectivity_path: Path,
+    root: Path,
 ) -> list[str]:
     errors: list[str] = []
     expected_calls = (
@@ -3499,6 +3503,10 @@ def firmware_wifi_setup_display_text_errors(
         ),
         (
             connectivity_path,
+            "lv_label_set_display_text(id(wifi_setup_instructions), msg.c_str());",
+        ),
+        (
+            wifi_setup_path,
             "lv_label_set_display_text(id(wifi_setup_instructions), msg.c_str());",
         ),
     )
@@ -3688,7 +3696,10 @@ def run_scan() -> int:
     errors.extend(firmware_connectivity_api_errors(CONNECTIVITY_PATHS, ROOT))
     errors.extend(
         firmware_wifi_setup_display_text_errors(
-            SCREEN_LOADING_PATH, CONNECTIVITY_PATHS[0], ROOT
+            SCREEN_LOADING_PATH,
+            SCREEN_WIFI_SETUP_PATH,
+            CONNECTIVITY_PATHS[0],
+            ROOT,
         )
     )
     errors.extend(firmware_ha_connection_screen_errors(CORE_INFRA_PATH, ROOT))
@@ -4633,19 +4644,25 @@ def expect_connectivity_api_errors(name: str, text: str, expected: tuple[str, ..
 
 
 def expect_wifi_setup_display_text_errors(
-    name: str, loading_text: str, connectivity_text: str, expected: tuple[str, ...]
+    name: str,
+    loading_text: str,
+    wifi_setup_text: str,
+    connectivity_text: str,
+    expected: tuple[str, ...],
 ) -> None:
     with TemporaryDirectory() as tmp:
         root = Path(tmp)
         loading_path = root / "common" / "device" / "screen_loading.yaml"
+        wifi_setup_path = root / "common" / "device" / "screen_wifi_setup.yaml"
         connectivity_path = root / "common" / "addon" / "connectivity.yaml"
         loading_path.parent.mkdir(parents=True)
         connectivity_path.parent.mkdir(parents=True)
         loading_path.write_text(loading_text, encoding="utf-8")
+        wifi_setup_path.write_text(wifi_setup_text, encoding="utf-8")
         connectivity_path.write_text(connectivity_text, encoding="utf-8")
 
         errors = firmware_wifi_setup_display_text_errors(
-            loading_path, connectivity_path, root
+            loading_path, wifi_setup_path, connectivity_path, root
         )
         for item in expected:
             assert any(item in error for error in errors), f"{name}: missing {item!r} in {errors!r}"
@@ -7844,14 +7861,17 @@ def run_self_test() -> int:
         "raw WiFi setup display names",
         "lv_label_set_text(id(loading_status_label), msg.c_str());\n",
         "lv_label_set_text(id(wifi_setup_instructions), msg.c_str());\n",
+        "lv_label_set_text(id(wifi_setup_instructions), msg.c_str());\n",
         (
             "common/device/screen_loading.yaml: normalize user-controlled WiFi setup names",
+            "common/device/screen_wifi_setup.yaml: normalize user-controlled WiFi setup names",
             "common/addon/connectivity.yaml: normalize user-controlled WiFi setup names",
         ),
     )
     expect_wifi_setup_display_text_errors(
         "normalized WiFi setup display names",
         "lv_label_set_display_text(id(loading_status_label), msg.c_str());\n",
+        "lv_label_set_display_text(id(wifi_setup_instructions), msg.c_str());\n",
         "lv_label_set_display_text(id(wifi_setup_instructions), msg.c_str());\n",
         (),
     )

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -1080,11 +1080,17 @@ def firmware_cover_art_refresh_errors(path: Path, root: Path) -> list[str]:
         errors.append(f"{rel}: reset artwork retry state when playback resumes without a visible image")
     if playback_started_body and "espcontrol::cover_art::display_allowed(" in playback_started_body:
         errors.append(f"{rel}: let the playback-start event activate cover art before mirrored playback state settles")
-    if (
-        "cover_art_artist_label" in text
-        and "if (!id(cover_art_artist).empty()) return id(cover_art_artist);" not in text
+    sync_text_body = yaml_script_body(text, "cover_art_sync_track_text")
+    source_display_normalized = sync_text_body is not None and re.search(
+        r"normalize_display_text\(\s*decode_html_entities\(id\(cover_art_media_source\)\)\)",
+        sync_text_body,
+    )
+    if sync_text_body is not None and (
+        "normalize_display_text(id(cover_art_title))" not in sync_text_body
+        or "normalize_display_text(id(cover_art_artist))" not in sync_text_body
+        or source_display_normalized is None
     ):
-        errors.append(f"{rel}: prefer a real artist name over the external-source fallback label")
+        errors.append(f"{rel}: normalize decoded cover art metadata only at the label boundary")
     pause_body = yaml_script_body(text, "cover_art_pause_after_touch")
     if pause_body is not None and (
         "target_mode_is(espcontrol::DisplayMode::COVER_ART)" not in pause_body
@@ -5890,6 +5896,17 @@ def run_self_test() -> int:
         ("restart its countdown after every touch",),
     )
     expect_cover_art_refresh_errors(
+        "cover art metadata bypasses display normalization",
+        "script:\n"
+        "  - id: cover_art_sync_track_text\n"
+        "    then:\n"
+        "      - lambda: |-\n"
+        "          return id(cover_art_title);\n"
+        "          return id(cover_art_artist);\n"
+        "          return id(cover_art_media_source);\n",
+        ("normalize decoded cover art metadata only at the label boundary",),
+    )
+    expect_cover_art_refresh_errors(
         "stale cover refresh guard present",
         "globals:\n"
         "  - id: cover_art_runtime\n"
@@ -5898,6 +5915,13 @@ def run_self_test() -> int:
         "# cover_art_runtime).effective_download_url\n"
         "  - id: cover_art_album\n"
         "script:\n"
+        "  - id: cover_art_sync_track_text\n"
+        "    then:\n"
+        "      - lambda: |-\n"
+        "          return normalize_display_text(id(cover_art_title));\n"
+        "          return normalize_display_text(id(cover_art_artist));\n"
+        "          return normalize_display_text(\n"
+        "            decode_html_entities(id(cover_art_media_source)));\n"
         "  - id: cover_art_resolve_home_assistant_base_url\n"
         "    then:\n"
         "      - lambda: |-\n"

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -13,6 +13,7 @@ from tempfile import TemporaryDirectory
 ROOT = Path(__file__).resolve().parents[1]
 FIRMWARE_DIR = ROOT / "components" / "espcontrol"
 CORE_INFRA_PATH = ROOT / "common" / "device" / "core_infra.yaml"
+SCREEN_LOADING_PATH = ROOT / "common" / "device" / "screen_loading.yaml"
 API_NAVIGATE_PATH = ROOT / "common" / "device" / "api_navigate.yaml"
 C6_FIRMWARE_UPDATE_PATH = ROOT / "common" / "device" / "esp32_c6_firmware_update.yaml"
 COVER_ART_PATH = ROOT / "common" / "device" / "screen_cover_art.yaml"
@@ -3487,6 +3488,30 @@ def firmware_connectivity_api_errors(paths: tuple[Path, ...], root: Path) -> lis
     return errors
 
 
+def firmware_wifi_setup_display_text_errors(
+    loading_path: Path, connectivity_path: Path, root: Path
+) -> list[str]:
+    errors: list[str] = []
+    expected_calls = (
+        (
+            loading_path,
+            "lv_label_set_display_text(id(loading_status_label), msg.c_str());",
+        ),
+        (
+            connectivity_path,
+            "lv_label_set_display_text(id(wifi_setup_instructions), msg.c_str());",
+        ),
+    )
+    for path, expected_call in expected_calls:
+        if not path.exists():
+            continue
+        if expected_call not in path.read_text(encoding="utf-8"):
+            errors.append(
+                f"{path.relative_to(root)}: normalize user-controlled WiFi setup names before display"
+            )
+    return errors
+
+
 def firmware_ha_connection_screen_errors(core_infra_path: Path, root: Path) -> list[str]:
     if not core_infra_path.exists():
         return []
@@ -3661,6 +3686,11 @@ def run_scan() -> int:
     errors.extend(firmware_navigation_target_errors(FIRMWARE_DIR, API_NAVIGATE_PATH, DEVICE_PACKAGE_PATHS, ROOT))
     errors.extend(firmware_todo_disabled_errors(DEVICE_DEVICE_PATHS, ROOT))
     errors.extend(firmware_connectivity_api_errors(CONNECTIVITY_PATHS, ROOT))
+    errors.extend(
+        firmware_wifi_setup_display_text_errors(
+            SCREEN_LOADING_PATH, CONNECTIVITY_PATHS[0], ROOT
+        )
+    )
     errors.extend(firmware_ha_connection_screen_errors(CORE_INFRA_PATH, ROOT))
     errors.extend(firmware_c6_update_status_errors(C6_FIRMWARE_UPDATE_PATH, ROOT))
     if errors:
@@ -4596,6 +4626,27 @@ def expect_connectivity_api_errors(name: str, text: str, expected: tuple[str, ..
         path.write_text(text, encoding="utf-8")
 
         errors = firmware_connectivity_api_errors((path,), root)
+        for item in expected:
+            assert any(item in error for error in errors), f"{name}: missing {item!r} in {errors!r}"
+        if not expected:
+            assert not errors, f"{name}: expected no errors, got {errors!r}"
+
+
+def expect_wifi_setup_display_text_errors(
+    name: str, loading_text: str, connectivity_text: str, expected: tuple[str, ...]
+) -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        loading_path = root / "common" / "device" / "screen_loading.yaml"
+        connectivity_path = root / "common" / "addon" / "connectivity.yaml"
+        loading_path.parent.mkdir(parents=True)
+        connectivity_path.parent.mkdir(parents=True)
+        loading_path.write_text(loading_text, encoding="utf-8")
+        connectivity_path.write_text(connectivity_text, encoding="utf-8")
+
+        errors = firmware_wifi_setup_display_text_errors(
+            loading_path, connectivity_path, root
+        )
         for item in expected:
             assert any(item in error for error in errors), f"{name}: missing {item!r} in {errors!r}"
         if not expected:
@@ -7788,6 +7839,21 @@ def run_self_test() -> int:
         "  on_client_connected:\n"
         "    - script.execute: navigate_after_api\n",
         ("wait for Home Assistant state subscription", "only navigate after a Home Assistant state connection"),
+    )
+    expect_wifi_setup_display_text_errors(
+        "raw WiFi setup display names",
+        "lv_label_set_text(id(loading_status_label), msg.c_str());\n",
+        "lv_label_set_text(id(wifi_setup_instructions), msg.c_str());\n",
+        (
+            "common/device/screen_loading.yaml: normalize user-controlled WiFi setup names",
+            "common/addon/connectivity.yaml: normalize user-controlled WiFi setup names",
+        ),
+    )
+    expect_wifi_setup_display_text_errors(
+        "normalized WiFi setup display names",
+        "lv_label_set_display_text(id(loading_status_label), msg.c_str());\n",
+        "lv_label_set_display_text(id(wifi_setup_instructions), msg.c_str());\n",
+        (),
     )
     expect_connectivity_api_errors(
         "home assistant state connected navigation",

--- a/scripts/check_firmware_parser.py
+++ b/scripts/check_firmware_parser.py
@@ -45,6 +45,7 @@ CLOCK_BAR_HEADER = ROOT / "components" / "espcontrol" / "clock_bar.h"
 LAYOUT_HEADER = ROOT / "components" / "espcontrol" / "button_grid_layout.h"
 LIMITS_HEADER = ROOT / "components" / "espcontrol" / "button_grid_limits.h"
 STRING_HEADER = ROOT / "components" / "espcontrol" / "button_grid_string.h"
+DISPLAY_TEXT_HEADER = ROOT / "components" / "espcontrol" / "display_text.h"
 BUTTON_GRID_FACADE = ROOT / "components" / "espcontrol" / "button_grid.h"
 CARD_NORMALIZATION_FIXTURES = ROOT / "common" / "config" / "card_normalization_fixtures.json"
 DEVICES_DIR = ROOT / "devices"
@@ -941,6 +942,7 @@ def main() -> int:
         shutil.copy2(LAYOUT_HEADER, tmp_path / "button_grid_layout.h")
         shutil.copy2(LIMITS_HEADER, tmp_path / "button_grid_limits.h")
         shutil.copy2(STRING_HEADER, tmp_path / "button_grid_string.h")
+        shutil.copy2(DISPLAY_TEXT_HEADER, tmp_path / "display_text.h")
         lvgl_stub = tmp_path / "esphome" / "components" / "lvgl" / "lvgl_esphome.h"
         lvgl_stub.parent.mkdir(parents=True, exist_ok=True)
         lvgl_stub.write_text("", encoding="utf-8")

--- a/tests/firmware/button_grid_foundations_test.cpp
+++ b/tests/firmware/button_grid_foundations_test.cpp
@@ -27,6 +27,18 @@ int main() {
 
   if (string_ref_limited(esphome::StringRef("calendar"), 4) != "cale") return EXIT_FAILURE;
   if (string_ref_limited(esphome::StringRef("clock"), 32) != "clock") return EXIT_FAILURE;
+  if (normalize_display_text("") != "") return EXIT_FAILURE;
+  if (normalize_display_text("Plain ASCII") != "Plain ASCII") return EXIT_FAILURE;
+  if (normalize_display_text("\xE1\xB9\xA2\xC3\xA0ng\xC3\xB3") != "S\xC3\xA0ng\xC3\xB3") {
+    return EXIT_FAILURE;
+  }
+  if (normalize_display_text("\xE1\xB9\xA3\xE1\xB9\xA2 \xE1\xB9\xA3") != "sS s") {
+    return EXIT_FAILURE;
+  }
+  if (normalize_display_text("Beyonc\xC3\xA9 \xE2\x80\x94 \xD7\xA9\xD7\x9C\xD7\x95\xD7\x9D") !=
+      "Beyonc\xC3\xA9 \xE2\x80\x94 \xD7\xA9\xD7\x9C\xD7\x95\xD7\x9D") {
+    return EXIT_FAILURE;
+  }
   if (decode_html_entities("Earth, Wind &amp; Fire") != "Earth, Wind & Fire") {
     return EXIT_FAILURE;
   }
@@ -48,6 +60,10 @@ int main() {
   }
   if (decode_html_entities("Leave &not_an_entity; unchanged") !=
       "Leave &not_an_entity; unchanged") {
+    return EXIT_FAILURE;
+  }
+  if (normalize_display_text(decode_html_entities("&#7778;ade &amp; &#7779;ade")) !=
+      "Sade & sade") {
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
## Purpose

Remove the Noto Sans fallback from device firmware and render unsupported `Ṣ` / `ṣ` as plain `S` / `s` without leaving a character gap.

## What changed

- Added a shared render-time text normalizer for the two UTF-8 sequences.
- Routed LVGL label text through the normalizer, including HTML-decoded media metadata, cover-art screensaver labels, and WiFi setup names and refreshes.
- Kept source Home Assistant values, configuration, stored data, and service-call values unchanged.
- Removed Noto Sans extras from all seven device font configurations while retaining Heebo.
- Removed the unused Latin Extended Additional glyph asset and documented the fallback policy.
- Added unit coverage and updated repository guards for the display-text boundary.

## Automated checks

- Full fast firmware validation profile: passed.
- Full fast documentation validation profile: passed.
- Firmware unit tests: 29/29 passed.
- ESPHome 2026.8.1 configuration validation: all seven factory configurations passed.
- ESPHome 2026.8.1 compile: all three official compile targets passed.
- Repository search: no Noto Sans or deleted glyph-file references remain.

## Firmware size comparison

| Factory target | main | branch | saving |
| --- | ---: | ---: | ---: |
| guition-esp32-p4-jc1060p470 | 5,211,652 | 5,207,636 | 4,016 bytes |
| guition-esp32-p4-jc4880p443 | 5,148,428 | 5,145,036 | 3,392 bytes |
| guition-esp32-s3-4848s040 | 4,813,379 | 4,808,367 | 5,012 bytes |

## Device testing requested

Flash the affected display and confirm normal boot, touch/navigation, and text layout. Then display `Ṣàngó` and a lowercase `ṣ` through:

1. Media title or artist metadata.
2. An entity name.
3. A custom card label.
4. The cover-art screensaver title, artist, and external source fields.
5. The fallback WiFi AP name or configured friendly name shown during network setup, including after the text refreshes.

Each should render as `Sàngó` and `s`, with no blank gap or missing-glyph box. If practical, also trigger an action using a raw value containing `Ṣ` or `ṣ` and confirm Home Assistant receives the original unmodified value.

This PR is intentionally left open for physical device testing.
