### PR TITLE
Prepare web assets for v2.8.4

### DIFF
--- a/docs/public/webserver/web-assets.json
+++ b/docs/public/webserver/web-assets.json
@@ -16,11 +16,11 @@
       ],
       "firmwareVersions": [
         "dev",
+        "v2.8.4",
         "v2.8.3",
         "v2.8.2",
         "v2.8.1",
-        "v2.8.0",
-        "v2.7.1"
+        "v2.8.0"
       ],
       "webAssetVersion": 1
     }

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -48,11 +48,11 @@ WEB_SOURCE_DIR = ROOT / "src" / "webserver"
 # list aligned with the GitHub Pages release catalogue in pages.yml.
 WEB_ASSET_SUPPORTED_FIRMWARE_VERSIONS = (
     "dev",
+    "v2.8.4",
     "v2.8.3",
     "v2.8.2",
     "v2.8.1",
     "v2.8.0",
-    "v2.7.1",
 )
 
 # Fixed editor controls use a few MDI glyphs that are not selectable Product

--- a/scripts/check_web_asset_manifest.js
+++ b/scripts/check_web_asset_manifest.js
@@ -79,6 +79,10 @@ function verifyManifest(webRoot) {
 
 async function verifyBridge() {
   const manifest = readJson(path.join(WEB_ROOT, "web-assets.json"));
+  const stableVersion = manifest.bundles[0].firmwareVersions.find(
+    (version) => /^v\d+\.\d+\.\d+$/.test(version),
+  );
+  assert(stableVersion, "web asset manifest must declare a stable firmware version");
   const loaded = [];
   let cleanedFallbackPath = "";
   const sandbox = {
@@ -114,18 +118,18 @@ async function verifyBridge() {
 
   const releaseLoaded = [];
   sandbox.document.currentScript.getAttribute = () =>
-    "https://assets.example/webserver/www.js?device=esp32-p4-86&v=v2.7.1";
+    `https://assets.example/webserver/www.js?device=esp32-p4-86&v=${stableVersion}`;
   sandbox.document.head.appendChild = (script) => releaseLoaded.push(script.src);
   vm.runInContext(fs.readFileSync(path.join(WEB_ROOT, "www.js"), "utf8"), sandbox);
   await new Promise((resolve) => setImmediate(resolve));
   assert(releaseLoaded.length === 1, "web bridge must load the supported stable firmware bundle");
-  assert(releaseLoaded[0] === `https://assets.example/webserver/${manifest.bundles[0].path}?device=esp32-p4-86&v=v2.7.1`,
+  assert(releaseLoaded[0] === `https://assets.example/webserver/${manifest.bundles[0].path}?device=esp32-p4-86&v=${stableVersion}`,
     "web bridge must select a bundle for an explicitly requested stable firmware version");
 
   let fallbackStarts = 0;
   sandbox.__ESPCONTROL_START_EMBEDDED__ = () => { fallbackStarts += 1; };
   sandbox.document.currentScript.getAttribute = () =>
-    "https://assets.example/webserver/www.js?device=esp32-p4-86&v=v2.7.1";
+    `https://assets.example/webserver/www.js?device=esp32-p4-86&v=${stableVersion}`;
   sandbox.document.head.appendChild = (script) => script.onerror();
   vm.runInContext(fs.readFileSync(path.join(WEB_ROOT, "www.js"), "utf8"), sandbox);
   await new Promise((resolve) => setImmediate(resolve));


### PR DESCRIPTION
## Purpose

Adds v2.8.4 to the declared immutable web bundle compatibility list before the release tag is created. It also makes the bridge check use a stable version from the rolling manifest instead of a version that ages out.

## Practical impact

The hosted bridge will select the declared immutable web bundle for v2.8.4 firmware while retaining dev and the five current stable releases.

## Automated checks

- `python3 scripts/build.py`
- `python3 scripts/build.py --check`
- `npm run check:web-asset-manifest`
- `npm run check:release-preflight`
- Full release preflight passed, including firmware tests, seven browser layouts, release contracts, and docs build

## Physical testing

Not required for this release metadata and test-only change.