### PR TITLE
Align JC8012P4A1 V2 socket capacity

### DIFF
--- a/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
@@ -34,6 +34,10 @@ esp32:
       disable_vfs_support_dir: false
     sdkconfig_options:
       CONFIG_SDMMC_HOST_DEFAULT: "y"
+      # ESPHome needs 18 sockets for this panel's API, web, diagnostics, and
+      # artwork services. Keep two spare so short-lived HTTP requests do not
+      # displace Home Assistant or remote connections.
+      CONFIG_LWIP_MAX_SOCKETS: "20"
       # HTTPS firmware checks need more stack on ESP32-P4; the default main
       # task stack can trip the stack protector during mbedTLS setup.
       CONFIG_ESP_MAIN_TASK_STACK_SIZE: "8192"


### PR DESCRIPTION
## Summary

- Add `CONFIG_LWIP_MAX_SOCKETS: "20"` to the JC8012P4A1 V2 profile.
- Match the existing V1 socket configuration and explanatory comment.

Related to #1844. Keep the issue open until physical V2 testing confirms the reported instability is resolved.

## Testing

- V2 factory firmware compiled successfully with ESPHome 2026.8.2.
- V1 factory firmware compiled successfully as a regression check.
- Physical V2 testing remains: exercise the web UI, Home Assistant API, and artwork fetching concurrently. Monitor free heap before and during the test, including whether it recovers afterward, and watch for disconnects, socket-allocation errors, or memory-allocation failures.
- Keep this PR open until the physical V2 test passes and the user confirms the result.