### PR TITLE
Remove duplicate panel IP display

### DIFF
--- a/common/addon/network.yaml
+++ b/common/addon/network.yaml
@@ -69,7 +69,7 @@ sensor:
         - script.execute: network_status_refresh
 
 # ---------------------------------------------------------------------------
-# IP address (text_sensor)
+# Network transport (text_sensor)
 # ---------------------------------------------------------------------------
 text_sensor:
   - platform: template
@@ -81,8 +81,3 @@ text_sensor:
     update_interval: 60s
     lambda: |-
       return {"wifi"};
-
-  - platform: wifi_info
-    ip_address:
-      name: IP Address
-      icon: mdi:ip-network

--- a/common/addon/network_ethernet.yaml
+++ b/common/addon/network_ethernet.yaml
@@ -42,7 +42,7 @@ sensor:
     internal: true
 
 # ---------------------------------------------------------------------------
-# IP address (text_sensor)
+# Network transport (text_sensor)
 # ---------------------------------------------------------------------------
 text_sensor:
   - platform: template
@@ -54,8 +54,3 @@ text_sensor:
     update_interval: 60s
     lambda: |-
       return {"ethernet"};
-
-  - platform: ethernet_info
-    ip_address:
-      name: IP Address
-      icon: mdi:ip-network


### PR DESCRIPTION
## Purpose
Removes the redundant Wi-Fi and Ethernet `IP Address` diagnostic sensors. The ESPHome web page already renders the active panel address in its built-in Connection section, so the extra sensors caused the IP to appear twice.

## Practical impact
The Connection section shows the panel IP once. The on-screen network status continues to obtain the address directly from the active network interface.

## Checks
- `git diff --check`
- `npm run check:config` (unit tests passed; bundle validation was blocked by a missing local VitePress font: `inter-roman-latin.woff2`)

Physical device testing is recommended on the affected display after flashing.