### PR TITLE
Fix cover card label padding

### DIFF
--- a/components/espcontrol/button_grid_access_cover_driver.h
+++ b/components/espcontrol/button_grid_access_cover_driver.h
@@ -129,7 +129,7 @@ inline void access_cover_driver_bind_slider(
     config.entity,
     context.runtime.driver == card_runtime::CardDriverId::COVER_TILT);
   if (config.label.empty()) {
-    subscribe_friendly_name(slot.text_lbl, config.entity);
+    subscribe_friendly_name_preserving_layout(slot.text_lbl, config.entity);
   }
 }
 

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -2091,8 +2091,10 @@ inline void grid_phase2(
       display_apply_main_width(sub_slot.icon_lbl, display);
       display_apply_slot_text_width(sub_slot, display);
       setup_card_visual(sub_slot, sb_cfg, context, cfg, palette, rs, cs);
-      apply_card_label_line_clamp(sub_slot.text_lbl, cfg, rs);
-      configure_button_label_wrap(sub_slot.text_lbl);
+      // The line clamp re-anchors labels at the button content origin. Slider
+      // cards remove button padding so their fill can reach the edges, so run
+      // the card-specific refresh after clamping to restore the captured inset.
+      refresh_card_layout(sub_slot, sb_cfg, cfg, rs, cs);
 
       if (espcontrol::cards::image_driver_bind_subpage(
             sub_slot, sb_cfg, context, cfg)) continue;

--- a/components/espcontrol/button_grid_subscriptions.h
+++ b/components/espcontrol/button_grid_subscriptions.h
@@ -377,6 +377,22 @@ inline void subscribe_friendly_name(lv_obj_t *text_lbl, const std::string &entit
   );
 }
 
+// Slider cards zero the button padding so their fill can reach the tile edges,
+// then position the label with a captured inset. Updating the friendly name
+// must not re-anchor that label at (0, 0), or it becomes flush with the tile.
+inline void subscribe_friendly_name_preserving_layout(
+    lv_obj_t *text_lbl, const std::string &entity_id) {
+  ha_subscribe_attribute(
+    entity_id, std::string("friendly_name"),
+    std::function<void(esphome::StringRef)>([text_lbl](esphome::StringRef name) {
+      if (!text_lbl) return;
+      configure_button_label_wrap(text_lbl);
+      lv_label_set_display_text(
+        text_lbl, string_ref_limited(name, HA_FRIENDLY_NAME_MAX_LEN).c_str());
+    })
+  );
+}
+
 // Subscribe to a toggle entity's state; updates checked visual, icon swap, sensor overlay
 inline void subscribe_toggle_state(lv_obj_t *btn_ptr, lv_obj_t *icon_lbl,
                                    lv_obj_t *sensor_ctr, lv_obj_t *text_lbl,

--- a/scripts/check_cover_art_contract.py
+++ b/scripts/check_cover_art_contract.py
@@ -517,10 +517,13 @@ if "configure_button_label_wrap(text_lbl);" not in subscriptions:
 for required in (
     "configure_button_label_wrap(entry->back_slot.text_lbl);",
     "configure_button_label_wrap(back_slot.text_lbl);",
-    "configure_button_label_wrap(sub_slot.text_lbl);",
 ):
     if required not in grid:
         raise SystemExit(f"Subpage label clamps must restore full-width wrapping: {required}")
+if "refresh_card_layout(sub_slot, sb_cfg, cfg, rs, cs);" not in grid:
+    raise SystemExit(
+        "Subpage cards must refresh their layout after label clamping so slider label insets are restored"
+    )
 if "image_card_align_label_stack(label, btn, icon);" not in image_cards:
     raise SystemExit("Image loading-state relayouts must retain the label stack")
 if "lv_obj_align(icon, LV_ALIGN_TOP_LEFT, -parent_x, -parent_y);" not in image_cards:

--- a/scripts/check_device_profiles.py
+++ b/scripts/check_device_profiles.py
@@ -769,8 +769,8 @@ def test_card_label_line_clamp_matches_preview_on_subpages() -> None:
     assert "apply_card_label_line_clamp(back_slot.text_lbl, cfg, sp_ord.back_row_span);" in grid, (
         "subpage back labels must follow the configured line limit"
     )
-    assert "apply_card_label_line_clamp(sub_slot.text_lbl, cfg, rs);" in grid, (
-        "subpage card labels must follow the configured line limit"
+    assert "refresh_card_layout(sub_slot, sb_cfg, cfg, rs, cs);" in grid, (
+        "subpage card labels must follow the configured line limit before card-specific geometry is restored"
     )
 
 

--- a/scripts/check_firmware_card_runtime.py
+++ b/scripts/check_firmware_card_runtime.py
@@ -199,6 +199,18 @@ def check_root(root: Path) -> list[str]:
             failures.append(
                 f"components/espcontrol/{GRID_HEADER}: route main and subpage setup through the shared card context"
             )
+        phase2_body = function_body(text, "grid_phase2") or ""
+        setup_subpage = phase2_body.find("setup_card_visual(sub_slot")
+        refresh_subpage = phase2_body.find("refresh_card_layout(sub_slot")
+        bind_subpage = phase2_body.find("image_driver_bind_subpage")
+        if not (
+            setup_subpage >= 0
+            and refresh_subpage > setup_subpage
+            and bind_subpage > refresh_subpage
+        ):
+            failures.append(
+                f"components/espcontrol/{GRID_HEADER}: refresh subpage card geometry after applying label clamps"
+            )
         if (
             "status_entity_driver_setup_visual( s, p, context, palette)" not in compact_grid
             or "status_entity_driver_bind_data( s, p, context, palette)" not in compact_grid

--- a/scripts/check_firmware_card_runtime.py
+++ b/scripts/check_firmware_card_runtime.py
@@ -744,6 +744,11 @@ def check_root(root: Path) -> list[str]:
                 failures.append(
                     f"components/espcontrol/{ACCESS_COVER_HEADER}: missing shared access/cover lifecycle guard {needle}"
                 )
+        bind_slider_body = function_body(text, "access_cover_driver_bind_slider") or ""
+        if "subscribe_friendly_name_preserving_layout" not in bind_slider_body:
+            failures.append(
+                f"components/espcontrol/{ACCESS_COVER_HEADER}: preserve slider label padding when the cover friendly name arrives"
+            )
     elif grid_header.exists():
         failures.append(
             f"components/espcontrol/{ACCESS_COVER_HEADER}: missing shared access/cover driver"


### PR DESCRIPTION
## Purpose
Restore the normal left and bottom inset on Cover slider-card labels after Home Assistant supplies the entity friendly name.

## Practical impact
Cover Position and Tilt cards without a custom label now keep their text aligned with the icon and neighboring cards instead of moving flush against the tile edge.

## Automated checks
- npm run check:fast
- 29 compiled firmware unit tests passed
- Firmware card-runtime checks and self-tests passed

## Device testing
Device testing is still required because this changes the on-device card layout.

Suggested check:
- Flash the affected display.
- Add or view a Cover Position or Tilt card that uses the Home Assistant friendly name rather than a custom label.
- Confirm the label keeps the same left and bottom padding as neighboring cards.
- Confirm the icon, slider fill, touch behavior, and longer labels still display correctly.