### PR TITLE
Keep camera card icon while loading

### DIFF
--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -453,8 +453,6 @@ inline void image_card_set_loading_state(lv_obj_t *loading_widget, const char *t
   if (!loading_widget) return;
   lv_obj_t *btn = lv_obj_get_parent(loading_widget);
   image_card_position_widget(btn, loading_widget, nullptr, nullptr);
-  lv_obj_t *icon = image_card_loading_icon(loading_widget);
-  if (icon) lv_label_set_display_text(icon, IMAGE_CARD_LOADING_ICON);
   lv_obj_t *label = image_card_loading_label(loading_widget);
   if (label) lv_label_set_display_text(label, espcontrol_i18n(text));
   image_card_refresh_loading_layout(loading_widget);
@@ -1364,8 +1362,14 @@ inline void image_card_configure_icon(BtnSlot &s, const ParsedCfg &p) {
     lv_obj_add_flag(s.icon_lbl, LV_OBJ_FLAG_HIDDEN);
     return;
   }
-  lv_label_set_display_text(s.icon_lbl, find_icon(
-    p.icon.empty() || p.icon == "Auto" ? "Camera" : p.icon.c_str()));
+  const char *glyph = find_icon(
+    p.icon.empty() || p.icon == "Auto" ? "Camera" : p.icon.c_str());
+  lv_label_set_display_text(s.icon_lbl, glyph);
+  lv_obj_t *widget = s.sensor_container
+    ? static_cast<lv_obj_t *>(lv_obj_get_user_data(s.sensor_container))
+    : nullptr;
+  lv_obj_t *loading_icon = image_card_loading_icon(image_card_loading_widget(widget));
+  if (loading_icon) lv_label_set_display_text(loading_icon, glyph);
   lv_obj_clear_flag(s.icon_lbl, LV_OBJ_FLAG_HIDDEN);
   image_card_align_icon(s.icon_lbl, s.btn);
 }

--- a/scripts/check_firmware_ha_bindings.py
+++ b/scripts/check_firmware_ha_bindings.py
@@ -2156,6 +2156,26 @@ def firmware_image_card_quality_errors(firmware_dir: Path, root: Path) -> list[s
         errors.append(f"{rel}: retain one shared modal image cache for instant reopen")
     if 'image_card_set_loading_state(loading, "Too many")' not in text:
         errors.append(f"{rel}: show a visible image-card limit message when downloaders run out")
+    loading_state = re.search(
+        r"inline\s+void\s+image_card_set_loading_state\s*\(\s*lv_obj_t\s*\*loading_widget.*?"
+        r"(?=\ninline\s+void\s+image_card_set_loading_state\s*\(\s*ImageCardCtx)",
+        text,
+        re.S,
+    )
+    configure_icon = re.search(
+        r"inline\s+void\s+image_card_configure_icon.*?(?=\ninline\s+std::string\s+image_card_join_url)",
+        text,
+        re.S,
+    )
+    loading_state_body = loading_state.group(0) if loading_state else ""
+    configure_icon_body = configure_icon.group(0) if configure_icon else ""
+    if (
+        not loading_state_body
+        or "IMAGE_CARD_LOADING_ICON" in loading_state_body
+        or "lv_label_set_display_text(label, espcontrol_i18n(text))" not in loading_state_body
+        or "lv_label_set_display_text(loading_icon, glyph)" not in configure_icon_body
+    ):
+        errors.append(f"{rel}: preserve the configured image-card icon while loading")
     modal_refresh = re.search(
         r"inline\s+bool\s+image_card_modal_refresh_supported\s*\(\s*\)\s*\{\s*return\s+true\s*;",
         text,
@@ -6545,6 +6565,7 @@ def run_self_test() -> int:
             "check free memory before image-card downloads",
             "include PSRAM in image-card memory checks",
             "show a visible image-card limit message when downloaders run out",
+            "preserve the configured image-card icon while loading",
             "keep modal-quality image refresh enabled on the 4.3-inch P4 screen",
             "size every image-card tile request to its on-screen bounds",
             "log image-card modal close events",
@@ -6632,7 +6653,17 @@ def run_self_test() -> int:
         "  lv_obj_t *loading = image_card_loading_widget(widget);\n"
         "  image_card_set_loading_state(loading, \"Too many\");\n"
         "  return true;\n"
-        "}\n",
+        "}\n"
+        "inline void image_card_set_loading_state(lv_obj_t *loading_widget, const char *text) {\n"
+        "  lv_obj_t *label = image_card_loading_label(loading_widget);\n"
+        "  lv_label_set_display_text(label, espcontrol_i18n(text));\n"
+        "}\n"
+        "inline void image_card_set_loading_state(ImageCardCtx *ctx, const char *text) {}\n"
+        "inline void image_card_configure_icon(BtnSlot &s, const ParsedCfg &p) {\n"
+        "  const char *glyph = find_icon(p.icon.c_str());\n"
+        "  lv_label_set_display_text(loading_icon, glyph);\n"
+        "}\n"
+        "inline std::string image_card_join_url(const std::string &base, const std::string &path) {}\n",
         (),
     )
     expect_image_card_startup_errors(


### PR DESCRIPTION
## Summary

- Keep the configured camera/image card icon visible while its image is loading.
- Limit loading-state updates to the status text.
- Add a firmware guard against restoring the generic loading glyph.

## Practical impact

- A camera card no longer swaps the user's selected icon for the generic loading icon while fetching an image.

## Documentation decision

- [x] No docs needed because this restores the configured-icon behavior and adds no new settings.

## Testing

- [x] Firmware Home Assistant binding scan passed.
- [x] Firmware Home Assistant binding self-tests passed.
- [x] Firmware unit tests passed (34/34).
- [ ] Full fast suite passed; it stopped at the generated-assets check because the local VitePress font dependency is missing.
- [x] Device testing is required before merge.

Affected display/device, if applicable:

- Any display using a camera/image card.

## Notes for testing

- Flash the affected display, configure a camera card with a custom icon, and trigger an image load or refresh.
- Confirm the icon remains unchanged while the text shows Loading (and during an Unavailable state, if practical).

## PR status

- [x] Ready for device test.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.