### PR TITLE
Mac Connector:  Clock on Mac lock

### DIFF
--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -189,10 +189,11 @@ script:
           then:
             - lambda: |-
                 const auto transition = id(espcontrol_app).display().resolve();
-                const bool schedule_owned = transition.winning_source.has_value() &&
+                const bool display_takeover_owned = transition.winning_source.has_value() &&
                     (*transition.winning_source == espcontrol::DisplayRequestSource::BOOT_GUARD ||
-                     *transition.winning_source == espcontrol::DisplayRequestSource::SCREEN_SCHEDULE);
-                if (schedule_owned && transition.target_mode == espcontrol::DisplayMode::CLOCK) {
+                     *transition.winning_source == espcontrol::DisplayRequestSource::SCREEN_SCHEDULE ||
+                     *transition.winning_source == espcontrol::DisplayRequestSource::COMPANION_SESSION);
+                if (display_takeover_owned && transition.target_mode == espcontrol::DisplayMode::CLOCK) {
                   backlight_close_modals_for_display_takeover();
                 }
             - if:

--- a/components/companion/companion.cpp
+++ b/components/companion/companion.cpp
@@ -465,6 +465,9 @@ void CompanionService::handle_message_(int socket_fd, const std::string &message
   } else if (parts[0] == "FOCUS" && parts.size() == 2 &&
              (parts[1].empty() || safe_field(parts[1], 96))) {
     companion_set_focused_application(parts[1]);
+  } else if (parts[0] == "SESSION" && parts.size() == 2 &&
+             (parts[1] == "locked" || parts[1] == "active")) {
+    companion_set_session_locked(parts[1] == "locked");
   } else if (parts[0] == "HEARTBEAT") {
     this->send_(socket_fd, "HEARTBEAT|ok");
   }

--- a/components/espcontrol/companion_controls.h
+++ b/components/espcontrol/companion_controls.h
@@ -108,6 +108,7 @@ struct CompanionRuntimeState {
   std::string focused_application_id;
   bool media_actions_supported{false};
   bool connected{false};
+  bool session_locked{false};
   CompanionNowPlayingSnapshot now_playing;
   CompanionSystemMetricsSnapshot system_metrics;
 };
@@ -118,6 +119,7 @@ struct CompanionRuntimeSnapshot {
   std::string focused_application_id;
   bool media_actions_supported{false};
   bool connected{false};
+  bool session_locked{false};
   CompanionNowPlayingSnapshot now_playing;
   CompanionSystemMetricsSnapshot system_metrics;
 };
