### PR TITLE
Experiment with 2-bpp text fonts

### DIFF
--- a/devices/esp32-p4-86/device/fonts.yaml
+++ b/devices/esp32-p4-86/device/fonts.yaml
@@ -31,7 +31,7 @@ font:
   - file: "gfonts://Roboto"
     id: font_text_body
     size: 33
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans"
@@ -43,7 +43,7 @@ font:
   - file: "gfonts://Roboto"
     id: font_text_small
     size: 27
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans"
@@ -55,7 +55,7 @@ font:
   - file: "gfonts://Roboto@Light"
     id: font_text_title
     size: 52
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans@Light"

--- a/devices/guition-esp32-p4-jc1060p470-v2/device/fonts.yaml
+++ b/devices/guition-esp32-p4-jc1060p470-v2/device/fonts.yaml
@@ -31,7 +31,7 @@ font:
   - file: "gfonts://Roboto"
     id: font_text_body
     size: 22
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans"
@@ -43,7 +43,7 @@ font:
   - file: "gfonts://Roboto"
     id: font_text_small
     size: 18
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans"
@@ -55,7 +55,7 @@ font:
   - file: "gfonts://Roboto@Light"
     id: font_text_title
     size: 43
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans@Light"
@@ -98,7 +98,7 @@ font:
   - file: "gfonts://Roboto"
     id: font_text_large
     size: 28
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans"

--- a/devices/guition-esp32-p4-jc1060p470/device/fonts.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/device/fonts.yaml
@@ -31,7 +31,7 @@ font:
   - file: "gfonts://Roboto"
     id: font_text_body
     size: 22
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans"
@@ -43,7 +43,7 @@ font:
   - file: "gfonts://Roboto"
     id: font_text_small
     size: 18
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans"
@@ -55,7 +55,7 @@ font:
   - file: "gfonts://Roboto@Light"
     id: font_text_title
     size: 43
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans@Light"
@@ -98,7 +98,7 @@ font:
   - file: "gfonts://Roboto"
     id: font_text_large
     size: 28
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans"

--- a/devices/guition-esp32-p4-jc4880p443/device/fonts.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/device/fonts.yaml
@@ -31,7 +31,7 @@ font:
   - file: "gfonts://Roboto"
     id: font_text_body
     size: 29
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans"
@@ -43,7 +43,7 @@ font:
   - file: "gfonts://Roboto"
     id: font_text_small
     size: 25
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans"
@@ -55,7 +55,7 @@ font:
   - file: "gfonts://Roboto@Light"
     id: font_text_title
     size: 56
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans@Light"

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/device/fonts.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/device/fonts.yaml
@@ -31,7 +31,7 @@ font:
   - file: "gfonts://Roboto"
     id: font_text_body
     size: 24
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans"
@@ -43,7 +43,7 @@ font:
   - file: "gfonts://Roboto"
     id: font_text_small
     size: 20
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans"
@@ -55,7 +55,7 @@ font:
   - file: "gfonts://Roboto@Light"
     id: font_text_title
     size: 46
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans@Light"
@@ -98,7 +98,7 @@ font:
   - file: "gfonts://Roboto"
     id: font_text_large
     size: 37
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans"

--- a/devices/guition-esp32-p4-jc8012p4a1/device/fonts.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/fonts.yaml
@@ -31,7 +31,7 @@ font:
   - file: "gfonts://Roboto"
     id: font_text_body
     size: 24
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans"
@@ -43,7 +43,7 @@ font:
   - file: "gfonts://Roboto"
     id: font_text_small
     size: 20
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans"
@@ -55,7 +55,7 @@ font:
   - file: "gfonts://Roboto@Light"
     id: font_text_title
     size: 46
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans@Light"
@@ -98,7 +98,7 @@ font:
   - file: "gfonts://Roboto"
     id: font_text_large
     size: 37
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans"

--- a/devices/guition-esp32-s3-4848s040/device/fonts.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/fonts.yaml
@@ -31,7 +31,7 @@ font:
   - file: "gfonts://Roboto"
     id: font_text_body
     size: 22
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans"
@@ -43,7 +43,7 @@ font:
   - file: "gfonts://Roboto"
     id: font_text_small
     size: 18
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans"
@@ -55,7 +55,7 @@ font:
   - file: "gfonts://Roboto@Light"
     id: font_text_title
     size: 34
-    bpp: 4
+    bpp: 2
     glyphs: !include ../../../common/assets/text_glyphs.yaml
     extras:
       - file: "gfonts://Noto+Sans@Light"


### PR DESCRIPTION
## Purpose

Measure the conservative OTA size benefit of compiling general text roles at 2-bpp while retaining 4-bpp for icons, cover art, media-control titles, numbers, and clocks.

## Changes

- Changes font_text_body, font_text_small, and font_text_title from 4-bpp to 2-bpp on all seven release devices.
- Changes font_text_large where that role exists.
- Leaves font sizes, weights, glyph sets, role mappings, generated files, and public interfaces unchanged.

## Measured impact

Clean baseline and experimental factory firmware were built with ESPHome 2026.8.1 for all seven release targets.

- OTA saving per device: 76,960 to 175,104 bytes (75.2 to 171.0 KiB).
- OTA reduction per device: 1.60% to 3.40%.
- Aggregate saving across the seven release images: 1,032,368 bytes (1,008.2 KiB).
- Every device gained OTA partition headroom.
- Every targeted compiled-font footprint decreased.
- Generated glyph counts were unchanged for every font; each changed text role retained 470 glyphs.

## Automated checks

- All seven baseline factory targets compiled successfully.
- All seven experimental factory targets compiled successfully.
- python3 scripts/check_icon_groups.py
- npm run check:device-matrix
- npm run check:device-profiles
- npm run check:product
- git diff --check

## Physical testing required

Visual quality has not been assessed from compilation alone. Before merging, flash representative hardware and inspect body text, secondary small text, titles, and large modal or setup text. Icons, cover-art text, clocks, and numbers remain at 4-bpp and can serve as visual references.

Affected displays: JC1060P470, JC1060P470 V2, JC4880P443, JC8012P4A1, JC8012P4A1 V2, ESP32-P4-86, and ESP32-S3-4848S040.