### PR TITLE
Move connection settings into Status tab

### DIFF
--- a/macos/Companion/Sources/Companion/CompanionApp.swift
+++ b/macos/Companion/Sources/Companion/CompanionApp.swift
@@ -267,30 +267,36 @@ private struct CompanionPairingDetails {
 private struct CompanionSettings: View {
     @ObservedObject var store: CompanionStore
     @State private var pairingCode = ""
+    @State private var isConnectionSettingsExpanded = false
     @FocusState private var focusedField: CompanionSettingsField?
 
     var body: some View {
         TabView {
             ScrollView {
-                GroupBox("Device connection") {
-                    connectionStatusPanel
+                VStack(alignment: .leading, spacing: 12) {
+                    GroupBox("Device connection") {
+                        connectionStatusPanel
+                            .padding(8)
+                    }
+
+                    GroupBox {
+                        DisclosureGroup(
+                            isExpanded: $isConnectionSettingsExpanded,
+                            content: {
+                                deviceConnectionSettings
+                                    .padding(.top, 8)
+                            },
+                            label: {
+                                Label("Connection settings", systemImage: "network")
+                            }
+                        )
                         .padding(8)
+                    }
                 }
                 .padding()
             }
             .tabItem {
                 Label("Status", systemImage: "dot.radiowaves.left.and.right")
-            }
-
-            ScrollView {
-                GroupBox("Connection settings") {
-                    deviceConnectionSettings
-                        .padding(8)
-                }
-                .padding()
-            }
-            .tabItem {
-                Label("Connection", systemImage: "network")
             }
 
             ScrollView {


### PR DESCRIPTION
## Summary
- Move the existing connection address, pairing, and forget controls into the Status tab.
- Keep the settings in a collapsed disclosure panel by default.
- Remove the separate Connection tab to keep status and setup together.

## Checks
- `swift build` passes in `macos/Companion`.
- `swift test` compiles the Companion target but cannot run in this environment because the available Command Line Tools do not provide XCTest.

## Device/app testing
- Run the macOS Companion app from this branch.
- Confirm the Status tab shows connection state and that Connection settings is collapsed initially.
- Expand it and confirm address editing, pairing, opening the device webserver, and forgetting the panel still work.