### PR TITLE
Fix unavailable Companion media cards

### DIFF
--- a/macos/Companion/Sources/MediaRemoteShim/MediaRemoteShim.m
+++ b/macos/Companion/Sources/MediaRemoteShim/MediaRemoteShim.m
@@ -15,6 +15,9 @@ static ECSendCommandFn ECSendCommand;
 static NSMutableArray<id> *ECObservers;
 
 static BOOL ECLoadMediaRemote(void) {
+  // Keep loading the framework independent from the optional Now Playing
+  // entry points. Media commands can remain usable when Apple changes or
+  // removes one of those read-only symbols.
   static dispatch_once_t once;
   dispatch_once(&once, ^{
     ECMediaRemoteHandle = dlopen(
@@ -30,20 +33,22 @@ static BOOL ECLoadMediaRemote(void) {
     ECSendCommand = (ECSendCommandFn) dlsym(
         ECMediaRemoteHandle, "MRMediaRemoteSendCommand");
   });
-  return ECRegisterNotifications != NULL && ECGetNowPlayingInfo != NULL &&
-         ECGetNowPlayingPID != NULL;
+  return ECMediaRemoteHandle != NULL;
 }
 
 @implementation ECMediaRemoteBridge
 
-+ (BOOL)isAvailable { return ECLoadMediaRemote(); }
++ (BOOL)isAvailable {
+  return ECLoadMediaRemote() && ECRegisterNotifications != NULL &&
+         ECGetNowPlayingInfo != NULL && ECGetNowPlayingPID != NULL;
+}
 
 + (BOOL)isCommandAvailable {
   return ECLoadMediaRemote() && ECSendCommand != NULL;
 }
 
 + (void)fetchNowPlaying:(ECMediaRemoteSnapshotHandler)handler {
-  if (!ECLoadMediaRemote()) {
+  if (![self isAvailable]) {
     dispatch_async(dispatch_get_main_queue(), ^{ handler(nil, nil); });
     return;
   }
@@ -57,7 +62,7 @@ static BOOL ECLoadMediaRemote(void) {
 }
 
 + (BOOL)startObservingChanges:(ECMediaRemoteChangeHandler)handler {
-  if (!ECLoadMediaRemote()) return NO;
+  if (![self isAvailable]) return NO;
   [self stopObservingChanges];
   ECRegisterNotifications(dispatch_get_main_queue());
   ECObservers = [NSMutableArray array];


### PR DESCRIPTION
## Purpose
Fix Companion media-control cards being marked unavailable when the macOS MediaRemote command API is present but an optional Now Playing read symbol is missing or changed.

## Change
The MediaRemote bridge now loads the framework independently. Media command availability checks only the command symbol, while Now Playing checks continue to require the read symbols they use.

## Checks
- `swift build` passed.
- Focused C++ Companion protocol test passed.
- Browserless application contract tests passed: 108 tests.
- Full Swift XCTest target could not run on this host because the command-line toolchain has no XCTest module.
- CMake firmware test runner is not installed in this environment.

## Physical testing
Not yet performed. After the matching Companion app and firmware are available, verify Play/Pause, Previous Track, and Next Track on the 4-inch S3 test display.