@@ -131,7 +133,16 @@ inline CompanionRuntimeSnapshot companion_runtime_snapshot() {
   auto &state = companion_runtime_state();
   std::lock_guard<std::mutex> lock(state.mutex);
   return {state.actions, state.values, state.focused_application_id, state.media_actions_supported,
-          state.connected, state.now_playing, state.system_metrics};
+          state.connected, state.session_locked, state.now_playing, state.system_metrics};
+}
+
+inline void companion_set_session_locked(bool locked) {
+  auto &state = companion_runtime_state();
+  {
+    std::lock_guard<std::mutex> lock(state.mutex);
+    if (state.session_locked == locked) return;
+    state.session_locked = locked;
+  }
 }
 
 inline CompanionNowPlayingHandler &companion_now_playing_handler() {
@@ -347,6 +358,7 @@ inline void companion_set_connected(bool connected) {
     if (!connected) {
       state.values.clear();
       state.focused_application_id.clear();
+      state.session_locked = false;
       state.media_actions_supported = false;
       state.system_metrics = {};
     }

--- a/components/espcontrol/display_mode_controller.h
+++ b/components/espcontrol/display_mode_controller.h
@@ -22,6 +22,7 @@ enum class DisplayRequestSource : uint8_t {
   IDLE_TIMER,
   PRESENCE_SENSOR,
   SCREEN_SCHEDULE,
+  COMPANION_SESSION,
   MANUAL_SLEEP,
   MEDIA_PLAYBACK,
   SETUP_TIMEOUT,
@@ -139,6 +140,7 @@ class DisplayModeController {
     if (apply_source(DisplayRequestSource::USER_WAKE, result)) return result;
     if (apply_source(DisplayRequestSource::BOOT_GUARD, result)) return result;
     if (apply_source(DisplayRequestSource::SCREEN_SCHEDULE, result)) return result;
+    if (apply_source(DisplayRequestSource::COMPANION_SESSION, result)) return result;
 
     if (takeover_active(DisplayTakeoverKind::INTERACTIVE)) {
       result.target_mode = DisplayMode::ACTIVE;
@@ -231,6 +233,8 @@ class DisplayModeController {
       case DisplayRequestSource::SCREEN_SCHEDULE:
         return mode == DisplayMode::ACTIVE || mode == DisplayMode::CLOCK ||
                mode == DisplayMode::DISPLAY_OFF;
+      case DisplayRequestSource::COMPANION_SESSION:
+        return mode == DisplayMode::CLOCK;
       case DisplayRequestSource::IDLE_TIMER:
       case DisplayRequestSource::PRESENCE_SENSOR:
         return mode == DisplayMode::DIMMED || mode == DisplayMode::CLOCK ||
@@ -246,7 +250,7 @@ class DisplayModeController {
     bool active{false};
   };
 
-  static constexpr std::size_t kRequestCount = 9;
+  static constexpr std::size_t kRequestCount = 10;
   static constexpr std::size_t kTakeoverCount = 2;
 
   static constexpr std::size_t source_index(DisplayRequestSource source) {
@@ -310,6 +314,7 @@ inline const char *display_request_source_name(
     case DisplayRequestSource::IDLE_TIMER: return "idle_timer";
     case DisplayRequestSource::PRESENCE_SENSOR: return "presence_sensor";
     case DisplayRequestSource::SCREEN_SCHEDULE: return "screen_schedule";
+    case DisplayRequestSource::COMPANION_SESSION: return "companion_session";
     case DisplayRequestSource::MANUAL_SLEEP: return "manual_sleep";
     case DisplayRequestSource::MEDIA_PLAYBACK: return "media_playback";
     case DisplayRequestSource::SETUP_TIMEOUT: return "setup_timeout";

--- a/devices/guition-esp32-s3-4848s040/device/lvgl.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/lvgl.yaml
@@ -182,3 +182,16 @@ interval:
             previous_companion_connection = connected;
             id(clock_bar_apply).execute();
           }
+          static bool previous_mac_session_locked = false;
+          const bool mac_session_locked = companion_runtime_snapshot().session_locked;
+          if (mac_session_locked != previous_mac_session_locked) {
+            previous_mac_session_locked = mac_session_locked;
+            auto &display = id(espcontrol_app).display();
+            if (mac_session_locked) {
+              display.request(espcontrol::DisplayRequestSource::COMPANION_SESSION,
+                              espcontrol::DisplayMode::CLOCK);
+            } else {
+              display.clear(espcontrol::DisplayRequestSource::COMPANION_SESSION);
+            }
+            id(display_mode_reconcile).execute();
+          }

--- a/macos/Companion/Sources/Companion/CompanionConnection.swift
+++ b/macos/Companion/Sources/Companion/CompanionConnection.swift
@@ -254,6 +254,7 @@ final class CompanionConnection: NSObject, @preconcurrency URLSessionDelegate, @
             store.updateStatus("Connected to \(store.panelHost)", connected: true)
             if let task { startHeartbeat(for: task) }
             publishCatalogue()
+            publishSessionLockState()
             store.republishCurrentNowPlaying()
             store.republishCurrentSystemMetrics()
         case "CATALOGUE":
@@ -413,6 +414,10 @@ final class CompanionConnection: NSObject, @preconcurrency URLSessionDelegate, @
         let identifier = store.focusedLaunchableApplicationIdentifier()
         guard identifier.isEmpty || Self.validCatalogueIdentifier(identifier) else { return }
         send("FOCUS|\(identifier)")
+    }
+
+    func publishSessionLockState() {
+        send("SESSION|\(store.isMacSessionLocked ? "locked" : "active")")
     }
 
     func publishMediaControlValues(_ values: [String: Int], unavailable: Set<String>) {

--- a/macos/Companion/Sources/Companion/CompanionStore.swift
+++ b/macos/Companion/Sources/Companion/CompanionStore.swift
@@ -48,6 +48,7 @@ final class CompanionStore: NSObject, ObservableObject {
         }
     }
     @Published private(set) var systemMetricsStatus = "Waiting for a panel connection"
+    private(set) var isMacSessionLocked = false
 
     private enum Keys {
         static let host = "panelHost"
@@ -86,6 +87,18 @@ final class CompanionStore: NSObject, ObservableObject {
             self,
             selector: #selector(frontmostApplicationDidChange(_:)),
             name: NSWorkspace.didActivateApplicationNotification,
+            object: nil
+        )
+        DistributedNotificationCenter.default().addObserver(
+            self,
+            selector: #selector(macSessionDidLock(_:)),
+            name: Notification.Name("com.apple.screenIsLocked"),
+            object: nil
+        )
+        DistributedNotificationCenter.default().addObserver(
+            self,
+            selector: #selector(macSessionDidUnlock(_:)),
+            name: Notification.Name("com.apple.screenIsUnlocked"),
             object: nil
         )
         migrateConnectionPreferences(from: [legacyDefaults, UserDefaults.standard].compactMap { $0 })
@@ -222,6 +235,20 @@ final class CompanionStore: NSObject, ObservableObject {
 
     @objc private func frontmostApplicationDidChange(_: Notification) {
         if isConnected { connection.publishFocusedApplication() }
+    }
+
+    @objc private func macSessionDidLock(_: Notification) {
+        setMacSessionLocked(true)
+    }
+
+    @objc private func macSessionDidUnlock(_: Notification) {
+        setMacSessionLocked(false)
+    }
+
+    private func setMacSessionLocked(_ locked: Bool) {
+        guard isMacSessionLocked != locked else { return }
+        isMacSessionLocked = locked
+        if isConnected { connection.publishSessionLockState() }
     }
 
     func chooseFolder() {

--- a/tests/firmware/companion_shortcut_test.cpp
+++ b/tests/firmware/companion_shortcut_test.cpp
@@ -31,6 +31,8 @@ int main() {
   assert(companion_card_refresh_requested().load());
   companion_set_connected(true);
   assert(companion_connected());
+  companion_set_session_locked(true);
+  assert(companion_runtime_snapshot().session_locked);
   assert(companion_metric_key_valid("stat.cpu"));
   assert(!companion_metric_key_valid("sensor.cpu"));
   assert(std::string(companion_metric_label_key("stat.memory")) == "memory");
@@ -98,6 +100,7 @@ int main() {
   assert(invoke_companion_url("com.apple.Safari", url_config, "test-1"));
   assert(invoked);
   companion_set_connected(false);
+  assert(!companion_runtime_snapshot().session_locked);
   assert(!companion_metric_value(companion_runtime_snapshot(), "stat.cpu", metric_value));
   assert(!companion_application_focused("com.apple.Safari"));
   companion_set_connected(true);

--- a/tests/firmware/display_mode_controller_test.cpp
+++ b/tests/firmware/display_mode_controller_test.cpp
@@ -21,10 +21,11 @@ static void activate_priority(DisplayModeController &controller, int priority) {
     case 3: controller.request(DisplayRequestSource::MANUAL_SLEEP, DisplayMode::DISPLAY_OFF); break;
     case 4: controller.request(DisplayRequestSource::USER_WAKE, DisplayMode::ACTIVE); break;
     case 5: controller.request(DisplayRequestSource::SCREEN_SCHEDULE, DisplayMode::CLOCK); break;
-    case 6: controller.begin_takeover(DisplayTakeoverKind::INTERACTIVE); break;
-    case 7: controller.request(DisplayRequestSource::MEDIA_PLAYBACK, DisplayMode::COVER_ART); break;
-    case 8: controller.request(DisplayRequestSource::IDLE_TIMER, DisplayMode::DIMMED); break;
-    case 9: controller.request(DisplayRequestSource::SETUP_TIMEOUT, DisplayMode::SETUP_DIMMED); break;
+    case 6: controller.request(DisplayRequestSource::COMPANION_SESSION, DisplayMode::CLOCK); break;
+    case 7: controller.begin_takeover(DisplayTakeoverKind::INTERACTIVE); break;
+    case 8: controller.request(DisplayRequestSource::MEDIA_PLAYBACK, DisplayMode::COVER_ART); break;
+    case 9: controller.request(DisplayRequestSource::IDLE_TIMER, DisplayMode::DIMMED); break;
+    case 10: controller.request(DisplayRequestSource::SETUP_TIMEOUT, DisplayMode::SETUP_DIMMED); break;
     default: break;
   }
 }
@@ -33,8 +34,8 @@ static DisplayMode expected_mode_for_priority(int priority) {
   const DisplayMode modes[] = {
       DisplayMode::ACTIVE, DisplayMode::ACTIVE, DisplayMode::ACTIVE,
       DisplayMode::DISPLAY_OFF, DisplayMode::ACTIVE, DisplayMode::CLOCK,
-      DisplayMode::ACTIVE, DisplayMode::COVER_ART, DisplayMode::DIMMED,
-      DisplayMode::SETUP_DIMMED};
+      DisplayMode::CLOCK, DisplayMode::ACTIVE, DisplayMode::COVER_ART,
+      DisplayMode::DIMMED, DisplayMode::SETUP_DIMMED};
   return modes[priority];
 }
 
@@ -65,11 +66,11 @@ int main() {
   CHECK(!presence_can_wake_display(scheduled_presence.resolve()));
 
   // Every higher-priority policy beats every lower-priority policy.
-  for (int higher = 1; higher <= 9; ++higher) {
-    for (int lower = higher + 1; lower <= 10; ++lower) {
+  for (int higher = 1; higher <= 10; ++higher) {
+    for (int lower = higher + 1; lower <= 11; ++lower) {
       // Setup timeout is deliberately nested inside onboarding: it may dim
       // instructions but cannot expose any other lower-priority policy.
-      if (higher == 2 && lower == 9) continue;
+      if (higher == 2 && lower == 10) continue;
       DisplayModeController pair;
       activate_priority(pair, lower);
       activate_priority(pair, higher);
@@ -186,6 +187,7 @@ int main() {
       {DisplayRequestSource::IDLE_TIMER, DisplayMode::DIMMED},
       {DisplayRequestSource::PRESENCE_SENSOR, DisplayMode::CLOCK},
       {DisplayRequestSource::SCREEN_SCHEDULE, DisplayMode::ACTIVE},
+      {DisplayRequestSource::COMPANION_SESSION, DisplayMode::CLOCK},
       {DisplayRequestSource::MANUAL_SLEEP, DisplayMode::DISPLAY_OFF},
       {DisplayRequestSource::MEDIA_PLAYBACK, DisplayMode::COVER_ART},
       {DisplayRequestSource::SETUP_TIMEOUT, DisplayMode::SETUP_DIMMED},
@@ -210,8 +212,19 @@ int main() {
   const auto first_art = cover_art.resolve();
   CHECK(decision_is(cover_art, DisplayMode::COVER_ART,
                     DisplayRequestSource::MEDIA_PLAYBACK));
+
   CHECK(!cover_art.generation_is_current(activation_generation));
   CHECK(cover_art.complete_transition(first_art));
+
+  // Locking the paired Mac temporarily replaces media and idle presentation
+  // with the clock, then unlocking restores the live request underneath.
+  CHECK(cover_art.request(DisplayRequestSource::COMPANION_SESSION,
+                          DisplayMode::CLOCK));
+  CHECK(decision_is(cover_art, DisplayMode::CLOCK,
+                    DisplayRequestSource::COMPANION_SESSION));
+  CHECK(cover_art.clear(DisplayRequestSource::COMPANION_SESSION));
+  CHECK(decision_is(cover_art, DisplayMode::COVER_ART,
+                    DisplayRequestSource::MEDIA_PLAYBACK));
 
   CHECK(cover_art.request(DisplayRequestSource::IDLE_TIMER, DisplayMode::DIMMED));
   const uint32_t artwork_generation = cover_art.generation();


### PR DESCRIPTION
Depends on #1820, which is stacked on #1807 and #1432. Merge the Companion stack in this order: #1432 → #1807 → #1820 → #1826.

## Purpose

Switch the paired EspControl display to its clock screensaver while the connected Mac session is locked.

## Practical impact

- Locking the Mac shows the panel clock within about half a second.
- Unlocking restores the live display mode that was underneath.
- Manual display-off, the night schedule, onboarding, and critical alarms retain higher priority.
- Disconnecting the Companion clears the lock state so the panel cannot remain stuck on the clock.

## Automated checks

- Native macOS Companion release build
- Companion protocol firmware test
- Display mode priority and restoration firmware test
- Generated output check
- Successful ESPHome compile and OTA upload to the second S3 at 192.168.6.100

## Physical testing

The second S3 has been flashed with this branch. Connect the matching Mac app, lock and unlock the Mac, then confirm the panel switches to the clock and restores its previous screen.

This PR must remain based on and tested with #1820 until that PR is merged.