### PR TITLE
Show music icon and label on idle cover art cards

### DIFF
--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -1122,7 +1122,9 @@ inline void media_playback_apply_state_to_now_playing_snapshot(
   ctx->external_source = state->external_source;
   const bool has_content = media_playback_has_current_content(state);
   const bool idle_placeholder = ctx->cover_art_mode &&
-    espcontrol::cover_art::media_cover_art_idle_placeholder_visible(has_content);
+    espcontrol::cover_art::media_cover_art_idle_placeholder_visible(
+      state->has_state, state->available, state->state_text, has_content,
+      ctx->external_source_fallback);
   media_cover_art_set_idle_placeholder(ctx, idle_placeholder);
   if (ctx->cover_art) {
     if (espcontrol::cover_art::media_card_artwork_should_clear(
@@ -2445,7 +2447,7 @@ inline std::string media_control_title_text(MediaControlCtx *ctx) {
 inline std::string media_control_artist_text(MediaControlCtx *ctx) {
   if (!ctx) return "";
   if (!espcontrol::media::media_modal_artist_visible(
-        ctx->cover_art_mode, ctx->state_text)) {
+        ctx->cover_art_mode, ctx->state_text, !ctx->artist.empty())) {
     return "";
   }
   if (!ctx->artist.empty()) return ctx->artist;
@@ -4618,7 +4620,9 @@ inline void setup_media_card(BtnSlot &s, const ParsedCfg &p, uint32_t on_color,
       lv_label_set_display_text(ctx->title_lbl, "");
       lv_obj_add_flag(ctx->title_lbl, LV_OBJ_FLAG_HIDDEN);
       lv_obj_add_flag(ctx->artist_lbl, LV_OBJ_FLAG_HIDDEN);
-      media_cover_art_set_idle_placeholder(ctx, true);
+      // Wait for a known, available inactive state before presenting the card
+      // as idle. Initial loading and unavailable entities are not idle.
+      media_cover_art_set_idle_placeholder(ctx, false);
       media_position_now_playing_artist(ctx);
       return;
     }

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -1072,14 +1072,27 @@ inline bool media_playback_has_current_content(const MediaPlaybackState *state) 
 
 inline void media_cover_art_set_idle_placeholder(MediaNowPlayingCtx *ctx,
                                                  bool visible) {
-  if (!ctx || !ctx->cover_art_mode || !ctx->icon_lbl) return;
-  if (visible) {
-    lv_label_set_display_text(ctx->icon_lbl, find_icon("Music"));
-    lv_obj_align(ctx->icon_lbl, LV_ALIGN_TOP_LEFT, 0, 0);
-    lv_obj_clear_flag(ctx->icon_lbl, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_move_foreground(ctx->icon_lbl);
-  } else {
-    lv_obj_add_flag(ctx->icon_lbl, LV_OBJ_FLAG_HIDDEN);
+  if (!ctx || !ctx->cover_art_mode) return;
+  if (ctx->icon_lbl) {
+    if (visible) {
+      lv_label_set_display_text(ctx->icon_lbl, find_icon("Music"));
+      lv_obj_align(ctx->icon_lbl, LV_ALIGN_TOP_LEFT, 0, 0);
+      lv_obj_clear_flag(ctx->icon_lbl, LV_OBJ_FLAG_HIDDEN);
+      lv_obj_move_foreground(ctx->icon_lbl);
+    } else {
+      lv_obj_add_flag(ctx->icon_lbl, LV_OBJ_FLAG_HIDDEN);
+    }
+  }
+  if (ctx->idle_lbl) {
+    if (visible) {
+      lv_label_set_display_text(ctx->idle_lbl, espcontrol_i18n("Idle"));
+      lv_obj_align(ctx->idle_lbl, LV_ALIGN_BOTTOM_LEFT, 0, 0);
+      configure_button_label_wrap(ctx->idle_lbl);
+      lv_obj_clear_flag(ctx->idle_lbl, LV_OBJ_FLAG_HIDDEN);
+      lv_obj_move_foreground(ctx->idle_lbl);
+    } else {
+      lv_obj_add_flag(ctx->idle_lbl, LV_OBJ_FLAG_HIDDEN);
+    }
   }
 }
 
@@ -4540,6 +4553,7 @@ inline void setup_media_card(BtnSlot &s, const ParsedCfg &p, uint32_t on_color,
     MediaNowPlayingCtx *ctx = new MediaNowPlayingCtx();
     ctx->btn = s.btn;
     ctx->icon_lbl = s.icon_lbl;
+    ctx->idle_lbl = s.text_lbl;
     ctx->content_padding = padding;
     ctx->cover_art_mode = mode == "cover_art";
     ctx->show_track_details = mode != "cover_art" || media_cover_art_details_enabled(p);

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -1581,6 +1581,12 @@ inline void media_playback_subscribe_playback_state(MediaPlaybackState *state) {
       [state, generation](esphome::StringRef state_ref) {
         if (!media_playback_generation_valid(state, generation)) return;
         std::string state_text = string_ref_limited(state_ref, HA_SHORT_STATE_MAX_LEN);
+        const bool had_content = !state->title.empty() || !state->artist.empty() ||
+                                 state->has_current_content_id ||
+                                 state->artwork_content_mask != 0;
+        const bool resync_content =
+          espcontrol::cover_art::media_state_change_needs_content_resync(
+            state->has_state, state->state_text, state_text, had_content);
         const bool invalidate_retained_content =
           espcontrol::cover_art::media_state_change_invalidates_retained_content(
             state->has_state, state->state_text, state_text);
@@ -1605,6 +1611,12 @@ inline void media_playback_subscribe_playback_state(MediaPlaybackState *state) {
         }
         media_playback_apply_state_to_consumers(state);
         media_playback_refresh_progress_timer(state);
+        // Attribute subscriptions only report values that changed. If an
+        // entity retains the same track while moving through idle, the local
+        // idle cleanup has no metadata callback to repopulate the card or its
+        // modal. Reannounce once on the idle-to-active edge to request the
+        // complete current Home Assistant snapshot.
+        if (resync_content) ha_reannounce_state_subscriptions();
       })
   );
 }

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -374,7 +374,9 @@ inline void media_control_apply_availability(lv_obj_t *visual_obj, lv_obj_t *inp
 
 inline void media_control_refresh_parent_card(MediaControlCtx *ctx) {
   if (!ctx) return;
-  if (ctx->label_lbl) {
+  if (ctx->label_lbl &&
+      espcontrol::media::media_control_updates_parent_label(
+        ctx->cover_art_mode)) {
     std::string label = ctx->label_shows_status
       ? media_status_text(ctx->state_text)
       : ctx->label;

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -63,6 +63,7 @@ struct MediaControlCtx {
   bool available = true;
   bool state_known = false;
   bool playing = false;
+  bool cover_art_mode = false;
   bool highlight_playing = true;
   bool volume_known = false;
   bool label_shows_status = false;
@@ -2429,6 +2430,10 @@ inline std::string media_control_title_text(MediaControlCtx *ctx) {
 
 inline std::string media_control_artist_text(MediaControlCtx *ctx) {
   if (!ctx) return "";
+  if (!espcontrol::media::media_modal_artist_visible(
+        ctx->cover_art_mode, ctx->state_text)) {
+    return "";
+  }
   if (!ctx->artist.empty()) return ctx->artist;
   if (!ctx->friendly_name.empty()) return ctx->friendly_name;
   return ctx->label;
@@ -4427,6 +4432,7 @@ inline MediaControlCtx *create_media_control_context(
   MediaControlCtx *ctx = new MediaControlCtx();
   ctx->entity_id = p.entity;
   ctx->label = media_control_card_label(p);
+  ctx->cover_art_mode = media_card_mode(p.sensor) == "cover_art";
   ctx->max_pct = media_volume_max_percent(p);
   ctx->speaker_group_entity = media_group_discovery_entity(media_speaker_group_entity(p));
   ctx->group_only = media_card_mode(p.sensor) == "speaker_group";

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -1070,6 +1070,19 @@ inline bool media_playback_has_current_content(const MediaPlaybackState *state) 
     state->has_state, state->available, has_content);
 }
 
+inline void media_cover_art_set_idle_placeholder(MediaNowPlayingCtx *ctx,
+                                                 bool visible) {
+  if (!ctx || !ctx->cover_art_mode || !ctx->icon_lbl) return;
+  if (visible) {
+    lv_label_set_display_text(ctx->icon_lbl, find_icon("Music"));
+    lv_obj_align(ctx->icon_lbl, LV_ALIGN_TOP_LEFT, 0, 0);
+    lv_obj_clear_flag(ctx->icon_lbl, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_move_foreground(ctx->icon_lbl);
+  } else {
+    lv_obj_add_flag(ctx->icon_lbl, LV_OBJ_FLAG_HIDDEN);
+  }
+}
+
 inline void media_playback_refresh_stable_artwork(MediaPlaybackState *state,
                                                   MediaNowPlayingCtx *ctx) {
   if (!state || !ctx || !ctx->cover_art) return;
@@ -1091,8 +1104,11 @@ inline void media_playback_apply_state_to_now_playing_snapshot(
   if (!state || !ctx) return;
   ctx->source_known = state->source_known;
   ctx->external_source = state->external_source;
+  const bool has_content = media_playback_has_current_content(state);
+  const bool idle_placeholder = ctx->cover_art_mode &&
+    espcontrol::cover_art::media_cover_art_idle_placeholder_visible(has_content);
+  media_cover_art_set_idle_placeholder(ctx, idle_placeholder);
   if (ctx->cover_art) {
-    const bool has_content = media_playback_has_current_content(state);
     if (espcontrol::cover_art::media_card_artwork_should_clear(
           state->has_state, state->available, state->state_text, has_content)) {
       image_card_clear_media_artwork(ctx->cover_art);
@@ -1104,11 +1120,13 @@ inline void media_playback_apply_state_to_now_playing_snapshot(
   }
   if (ctx->title_lbl) {
     const std::string title =
-      ctx->external_source_fallback && state->external_source && !state->source.empty()
+      idle_placeholder ? std::string()
+      : ctx->external_source_fallback && state->external_source && !state->source.empty()
         ? state->source
         : state->title.empty() ? std::string("--") : state->title;
     lv_label_set_display_text(ctx->title_lbl, title.c_str());
-    if (ctx->show_track_details || ctx->external_source_fallback) {
+    if (!idle_placeholder &&
+        (ctx->show_track_details || ctx->external_source_fallback)) {
       lv_obj_clear_flag(ctx->title_lbl, LV_OBJ_FLAG_HIDDEN);
     } else {
       lv_obj_add_flag(ctx->title_lbl, LV_OBJ_FLAG_HIDDEN);
@@ -1118,7 +1136,8 @@ inline void media_playback_apply_state_to_now_playing_snapshot(
     std::strncpy(ctx->artist, state->artist.c_str(), sizeof(ctx->artist) - 1);
     ctx->artist[sizeof(ctx->artist) - 1] = '\0';
     media_apply_now_playing_artist_text(ctx);
-    if (espcontrol::cover_art::media_now_playing_artist_visible(
+    if (!idle_placeholder &&
+        espcontrol::cover_art::media_now_playing_artist_visible(
           !state->artist.empty(), ctx->external_source,
           ctx->show_track_details, ctx->external_source_fallback)) {
       lv_obj_clear_flag(ctx->artist_lbl, LV_OBJ_FLAG_HIDDEN);
@@ -4520,7 +4539,9 @@ inline void setup_media_card(BtnSlot &s, const ParsedCfg &p, uint32_t on_color,
     lv_color_t text_color = lv_obj_get_style_text_color(s.sensor_lbl, LV_PART_MAIN);
     MediaNowPlayingCtx *ctx = new MediaNowPlayingCtx();
     ctx->btn = s.btn;
+    ctx->icon_lbl = s.icon_lbl;
     ctx->content_padding = padding;
+    ctx->cover_art_mode = mode == "cover_art";
     ctx->show_track_details = mode != "cover_art" || media_cover_art_details_enabled(p);
     ctx->play_pause_background = mode == "now_playing" && media_now_playing_play_pause_enabled(p);
     if (mode == "now_playing" && media_now_playing_progress_enabled(p)) {
@@ -4560,6 +4581,10 @@ inline void setup_media_card(BtnSlot &s, const ParsedCfg &p, uint32_t on_color,
         media_title_font, layout_padding,
         media_cover_art_title_line_limit(row_span, col_span),
         true, 0);
+      lv_label_set_display_text(ctx->title_lbl, "");
+      lv_obj_add_flag(ctx->title_lbl, LV_OBJ_FLAG_HIDDEN);
+      lv_obj_add_flag(ctx->artist_lbl, LV_OBJ_FLAG_HIDDEN);
+      media_cover_art_set_idle_placeholder(ctx, true);
       media_position_now_playing_artist(ctx);
       return;
     }

--- a/components/espcontrol/button_grid_sliders.h
+++ b/components/espcontrol/button_grid_sliders.h
@@ -98,6 +98,7 @@ struct SliderCtx {
 };
 
 struct MediaNowPlayingCtx {
+  lv_obj_t *icon_lbl = nullptr;
   lv_obj_t *title_lbl = nullptr;
   lv_obj_t *artist_lbl = nullptr;
   lv_obj_t *progress_slider = nullptr;
@@ -113,6 +114,7 @@ struct MediaNowPlayingCtx {
   bool source_known = false;
   bool external_source = false;
   bool external_source_fallback = false;
+  bool cover_art_mode = false;
   bool show_track_details = true;
   bool play_pause_background = false;
   bool artist_below_title = false;

--- a/components/espcontrol/button_grid_sliders.h
+++ b/components/espcontrol/button_grid_sliders.h
@@ -99,6 +99,7 @@ struct SliderCtx {
 
 struct MediaNowPlayingCtx {
   lv_obj_t *icon_lbl = nullptr;
+  lv_obj_t *idle_lbl = nullptr;
   lv_obj_t *title_lbl = nullptr;
   lv_obj_t *artist_lbl = nullptr;
   lv_obj_t *progress_slider = nullptr;

--- a/components/espcontrol/cover_art.h
+++ b/components/espcontrol/cover_art.h
@@ -94,6 +94,10 @@ inline bool media_entity_content_available(bool state_known, bool available,
   return state_known && available && has_content;
 }
 
+inline bool media_cover_art_idle_placeholder_visible(bool has_content) {
+  return !has_content;
+}
+
 inline bool use_secondary_media_entity(bool primary_external,
                                        bool secondary_configured,
                                        bool secondary_playback_active,

--- a/components/espcontrol/cover_art.h
+++ b/components/espcontrol/cover_art.h
@@ -102,8 +102,11 @@ inline bool media_entity_content_available(bool state_known, bool available,
   return state_known && available && has_content;
 }
 
-inline bool media_cover_art_idle_placeholder_visible(bool has_content) {
-  return !has_content;
+inline bool media_cover_art_idle_placeholder_visible(
+    bool state_known, bool available, const std::string &state,
+    bool has_content, bool external_source_fallback) {
+  return state_known && available && !media_entity_state_usable(state) &&
+         !has_content && !external_source_fallback;
 }
 
 inline bool use_secondary_media_entity(bool primary_external,

--- a/components/espcontrol/cover_art.h
+++ b/components/espcontrol/cover_art.h
@@ -82,6 +82,14 @@ inline bool media_state_change_invalidates_retained_content(
          normalized_media_source(previous_state) != normalized_next;
 }
 
+inline bool media_state_change_needs_content_resync(
+    bool previous_state_known, const std::string &previous_state,
+    const std::string &next_state, bool has_content) {
+  return previous_state_known &&
+         !media_entity_state_usable(previous_state) &&
+         media_entity_state_usable(next_state) && !has_content;
+}
+
 inline bool media_card_artwork_should_clear(bool state_known, bool available,
                                             const std::string &state,
                                             bool has_content) {

--- a/components/espcontrol/media_metadata_policy.h
+++ b/components/espcontrol/media_metadata_policy.h
@@ -167,4 +167,9 @@ inline bool should_replace_media_metadata_identity(
   return !next_content_id.empty();
 }
 
+inline bool media_modal_artist_visible(bool cover_art_mode,
+                                       const std::string &state) {
+  return !cover_art_mode || normalize_media_kind_token(state) != "idle";
+}
+
 }  // namespace espcontrol::media

--- a/components/espcontrol/media_metadata_policy.h
+++ b/components/espcontrol/media_metadata_policy.h
@@ -168,8 +168,10 @@ inline bool should_replace_media_metadata_identity(
 }
 
 inline bool media_modal_artist_visible(bool cover_art_mode,
-                                       const std::string &state) {
-  return !cover_art_mode || normalize_media_kind_token(state) != "idle";
+                                       const std::string &state,
+                                       bool artist_present) {
+  return artist_present || !cover_art_mode ||
+         normalize_media_kind_token(state) != "idle";
 }
 
 inline bool media_control_updates_parent_label(bool cover_art_mode) {

--- a/components/espcontrol/media_metadata_policy.h
+++ b/components/espcontrol/media_metadata_policy.h
@@ -172,4 +172,8 @@ inline bool media_modal_artist_visible(bool cover_art_mode,
   return !cover_art_mode || normalize_media_kind_token(state) != "idle";
 }
 
+inline bool media_control_updates_parent_label(bool cover_art_mode) {
+  return !cover_art_mode;
+}
+
 }  // namespace espcontrol::media

--- a/tests/firmware/artwork_controller_test.cpp
+++ b/tests/firmware/artwork_controller_test.cpp
@@ -35,6 +35,7 @@ using espcontrol::cover_art::media_card_artwork_suppressed;
 using espcontrol::cover_art::media_cover_art_idle_placeholder_visible;
 using espcontrol::cover_art::media_external_source_stale_for_current_content;
 using espcontrol::cover_art::media_now_playing_artist_visible;
+using espcontrol::cover_art::media_state_change_needs_content_resync;
 
 int main() {
   RefreshTrigger trigger;
@@ -66,6 +67,15 @@ int main() {
   // until Home Assistant reports current media content.
   assert(media_cover_art_idle_placeholder_visible(false));
   assert(!media_cover_art_idle_placeholder_visible(true));
+
+  // Attribute values can remain unchanged while a player passes through
+  // idle. Re-request the current snapshot when playback resumes without any
+  // locally retained track data so both the card and modal recover.
+  assert(media_state_change_needs_content_resync(true, "idle", "playing", false));
+  assert(media_state_change_needs_content_resync(true, "off", "paused", false));
+  assert(!media_state_change_needs_content_resync(true, "playing", "paused", false));
+  assert(!media_state_change_needs_content_resync(true, "idle", "playing", true));
+  assert(!media_state_change_needs_content_resync(false, "unknown", "playing", false));
 
   // A source attribute omitted from the latest Home Assistant state must not
   // leave a retained TV route active once current music content arrives.

--- a/tests/firmware/artwork_controller_test.cpp
+++ b/tests/firmware/artwork_controller_test.cpp
@@ -32,6 +32,7 @@ using espcontrol::artwork::artwork_selection_needs_download;
 using espcontrol::artwork::source_response_can_apply_immediately;
 using espcontrol::cover_art::RuntimeState;
 using espcontrol::cover_art::media_card_artwork_suppressed;
+using espcontrol::cover_art::media_cover_art_idle_placeholder_visible;
 using espcontrol::cover_art::media_external_source_stale_for_current_content;
 using espcontrol::cover_art::media_now_playing_artist_visible;
 
@@ -60,6 +61,11 @@ int main() {
   assert(media_now_playing_artist_visible(true, false, true, false));
   assert(!media_now_playing_artist_visible(false, false, true, false));
   assert(!media_now_playing_artist_visible(true, false, false, false));
+
+  // Cover-art cards use their music icon instead of placeholder punctuation
+  // until Home Assistant reports current media content.
+  assert(media_cover_art_idle_placeholder_visible(false));
+  assert(!media_cover_art_idle_placeholder_visible(true));
 
   // A source attribute omitted from the latest Home Assistant state must not
   // leave a retained TV route active once current music content arrives.

--- a/tests/firmware/artwork_controller_test.cpp
+++ b/tests/firmware/artwork_controller_test.cpp
@@ -63,10 +63,21 @@ int main() {
   assert(!media_now_playing_artist_visible(false, false, true, false));
   assert(!media_now_playing_artist_visible(true, false, false, false));
 
-  // Cover-art cards use their music icon instead of placeholder punctuation
-  // until Home Assistant reports current media content.
-  assert(media_cover_art_idle_placeholder_visible(false));
-  assert(!media_cover_art_idle_placeholder_visible(true));
+  // Cover-art cards use their music icon only for a known, available inactive
+  // player. Loading, unavailable, active, and external-source fallback states
+  // must retain their distinct presentation.
+  assert(media_cover_art_idle_placeholder_visible(
+    true, true, "idle", false, false));
+  assert(!media_cover_art_idle_placeholder_visible(
+    false, true, "unknown", false, false));
+  assert(!media_cover_art_idle_placeholder_visible(
+    true, false, "unavailable", false, false));
+  assert(!media_cover_art_idle_placeholder_visible(
+    true, true, "playing", false, false));
+  assert(!media_cover_art_idle_placeholder_visible(
+    true, true, "idle", true, false));
+  assert(!media_cover_art_idle_placeholder_visible(
+    true, true, "idle", false, true));
 
   // Attribute values can remain unchanged while a player passes through
   // idle. Re-request the current snapshot when playback resumes without any

--- a/tests/firmware/media_metadata_policy_test.cpp
+++ b/tests/firmware/media_metadata_policy_test.cpp
@@ -38,11 +38,12 @@ int main() {
 
   // An idle cover-art modal must not substitute the card label for missing
   // artist metadata. Other media modals retain their existing fallback.
-  assert(!media_modal_artist_visible(true, "idle"));
-  assert(!media_modal_artist_visible(true, "Idle"));
-  assert(media_modal_artist_visible(true, "playing"));
-  assert(media_modal_artist_visible(true, "paused"));
-  assert(media_modal_artist_visible(false, "idle"));
+  assert(!media_modal_artist_visible(true, "idle", false));
+  assert(!media_modal_artist_visible(true, "Idle", false));
+  assert(media_modal_artist_visible(true, "idle", true));
+  assert(media_modal_artist_visible(true, "playing", false));
+  assert(media_modal_artist_visible(true, "paused", false));
+  assert(media_modal_artist_visible(false, "idle", false));
   assert(!media_control_updates_parent_label(true));
   assert(media_control_updates_parent_label(false));
 

--- a/tests/firmware/media_metadata_policy_test.cpp
+++ b/tests/firmware/media_metadata_policy_test.cpp
@@ -10,6 +10,7 @@ int main() {
   using espcontrol::media::media_content_id_should_clear_external_source;
   using espcontrol::media::media_content_id_should_override_source_update;
   using espcontrol::media::media_content_id_should_replace_external_source;
+  using espcontrol::media::media_control_updates_parent_label;
   using espcontrol::media::media_item_kind;
   using espcontrol::media::media_modal_artist_visible;
   using espcontrol::media::media_metadata_clear_decision;
@@ -42,6 +43,8 @@ int main() {
   assert(media_modal_artist_visible(true, "playing"));
   assert(media_modal_artist_visible(true, "paused"));
   assert(media_modal_artist_visible(false, "idle"));
+  assert(!media_control_updates_parent_label(true));
+  assert(media_control_updates_parent_label(false));
 
   // Sonos exposes TV audio as a home-theatre SPDIF stream. Music services use
   // ordinary provider IDs and must not inherit a retained TV classification.

--- a/tests/firmware/media_metadata_policy_test.cpp
+++ b/tests/firmware/media_metadata_policy_test.cpp
@@ -11,6 +11,7 @@ int main() {
   using espcontrol::media::media_content_id_should_override_source_update;
   using espcontrol::media::media_content_id_should_replace_external_source;
   using espcontrol::media::media_item_kind;
+  using espcontrol::media::media_modal_artist_visible;
   using espcontrol::media::media_metadata_clear_decision;
   using espcontrol::media::should_replace_media_metadata_identity;
 
@@ -33,6 +34,14 @@ int main() {
          MediaItemKind::AUDIOBOOK);
   assert(media_item_kind("opaque-content-id", "music") ==
          MediaItemKind::UNKNOWN);
+
+  // An idle cover-art modal must not substitute the card label for missing
+  // artist metadata. Other media modals retain their existing fallback.
+  assert(!media_modal_artist_visible(true, "idle"));
+  assert(!media_modal_artist_visible(true, "Idle"));
+  assert(media_modal_artist_visible(true, "playing"));
+  assert(media_modal_artist_visible(true, "paused"));
+  assert(media_modal_artist_visible(false, "idle"));
 
   // Sonos exposes TV audio as a home-theatre SPDIF stream. Music services use
   // ordinary provider IDs and must not inherit a retained TV classification.


### PR DESCRIPTION
## Summary

- Replace the idle Media Cover Art card placeholder with the standard music icon.
- Show the translated Idle label in the card label area while no media content is available.
- Hide the idle icon and label when content returns, and restore both when the player becomes empty again.
- Keep the artist line empty in the cover-art control modal while the player is idle instead of falling back to the Cover Art card label.

## Practical impact

- Empty cover-art cards now clearly communicate that the player is idle instead of showing two dashes.
- Opening the idle card no longer shows Cover Art as if it were an artist name.
- The Idle label uses the existing firmware translation key and follows the display language.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- These are small visual corrections with no setup or configuration changes to document.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.
- [ ] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- Any display using a Media Cover Art card; the main 4-inch S3 is the representative test device.

## Notes for testing

- The full fast validation suite passes, including all 29 firmware unit tests and 105 web/product smoke tests.
- The focused media metadata policy and cover-art contract checks pass.
- Firmware translation generation and consistency checks pass.
- The main 4-inch S3 dev firmware compiles successfully with ESPHome 2026.8.1.
- Leave the configured media player idle and confirm the card shows the music icon with the translated Idle label.
- Open the idle card modal and confirm its artist line is empty rather than showing Cover Art.
- Start playback and confirm real title and artist metadata appear, then stop or clear playback and confirm the idle card state returns.

## PR status

- [x] Checks running or waiting.
- [ ] Needs automated fix.
- [ ] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.