### PR TITLE
Prevent S3 cover-art refresh stack overflows

### DIFF
--- a/components/artwork_image/artwork_image.cpp
+++ b/components/artwork_image/artwork_image.cpp
@@ -1014,6 +1014,7 @@ size_t ArtworkImage::get_sane_content_length_() const {
 }
 
 void ArtworkImage::loop() {
+  ImageService::instance().process_pending();
   this->cleanup_retired_buffers_(false);
   if (this->s3_transfer_pending_) {
     this->consume_s3_transfer_result_();

--- a/components/artwork_image/image_service.cpp
+++ b/components/artwork_image/image_service.cpp
@@ -12,38 +12,33 @@ ImageService &ImageService::instance() {
 
 void ImageService::request(ArtworkImage *owner, uint32_t generation, ImageRequestPriority priority) {
   if (owner == nullptr || this->active_ == owner) return;
+  owner->enable_loop();
   this->queue_.enqueue(owner, generation, priority);
-  this->dispatch_next_();
 }
 
 void ImageService::complete(ArtworkImage *owner) {
   if (this->active_ == owner) this->active_ = nullptr;
-  this->dispatch_next_();
 }
 
 void ImageService::complete_and_request(ArtworkImage *owner, uint32_t generation,
                                         ImageRequestPriority priority) {
   if (owner == nullptr || this->active_ != owner) return;
+  owner->enable_loop();
   this->queue_.enqueue(owner, generation, priority);
   this->active_ = nullptr;
-  this->dispatch_next_();
 }
 
 void ImageService::cancel(ArtworkImage *owner) {
   this->queue_.remove(owner);
   if (this->active_ == owner) this->active_ = nullptr;
-  this->dispatch_next_();
 }
 
-void ImageService::dispatch_next_() {
-  if (this->dispatching_ || this->active_ != nullptr) return;
-  this->dispatching_ = true;
-  ImageRequestQueue<ArtworkImage>::Request request;
-  while (this->active_ == nullptr && this->queue_.pop_next(request)) {
-    this->active_ = request.owner;
-    if (!request.owner->start_service_update_(request.generation)) this->active_ = nullptr;
-  }
-  this->dispatching_ = false;
+void ImageService::process_pending() {
+  dispatch_next_image_request(
+      this->queue_, this->active_, this->dispatching_,
+      [](const ImageRequestQueue<ArtworkImage>::Request &request) {
+        return request.owner->start_service_update_(request.generation);
+      });
 }
 
 }  // namespace artwork_image

--- a/components/artwork_image/image_service.h
+++ b/components/artwork_image/image_service.h
@@ -72,6 +72,21 @@ template<typename Owner> class ImageRequestQueue {
   uint64_t next_sequence_{0};
 };
 
+// Keep dispatch separate from queue mutations so callers can defer starting work
+// until their normal loop task is running.
+template<typename Owner, typename Start>
+void dispatch_next_image_request(ImageRequestQueue<Owner> &queue, Owner *&active,
+                                 bool &dispatching, Start &&start) {
+  if (dispatching || active != nullptr) return;
+  dispatching = true;
+  typename ImageRequestQueue<Owner>::Request request;
+  while (active == nullptr && queue.pop_next(request)) {
+    active = request.owner;
+    if (!start(request)) active = nullptr;
+  }
+  dispatching = false;
+}
+
 class ImageService {
  public:
   static ImageService &instance();
@@ -80,13 +95,12 @@ class ImageService {
   void complete(ArtworkImage *owner);
   void complete_and_request(ArtworkImage *owner, uint32_t generation, ImageRequestPriority priority);
   void cancel(ArtworkImage *owner);
+  void process_pending();
 
   bool is_active(const ArtworkImage *owner) const { return this->active_ == owner; }
   size_t queued_requests() const { return this->queue_.size(); }
 
  private:
-  void dispatch_next_();
-
   ArtworkImage *active_{nullptr};
   ImageRequestQueue<ArtworkImage> queue_{};
   bool dispatching_{false};

--- a/tests/firmware/CMakeLists.txt
+++ b/tests/firmware/CMakeLists.txt
@@ -218,10 +218,13 @@ target_compile_options(home_assistant_endpoint_policy_test PRIVATE -Wall -Wextra
 target_include_directories(home_assistant_endpoint_policy_test PRIVATE ../../components/espcontrol)
 add_test(NAME home_assistant_endpoint_policy_test COMMAND home_assistant_endpoint_policy_test)
 
-add_executable(image_service_test image_service_test.cpp)
+# Compile the unchanged service implementation beside the build output so its
+# quoted artwork_image.h include resolves to the hardware-free test double.
+configure_file(../../components/artwork_image/image_service.cpp image_service.cpp COPYONLY)
+add_executable(image_service_test image_service_test.cpp ${CMAKE_CURRENT_BINARY_DIR}/image_service.cpp)
 target_compile_features(image_service_test PRIVATE cxx_std_17)
 target_compile_options(image_service_test PRIVATE -Wall -Wextra -Werror)
-target_include_directories(image_service_test PRIVATE ../../components/artwork_image)
+target_include_directories(image_service_test PRIVATE stubs/artwork_image ../../components/artwork_image)
 add_test(NAME image_service_test COMMAND image_service_test)
 
 add_executable(bmp_stream_test bmp_stream_test.cpp)

--- a/tests/firmware/image_service_test.cpp
+++ b/tests/firmware/image_service_test.cpp
@@ -1,9 +1,11 @@
 #include <cassert>
+#include <vector>
 
 #include "image_service.h"
 
 using esphome::artwork_image::ImageRequestPriority;
 using esphome::artwork_image::ImageRequestQueue;
+using esphome::artwork_image::dispatch_next_image_request;
 
 int main() {
   int background = 1;
@@ -20,17 +22,47 @@ int main() {
   queue.enqueue(&modal, 1, ImageRequestPriority::MODAL);
 
   ImageRequestQueue<int>::Request request;
-  assert(queue.pop_next(request));
-  assert(request.owner == &modal);
-  assert(queue.pop_next(request));
-  assert(request.owner == &cover_art);
-  assert(queue.pop_next(request));
-  assert(request.owner == &first_tile);
-  assert(queue.pop_next(request));
-  assert(request.owner == &second_tile);
-  assert(queue.pop_next(request));
-  assert(request.owner == &background);
-  assert(!queue.pop_next(request));
+  std::vector<int *> started;
+  int *active = nullptr;
+  bool dispatching = false;
+  auto start = [&started](const ImageRequestQueue<int>::Request &next) {
+    started.push_back(next.owner);
+    return true;
+  };
+
+  // Queuing a request must not invoke its start callback synchronously.
+  assert(started.empty());
+  dispatch_next_image_request(queue, active, dispatching, start);
+  assert(started.size() == 1);
+  assert(started.back() == &modal);
+  assert(active == &modal);
+
+  // An active request blocks dispatch until a later processing pass.
+  dispatch_next_image_request(queue, active, dispatching, start);
+  assert(started.size() == 1);
+  active = nullptr;
+  dispatch_next_image_request(queue, active, dispatching, start);
+  assert(started.size() == 2);
+  assert(started.back() == &cover_art);
+  assert(active == &cover_art);
+
+  active = nullptr;
+  dispatch_next_image_request(queue, active, dispatching, start);
+  assert(started.size() == 3);
+  assert(started.back() == &first_tile);
+  active = nullptr;
+  dispatch_next_image_request(queue, active, dispatching, start);
+  assert(started.size() == 4);
+  assert(started.back() == &second_tile);
+  active = nullptr;
+  dispatch_next_image_request(queue, active, dispatching, start);
+  assert(started.size() == 5);
+  assert(started.back() == &background);
+  assert(active == &background);
+
+  active = nullptr;
+  dispatch_next_image_request(queue, active, dispatching, start);
+  assert(started.size() == 5);
 
   // Repeated requests from one consumer are coalesced to the latest generation.
   queue.enqueue(&first_tile, 10, ImageRequestPriority::TILE);
@@ -45,4 +77,11 @@ int main() {
   assert(queue.contains(&cover_art));
   assert(queue.remove(&cover_art));
   assert(!queue.contains(&cover_art));
+
+  // A failed start releases the active slot and does not leave queued work behind.
+  queue.enqueue(&background, 20, ImageRequestPriority::BACKGROUND);
+  auto fail_start = [](const ImageRequestQueue<int>::Request &) { return false; };
+  dispatch_next_image_request(queue, active, dispatching, fail_start);
+  assert(active == nullptr);
+  assert(!queue.pop_next(request));
 }

--- a/tests/firmware/image_service_test.cpp
+++ b/tests/firmware/image_service_test.cpp
@@ -1,13 +1,16 @@
 #include <cassert>
 #include <vector>
 
+#include "artwork_image.h"
 #include "image_service.h"
 
+using esphome::artwork_image::ArtworkImage;
+using esphome::artwork_image::ImageService;
 using esphome::artwork_image::ImageRequestPriority;
 using esphome::artwork_image::ImageRequestQueue;
 using esphome::artwork_image::dispatch_next_image_request;
 
-int main() {
+static void test_queue_ordering() {
   int background = 1;
   int first_tile = 2;
   int second_tile = 3;
@@ -30,8 +33,6 @@ int main() {
     return true;
   };
 
-  // Queuing a request must not invoke its start callback synchronously.
-  assert(started.empty());
   dispatch_next_image_request(queue, active, dispatching, start);
   assert(started.size() == 1);
   assert(started.back() == &modal);
@@ -84,4 +85,138 @@ int main() {
   dispatch_next_image_request(queue, active, dispatching, fail_start);
   assert(active == nullptr);
   assert(!queue.pop_next(request));
+}
+
+static void test_request_defers_and_wakes_idle_image() {
+  ImageService service;
+  ArtworkImage image;
+  assert(!image.loop_enabled);
+
+  service.request(&image, 1, ImageRequestPriority::COVER_ART);
+  assert(image.loop_enabled);
+  assert(image.started_generations.empty());
+  assert(!service.is_active(&image));
+  assert(service.queued_requests() == 1);
+
+  service.request(&image, 2, ImageRequestPriority::COVER_ART);
+  assert(image.started_generations.empty());
+  assert(service.queued_requests() == 1);
+  service.process_pending();
+  assert(image.started_generations == std::vector<uint32_t>{2});
+  assert(service.is_active(&image));
+  service.process_pending();
+  assert(image.started_generations.size() == 1);
+}
+
+static void test_completion_defers_next_request() {
+  ImageService service;
+  ArtworkImage first;
+  ArtworkImage next;
+  service.request(&first, 1, ImageRequestPriority::TILE);
+  service.process_pending();
+  service.request(&next, 1, ImageRequestPriority::TILE);
+  service.complete(&next);
+  assert(service.is_active(&first));
+
+  service.complete(&first);
+  assert(!service.is_active(&first));
+  assert(next.started_generations.empty());
+  assert(service.queued_requests() == 1);
+  service.process_pending();
+  assert(next.started_generations == std::vector<uint32_t>{1});
+  assert(service.is_active(&next));
+}
+
+static void test_cancellation_defers_next_request() {
+  ImageService service;
+  ArtworkImage active;
+  ArtworkImage cancelled;
+  ArtworkImage next;
+  service.request(&active, 1, ImageRequestPriority::TILE);
+  service.process_pending();
+  service.request(&cancelled, 1, ImageRequestPriority::MODAL);
+  service.request(&next, 1, ImageRequestPriority::TILE);
+
+  service.cancel(&cancelled);
+  assert(service.is_active(&active));
+  assert(service.queued_requests() == 1);
+  service.cancel(&active);
+  assert(!service.is_active(&active));
+  assert(next.started_generations.empty());
+  service.process_pending();
+  assert(cancelled.started_generations.empty());
+  assert(next.started_generations == std::vector<uint32_t>{1});
+  assert(service.is_active(&next));
+}
+
+static void test_followup_defers_and_wakes_image() {
+  ImageService service;
+  ArtworkImage image;
+  ArtworkImage tile;
+  service.request(&image, 1, ImageRequestPriority::COVER_ART);
+  service.process_pending();
+  service.request(&tile, 1, ImageRequestPriority::TILE);
+  image.loop_enabled = false;
+
+  service.complete_and_request(&image, 2, ImageRequestPriority::COVER_ART);
+  assert(image.loop_enabled);
+  assert(image.started_generations == std::vector<uint32_t>{1});
+  assert(tile.started_generations.empty());
+  assert(!service.is_active(&image));
+  assert(service.queued_requests() == 2);
+
+  service.process_pending();
+  assert((image.started_generations == std::vector<uint32_t>{1, 2}));
+  assert(tile.started_generations.empty());
+  assert(service.is_active(&image));
+  service.complete(&image);
+  assert(tile.started_generations.empty());
+  service.process_pending();
+  assert(service.is_active(&tile));
+}
+
+static void test_start_callback_cannot_dispatch_recursively() {
+  ImageService service;
+  ArtworkImage image;
+  bool inside_start = false;
+  image.on_start = [&](uint32_t generation) {
+    assert(!inside_start);
+    inside_start = true;
+    if (generation == 1) {
+      service.complete_and_request(&image, 2, ImageRequestPriority::COVER_ART);
+      service.process_pending();
+      assert(image.started_generations.size() == 1);
+    }
+    inside_start = false;
+  };
+
+  service.request(&image, 1, ImageRequestPriority::COVER_ART);
+  assert(image.started_generations.empty());
+  service.process_pending();
+  assert((image.started_generations == std::vector<uint32_t>{1, 2}));
+  assert(service.is_active(&image));
+}
+
+static void test_rejected_start_releases_active_slot() {
+  ImageService service;
+  ArtworkImage stale;
+  ArtworkImage next;
+  stale.accept_start = false;
+  service.request(&stale, 1, ImageRequestPriority::MODAL);
+  service.request(&next, 2, ImageRequestPriority::TILE);
+  service.process_pending();
+  assert(stale.started_generations == std::vector<uint32_t>{1});
+  assert(next.started_generations == std::vector<uint32_t>{2});
+  assert(service.is_active(&next));
+  assert(service.queued_requests() == 0);
+}
+
+int main() {
+  test_queue_ordering();
+  test_request_defers_and_wakes_idle_image();
+  test_completion_defers_next_request();
+  test_cancellation_defers_next_request();
+  test_followup_defers_and_wakes_image();
+  test_start_callback_cannot_dispatch_recursively();
+  test_rejected_start_releases_active_slot();
 }

--- a/tests/firmware/stubs/artwork_image/artwork_image.h
+++ b/tests/firmware/stubs/artwork_image/artwork_image.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+namespace esphome {
+namespace artwork_image {
+
+// Only the hardware boundary is replaced; image_service.cpp is compiled as-is.
+class ArtworkImage {
+ public:
+  void enable_loop() { this->loop_enabled = true; }
+
+  bool loop_enabled{false};
+  bool accept_start{true};
+  std::vector<uint32_t> started_generations;
+  std::function<void(uint32_t)> on_start;
+
+ private:
+  bool start_service_update_(uint32_t generation) {
+    this->started_generations.push_back(generation);
+    if (this->on_start) this->on_start(generation);
+    return this->accept_start;
+  }
+
+  friend class ImageService;
+};
+
+}  // namespace artwork_image
+}  // namespace esphome


### PR DESCRIPTION
## Purpose
Defer artwork image request dispatch until ArtworkImage::loop() so Home Assistant and media callbacks only update queue state. This removes the recursive callback chain that can exhaust ESPHome's fixed 8 KiB loopTask stack while preserving priority/FIFO ordering, generation coalescing, cancellation, stale-result filtering, single-request activity, and follow-up requests.

## Testing
- CTest: 34/34 firmware unit tests passed, including the real ImageService implementation with a hardware-free ArtworkImage test double
- Regression coverage checks deferred requests, completion, cancellation, follow-up requests, idle wake-up, generation coalescing, rejected starts, and recursive dispatch
- Six deliberate regression variants were caught: immediate dispatch in each of request/complete/cancel/complete_and_request, and missing wake-up in request/complete_and_request
- python3 scripts/check_device_profiles.py passed
- ESPHome 2026.8.2 factory compiles passed for guition-esp32-s3-4848s040, guition-esp32-p4-jc1060p470, and guition-esp32-p4-jc4880p443
- Physical Guition ESP32-S3-4848S040 acceptance testing remains pending
