### PR TITLE
Prepare web assets for v2.8.5

### DIFF
--- a/docs/public/webserver/web-assets.json
+++ b/docs/public/webserver/web-assets.json
@@ -16,11 +16,11 @@
       ],
       "firmwareVersions": [
         "dev",
+        "v2.8.5",
         "v2.8.4",
         "v2.8.3",
         "v2.8.2",
-        "v2.8.1",
-        "v2.8.0"
+        "v2.8.1"
       ],
       "webAssetVersion": 1
     }

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -48,11 +48,11 @@ WEB_SOURCE_DIR = ROOT / "src" / "webserver"
 # list aligned with the GitHub Pages release catalogue in pages.yml.
 WEB_ASSET_SUPPORTED_FIRMWARE_VERSIONS = (
     "dev",
+    "v2.8.5",
     "v2.8.4",
     "v2.8.3",
     "v2.8.2",
     "v2.8.1",
-    "v2.8.0",
 )
 
 # Fixed editor controls use a few MDI glyphs that are not selectable Product


### PR DESCRIPTION
Adds v2.8.5 to the immutable web bundle compatibility list so released firmware selects the matching hosted web assets.\n\nValidation: npm run check:release-preflight passed.