### PR TITLE
Restore 7-inch pixel compensation

### DIFF
--- a/components/espcontrol/button_grid_alarm.h
+++ b/components/espcontrol/button_grid_alarm.h
@@ -1388,7 +1388,6 @@ inline lv_obj_t *alarm_control_create_mode_button(
     lv_obj_t **label_out) {
   lv_obj_t *btn = lv_btn_create(parent);
   lv_obj_set_size(btn, width, height);
-  apply_width_compensation(btn, ctx ? ctx->width_compensation_percent : 100);
   lv_obj_set_style_radius(btn, radius, LV_PART_MAIN);
   lv_obj_set_style_bg_color(btn, lv_color_hex(alarm_control_inactive_color(ctx)), LV_PART_MAIN);
   lv_obj_set_style_bg_opa(btn, LV_OPA_COVER, LV_PART_MAIN);
@@ -1411,7 +1410,6 @@ inline lv_obj_t *alarm_control_create_mode_button(
   lv_obj_set_style_text_color(icon, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_align(icon, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (icon_font) lv_obj_set_style_text_font(icon, icon_font, LV_PART_MAIN);
-  apply_width_compensation(icon, ctx ? ctx->width_compensation_percent : 100);
   lv_obj_clear_flag(icon, LV_OBJ_FLAG_CLICKABLE);
   lv_obj_align(icon, LV_ALIGN_CENTER, 0, -height / 7);
 

--- a/components/espcontrol/button_grid_alarm.h
+++ b/components/espcontrol/button_grid_alarm.h
@@ -1299,7 +1299,7 @@ inline void alarm_pin_open_modal(AlarmActionCtx *action) {
   lv_obj_set_style_text_color(ui.pin_lbl, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_align(ui.pin_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (pin_label_font) lv_obj_set_style_text_font(ui.pin_lbl, pin_label_font, LV_PART_MAIN);
-  apply_width_compensation(ui.pin_lbl, action->card->width_compensation_percent);
+  apply_text_width_compensation(ui.pin_lbl);
   lv_coord_t pin_w = layout.panel_w - (layout.inset + layout.back_size) * 2;
   if (pin_w < 60) pin_w = layout.panel_w - layout.inset * 2;
   lv_obj_set_width(ui.pin_lbl, pin_w);
@@ -1420,7 +1420,7 @@ inline lv_obj_t *alarm_control_create_mode_button(
   lv_obj_set_style_text_color(label, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (label_font) lv_obj_set_style_text_font(label, label_font, LV_PART_MAIN);
-  apply_width_compensation(label, ctx ? ctx->width_compensation_percent : 100);
+  apply_text_width_compensation(label);
   lv_obj_clear_flag(label, LV_OBJ_FLAG_CLICKABLE);
   lv_obj_align(label, LV_ALIGN_CENTER, 0, height / 5);
 
@@ -1461,7 +1461,7 @@ inline void alarm_control_create_arming_view(AlarmControlModalUi &ui,
   lv_obj_set_style_text_color(ui.arming_title, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_align(ui.arming_title, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (title_font) lv_obj_set_style_text_font(ui.arming_title, title_font, LV_PART_MAIN);
-  apply_width_compensation(ui.arming_title, ctx ? ctx->width_compensation_percent : 100);
+  apply_text_width_compensation(ui.arming_title);
   lv_obj_set_width(ui.arming_title, layout.panel_w - layout.inset * 2);
   lv_obj_align(ui.arming_title, LV_ALIGN_CENTER, 0, status_center_y);
   lv_obj_update_layout(ui.arming_title);
@@ -1472,7 +1472,7 @@ inline void alarm_control_create_arming_view(AlarmControlModalUi &ui,
   lv_obj_set_style_text_color(ui.arming_countdown, lv_color_hex(DARK_TEXT_MUTED), LV_PART_MAIN);
   lv_obj_set_style_text_align(ui.arming_countdown, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (countdown_font) lv_obj_set_style_text_font(ui.arming_countdown, countdown_font, LV_PART_MAIN);
-  apply_width_compensation(ui.arming_countdown, ctx ? ctx->width_compensation_percent : 100);
+  apply_text_width_compensation(ui.arming_countdown);
   lv_obj_set_width(ui.arming_countdown, layout.panel_w - layout.inset * 2);
   lv_obj_align(ui.arming_countdown, LV_ALIGN_CENTER, 0, countdown_y);
   lv_obj_add_flag(ui.arming_countdown, LV_OBJ_FLAG_HIDDEN);

--- a/components/espcontrol/button_grid_climate.h
+++ b/components/espcontrol/button_grid_climate.h
@@ -2006,7 +2006,8 @@ inline void climate_control_layout_modal(ClimateControlCtx *ctx) {
   int tab_count = tabs_layout.tab_count;
   bool show_tab_bar = tabs_layout.show_tab_bar;
   lv_coord_t tab_frame_h = tabs_layout.tab_frame_h;
-  control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);
+  control_modal_apply_tab_row(
+    ui.tab_row, layout, tabs_layout, ctx->width_compensation_percent);
   for (int i = 0; show_tab_bar && i < tab_count; i++) {
     lv_obj_t *tab_btn = climate_control_tab_button(ui, visible_tabs.tabs[i]);
     if (!tab_btn) continue;

--- a/components/espcontrol/button_grid_climate.h
+++ b/components/espcontrol/button_grid_climate.h
@@ -2363,7 +2363,7 @@ inline void climate_control_open_modal(ClimateControlCtx *ctx) {
   lv_obj_set_style_text_color(ui.target_lbl, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_align(ui.target_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (ctx->number_font) lv_obj_set_style_text_font(ui.target_lbl, ctx->number_font, LV_PART_MAIN);
-  apply_width_compensation(ui.target_lbl, ctx->width_compensation_percent);
+  apply_text_width_compensation(ui.target_lbl);
 
   auto create_range_target_label = [&]() {
     lv_obj_t *label = lv_label_create(ui.target_row);
@@ -2374,7 +2374,7 @@ inline void climate_control_open_modal(ClimateControlCtx *ctx) {
     const lv_font_t *range_font = ctx->range_number_font
       ? ctx->range_number_font : ctx->number_font;
     if (range_font) lv_obj_set_style_text_font(label, range_font, LV_PART_MAIN);
-    apply_width_compensation(label, ctx->width_compensation_percent);
+    apply_text_width_compensation(label);
     lv_obj_clear_flag(label, LV_OBJ_FLAG_CLICKABLE);
     lv_obj_clear_flag(label, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_add_flag(label, LV_OBJ_FLAG_HIDDEN);
@@ -2399,7 +2399,7 @@ inline void climate_control_open_modal(ClimateControlCtx *ctx) {
   lv_obj_set_style_text_color(ui.unit_lbl, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_align(ui.unit_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (ctx->unit_font) lv_obj_set_style_text_font(ui.unit_lbl, ctx->unit_font, LV_PART_MAIN);
-  apply_width_compensation(ui.unit_lbl, ctx->width_compensation_percent);
+  apply_text_width_compensation(ui.unit_lbl);
 
   ui.status_lbl = lv_label_create(ui.panel);
   lv_obj_set_style_text_color(ui.status_lbl, lv_color_hex(DARK_TEXT_MUTED), LV_PART_MAIN);

--- a/components/espcontrol/button_grid_climate.h
+++ b/components/espcontrol/button_grid_climate.h
@@ -1438,6 +1438,7 @@ inline lv_obj_t *climate_create_option_chip(lv_obj_t *parent, const char *icon,
   lv_obj_set_style_text_color(icon_lbl, lv_color_hex(DARK_TEXT_SOFT), LV_PART_MAIN);
   lv_obj_set_style_text_align(icon_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (icon_font) lv_obj_set_style_text_font(icon_lbl, icon_font, LV_PART_MAIN);
+  apply_width_compensation(icon_lbl, width_compensation_percent);
 
   lv_obj_t *text_col = lv_obj_create(btn);
   lv_obj_add_flag(text_col, LV_OBJ_FLAG_SCROLL_CHAIN_HOR);
@@ -1584,11 +1585,9 @@ inline void climate_center_tab_icon(lv_obj_t *label) {
 
 inline lv_obj_t *climate_control_create_tab_button(lv_obj_t *parent, const char *icon,
                                                    const lv_font_t *font,
-                                                   ClimateControlTab tab,
-                                                   int width_compensation_percent) {
+                                                   ClimateControlTab tab) {
   lv_obj_t *btn = lv_btn_create(parent);
   if (!btn) return nullptr;
-  apply_width_compensation(btn, width_compensation_percent);
   lv_obj_set_style_bg_color(btn, lv_color_hex(SECONDARY_GREY), LV_PART_MAIN);
   lv_obj_set_style_bg_opa(btn, LV_OPA_TRANSP, LV_PART_MAIN);
   lv_obj_set_style_border_width(btn, 0, LV_PART_MAIN);
@@ -1736,8 +1735,10 @@ inline void climate_open_inline_option_list(ClimateControlCtx *ctx, const std::s
       } else if (ctx->icon_font) {
         lv_obj_set_style_text_font(icon_lbl, ctx->icon_font, LV_PART_MAIN);
       }
-      if (compact_portrait_layout && !ctx->card_icon_font) lv_obj_set_style_transform_zoom(
-        icon_lbl, CLIMATE_MODAL_COMPACT_PORTRAIT_OPTION_ICON_ZOOM, LV_PART_MAIN);
+      apply_icon_width_compensation(
+        icon_lbl,
+        compact_portrait_layout && !ctx->card_icon_font
+          ? CLIMATE_MODAL_COMPACT_PORTRAIT_OPTION_ICON_ZOOM : 256);
 
       lv_obj_t *label = lv_label_create(content_parent);
       lv_label_set_display_text(label, climate_option_label(option).c_str());
@@ -2242,19 +2243,19 @@ inline void climate_control_open_modal(ClimateControlCtx *ctx) {
   ui.tab_row = control_modal_create_tab_row(ui.panel);
   ui.temperature_tab = climate_control_create_tab_button(
     ui.tab_row, find_icon("Thermometer"), ctx->icon_font,
-    ClimateControlTab::TEMPERATURE, ctx->width_compensation_percent);
+    ClimateControlTab::TEMPERATURE);
   ui.mode_tab = climate_control_create_tab_button(
     ui.tab_row, find_icon("Fire"), ctx->icon_font,
-    ClimateControlTab::MODE, ctx->width_compensation_percent);
+    ClimateControlTab::MODE);
   ui.preset_tab = climate_control_create_tab_button(
     ui.tab_row, find_icon("Air Filter"), ctx->icon_font,
-    ClimateControlTab::PRESET, ctx->width_compensation_percent);
+    ClimateControlTab::PRESET);
   ui.fan_tab = climate_control_create_tab_button(
     ui.tab_row, find_icon("Fan"), ctx->icon_font,
-    ClimateControlTab::FAN, ctx->width_compensation_percent);
+    ClimateControlTab::FAN);
   ui.swing_tab = climate_control_create_tab_button(
     ui.tab_row, find_icon("Arrow Up Down"), ctx->icon_font,
-    ClimateControlTab::SWING, ctx->width_compensation_percent);
+    ClimateControlTab::SWING);
 
   ui.menu_view = lv_obj_create(ui.panel);
   lv_obj_set_style_bg_opa(ui.menu_view, LV_OPA_TRANSP, LV_PART_MAIN);

--- a/components/espcontrol/button_grid_display.h
+++ b/components/espcontrol/button_grid_display.h
@@ -71,6 +71,7 @@ inline int display_width_percent(int percent) {
 
 inline void display_set_width_axis(const DisplayProfile &profile) {
   set_width_compensation_vertical_axis(profile.width.vertical_axis);
+  set_icon_width_compensation_percent(profile.width.main_percent);
   set_text_width_compensation_percent(profile.width.text_percent);
 }
 

--- a/components/espcontrol/button_grid_display.h
+++ b/components/espcontrol/button_grid_display.h
@@ -28,6 +28,7 @@ struct DisplayFontRoles {
 struct DisplayWidthTokens {
   bool vertical_axis = false;
   int main_percent = 100;
+  int text_percent = 100;
   int volume_percent = 100;
 };
 
@@ -70,6 +71,7 @@ inline int display_width_percent(int percent) {
 
 inline void display_set_width_axis(const DisplayProfile &profile) {
   set_width_compensation_vertical_axis(profile.width.vertical_axis);
+  set_text_width_compensation_percent(profile.width.text_percent);
 }
 
 inline DisplayModalProfile &display_active_modal_profile() {
@@ -103,8 +105,17 @@ inline int display_volume_width_percent(const DisplayProfile &profile) {
   return display_width_percent(profile.width.volume_percent);
 }
 
+inline int display_text_width_percent(const DisplayProfile &profile) {
+  return display_width_percent(profile.width.text_percent);
+}
+
 inline void display_apply_main_width(lv_obj_t *obj, const DisplayProfile &profile) {
   apply_width_compensation(obj, display_main_width_percent(profile));
+}
+
+inline void display_apply_text_width(lv_obj_t *obj, const DisplayProfile &profile) {
+  (void) profile;
+  apply_text_width_compensation(obj);
 }
 
 inline void display_apply_slot_text_width(const BtnSlot &slot, const DisplayProfile &profile) {

--- a/components/espcontrol/button_grid_fan.h
+++ b/components/espcontrol/button_grid_fan.h
@@ -858,7 +858,8 @@ inline void fan_control_layout_modal(FanCardCtx *ctx) {
   int tab_count = static_cast<int>(visible_tabs.count);
   bool show_tab_bar = visible_tabs.count > 1;
   ControlModalTabLayout tabs_layout = control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);
-  control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);
+  control_modal_apply_tab_row(
+    ui.tab_row, layout, tabs_layout, ctx->width_compensation_percent);
   for (int i = 0; show_tab_bar && i < tab_count; i++) {
     lv_obj_t *tab_btn = fan_control_tab_button(ui, visible_tabs.tabs[i]);
     if (!tab_btn) continue;

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -21,6 +21,7 @@ struct GridConfig {
   bool info_only = false;
   bool subpage_chevrons_enabled = true;
   int width_compensation_percent = 100;
+  int text_width_compensation_percent = 100;
   int volume_width_compensation_percent = 100;
   int media_artwork_width_compensation_percent = 100;
   DisplayModalProfile modal_profile;
@@ -93,6 +94,7 @@ inline DisplayProfile display_profile_from_grid_config(const GridConfig &cfg) {
   profile.fonts.volume_icon = cfg.volume_icon_font;
   profile.width.vertical_axis = cfg.width_compensation_vertical;
   profile.width.main_percent = cfg.width_compensation_percent;
+  profile.width.text_percent = cfg.text_width_compensation_percent;
   profile.width.volume_percent = cfg.volume_width_compensation_percent;
   profile.large_numbers.font = cfg.sp_large_sensor_font;
   profile.large_numbers.unit_offset_percent = cfg.large_sensor_unit_offset_percent;
@@ -797,8 +799,8 @@ inline void refresh_media_card_layout(BtnSlot &s, const ParsedCfg &p,
         lv_obj_add_flag(ctx->title_lbl, LV_OBJ_FLAG_HIDDEN);
         lv_obj_add_flag(ctx->artist_lbl, LV_OBJ_FLAG_HIDDEN);
       }
-      display_apply_main_width(ctx->title_lbl, display);
-      display_apply_main_width(ctx->artist_lbl, display);
+      display_apply_text_width(ctx->title_lbl, display);
+      display_apply_text_width(ctx->artist_lbl, display);
       setup_media_now_playing_layout(
         s.btn, s.icon_lbl, ctx->title_lbl, ctx->artist_lbl,
         title_font, padding,
@@ -814,8 +816,8 @@ inline void refresh_media_card_layout(BtnSlot &s, const ParsedCfg &p,
     MediaNowPlayingCtx *ctx = (MediaNowPlayingCtx *)lv_obj_get_user_data(s.sensor_container);
     if (!ctx) return;
     const CardPadding padding = ctx->progress_slider ? ctx->content_padding : CardPadding{};
-    if (ctx->title_lbl) display_apply_main_width(ctx->title_lbl, display);
-    if (ctx->artist_lbl) display_apply_main_width(ctx->artist_lbl, display);
+    if (ctx->title_lbl) display_apply_text_width(ctx->title_lbl, display);
+    if (ctx->artist_lbl) display_apply_text_width(ctx->artist_lbl, display);
     setup_media_now_playing_layout(
       s.btn, s.icon_lbl, ctx->title_lbl, ctx->artist_lbl,
       display_media_title_font(display), padding,
@@ -839,7 +841,7 @@ inline void refresh_media_card_layout(BtnSlot &s, const ParsedCfg &p,
       ? ctx->content_pad_bottom
       : lv_obj_get_style_pad_bottom(s.btn, LV_PART_MAIN);
     if (ctx && ctx->media_value_lbl) {
-      display_apply_main_width(ctx->media_value_lbl, display);
+      display_apply_text_width(ctx->media_value_lbl, display);
       lv_obj_align(ctx->media_value_lbl, LV_ALIGN_TOP_LEFT, position_left, position_top);
       lv_obj_move_foreground(ctx->media_value_lbl);
     }

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -1182,6 +1182,7 @@ inline void setup_image_card(BtnSlot &s) {
   lv_obj_set_style_text_color(loading_icon, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_opa(loading_icon, LV_OPA_COVER, LV_PART_MAIN);
   lv_label_set_display_text(loading_icon, IMAGE_CARD_LOADING_ICON);
+  apply_icon_width_compensation(loading_icon);
 
   lv_obj_t *loading_label = lv_label_create(loading);
   image_card_apply_loading_fonts(loading, loading_icon_font, loading_label_font);
@@ -1997,6 +1998,7 @@ inline void image_card_open_modal(ImageCardCtx *ctx) {
   lv_obj_set_style_text_color(loading_icon, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_opa(loading_icon, LV_OPA_COVER, LV_PART_MAIN);
   lv_label_set_display_text(loading_icon, IMAGE_CARD_LOADING_ICON);
+  apply_icon_width_compensation(loading_icon);
 
   lv_obj_t *loading_label = lv_label_create(ui.loading_widget);
   if (!loading_label) {

--- a/components/espcontrol/button_grid_layout.h
+++ b/components/espcontrol/button_grid_layout.h
@@ -30,6 +30,15 @@ inline void set_width_compensation_vertical_axis(bool vertical) {
   width_compensation_vertical_axis() = vertical;
 }
 
+inline int &text_width_compensation_percent() {
+  static int percent = 100;
+  return percent;
+}
+
+inline void set_text_width_compensation_percent(int percent) {
+  text_width_compensation_percent() = normalize_width_compensation_percent(percent);
+}
+
 inline lv_coord_t compensated_width(lv_coord_t width, int percent) {
   if (width_compensation_vertical_axis()) return width;
   percent = normalize_width_compensation_percent(percent);
@@ -43,10 +52,15 @@ inline void apply_width_compensation(lv_obj_t *obj, int percent) {
   lv_obj_set_style_transform_scale_y(obj, width_compensation_vertical_axis() ? scale : 256, LV_PART_MAIN);
 }
 
+inline void apply_text_width_compensation(lv_obj_t *obj) {
+  apply_width_compensation(obj, text_width_compensation_percent());
+}
+
 inline void apply_slot_text_width_compensation(const BtnSlot &s, int percent) {
-  apply_width_compensation(s.text_lbl, percent);
-  apply_width_compensation(s.sensor_container, percent);
-  apply_width_compensation(s.subpage_lbl, percent);
+  (void) percent;
+  apply_text_width_compensation(s.text_lbl);
+  apply_text_width_compensation(s.sensor_container);
+  apply_text_width_compensation(s.subpage_lbl);
 }
 
 // ── Grid layout parsing ───────────────────────────────────────────────

--- a/components/espcontrol/button_grid_layout.h
+++ b/components/espcontrol/button_grid_layout.h
@@ -30,6 +30,15 @@ inline void set_width_compensation_vertical_axis(bool vertical) {
   width_compensation_vertical_axis() = vertical;
 }
 
+inline int &icon_width_compensation_percent() {
+  static int percent = 100;
+  return percent;
+}
+
+inline void set_icon_width_compensation_percent(int percent) {
+  icon_width_compensation_percent() = normalize_width_compensation_percent(percent);
+}
+
 inline int &text_width_compensation_percent() {
   static int percent = 100;
   return percent;
@@ -54,6 +63,15 @@ inline void apply_width_compensation(lv_obj_t *obj, int percent) {
 
 inline void apply_text_width_compensation(lv_obj_t *obj) {
   apply_width_compensation(obj, text_width_compensation_percent());
+}
+
+inline void apply_icon_width_compensation(lv_obj_t *obj, int zoom = 256) {
+  if (!obj) return;
+  int compensated_zoom = zoom * icon_width_compensation_percent() / 100;
+  lv_obj_set_style_transform_scale_x(
+    obj, width_compensation_vertical_axis() ? zoom : compensated_zoom, LV_PART_MAIN);
+  lv_obj_set_style_transform_scale_y(
+    obj, width_compensation_vertical_axis() ? compensated_zoom : zoom, LV_PART_MAIN);
 }
 
 inline void apply_slot_text_width_compensation(const BtnSlot &s, int percent) {

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -4087,7 +4087,8 @@ inline void media_control_layout_modal(MediaControlCtx *ctx) {
   ControlModalTabLayout tabs_layout = {};
   if (show_tabs) {
     tabs_layout = control_modal_calc_tab_layout(layout, media_control_tab_count, true);
-    control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);
+    control_modal_apply_tab_row(
+      ui.tab_row, layout, tabs_layout, ctx->width_compensation_percent);
   }
 
   struct MediaControlTabLayout {

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -2832,11 +2832,9 @@ inline void media_control_layout_modal(MediaControlCtx *ctx);
 
 inline lv_obj_t *media_control_create_tab_button(lv_obj_t *parent, const char *icon,
                                                  const lv_font_t *font,
-                                                 MediaControlTab tab,
-                                                 int width_compensation_percent) {
+                                                 MediaControlTab tab) {
   lv_obj_t *btn = control_modal_create_flat_icon_button(
-    parent, icon, font, SECONDARY_GREY, LV_OPA_TRANSP,
-    width_compensation_percent, 180);
+    parent, icon, font, SECONDARY_GREY, LV_OPA_TRANSP, 100, 180);
   if (!btn) return nullptr;
   light_control_center_icon_label(control_modal_icon_label(btn));
   lv_obj_add_event_cb(btn, [](lv_event_t *e) {
@@ -2876,7 +2874,7 @@ inline bool media_control_ensure_progress_tab_button(MediaControlCtx *ctx) {
   if (!ui.progress_tab) {
     ui.progress_tab = media_control_create_tab_button(
       ui.tab_row, find_icon("Progress Clock"), ctx->icon_font,
-      MediaControlTab::PROGRESS, ctx->width_compensation_percent);
+      MediaControlTab::PROGRESS);
   }
   if (!ui.progress_tab) return false;
   lv_obj_clear_flag(ui.progress_tab, LV_OBJ_FLAG_HIDDEN);
@@ -2902,7 +2900,7 @@ inline bool media_control_ensure_speakers_tab_button(MediaControlCtx *ctx) {
   if (!ui.speakers_tab) {
     ui.speakers_tab = media_control_create_tab_button(
       ui.tab_row, find_icon("Speaker Multiple"), ctx->icon_font,
-      MediaControlTab::SPEAKERS, ctx->width_compensation_percent);
+      MediaControlTab::SPEAKERS);
   }
   if (!ui.speakers_tab) return false;
   lv_obj_clear_flag(ui.speakers_tab, LV_OBJ_FLAG_HIDDEN);
@@ -2921,7 +2919,7 @@ inline bool media_control_ensure_power_tab_button(MediaControlCtx *ctx) {
   if (!ui.power_tab) {
     ui.power_tab = media_control_create_tab_button(
       ui.tab_row, find_icon("Power"), ctx->icon_font,
-      MediaControlTab::POWER, ctx->width_compensation_percent);
+      MediaControlTab::POWER);
   }
   if (!ui.power_tab) return false;
   lv_obj_clear_flag(ui.power_tab, LV_OBJ_FLAG_HIDDEN);
@@ -2941,9 +2939,11 @@ inline lv_obj_t *media_control_create_box(lv_obj_t *parent) {
 
 inline lv_obj_t *media_control_create_icon_button(lv_obj_t *parent, const char *icon,
                                                   const lv_font_t *font,
-                                                  uint32_t pressed_color) {
+                                                  uint32_t pressed_color,
+                                                  int width_compensation_percent) {
   lv_obj_t *btn = control_modal_create_flat_icon_button(
-    parent, icon, font, SECONDARY_GREY, LV_OPA_COVER);
+    parent, icon, font, SECONDARY_GREY, LV_OPA_COVER,
+    width_compensation_percent);
   if (!btn) return nullptr;
   control_modal_apply_pressed_fill_color(btn, pressed_color);
   return btn;
@@ -2992,18 +2992,23 @@ inline void media_control_create_controls_tab_content(MediaControlCtx *ctx) {
 
   if (media_control_shuffle_supported(ctx)) {
     ui.shuffle_btn = media_control_create_icon_button(
-      ui.content_box, find_icon("Shuffle"), ctx->icon_font, ctx->accent_color);
+      ui.content_box, find_icon("Shuffle"), ctx->icon_font, ctx->accent_color,
+      ctx->width_compensation_percent);
   }
   ui.previous_btn = media_control_create_icon_button(
-    ui.content_box, find_icon("Skip Previous"), ctx->icon_font, ctx->accent_color);
+    ui.content_box, find_icon("Skip Previous"), ctx->icon_font, ctx->accent_color,
+    ctx->width_compensation_percent);
   ui.play_btn = media_control_create_icon_button(
-    ui.content_box, find_icon("Play"), ctx->icon_font, ctx->accent_color);
+    ui.content_box, find_icon("Play"), ctx->icon_font, ctx->accent_color,
+    ctx->width_compensation_percent);
   ui.play_icon_lbl = ui.play_btn ? lv_obj_get_child(ui.play_btn, 0) : nullptr;
   ui.next_btn = media_control_create_icon_button(
-    ui.content_box, find_icon("Skip Next"), ctx->icon_font, ctx->accent_color);
+    ui.content_box, find_icon("Skip Next"), ctx->icon_font, ctx->accent_color,
+    ctx->width_compensation_percent);
   if (media_control_repeat_supported(ctx)) {
     ui.repeat_btn = media_control_create_icon_button(
-      ui.content_box, find_icon("Repeat"), ctx->icon_font, ctx->accent_color);
+      ui.content_box, find_icon("Repeat"), ctx->icon_font, ctx->accent_color,
+      ctx->width_compensation_percent);
     ui.repeat_icon_lbl = ui.repeat_btn ? lv_obj_get_child(ui.repeat_btn, 0) : nullptr;
   }
   if (ui.shuffle_btn) lv_obj_add_event_cb(ui.shuffle_btn, [](lv_event_t *) {
@@ -3714,8 +3719,8 @@ inline void media_control_add_speaker_candidate(MediaControlCtx *ctx,
   lv_label_set_display_text(row->speaker_icon, find_icon("Speaker"));
   lv_obj_set_style_text_align(row->speaker_icon, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (ctx->icon_font) lv_obj_set_style_text_font(row->speaker_icon, ctx->icon_font, LV_PART_MAIN);
-  lv_obj_set_style_transform_zoom(
-    row->speaker_icon, MEDIA_CONTROL_SPEAKER_ROW_ICON_ZOOM, LV_PART_MAIN);
+  apply_icon_width_compensation(
+    row->speaker_icon, MEDIA_CONTROL_SPEAKER_ROW_ICON_ZOOM);
   lv_obj_align(row->speaker_icon, LV_ALIGN_LEFT_MID, compact_pad_x, 0);
 
   row->name_label = lv_label_create(row->row);
@@ -3781,8 +3786,8 @@ inline void media_control_add_speaker_candidate(MediaControlCtx *ctx,
   lv_label_set_display_text(row->speaker_icon, find_icon("Speaker"));
   lv_obj_set_style_text_align(row->speaker_icon, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (ctx->icon_font) lv_obj_set_style_text_font(row->speaker_icon, ctx->icon_font, LV_PART_MAIN);
-  lv_obj_set_style_transform_zoom(
-    row->speaker_icon, MEDIA_CONTROL_SPEAKER_ROW_ICON_ZOOM, LV_PART_MAIN);
+  apply_icon_width_compensation(
+    row->speaker_icon, MEDIA_CONTROL_SPEAKER_ROW_ICON_ZOOM);
 
   row->text_box = lv_obj_create(row->content_box);
   lv_obj_set_size(row->text_box, 0, LV_SIZE_CONTENT);
@@ -3959,7 +3964,8 @@ inline void media_control_create_power_tab_content(MediaControlCtx *ctx) {
   if (!ctx || !ui.content_box || ui.power_btn) return;
 
   ui.power_btn = media_control_create_icon_button(
-    ui.content_box, find_icon("Power"), ctx->icon_font, ctx->accent_color);
+    ui.content_box, find_icon("Power"), ctx->icon_font, ctx->accent_color,
+    ctx->width_compensation_percent);
   ui.power_icon_lbl = ui.power_btn ? control_modal_icon_label(ui.power_btn) : nullptr;
   if (ui.power_btn) {
     lv_obj_add_event_cb(ui.power_btn, [](lv_event_t *) {
@@ -4437,10 +4443,10 @@ inline void media_control_open_modal(MediaControlCtx *ctx) {
     }
     ui.controls_tab = media_control_create_tab_button(
       ui.tab_row, find_icon("Speaker"), ctx->icon_font,
-      MediaControlTab::CONTROLS, ctx->width_compensation_percent);
+      MediaControlTab::CONTROLS);
     ui.volume_tab = media_control_create_tab_button(
       ui.tab_row, find_icon("Volume High"), ctx->icon_font,
-      MediaControlTab::VOLUME, ctx->width_compensation_percent);
+      MediaControlTab::VOLUME);
     progress_tab_ready = media_control_ensure_progress_tab_button(ctx);
     media_control_ensure_speakers_tab_button(ctx);
     power_tab_ready = media_control_ensure_power_tab_button(ctx);

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -2336,7 +2336,8 @@ inline lv_obj_t *setup_media_position_layout(lv_obj_t *btn, lv_obj_t *icon_lbl,
   lv_obj_t *value_lbl = lv_label_create(btn);
   if (value_font) lv_obj_set_style_text_font(value_lbl, value_font, LV_PART_MAIN);
   lv_obj_set_style_text_color(value_lbl, text_color, LV_PART_MAIN);
-  apply_width_compensation(value_lbl, width_compensation_percent);
+  (void) width_compensation_percent;
+  apply_text_width_compensation(value_lbl);
   lv_label_set_display_text(value_lbl, "0:00");
   lv_obj_align(value_lbl, LV_ALIGN_TOP_LEFT, padding.left, padding.top);
   lv_obj_set_style_bg_color(btn, lv_color_hex(background_color), LV_PART_MAIN);
@@ -2978,7 +2979,7 @@ inline void media_control_create_controls_tab_content(MediaControlCtx *ctx) {
   lv_obj_set_style_text_line_space(ui.title_lbl, 0, LV_PART_MAIN);
   if (ctx->title_font) lv_obj_set_style_text_font(ui.title_lbl, ctx->title_font, LV_PART_MAIN);
   lv_label_set_long_mode(ui.title_lbl, LV_LABEL_LONG_WRAP);
-  apply_width_compensation(ui.title_lbl, ctx->width_compensation_percent);
+  apply_text_width_compensation(ui.title_lbl);
 
   ui.artist_lbl = lv_label_create(ui.content_box);
   if (ui.artist_lbl) {
@@ -2986,7 +2987,7 @@ inline void media_control_create_controls_tab_content(MediaControlCtx *ctx) {
     lv_obj_set_style_text_align(ui.artist_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
     if (ctx->label_font) lv_obj_set_style_text_font(ui.artist_lbl, ctx->label_font, LV_PART_MAIN);
     lv_label_set_long_mode(ui.artist_lbl, LV_LABEL_LONG_DOT);
-    apply_width_compensation(ui.artist_lbl, ctx->width_compensation_percent);
+    apply_text_width_compensation(ui.artist_lbl);
   }
 
   if (media_control_shuffle_supported(ctx)) {
@@ -3064,7 +3065,7 @@ inline void media_control_create_progress_tab_content(MediaControlCtx *ctx) {
     lv_obj_set_style_text_color(ui.progress_time_lbl, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
     lv_obj_set_style_text_align(ui.progress_time_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
     if (ctx->title_font) lv_obj_set_style_text_font(ui.progress_time_lbl, ctx->title_font, LV_PART_MAIN);
-    apply_width_compensation(ui.progress_time_lbl, ctx->width_compensation_percent);
+    apply_text_width_compensation(ui.progress_time_lbl);
   }
   lv_obj_add_event_cb(ui.progress_slider, [](lv_event_t *e) {
     MediaControlModalUi &ui = media_control_modal_ui();
@@ -3183,7 +3184,7 @@ inline void media_control_create_volume_tab_content(MediaControlCtx *ctx) {
     lv_obj_set_style_text_color(ui.volume_group_lbl, lv_color_hex(DARK_TEXT_MUTED), LV_PART_MAIN);
     lv_obj_set_style_text_align(ui.volume_group_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
     if (ctx->label_font) lv_obj_set_style_text_font(ui.volume_group_lbl, ctx->label_font, LV_PART_MAIN);
-    apply_width_compensation(ui.volume_group_lbl, ctx->width_compensation_percent);
+    apply_text_width_compensation(ui.volume_group_lbl);
     lv_obj_add_flag(ui.volume_group_lbl, LV_OBJ_FLAG_HIDDEN);
   }
 
@@ -3193,7 +3194,7 @@ inline void media_control_create_volume_tab_content(MediaControlCtx *ctx) {
     lv_obj_set_style_text_color(ui.volume_pct_lbl, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
     lv_obj_set_style_text_align(ui.volume_pct_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
     if (ctx->number_font) lv_obj_set_style_text_font(ui.volume_pct_lbl, ctx->number_font, LV_PART_MAIN);
-    apply_width_compensation(ui.volume_pct_lbl, ctx->width_compensation_percent);
+    apply_text_width_compensation(ui.volume_pct_lbl);
   }
 
   ui.volume_minus_btn = control_modal_create_round_button(
@@ -3976,7 +3977,7 @@ inline void media_control_create_power_tab_content(MediaControlCtx *ctx) {
     if (ctx->label_font) {
       lv_obj_set_style_text_font(ui.power_status_lbl, ctx->label_font, LV_PART_MAIN);
     }
-    apply_width_compensation(ui.power_status_lbl, ctx->width_compensation_percent);
+    apply_text_width_compensation(ui.power_status_lbl);
   }
   media_control_refresh_power(ctx);
 }
@@ -4318,13 +4319,13 @@ inline void media_control_layout_modal(MediaControlCtx *ctx) {
     control_modal_apply_step_buttons_layout(
       ui.volume_minus_btn, ui.volume_plus_btn, volume_buttons_layout);
     if (ui.volume_pct_lbl) {
-      apply_width_compensation(ui.volume_pct_lbl, ctx->width_compensation_percent);
+      apply_text_width_compensation(ui.volume_pct_lbl);
       lv_obj_align(ui.volume_pct_lbl, LV_ALIGN_CENTER, 0,
         volume_layout.arc_center_y +
         control_modal_scaled_px(MEDIA_CONTROL_VOLUME_VALUE_Y_REF_PX, volume_layout.short_side));
     }
     if (ui.volume_group_lbl && ui.volume_pct_lbl) {
-      apply_width_compensation(ui.volume_group_lbl, ctx->width_compensation_percent);
+      apply_text_width_compensation(ui.volume_group_lbl);
       lv_obj_align_to(ui.volume_group_lbl, ui.volume_pct_lbl,
         LV_ALIGN_OUT_TOP_MID, 0, -control_modal_scaled_px(4, volume_layout.short_side));
     }
@@ -4526,13 +4527,13 @@ inline void setup_media_card(BtnSlot &s, const ParsedCfg &p, uint32_t on_color,
       if (s.unit_lbl) lv_obj_add_flag(s.unit_lbl, LV_OBJ_FLAG_HIDDEN);
       lv_obj_t *title_lbl = lv_label_create(s.btn);
       lv_obj_set_style_text_color(title_lbl, lv_color_white(), LV_PART_MAIN);
-      apply_width_compensation(title_lbl, width_compensation_percent);
+      apply_text_width_compensation(title_lbl);
       lv_obj_t *artist_lbl = lv_label_create(s.btn);
       lv_obj_set_style_text_color(artist_lbl, lv_color_white(), LV_PART_MAIN);
       if (media_artist_font) {
         lv_obj_set_style_text_font(artist_lbl, media_artist_font, LV_PART_MAIN);
       }
-      apply_width_compensation(artist_lbl, width_compensation_percent);
+      apply_text_width_compensation(artist_lbl);
       if (s.text_lbl) {
         lv_label_set_display_text(s.text_lbl, "");
         lv_obj_add_flag(s.text_lbl, LV_OBJ_FLAG_HIDDEN);
@@ -4557,7 +4558,7 @@ inline void setup_media_card(BtnSlot &s, const ParsedCfg &p, uint32_t on_color,
     }
     lv_obj_t *title_lbl = lv_label_create(s.btn);
     lv_obj_set_style_text_color(title_lbl, text_color, LV_PART_MAIN);
-    apply_width_compensation(title_lbl, width_compensation_percent);
+    apply_text_width_compensation(title_lbl);
     s.sensor_lbl = title_lbl;
     ctx->title_lbl = title_lbl;
     ctx->artist_lbl = s.text_lbl;

--- a/components/espcontrol/button_grid_modal.h
+++ b/components/espcontrol/button_grid_modal.h
@@ -874,7 +874,8 @@ inline lv_obj_t *control_modal_create_title(lv_obj_t *parent,
   lv_obj_set_style_text_color(title, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_align(title, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (font) lv_obj_set_style_text_font(title, font, LV_PART_MAIN);
-  apply_width_compensation(title, width_compensation_percent);
+  (void) width_compensation_percent;
+  apply_text_width_compensation(title);
   return title;
 }
 
@@ -922,7 +923,8 @@ inline lv_obj_t *control_modal_create_list_row(lv_obj_t *parent,
   lv_obj_set_style_text_color(value, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_align(value, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (font) lv_obj_set_style_text_font(value, font, LV_PART_MAIN);
-  apply_width_compensation(value, width_compensation_percent);
+  (void) width_compensation_percent;
+  apply_text_width_compensation(value);
   lv_obj_center(value);
   return btn;
 }

--- a/components/espcontrol/button_grid_modal.h
+++ b/components/espcontrol/button_grid_modal.h
@@ -407,11 +407,13 @@ inline espcontrol::modal::ContentLayout control_modal_calc_content_layout(
 
 inline void control_modal_apply_tab_row(lv_obj_t *tab_row,
                                         const ControlModalLayout &layout,
-                                        const ControlModalTabLayout &tabs_layout) {
+                                        const ControlModalTabLayout &tabs_layout,
+                                        int width_compensation_percent) {
   if (!tab_row) return;
   if (tabs_layout.show_tab_bar) {
     lv_obj_clear_flag(tab_row, LV_OBJ_FLAG_HIDDEN);
     lv_obj_set_size(tab_row, tabs_layout.tab_frame_w, tabs_layout.tab_frame_h);
+    apply_width_compensation(tab_row, width_compensation_percent);
     lv_obj_set_style_radius(tab_row, tabs_layout.tab_frame_h / 2, LV_PART_MAIN);
     lv_obj_align(tab_row, LV_ALIGN_TOP_LEFT, tabs_layout.row_left, layout.inset + 2);
   } else {
@@ -447,12 +449,10 @@ inline uint16_t control_modal_tab_icon_zoom(const ControlModalLayout &layout) {
 inline void control_modal_layout_tab_button(lv_obj_t *tab_btn,
                                             const ControlModalLayout &layout,
                                             const ControlModalTabLayout &tabs_layout,
-                                            int index, bool active,
-                                            int width_compensation_percent = 100) {
+                                            int index, bool active) {
   if (!tab_btn || !tabs_layout.show_tab_bar) return;
   lv_coord_t tab_btn_size = active ? tabs_layout.selected_tab_size : tabs_layout.tab_size;
   lv_obj_set_size(tab_btn, tab_btn_size, tab_btn_size);
-  apply_width_compensation(tab_btn, width_compensation_percent);
   lv_obj_set_style_radius(tab_btn, tab_btn_size / 2, LV_PART_MAIN);
   lv_coord_t first_tab_x = (tabs_layout.tab_frame_w - tabs_layout.tabs_total_w) / 2;
   lv_coord_t tab_x = first_tab_x + index * (tabs_layout.tab_size + tabs_layout.tab_gap);

--- a/components/espcontrol/button_grid_sliders.h
+++ b/components/espcontrol/button_grid_sliders.h
@@ -3485,7 +3485,7 @@ inline void media_volume_open_modal(MediaVolumeCtx *ctx) {
   lv_obj_set_style_text_color(ui.title_lbl, lv_color_hex(DARK_TEXT_MUTED), LV_PART_MAIN);
   lv_obj_set_style_text_align(ui.title_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (ctx->label_font) lv_obj_set_style_text_font(ui.title_lbl, ctx->label_font, LV_PART_MAIN);
-  apply_width_compensation(ui.title_lbl, ctx->width_compensation_percent);
+  apply_text_width_compensation(ui.title_lbl);
 
   ui.pct_row = lv_obj_create(ui.panel);
   lv_obj_set_size(ui.pct_row, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
@@ -3504,7 +3504,7 @@ inline void media_volume_open_modal(MediaVolumeCtx *ctx) {
   lv_obj_set_style_text_color(ui.pct_lbl, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
   lv_obj_set_style_text_align(ui.pct_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (ctx->number_font) lv_obj_set_style_text_font(ui.pct_lbl, ctx->number_font, LV_PART_MAIN);
-  apply_width_compensation(ui.pct_lbl, ctx->width_compensation_percent);
+  apply_text_width_compensation(ui.pct_lbl);
 
   ui.pct_unit_lbl = lv_label_create(ui.pct_row);
   lv_label_set_display_text(ui.pct_unit_lbl, "");
@@ -3512,7 +3512,7 @@ inline void media_volume_open_modal(MediaVolumeCtx *ctx) {
   lv_obj_set_style_text_align(ui.pct_unit_lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (ctx->unit_font) lv_obj_set_style_text_font(ui.pct_unit_lbl, ctx->unit_font, LV_PART_MAIN);
   lv_obj_set_style_translate_y(ui.pct_unit_lbl, MEDIA_VOLUME_UNIT_Y_REF_PX, LV_PART_MAIN);
-  apply_width_compensation(ui.pct_unit_lbl, ctx->width_compensation_percent);
+  apply_text_width_compensation(ui.pct_unit_lbl);
 
   ui.minus_btn = control_modal_create_round_button(ui.panel, 72, find_icon("Minus"),
     ctx->icon_font, DARK_CONTROL_NEUTRAL, SECONDARY_GREY, ctx->width_compensation_percent);

--- a/components/espcontrol/button_grid_sliders.h
+++ b/components/espcontrol/button_grid_sliders.h
@@ -581,11 +581,9 @@ inline void light_control_center_icon_label(lv_obj_t *label) {
 
 inline lv_obj_t *light_control_create_tab_button(lv_obj_t *parent, const char *icon,
                                                  const lv_font_t *font,
-                                                 LightControlTab tab,
-                                                 int width_compensation_percent) {
+                                                 LightControlTab tab) {
   lv_obj_t *btn = lv_btn_create(parent);
   if (!btn) return nullptr;
-  apply_width_compensation(btn, width_compensation_percent);
   lv_obj_set_style_bg_color(btn, lv_color_hex(SECONDARY_GREY), LV_PART_MAIN);
   lv_obj_set_style_bg_opa(btn, LV_OPA_TRANSP, LV_PART_MAIN);
   lv_obj_set_style_border_width(btn, 0, LV_PART_MAIN);
@@ -953,16 +951,16 @@ inline void light_control_open_modal(LightControlCtx *ctx) {
   ui.tab_row = control_modal_create_tab_row(ui.panel);
   ui.power_tab = light_control_create_tab_button(
     ui.tab_row, find_icon("Power"), ctx->icon_font,
-    LightControlTab::POWER, ctx->width_compensation_percent);
+    LightControlTab::POWER);
   ui.brightness_tab = light_control_create_tab_button(
     ui.tab_row, find_icon("Lightbulb"), ctx->icon_font,
-    LightControlTab::BRIGHTNESS, ctx->width_compensation_percent);
+    LightControlTab::BRIGHTNESS);
   ui.temperature_tab = light_control_create_tab_button(
     ui.tab_row, find_icon("Thermometer"), ctx->icon_font,
-    LightControlTab::TEMPERATURE, ctx->width_compensation_percent);
+    LightControlTab::TEMPERATURE);
   ui.color_tab = light_control_create_tab_button(
     ui.tab_row, find_icon("Palette"), ctx->icon_font,
-    LightControlTab::COLOR, ctx->width_compensation_percent);
+    LightControlTab::COLOR);
 
   ui.power_group = lv_obj_create(ui.panel);
   lv_obj_set_style_bg_color(ui.power_group, lv_color_hex(SECONDARY_GREY), LV_PART_MAIN);
@@ -1858,11 +1856,9 @@ inline void cover_control_refresh_preset_selection(CoverControlCtx *ctx);
 
 inline lv_obj_t *cover_control_create_tab_button(lv_obj_t *parent, const char *icon,
                                                  const lv_font_t *font,
-                                                 CoverControlTab tab,
-                                                 int width_compensation_percent) {
+                                                 CoverControlTab tab) {
   lv_obj_t *btn = lv_btn_create(parent);
   if (!btn) return nullptr;
-  apply_width_compensation(btn, width_compensation_percent);
   lv_obj_set_style_bg_color(btn, lv_color_hex(SECONDARY_GREY), LV_PART_MAIN);
   lv_obj_set_style_bg_opa(btn, LV_OPA_TRANSP, LV_PART_MAIN);
   lv_obj_set_style_border_width(btn, 0, LV_PART_MAIN);
@@ -1891,9 +1887,11 @@ inline lv_obj_t *cover_control_create_tab_button(lv_obj_t *parent, const char *i
 }
 
 inline lv_obj_t *cover_control_create_wide_icon_button(lv_obj_t *parent, const char *icon,
-                                                       const lv_font_t *font) {
+                                                       const lv_font_t *font,
+                                                       int width_compensation_percent) {
   lv_obj_t *btn = lv_btn_create(parent);
   if (!btn) return nullptr;
+  apply_width_compensation(btn, width_compensation_percent);
   lv_obj_set_style_bg_color(btn, lv_color_hex(SECONDARY_GREY), LV_PART_MAIN);
   lv_obj_set_style_bg_opa(btn, LV_OPA_COVER, LV_PART_MAIN);
   lv_obj_set_style_border_width(btn, 0, LV_PART_MAIN);
@@ -1914,7 +1912,8 @@ inline lv_obj_t *cover_control_create_wide_icon_button(lv_obj_t *parent, const c
 
 inline lv_obj_t *cover_control_create_preset_button(lv_obj_t *parent, int pct,
                                                     const lv_font_t *icon_font,
-                                                    const lv_font_t *label_font) {
+                                                    const lv_font_t *label_font,
+                                                    int width_compensation_percent) {
   lv_obj_t *btn = lv_btn_create(parent);
   if (!btn) return nullptr;
   lv_obj_set_size(btn, 118, 118);
@@ -1943,6 +1942,7 @@ inline lv_obj_t *cover_control_create_preset_button(lv_obj_t *parent, int pct,
     lv_obj_set_style_text_color(icon, lv_color_hex(DARK_TEXT_PRIMARY), LV_PART_MAIN);
     lv_obj_set_style_text_align(icon, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
     if (icon_font) lv_obj_set_style_text_font(icon, icon_font, LV_PART_MAIN);
+    apply_width_compensation(icon, width_compensation_percent);
     lv_obj_clear_flag(icon, LV_OBJ_FLAG_CLICKABLE);
   }
 
@@ -2446,16 +2446,16 @@ inline void cover_control_open_modal(CoverControlCtx *ctx) {
   ui.tab_row = control_modal_create_tab_row(ui.panel);
   ui.position_tab = cover_control_create_tab_button(
     ui.tab_row, find_icon("View Headline"), ctx->icon_font,
-    CoverControlTab::POSITION, ctx->width_compensation_percent);
+    CoverControlTab::POSITION);
   ui.controls_tab = cover_control_create_tab_button(
     ui.tab_row, find_icon("Swap Vertical"), ctx->icon_font,
-    CoverControlTab::CONTROLS, ctx->width_compensation_percent);
+    CoverControlTab::CONTROLS);
   ui.tilt_tab = cover_control_create_tab_button(
     ui.tab_row, find_icon("Swap Vertical"), ctx->icon_font,
-    CoverControlTab::TILT, ctx->width_compensation_percent);
+    CoverControlTab::TILT);
   ui.presets_tab = cover_control_create_tab_button(
     ui.tab_row, find_icon("Roller Shade"), ctx->icon_font,
-    CoverControlTab::PRESETS, ctx->width_compensation_percent);
+    CoverControlTab::PRESETS);
 
   ui.controls_box = lv_obj_create(ui.panel);
   lv_obj_set_style_bg_opa(ui.controls_box, LV_OPA_TRANSP, LV_PART_MAIN);
@@ -2464,11 +2464,14 @@ inline void cover_control_open_modal(CoverControlCtx *ctx) {
   lv_obj_set_style_pad_all(ui.controls_box, 0, LV_PART_MAIN);
   lv_obj_clear_flag(ui.controls_box, LV_OBJ_FLAG_SCROLLABLE);
   ui.up_btn = cover_control_create_wide_icon_button(
-    ui.controls_box, find_icon("Arrow Up"), ctx->icon_font);
+    ui.controls_box, find_icon("Arrow Up"), ctx->icon_font,
+    ctx->width_compensation_percent);
   ui.stop_btn = cover_control_create_wide_icon_button(
-    ui.controls_box, find_icon("Stop"), ctx->icon_font);
+    ui.controls_box, find_icon("Stop"), ctx->icon_font,
+    ctx->width_compensation_percent);
   ui.down_btn = cover_control_create_wide_icon_button(
-    ui.controls_box, find_icon("Arrow Down"), ctx->icon_font);
+    ui.controls_box, find_icon("Arrow Down"), ctx->icon_font,
+    ctx->width_compensation_percent);
   if (ui.up_btn) {
     lv_obj_add_event_cb(ui.up_btn, [](lv_event_t *e) {
       (void) e;
@@ -2516,7 +2519,7 @@ inline void cover_control_open_modal(CoverControlCtx *ctx) {
     ui.preset_btns[i] = cover_control_create_preset_button(
       ui.presets_box, preset_values[i],
       cover_control_preset_icon_font(ctx, control_modal_calc_layout(ctx->width_compensation_percent)),
-      ctx->option_menu_font);
+      ctx->option_menu_font, ctx->width_compensation_percent);
   }
 
   ui.position_slider = lv_slider_create(ui.panel);

--- a/components/espcontrol/button_grid_sliders.h
+++ b/components/espcontrol/button_grid_sliders.h
@@ -850,7 +850,8 @@ inline void light_control_layout_modal(LightControlCtx *ctx) {
   int tab_count = static_cast<int>(visible_tabs.count);
   bool show_tab_bar = tab_count > 1;
   ControlModalTabLayout tabs_layout = control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);
-  control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);
+  control_modal_apply_tab_row(
+    ui.tab_row, layout, tabs_layout, ctx->width_compensation_percent);
   for (int i = 0; show_tab_bar && i < tab_count; i++) {
     lv_obj_t *tab_btn = light_control_tab_button(ui, visible_tabs.tabs[i]);
     if (!tab_btn) continue;
@@ -2165,13 +2166,13 @@ inline void cover_control_layout_modal(CoverControlCtx *ctx) {
   int tab_count = static_cast<int>(visible_tabs.count);
   bool show_tab_bar = tab_count > 1;
   ControlModalTabLayout tabs_layout = control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);
-  control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);
+  control_modal_apply_tab_row(
+    ui.tab_row, layout, tabs_layout, ctx->width_compensation_percent);
   for (int i = 0; show_tab_bar && i < tab_count; i++) {
     lv_obj_t *tab_btn = cover_control_tab_button(ui, visible_tabs.tabs[i]);
     if (!tab_btn) continue;
     bool active = (visible_tabs.tabs[i] == ui.tab);
-    control_modal_layout_tab_button(
-      tab_btn, layout, tabs_layout, i, active, ctx->width_compensation_percent);
+    control_modal_layout_tab_button(tab_btn, layout, tabs_layout, i, active);
   }
 
   const espcontrol::modal::ContentLayout content = control_modal_calc_content_layout(

--- a/components/espcontrol/button_grid_todo.h
+++ b/components/espcontrol/button_grid_todo.h
@@ -1051,7 +1051,7 @@ inline lv_obj_t *todo_modal_create_list_item_row(
       lv_obj_update_layout(check);
       lv_coord_t offset_x = lv_obj_get_width(check) * (256 - check_zoom) / 512;
       lv_coord_t offset_y = lv_obj_get_height(check) * (256 - check_zoom) / 512;
-      lv_obj_set_style_transform_zoom(check, check_zoom, LV_PART_MAIN);
+      apply_icon_width_compensation(check, check_zoom);
       lv_obj_align(check, LV_ALIGN_CENTER, offset_x, offset_y);
     }
     label_x = checkbox_size + gap;

--- a/components/espcontrol/button_grid_todo.h
+++ b/components/espcontrol/button_grid_todo.h
@@ -315,7 +315,7 @@ inline lv_obj_t *todo_lite_create_row(TodoCardCtx *ctx, TodoLiteItem *item,
   lv_obj_set_style_text_color(label, lv_color_hex(DARK_TEXT_SOFT), LV_PART_MAIN);
   lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN);
   if (ctx && ctx->label_font) lv_obj_set_style_text_font(label, ctx->label_font, LV_PART_MAIN);
-  apply_width_compensation(label, ctx ? ctx->width_compensation_percent : 100);
+  apply_text_width_compensation(label);
   lv_obj_align(label, LV_ALIGN_LEFT_MID, label_x, 0);
   return row;
 }
@@ -340,7 +340,7 @@ inline lv_obj_t *todo_lite_create_note_row(TodoCardCtx *ctx, const char *text,
   lv_obj_set_style_text_color(label, lv_color_hex(DARK_TEXT_MUTED), LV_PART_MAIN);
   lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   if (ctx && ctx->label_font) lv_obj_set_style_text_font(label, ctx->label_font, LV_PART_MAIN);
-  apply_width_compensation(label, ctx ? ctx->width_compensation_percent : 100);
+  apply_text_width_compensation(label);
   lv_obj_center(label);
   return row;
 }
@@ -1066,7 +1066,8 @@ inline lv_obj_t *todo_modal_create_list_item_row(
     lv_color_hex(show_checkbox ? DARK_TEXT_SOFT : DARK_TEXT_MUTED), LV_PART_MAIN);
   lv_obj_set_style_text_align(value, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN);
   if (font) lv_obj_set_style_text_font(value, font, LV_PART_MAIN);
-  apply_width_compensation(value, width_compensation_percent);
+  (void) width_compensation_percent;
+  apply_text_width_compensation(value);
   lv_obj_align(value, LV_ALIGN_LEFT_MID, label_x, 0);
 
   return row;

--- a/components/espcontrol/button_grid_weather_driver.h
+++ b/components/espcontrol/button_grid_weather_driver.h
@@ -49,10 +49,8 @@ inline bool weather_driver_setup_visual(
           : espcontrol_i18n(std::string("Tomorrow")))
       : config.label;
     lv_label_set_display_text(slot.text_lbl, label.c_str());
-    apply_width_compensation(
-      slot.sensor_container, display_main_width_percent(display));
-    apply_width_compensation(
-      slot.text_lbl, display_main_width_percent(display));
+    display_apply_text_width(slot.sensor_container, display);
+    display_apply_text_width(slot.text_lbl, display);
     register_weather_forecast_card(
       slot.btn, slot.sensor_lbl, slot.unit_lbl, slot.text_lbl,
       config.entity, day, config.label);

--- a/devices/esp32-p4-86/device/sensors.yaml
+++ b/devices/esp32-p4-86/device/sensors.yaml
@@ -126,9 +126,10 @@ script:
             return true;
           });
           set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-          apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-          apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-          apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+          set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+          apply_text_width_compensation(id(display_time));
+          apply_text_width_compensation(id(temperatures));
+          apply_text_width_compensation(id(clock_label));
           // END GENERATED REFRESH GRID WIRING
           #define SP_CFG(n) subpage_##n##_config
           #define SP_EXT(n) subpage_##n##_config_ext
@@ -303,9 +304,10 @@ script:
             return true;
           });
           set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-          apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-          apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-          apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+          set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+          apply_text_width_compensation(id(display_time));
+          apply_text_width_compensation(id(temperatures));
+          apply_text_width_compensation(id(clock_label));
           // END GENERATED SUBPAGE REFRESH WIRING
           #define SP_CFG(n) subpage_##n##_config
           #define SP_EXT(n) subpage_##n##_config_ext
@@ -475,9 +477,10 @@ esphome:
               return true;
             });
             set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-            apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-            apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-            apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+            set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+            apply_text_width_compensation(id(display_time));
+            apply_text_width_compensation(id(temperatures));
+            apply_text_width_compensation(id(clock_label));
             // END GENERATED PHASE 1 GRID WIRING
             grid_phase1(slots, cfg,
               id(button_order).state,
@@ -643,9 +646,10 @@ esphome:
               return true;
             });
             set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-            apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-            apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-            apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+            set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+            apply_text_width_compensation(id(display_time));
+            apply_text_width_compensation(id(temperatures));
+            apply_text_width_compensation(id(clock_label));
             // END GENERATED PHASE 2 GRID WIRING
             grid_phase2(slots, cfg, sp_cfgs, sp_ext, sp_ext2, sp_ext3, sp_ext4, sp_ext5, sp_ext6, sp_ext7,
               id(button_order).state,

--- a/devices/guition-esp32-p4-jc1060p470-v2/device/sensors.yaml
+++ b/devices/guition-esp32-p4-jc1060p470-v2/device/sensors.yaml
@@ -119,9 +119,10 @@ script:
             return true;
           });
           set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-          apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-          apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-          apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+          set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+          apply_text_width_compensation(id(display_time));
+          apply_text_width_compensation(id(temperatures));
+          apply_text_width_compensation(id(clock_label));
           // END GENERATED REFRESH GRID WIRING
           #define SP_CFG(n) subpage_##n##_config
           #define SP_EXT(n) subpage_##n##_config_ext
@@ -295,9 +296,10 @@ script:
             return true;
           });
           set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-          apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-          apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-          apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+          set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+          apply_text_width_compensation(id(display_time));
+          apply_text_width_compensation(id(temperatures));
+          apply_text_width_compensation(id(clock_label));
           // END GENERATED SUBPAGE REFRESH WIRING
           #define SP_CFG(n) subpage_##n##_config
           #define SP_EXT(n) subpage_##n##_config_ext
@@ -466,9 +468,10 @@ esphome:
               return true;
             });
             set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-            apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-            apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-            apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+            set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+            apply_text_width_compensation(id(display_time));
+            apply_text_width_compensation(id(temperatures));
+            apply_text_width_compensation(id(clock_label));
             // END GENERATED PHASE 1 GRID WIRING
             grid_phase1(slots, cfg,
               id(button_order).state,
@@ -633,9 +636,10 @@ esphome:
               return true;
             });
             set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-            apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-            apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-            apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+            set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+            apply_text_width_compensation(id(display_time));
+            apply_text_width_compensation(id(temperatures));
+            apply_text_width_compensation(id(clock_label));
             // END GENERATED PHASE 2 GRID WIRING
             grid_phase2(slots, cfg, sp_cfgs, sp_ext, sp_ext2, sp_ext3, sp_ext4, sp_ext5, sp_ext6, sp_ext7,
               id(button_order).state,

--- a/devices/guition-esp32-p4-jc1060p470-v2/device/sensors.yaml
+++ b/devices/guition-esp32-p4-jc1060p470-v2/device/sensors.yaml
@@ -58,6 +58,7 @@ script:
           cfg.wrap_tall_labels = true;
           cfg.label_lines = 2;
           cfg.label_lines_tall = 3;
+          cfg.width_compensation_percent = 95;
           cfg.volume_width_compensation_percent = 95;
           cfg.media_artwork_width_compensation_percent = 98;
           cfg.modal_profile.layout_family = DisplayModalLayoutFamily::WIDE_LANDSCAPE;
@@ -233,6 +234,7 @@ script:
           cfg.wrap_tall_labels = true;
           cfg.label_lines = 2;
           cfg.label_lines_tall = 3;
+          cfg.width_compensation_percent = 95;
           cfg.volume_width_compensation_percent = 95;
           cfg.media_artwork_width_compensation_percent = 98;
           cfg.modal_profile.layout_family = DisplayModalLayoutFamily::WIDE_LANDSCAPE;
@@ -403,6 +405,7 @@ esphome:
             cfg.wrap_tall_labels = true;
             cfg.label_lines = 2;
             cfg.label_lines_tall = 3;
+            cfg.width_compensation_percent = 95;
             cfg.volume_width_compensation_percent = 95;
             cfg.media_artwork_width_compensation_percent = 98;
             cfg.modal_profile.layout_family = DisplayModalLayoutFamily::WIDE_LANDSCAPE;
@@ -569,6 +572,7 @@ esphome:
             cfg.wrap_tall_labels = true;
             cfg.label_lines = 2;
             cfg.label_lines_tall = 3;
+            cfg.width_compensation_percent = 95;
             cfg.volume_width_compensation_percent = 95;
             cfg.media_artwork_width_compensation_percent = 98;
             cfg.modal_profile.layout_family = DisplayModalLayoutFamily::WIDE_LANDSCAPE;

--- a/devices/guition-esp32-p4-jc1060p470/device/sensors.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/device/sensors.yaml
@@ -119,9 +119,10 @@ script:
             return true;
           });
           set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-          apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-          apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-          apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+          set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+          apply_text_width_compensation(id(display_time));
+          apply_text_width_compensation(id(temperatures));
+          apply_text_width_compensation(id(clock_label));
           // END GENERATED REFRESH GRID WIRING
           #define SP_CFG(n) subpage_##n##_config
           #define SP_EXT(n) subpage_##n##_config_ext
@@ -295,9 +296,10 @@ script:
             return true;
           });
           set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-          apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-          apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-          apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+          set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+          apply_text_width_compensation(id(display_time));
+          apply_text_width_compensation(id(temperatures));
+          apply_text_width_compensation(id(clock_label));
           // END GENERATED SUBPAGE REFRESH WIRING
           #define SP_CFG(n) subpage_##n##_config
           #define SP_EXT(n) subpage_##n##_config_ext
@@ -466,9 +468,10 @@ esphome:
               return true;
             });
             set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-            apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-            apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-            apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+            set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+            apply_text_width_compensation(id(display_time));
+            apply_text_width_compensation(id(temperatures));
+            apply_text_width_compensation(id(clock_label));
             // END GENERATED PHASE 1 GRID WIRING
             grid_phase1(slots, cfg,
               id(button_order).state,
@@ -633,9 +636,10 @@ esphome:
               return true;
             });
             set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-            apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-            apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-            apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+            set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+            apply_text_width_compensation(id(display_time));
+            apply_text_width_compensation(id(temperatures));
+            apply_text_width_compensation(id(clock_label));
             // END GENERATED PHASE 2 GRID WIRING
             grid_phase2(slots, cfg, sp_cfgs, sp_ext, sp_ext2, sp_ext3, sp_ext4, sp_ext5, sp_ext6, sp_ext7,
               id(button_order).state,

--- a/devices/guition-esp32-p4-jc1060p470/device/sensors.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/device/sensors.yaml
@@ -58,6 +58,7 @@ script:
           cfg.wrap_tall_labels = true;
           cfg.label_lines = 2;
           cfg.label_lines_tall = 3;
+          cfg.width_compensation_percent = 95;
           cfg.volume_width_compensation_percent = 95;
           cfg.media_artwork_width_compensation_percent = 98;
           cfg.modal_profile.layout_family = DisplayModalLayoutFamily::WIDE_LANDSCAPE;
@@ -233,6 +234,7 @@ script:
           cfg.wrap_tall_labels = true;
           cfg.label_lines = 2;
           cfg.label_lines_tall = 3;
+          cfg.width_compensation_percent = 95;
           cfg.volume_width_compensation_percent = 95;
           cfg.media_artwork_width_compensation_percent = 98;
           cfg.modal_profile.layout_family = DisplayModalLayoutFamily::WIDE_LANDSCAPE;
@@ -403,6 +405,7 @@ esphome:
             cfg.wrap_tall_labels = true;
             cfg.label_lines = 2;
             cfg.label_lines_tall = 3;
+            cfg.width_compensation_percent = 95;
             cfg.volume_width_compensation_percent = 95;
             cfg.media_artwork_width_compensation_percent = 98;
             cfg.modal_profile.layout_family = DisplayModalLayoutFamily::WIDE_LANDSCAPE;
@@ -569,6 +572,7 @@ esphome:
             cfg.wrap_tall_labels = true;
             cfg.label_lines = 2;
             cfg.label_lines_tall = 3;
+            cfg.width_compensation_percent = 95;
             cfg.volume_width_compensation_percent = 95;
             cfg.media_artwork_width_compensation_percent = 98;
             cfg.modal_profile.layout_family = DisplayModalLayoutFamily::WIDE_LANDSCAPE;

--- a/devices/guition-esp32-p4-jc4880p443/device/sensors.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/device/sensors.yaml
@@ -106,9 +106,10 @@ script:
             return true;
           });
           set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-          apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-          apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-          apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+          set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+          apply_text_width_compensation(id(display_time));
+          apply_text_width_compensation(id(temperatures));
+          apply_text_width_compensation(id(clock_label));
           // END GENERATED REFRESH GRID WIRING
           #define SP_CFG(n) subpage_##n##_config
           #define SP_EXT(n) subpage_##n##_config_ext
@@ -255,9 +256,10 @@ script:
             return true;
           });
           set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-          apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-          apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-          apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+          set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+          apply_text_width_compensation(id(display_time));
+          apply_text_width_compensation(id(temperatures));
+          apply_text_width_compensation(id(clock_label));
           // END GENERATED SUBPAGE REFRESH WIRING
           #define SP_CFG(n) subpage_##n##_config
           #define SP_EXT(n) subpage_##n##_config_ext
@@ -399,9 +401,10 @@ esphome:
               return true;
             });
             set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-            apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-            apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-            apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+            set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+            apply_text_width_compensation(id(display_time));
+            apply_text_width_compensation(id(temperatures));
+            apply_text_width_compensation(id(clock_label));
             // END GENERATED PHASE 1 GRID WIRING
             grid_phase1(slots, cfg,
               id(button_order).state,
@@ -539,9 +542,10 @@ esphome:
               return true;
             });
             set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-            apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-            apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-            apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+            set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+            apply_text_width_compensation(id(display_time));
+            apply_text_width_compensation(id(temperatures));
+            apply_text_width_compensation(id(clock_label));
             // END GENERATED PHASE 2 GRID WIRING
             grid_phase2(slots, cfg, sp_cfgs, sp_ext, sp_ext2, sp_ext3, sp_ext4, sp_ext5, sp_ext6, sp_ext7,
               id(button_order).state,

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/device/sensors.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/device/sensors.yaml
@@ -122,9 +122,10 @@ script:
             return true;
           });
           set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-          apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-          apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-          apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+          set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+          apply_text_width_compensation(id(display_time));
+          apply_text_width_compensation(id(temperatures));
+          apply_text_width_compensation(id(clock_label));
           // END GENERATED REFRESH GRID WIRING
           #define SP_CFG(n) subpage_##n##_config
           #define SP_EXT(n) subpage_##n##_config_ext
@@ -309,9 +310,10 @@ script:
             return true;
           });
           set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-          apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-          apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-          apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+          set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+          apply_text_width_compensation(id(display_time));
+          apply_text_width_compensation(id(temperatures));
+          apply_text_width_compensation(id(clock_label));
           // END GENERATED SUBPAGE REFRESH WIRING
           #define SP_CFG(n) subpage_##n##_config
           #define SP_EXT(n) subpage_##n##_config_ext
@@ -491,9 +493,10 @@ esphome:
               return true;
             });
             set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-            apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-            apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-            apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+            set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+            apply_text_width_compensation(id(display_time));
+            apply_text_width_compensation(id(temperatures));
+            apply_text_width_compensation(id(clock_label));
             // END GENERATED PHASE 1 GRID WIRING
             grid_phase1(slots, cfg,
               id(button_order).state,
@@ -669,9 +672,10 @@ esphome:
               return true;
             });
             set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-            apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-            apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-            apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+            set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+            apply_text_width_compensation(id(display_time));
+            apply_text_width_compensation(id(temperatures));
+            apply_text_width_compensation(id(clock_label));
             // END GENERATED PHASE 2 GRID WIRING
             grid_phase2(slots, cfg, sp_cfgs, sp_ext, sp_ext2, sp_ext3, sp_ext4, sp_ext5, sp_ext6, sp_ext7,
               id(button_order).state,

--- a/devices/guition-esp32-p4-jc8012p4a1/device/sensors.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/sensors.yaml
@@ -122,9 +122,10 @@ script:
             return true;
           });
           set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-          apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-          apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-          apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+          set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+          apply_text_width_compensation(id(display_time));
+          apply_text_width_compensation(id(temperatures));
+          apply_text_width_compensation(id(clock_label));
           // END GENERATED REFRESH GRID WIRING
           #define SP_CFG(n) subpage_##n##_config
           #define SP_EXT(n) subpage_##n##_config_ext
@@ -309,9 +310,10 @@ script:
             return true;
           });
           set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-          apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-          apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-          apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+          set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+          apply_text_width_compensation(id(display_time));
+          apply_text_width_compensation(id(temperatures));
+          apply_text_width_compensation(id(clock_label));
           // END GENERATED SUBPAGE REFRESH WIRING
           #define SP_CFG(n) subpage_##n##_config
           #define SP_EXT(n) subpage_##n##_config_ext
@@ -491,9 +493,10 @@ esphome:
               return true;
             });
             set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-            apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-            apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-            apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+            set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+            apply_text_width_compensation(id(display_time));
+            apply_text_width_compensation(id(temperatures));
+            apply_text_width_compensation(id(clock_label));
             // END GENERATED PHASE 1 GRID WIRING
             grid_phase1(slots, cfg,
               id(button_order).state,
@@ -669,9 +672,10 @@ esphome:
               return true;
             });
             set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-            apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-            apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-            apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+            set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+            apply_text_width_compensation(id(display_time));
+            apply_text_width_compensation(id(temperatures));
+            apply_text_width_compensation(id(clock_label));
             // END GENERATED PHASE 2 GRID WIRING
             grid_phase2(slots, cfg, sp_cfgs, sp_ext, sp_ext2, sp_ext3, sp_ext4, sp_ext5, sp_ext6, sp_ext7,
               id(button_order).state,

--- a/devices/guition-esp32-s3-4848s040/device/sensors.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/sensors.yaml
@@ -103,9 +103,10 @@ script:
             return true;
           });
           set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-          apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-          apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-          apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+          set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+          apply_text_width_compensation(id(display_time));
+          apply_text_width_compensation(id(temperatures));
+          apply_text_width_compensation(id(clock_label));
           // END GENERATED REFRESH GRID WIRING
           #define SP_CFG(n) subpage_##n##_config
           #define SP_EXT(n) subpage_##n##_config_ext
@@ -229,9 +230,10 @@ script:
             return true;
           });
           set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-          apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-          apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-          apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+          set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+          apply_text_width_compensation(id(display_time));
+          apply_text_width_compensation(id(temperatures));
+          apply_text_width_compensation(id(clock_label));
           // END GENERATED SUBPAGE REFRESH WIRING
           #define SP_CFG(n) subpage_##n##_config
           #define SP_EXT(n) subpage_##n##_config_ext
@@ -350,9 +352,10 @@ esphome:
               return true;
             });
             set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-            apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-            apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-            apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+            set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+            apply_text_width_compensation(id(display_time));
+            apply_text_width_compensation(id(temperatures));
+            apply_text_width_compensation(id(clock_label));
             // END GENERATED PHASE 1 GRID WIRING
             grid_phase1(slots, cfg,
               id(button_order).state,
@@ -467,9 +470,10 @@ esphome:
               return true;
             });
             set_width_compensation_vertical_axis(cfg.width_compensation_vertical);
-            apply_width_compensation(id(display_time), cfg.width_compensation_percent);
-            apply_width_compensation(id(temperatures), cfg.width_compensation_percent);
-            apply_width_compensation(id(clock_label), cfg.width_compensation_percent);
+            set_text_width_compensation_percent(cfg.text_width_compensation_percent);
+            apply_text_width_compensation(id(display_time));
+            apply_text_width_compensation(id(temperatures));
+            apply_text_width_compensation(id(clock_label));
             // END GENERATED PHASE 2 GRID WIRING
             grid_phase2(slots, cfg, sp_cfgs, sp_ext, sp_ext2, sp_ext3,
               id(button_order).state,

--- a/devices/manifest.json
+++ b/devices/manifest.json
@@ -107,6 +107,7 @@
         "display": {
           "wrapTallLabels": true,
           "widthCompensationPercent": 95,
+          "textWidthCompensationPercent": 100,
           "volumeWidthCompensationPercent": 95,
           "refreshRebuildsSubpages": true,
           "mediaArtworkWidthCompensationPercent": 98,
@@ -301,6 +302,7 @@
         "display": {
           "wrapTallLabels": true,
           "widthCompensationPercent": 95,
+          "textWidthCompensationPercent": 100,
           "volumeWidthCompensationPercent": 95,
           "refreshRebuildsSubpages": true,
           "mediaArtworkWidthCompensationPercent": 98,

--- a/devices/manifest.json
+++ b/devices/manifest.json
@@ -106,6 +106,7 @@
         },
         "display": {
           "wrapTallLabels": true,
+          "widthCompensationPercent": 95,
           "volumeWidthCompensationPercent": 95,
           "refreshRebuildsSubpages": true,
           "mediaArtworkWidthCompensationPercent": 98,
@@ -299,6 +300,7 @@
         },
         "display": {
           "wrapTallLabels": true,
+          "widthCompensationPercent": 95,
           "volumeWidthCompensationPercent": 95,
           "refreshRebuildsSubpages": true,
           "mediaArtworkWidthCompensationPercent": 98,

--- a/product/product_snapshot.json
+++ b/product/product_snapshot.json
@@ -122,6 +122,7 @@
         },
         "display": {
           "wrapTallLabels": true,
+          "widthCompensationPercent": 95,
           "volumeWidthCompensationPercent": 95,
           "refreshRebuildsSubpages": true,
           "mediaArtworkWidthCompensationPercent": 98,
@@ -320,6 +321,7 @@
         },
         "display": {
           "wrapTallLabels": true,
+          "widthCompensationPercent": 95,
           "volumeWidthCompensationPercent": 95,
           "refreshRebuildsSubpages": true,
           "mediaArtworkWidthCompensationPercent": 98,

--- a/product/product_snapshot.json
+++ b/product/product_snapshot.json
@@ -123,6 +123,7 @@
         "display": {
           "wrapTallLabels": true,
           "widthCompensationPercent": 95,
+          "textWidthCompensationPercent": 100,
           "volumeWidthCompensationPercent": 95,
           "refreshRebuildsSubpages": true,
           "mediaArtworkWidthCompensationPercent": 98,
@@ -322,6 +323,7 @@
         "display": {
           "wrapTallLabels": true,
           "widthCompensationPercent": 95,
+          "textWidthCompensationPercent": 100,
           "volumeWidthCompensationPercent": 95,
           "refreshRebuildsSubpages": true,
           "mediaArtworkWidthCompensationPercent": 98,

--- a/product/v2/device_catalog.json
+++ b/product/v2/device_catalog.json
@@ -104,6 +104,7 @@
           "display": {
             "wrapTallLabels": true,
             "widthCompensationPercent": 95,
+            "textWidthCompensationPercent": 100,
             "volumeWidthCompensationPercent": 95,
             "refreshRebuildsSubpages": true,
             "mediaArtworkWidthCompensationPercent": 98

--- a/product/v2/device_catalog.json
+++ b/product/v2/device_catalog.json
@@ -103,6 +103,7 @@
         "firmware": {
           "display": {
             "wrapTallLabels": true,
+            "widthCompensationPercent": 95,
             "volumeWidthCompensationPercent": 95,
             "refreshRebuildsSubpages": true,
             "mediaArtworkWidthCompensationPercent": 98

--- a/scripts/check_device_profiles.py
+++ b/scripts/check_device_profiles.py
@@ -450,6 +450,28 @@ def test_rotation_refresh_rebuilds_subpages() -> None:
         )
 
 
+def test_seven_inch_width_compensation_rotates_with_screen() -> None:
+    profiles = load_device_profiles()
+    for slug in (
+        "guition-esp32-p4-jc1060p470",
+        "guition-esp32-p4-jc1060p470-v2",
+    ):
+        profile = profiles[slug]
+        assert profile["rotation"]["rotateWidthCompensation"], (
+            f"{slug}: portrait rotation must move pixel compensation to the rotated axis"
+        )
+        assert profile["firmware"]["display"]["widthCompensationPercent"] == 95, (
+            f"{slug}: 7-inch pixel compensation must remain at 95%"
+        )
+        sensors = (ROOT / "devices" / slug / "device" / "sensors.yaml").read_text(encoding="utf-8")
+        assert "cfg.width_compensation_percent = 95;" in sensors, (
+            f"{slug}: generated firmware is missing 7-inch pixel compensation"
+        )
+        assert "cfg.width_compensation_vertical = portrait;" in sensors, (
+            f"{slug}: generated firmware does not rotate the compensation axis in portrait"
+        )
+
+
 def test_subpage_config_changes_schedule_live_refresh() -> None:
     templates = {
         "common/config/button_template.yaml": 8,
@@ -868,6 +890,7 @@ def main() -> int:
     test_local_voice_generation_uses_capability()
     test_square_s3_reapplies_clock_bar_after_screen_changes()
     test_rotation_refresh_rebuilds_subpages()
+    test_seven_inch_width_compensation_rotates_with_screen()
     test_subpage_config_changes_schedule_live_refresh()
     test_web_screen_aspect_matches_public_resolution()
     test_web_grid_spacing_matches_across_screen_sizes()

--- a/scripts/check_device_profiles.py
+++ b/scripts/check_device_profiles.py
@@ -463,12 +463,18 @@ def test_seven_inch_width_compensation_rotates_with_screen() -> None:
         assert profile["firmware"]["display"]["widthCompensationPercent"] == 95, (
             f"{slug}: 7-inch pixel compensation must remain at 95%"
         )
+        assert profile["firmware"]["display"]["textWidthCompensationPercent"] == 100, (
+            f"{slug}: 7-inch text must retain its natural proportions"
+        )
         sensors = (ROOT / "devices" / slug / "device" / "sensors.yaml").read_text(encoding="utf-8")
         assert "cfg.width_compensation_percent = 95;" in sensors, (
             f"{slug}: generated firmware is missing 7-inch pixel compensation"
         )
         assert "cfg.width_compensation_vertical = portrait;" in sensors, (
             f"{slug}: generated firmware does not rotate the compensation axis in portrait"
+        )
+        assert "apply_text_width_compensation(id(display_time));" in sensors, (
+            f"{slug}: clock-bar text must use the independent text compensation policy"
         )
 
 

--- a/scripts/check_firmware_display_tokens.py
+++ b/scripts/check_firmware_display_tokens.py
@@ -118,6 +118,45 @@ def check_root(root: Path) -> list[str]:
                 failures.append(
                     f"components/espcontrol/{name}: pass display compensation to every modal tab controller"
                 )
+        tab_creators = {
+            "button_grid_sliders.h": (
+                "light_control_create_tab_button",
+                "cover_control_create_tab_button",
+            ),
+            "button_grid_climate.h": ("climate_control_create_tab_button",),
+            "button_grid_media.h": ("media_control_create_tab_button",),
+            "button_grid_fan.h": ("fan_control_create_tab_button",),
+        }
+        for name, creators in tab_creators.items():
+            text = resolved_tab_paths[name].read_text(encoding="utf-8")
+            for creator in creators:
+                body = re.search(
+                    rf"inline lv_obj_t \*{creator}\(.*?\n\}}",
+                    text,
+                    re.S,
+                )
+                if body is None or "width_compensation_percent" in body.group(0):
+                    failures.append(
+                        f"components/espcontrol/{name}: compensate tab icons once through the shared row"
+                    )
+
+    alarm_path = root / FIRMWARE_DIR.relative_to(ROOT) / "button_grid_alarm.h"
+    if alarm_path.exists():
+        alarm_text = alarm_path.read_text(encoding="utf-8")
+        mode_button = re.search(
+            r"inline lv_obj_t \*alarm_control_create_mode_button\(.*?\n\}",
+            alarm_text,
+            re.S,
+        )
+        if (
+            "apply_width_compensation(ui.rail, ctx->width_compensation_percent);"
+            not in alarm_text
+            or mode_button is None
+            or "apply_width_compensation" in mode_button.group(0)
+        ):
+            failures.append(
+                "components/espcontrol/button_grid_alarm.h: compensate alarm action icons once through the shared rail"
+            )
     return failures
 
 
@@ -174,6 +213,17 @@ def run_self_test() -> None:
                 )
             },
             ("keep firmware constant names unique",),
+        ),
+        (
+            {
+                "button_grid_alarm.h": (
+                    "inline lv_obj_t *alarm_control_create_mode_button() {\n"
+                    "  apply_width_compensation(icon, 95);\n"
+                    "}\n"
+                    "apply_width_compensation(ui.rail, ctx->width_compensation_percent);\n"
+                )
+            },
+            ("compensate alarm action icons once through the shared rail",),
         ),
     )
     for files, expected in cases:

--- a/scripts/check_firmware_display_tokens.py
+++ b/scripts/check_firmware_display_tokens.py
@@ -81,6 +81,43 @@ def check_root(root: Path) -> list[str]:
                 if pattern.search(line):
                     rel = path.relative_to(root)
                     failures.append(f"{rel}:{line_no}: {message}")
+
+    tab_files = {
+        "button_grid_modal.h": 0,
+        "button_grid_sliders.h": 2,
+        "button_grid_fan.h": 1,
+        "button_grid_climate.h": 1,
+        "button_grid_media.h": 1,
+    }
+    tab_paths = {name: FIRMWARE_DIR.relative_to(ROOT) / name for name in tab_files}
+    resolved_tab_paths = {name: root / relative for name, relative in tab_paths.items()}
+    if all(path.exists() for path in resolved_tab_paths.values()):
+        modal_text = resolved_tab_paths["button_grid_modal.h"].read_text(encoding="utf-8")
+        if "apply_width_compensation(tab_row, width_compensation_percent);" not in modal_text:
+            failures.append(
+                "components/espcontrol/button_grid_modal.h: compensate the shared tab controller container"
+            )
+        tab_button_body = re.search(
+            r"inline void control_modal_layout_tab_button\([^)]*\)\s*\{(?P<body>.*?)\n\}",
+            modal_text,
+            re.S,
+        )
+        if tab_button_body is None or "apply_width_compensation(tab_btn" in tab_button_body.group("body"):
+            failures.append(
+                "components/espcontrol/button_grid_modal.h: apply tab compensation once at the shared container"
+            )
+        compensated_call = re.compile(
+            r"control_modal_apply_tab_row\(\s*ui\.tab_row,\s*layout,\s*tabs_layout,\s*"
+            r"ctx->width_compensation_percent\s*\);"
+        )
+        for name, expected_count in tab_files.items():
+            if expected_count == 0:
+                continue
+            text = resolved_tab_paths[name].read_text(encoding="utf-8")
+            if len(compensated_call.findall(text)) != expected_count:
+                failures.append(
+                    f"components/espcontrol/{name}: pass display compensation to every modal tab controller"
+                )
     return failures
 
 

--- a/scripts/check_firmware_modals.py
+++ b/scripts/check_firmware_modals.py
@@ -476,7 +476,7 @@ def firmware_cover_control_tab_errors(root: Path) -> list[str]:
     text = path.read_text(encoding="utf-8")
     if "bool show_tab_bar = visible_tabs.count > 1;" not in text:
         errors.append("components/espcontrol/button_grid_sliders.h: hide cover modal tabs when only one control is visible")
-    if "control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);" not in text:
+    if "ui.tab_row, layout, tabs_layout, ctx->width_compensation_percent);" not in text:
         errors.append("components/espcontrol/button_grid_sliders.h: keep cover modal tab row hidden through the shared tab layout helper")
     if "control_modal_calc_content_layout(\n    layout, tabs_layout, show_tab_bar, 160)" not in text:
         errors.append("components/espcontrol/button_grid_sliders.h: position cover modal content with the shared content recipe")
@@ -499,7 +499,7 @@ def firmware_light_control_tab_errors(root: Path) -> list[str]:
         errors.append("components/espcontrol/button_grid_sliders.h: keep light modal tab visibility helper")
     if text.count("bool show_tab_bar = visible_tabs.count > 1;") < 2:
         errors.append("components/espcontrol/button_grid_sliders.h: hide light and cover modal tabs when only one control is visible")
-    if text.count("control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);") < 2:
+    if text.count("ui.tab_row, layout, tabs_layout, ctx->width_compensation_percent);") < 2:
         errors.append("components/espcontrol/button_grid_sliders.h: keep single-tab modal rows hidden through the shared tab layout helper")
     if text.count("control_modal_calc_content_layout(\n    layout, tabs_layout, show_tab_bar, 160)") < 2:
         errors.append("components/espcontrol/button_grid_sliders.h: let single-control modals use the shared content recipe")
@@ -586,21 +586,21 @@ def firmware_modal_tab_layout_errors(root: Path) -> list[str]:
     required_by_file = {
         "button_grid_climate.h": (
             "return control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);",
-            "control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);",
+            "ui.tab_row, layout, tabs_layout, ctx->width_compensation_percent);",
             "control_modal_layout_tab_button(tab_btn, layout, tabs_layout, i, active);",
             "return control_modal_shared_tab_content_gap(layout);",
             "ui.tab_row = control_modal_create_tab_row(ui.panel);",
         ),
         "button_grid_fan.h": (
             "ControlModalTabLayout tabs_layout = control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);",
-            "control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);",
+            "ui.tab_row, layout, tabs_layout, ctx->width_compensation_percent);",
             "control_modal_layout_tab_button(tab_btn, layout, tabs_layout, i, active);",
             "control_modal_calc_content_layout(",
             "ui.tab_row = control_modal_create_tab_row(ui.panel);",
         ),
         "button_grid_media.h": (
             "control_modal_calc_tab_layout(layout, media_control_tab_count, true)",
-            "control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);",
+            "ui.tab_row, layout, tabs_layout, ctx->width_compensation_percent);",
             "control_modal_layout_tab_button(tabs[i].btn, layout, tabs_layout, i, active);",
             "control_modal_calc_content_layout(",
             "ui.tab_row = control_modal_create_tab_row(ui.panel);",
@@ -608,7 +608,7 @@ def firmware_modal_tab_layout_errors(root: Path) -> list[str]:
     }
     sliders_required = (
         "ControlModalTabLayout tabs_layout = control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);",
-        "control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);",
+        "ui.tab_row, layout, tabs_layout, ctx->width_compensation_percent);",
         "control_modal_layout_tab_button(",
         "control_modal_calc_content_layout(",
         "ui.tab_row = control_modal_create_tab_row(ui.panel);",
@@ -635,7 +635,7 @@ def firmware_modal_tab_layout_errors(root: Path) -> list[str]:
                 break
         if (
             text.count("ControlModalTabLayout tabs_layout = control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);") < 2
-            or text.count("control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);") < 2
+            or text.count("ui.tab_row, layout, tabs_layout, ctx->width_compensation_percent);") < 2
             or text.count("control_modal_calc_content_layout(") < 2
             or text.count("ui.tab_row = control_modal_create_tab_row(ui.panel);") < 2
         ):
@@ -1346,39 +1346,39 @@ def valid_modal_tab_layout_files() -> dict[str, str]:
             "inline lv_coord_t control_modal_shared_tab_content_gap(const ControlModalLayout &layout) { return 0; }\n"
             "inline ControlModalTabLayout control_modal_calc_tab_layout(const ControlModalLayout &layout, int tab_count, bool show_tab_bar) { return espcontrol::modal::calculate_tabs(); }\n"
             "inline ContentLayout control_modal_calc_content_layout() {}\n"
-            "inline void control_modal_apply_tab_row(lv_obj_t *tab_row, const ControlModalLayout &layout, const ControlModalTabLayout &tabs_layout) {}\n"
+            "inline void control_modal_apply_tab_row(lv_obj_t *tab_row, const ControlModalLayout &layout, const ControlModalTabLayout &tabs_layout, int width_compensation_percent) {}\n"
             "inline lv_obj_t *control_modal_create_tab_row(lv_obj_t *panel) {}\n"
             "inline void control_modal_layout_tab_button(lv_obj_t *tab_btn, const ControlModalLayout &layout, const ControlModalTabLayout &tabs_layout, int index, bool active) {}\n"
         ),
         "components/espcontrol/button_grid_climate.h": (
             "return control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);\n"
             "return control_modal_shared_tab_content_gap(layout);\n"
-            "control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);\n"
+            "control_modal_apply_tab_row(\nui.tab_row, layout, tabs_layout, ctx->width_compensation_percent);\n"
             "control_modal_layout_tab_button(tab_btn, layout, tabs_layout, i, active);\n"
             "ui.tab_row = control_modal_create_tab_row(ui.panel);\n"
         ),
         "components/espcontrol/button_grid_fan.h": (
             "ControlModalTabLayout tabs_layout = control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);\n"
-            "control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);\n"
+            "control_modal_apply_tab_row(\nui.tab_row, layout, tabs_layout, ctx->width_compensation_percent);\n"
             "control_modal_layout_tab_button(tab_btn, layout, tabs_layout, i, active);\n"
             "control_modal_calc_content_layout(\n"
             "ui.tab_row = control_modal_create_tab_row(ui.panel);\n"
         ),
         "components/espcontrol/button_grid_media.h": (
             "control_modal_calc_tab_layout(layout, media_control_tab_count, true)\n"
-            "control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);\n"
+            "control_modal_apply_tab_row(\nui.tab_row, layout, tabs_layout, ctx->width_compensation_percent);\n"
             "control_modal_layout_tab_button(tabs[i].btn, layout, tabs_layout, i, active);\n"
             "control_modal_calc_content_layout(\n"
             "ui.tab_row = control_modal_create_tab_row(ui.panel);\n"
         ),
         "components/espcontrol/button_grid_sliders.h": (
             "ControlModalTabLayout tabs_layout = control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);\n"
-            "control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);\n"
+            "control_modal_apply_tab_row(\nui.tab_row, layout, tabs_layout, ctx->width_compensation_percent);\n"
             "control_modal_layout_tab_button(\n"
             "control_modal_calc_content_layout(\n"
             "ui.tab_row = control_modal_create_tab_row(ui.panel);\n"
             "ControlModalTabLayout tabs_layout = control_modal_calc_tab_layout(layout, tab_count, show_tab_bar);\n"
-            "control_modal_apply_tab_row(ui.tab_row, layout, tabs_layout);\n"
+            "control_modal_apply_tab_row(\nui.tab_row, layout, tabs_layout, ctx->width_compensation_percent);\n"
             "control_modal_layout_tab_button(\n"
             "control_modal_calc_content_layout(\n"
             "ui.tab_row = control_modal_create_tab_row(ui.panel);\n"

--- a/scripts/check_firmware_parser.py
+++ b/scripts/check_firmware_parser.py
@@ -679,10 +679,17 @@ int main() {
   apply_width_compensation(&compensated_obj, 95);
   assert(compensated_obj.transform_scale_x == width_compensation_scale(95));
   assert(compensated_obj.transform_scale_y == 256);
+  set_text_width_compensation_percent(100);
+  apply_text_width_compensation(&compensated_obj);
+  assert(compensated_obj.transform_scale_x == 256);
+  assert(compensated_obj.transform_scale_y == 256);
   set_width_compensation_vertical_axis(true);
   apply_width_compensation(&compensated_obj, 95);
   assert(compensated_obj.transform_scale_x == 256);
   assert(compensated_obj.transform_scale_y == width_compensation_scale(95));
+  apply_text_width_compensation(&compensated_obj);
+  assert(compensated_obj.transform_scale_x == 256);
+  assert(compensated_obj.transform_scale_y == 256);
   set_width_compensation_vertical_axis(false);
   assert(clamp_percent_value(-1) == 0);
   assert(clamp_percent_value(101) == 100);

--- a/scripts/check_firmware_parser.py
+++ b/scripts/check_firmware_parser.py
@@ -83,6 +83,8 @@ class StringRef {
 
 struct lv_obj_t {
   int flags = 0;
+  int transform_scale_x = 256;
+  int transform_scale_y = 256;
   std::string text;
   void *user_data = nullptr;
 };
@@ -141,8 +143,12 @@ constexpr int LV_GRAD_DIR_HOR = 1;
 inline int lv_color_hex(uint32_t value) { return static_cast<int>(value); }
 inline int lv_pct(int value) { return value; }
 inline lv_obj_t *lv_scr_act() { return lv_active_screen; }
-inline void lv_obj_set_style_transform_scale_x(lv_obj_t *, int, int) {}
-inline void lv_obj_set_style_transform_scale_y(lv_obj_t *, int, int) {}
+inline void lv_obj_set_style_transform_scale_x(lv_obj_t *obj, int scale, int) {
+  if (obj) obj->transform_scale_x = scale;
+}
+inline void lv_obj_set_style_transform_scale_y(lv_obj_t *obj, int scale, int) {
+  if (obj) obj->transform_scale_y = scale;
+}
 inline void lv_obj_set_style_bg_color(lv_obj_t *, int, lv_style_selector_t) {}
 inline void lv_obj_set_style_bg_grad_color(lv_obj_t *, lv_color_t, lv_style_selector_t) {}
 inline void lv_obj_set_style_bg_grad_dir(lv_obj_t *, int, lv_style_selector_t) {}
@@ -668,6 +674,16 @@ int main() {
   assert(normalize_width_compensation_percent(25) == 50);
   assert(normalize_width_compensation_percent(175) == 150);
   assert(width_compensation_scale(100) == 256);
+  lv_obj_t compensated_obj;
+  set_width_compensation_vertical_axis(false);
+  apply_width_compensation(&compensated_obj, 95);
+  assert(compensated_obj.transform_scale_x == width_compensation_scale(95));
+  assert(compensated_obj.transform_scale_y == 256);
+  set_width_compensation_vertical_axis(true);
+  apply_width_compensation(&compensated_obj, 95);
+  assert(compensated_obj.transform_scale_x == 256);
+  assert(compensated_obj.transform_scale_y == width_compensation_scale(95));
+  set_width_compensation_vertical_axis(false);
   assert(clamp_percent_value(-1) == 0);
   assert(clamp_percent_value(101) == 100);
   int brightness_pct = -1;

--- a/scripts/check_firmware_parser.py
+++ b/scripts/check_firmware_parser.py
@@ -679,6 +679,10 @@ int main() {
   apply_width_compensation(&compensated_obj, 95);
   assert(compensated_obj.transform_scale_x == width_compensation_scale(95));
   assert(compensated_obj.transform_scale_y == 256);
+  set_icon_width_compensation_percent(95);
+  apply_icon_width_compensation(&compensated_obj, 180);
+  assert(compensated_obj.transform_scale_x == 171);
+  assert(compensated_obj.transform_scale_y == 180);
   set_text_width_compensation_percent(100);
   apply_text_width_compensation(&compensated_obj);
   assert(compensated_obj.transform_scale_x == 256);
@@ -687,6 +691,9 @@ int main() {
   apply_width_compensation(&compensated_obj, 95);
   assert(compensated_obj.transform_scale_x == 256);
   assert(compensated_obj.transform_scale_y == width_compensation_scale(95));
+  apply_icon_width_compensation(&compensated_obj, 180);
+  assert(compensated_obj.transform_scale_x == 180);
+  assert(compensated_obj.transform_scale_y == 171);
   apply_text_width_compensation(&compensated_obj);
   assert(compensated_obj.transform_scale_x == 256);
   assert(compensated_obj.transform_scale_y == 256);

--- a/scripts/device_profiles.py
+++ b/scripts/device_profiles.py
@@ -541,6 +541,7 @@ def validate_display(slug: str, device: dict[str, Any], errors: list[str]) -> No
 
     for key in (
         "widthCompensationPercent",
+        "textWidthCompensationPercent",
         "volumeWidthCompensationPercent",
         "mediaArtworkWidthCompensationPercent",
     ):
@@ -959,6 +960,8 @@ def slot_device(profile: dict[str, Any]) -> dict[str, Any]:
         slot["portrait_cols"] = layout["portraitCols"]
     if display.get("widthCompensationPercent", 100) != 100:
         slot["width_compensation_percent"] = display["widthCompensationPercent"]
+    if display.get("textWidthCompensationPercent", 100) != 100:
+        slot["text_width_compensation_percent"] = display["textWidthCompensationPercent"]
     if display.get("volumeWidthCompensationPercent", 100) != 100:
         slot["volume_width_compensation_percent"] = display["volumeWidthCompensationPercent"]
     if display.get("mediaArtworkWidthCompensationPercent", 100) != 100:

--- a/scripts/generate_device_slots.py
+++ b/scripts/generate_device_slots.py
@@ -375,6 +375,8 @@ def cfg_lines(device: dict) -> list[str]:
     lines.append(f"            cfg.label_lines_tall = {device['label_lines_tall']};")
     if device.get("width_compensation_percent", 100) != 100:
         lines.append(f"            cfg.width_compensation_percent = {device['width_compensation_percent']};")
+    if device.get("text_width_compensation_percent", 100) != 100:
+        lines.append(f"            cfg.text_width_compensation_percent = {device['text_width_compensation_percent']};")
     if device.get("volume_width_compensation_percent", 100) != 100:
         lines.append(
             f"            cfg.volume_width_compensation_percent = {device['volume_width_compensation_percent']};"
@@ -521,9 +523,10 @@ def cfg_lines(device: dict) -> list[str]:
     lines.append("              return true;")
     lines.append("            });")
     lines.append("            set_width_compensation_vertical_axis(cfg.width_compensation_vertical);")
-    lines.append("            apply_width_compensation(id(display_time), cfg.width_compensation_percent);")
-    lines.append("            apply_width_compensation(id(temperatures), cfg.width_compensation_percent);")
-    lines.append("            apply_width_compensation(id(clock_label), cfg.width_compensation_percent);")
+    lines.append("            set_text_width_compensation_percent(cfg.text_width_compensation_percent);")
+    lines.append("            apply_text_width_compensation(id(display_time));")
+    lines.append("            apply_text_width_compensation(id(temperatures));")
+    lines.append("            apply_text_width_compensation(id(clock_label));")
     return lines
 
 


### PR DESCRIPTION
## Purpose

Restore the 95% pixel-width compensation for the shared 7-inch display profile without distorting ordinary text. The original setting had been removed while removing label compensation, which left the portrait axis switch active but scaling by 100%.

## Practical impact

Both Guition JC1060P470 revisions now apply the intended 95% correction to icons and geometric controls. Landscape orientations apply it on logical X; 90 and 270 degree portrait orientations apply it on logical Y, corresponding to the same physical panel axis after rotation.

Ordinary text uses a separate 100% policy, preserving natural font proportions in cards, clock-bar content, weather values, media labels, and modal text.

Modal tab controllers for Light, Cover, Fan, Climate, and Media now receive compensation once through their shared container. This keeps the tab background, buttons, and icons proportionate in portrait without double-scaling individual tabs.

Generated boot and refresh paths have been updated for all device profiles. Regression checks protect the 7-inch profile values, generated wiring, LVGL X/Y behavior, and compensation coverage for every modal tab controller.

## Automated checks

- `npm run check:fast` — passed
- ESPHome 2026.8.1 compile for Guition JC1060P470 V1 — passed
- Generated manifest, snapshot, and device YAML checks — passed
- Firmware parser tests verify 95% X/Y geometry scaling and 100% text scaling in both orientations — passed
- Modal regression checks verify Light, Cover, Fan, Climate, and Media tab controllers pass the display compensation to the shared tab container — passed

## Device testing

The updated PR firmware at commit `91726988a` has been flashed over OTA to the Guition JC1060P470 V1 at 192.168.6.102. The device rebooted and returned online successfully.

Please check rotations 0, 90, 180, and 270. In each modal, confirm the Light, Cover, Fan, Climate, and Media tab backgrounds, buttons, and icons look correctly proportioned. Also confirm text retains natural proportions, with no clipping or touch/navigation regressions.

The V2 hardware still requires physical testing.
