### PR TITLE
Bridge firmware updates to EspDesktop

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,6 +14,8 @@ on:
   workflow_run:
     workflows: ["Build Release"]
     types: [completed]
+  schedule:
+    - cron: '17 */6 * * *'
   workflow_dispatch:
 
 permissions:
@@ -28,6 +30,7 @@ concurrency:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ESPCONTROL_NPM_CACHE_MAX_MB: 512
+  ESPDESKTOP_RELEASE_REPOSITORY: jtenniswood/espdesktop
 
 jobs:
   build-docs:
@@ -84,18 +87,26 @@ jobs:
           echo "DEVICE_SLUGS=${DEVICE_SLUGS}" >> "$GITHUB_ENV"
 
       - name: Download firmware from stable releases
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
+          RELEASE_REPOSITORY="${ESPDESKTOP_RELEASE_REPOSITORY}"
           RELEASES_JSON=$(curl -fsSL \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases?per_page=30")
+            "https://api.github.com/repos/${RELEASE_REPOSITORY}/releases?per_page=30")
           STABLE_RELEASES_JSON=$(printf '%s' "${RELEASES_JSON}" | jq -c '[.[] | select((.draft | not) and (.prerelease | not))][0:5]')
           RELEASE_COUNT=$(printf '%s' "${STABLE_RELEASES_JSON}" | jq 'length')
 
           if [ "${RELEASE_COUNT}" -eq 0 ]; then
-            echo "::warning::No stable firmware releases found"
+            echo "::warning::No stable EspDesktop firmware release found yet; retaining the latest EspControl firmware at the compatibility URL"
+            RELEASE_REPOSITORY="${GITHUB_REPOSITORY}"
+            RELEASES_JSON=$(curl -fsSL \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${RELEASE_REPOSITORY}/releases?per_page=30")
+            STABLE_RELEASES_JSON=$(printf '%s' "${RELEASES_JSON}" | jq -c '[.[] | select((.draft | not) and (.prerelease | not))][0:5]')
+            RELEASE_COUNT=$(printf '%s' "${STABLE_RELEASES_JSON}" | jq 'length')
+          fi
+
+          if [ "${RELEASE_COUNT}" -eq 0 ]; then
+            echo "::warning::No stable firmware releases are available from either repository"
             exit 0
           fi
 
@@ -104,16 +115,12 @@ jobs:
             ASSET_NAME="$2"
             OUTPUT_PATH="$3"
             ASSET_URL=$(printf '%s' "${RELEASE_JSON}" | jq -r --arg name "${ASSET_NAME}" \
-              '.assets[]? | select(.name == $name) | .url' | head -n 1)
+              '.assets[]? | select(.name == $name) | .browser_download_url' | head -n 1)
             if [ -z "${ASSET_URL}" ]; then
               return 1
             fi
             mkdir -p "$(dirname "${OUTPUT_PATH}")"
-            curl -fsSL \
-              -H "Authorization: Bearer ${GH_TOKEN}" \
-              -H "Accept: application/octet-stream" \
-              "${ASSET_URL}" \
-              -o "${OUTPUT_PATH}"
+            curl -fsSL "${ASSET_URL}" -o "${OUTPUT_PATH}"
           }
 
           ota_md5() {
@@ -204,29 +211,29 @@ jobs:
           done
 
       - name: Download firmware from latest pre-release
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           RELEASES_JSON=$(curl -fsSL \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases?per_page=20")
+            "https://api.github.com/repos/${ESPDESKTOP_RELEASE_REPOSITORY}/releases?per_page=20")
           BETA_ASSETS=$(printf '%s' "${RELEASES_JSON}" | jq -c '[.[] | select((.draft | not) and .prerelease)][0].assets // []')
+
+          if [ "${BETA_ASSETS}" = "[]" ]; then
+            RELEASES_JSON=$(curl -fsSL \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases?per_page=20")
+            BETA_ASSETS=$(printf '%s' "${RELEASES_JSON}" | jq -c '[.[] | select((.draft | not) and .prerelease)][0].assets // []')
+          fi
 
           if [ "${BETA_ASSETS}" != "[]" ]; then
             download_beta_asset() {
               ASSET_NAME="$1"
               OUTPUT_PATH="$2"
               ASSET_URL=$(printf '%s' "${BETA_ASSETS}" | jq -r --arg name "${ASSET_NAME}" \
-                '.[] | select(.name == $name) | .url' | head -n 1)
+                '.[] | select(.name == $name) | .browser_download_url' | head -n 1)
               if [ -z "${ASSET_URL}" ]; then
                 return 0
               fi
-              curl -fsSL \
-                -H "Authorization: Bearer ${GH_TOKEN}" \
-                -H "Accept: application/octet-stream" \
-                "${ASSET_URL}" \
-                -o "${OUTPUT_PATH}"
+              curl -fsSL "${ASSET_URL}" -o "${OUTPUT_PATH}"
             }
 
             for SLUG in $DEVICE_SLUGS; do

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,6 +31,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ESPCONTROL_NPM_CACHE_MAX_MB: 512
   ESPDESKTOP_RELEASE_REPOSITORY: jtenniswood/espdesktop
+  OPTIONAL_STABLE_FIRMWARE_SLUGS: guition-esp32-p4-jc8012p4a1 guition-esp32-p4-jc8012p4a1-v2 guition-esp32-p4-jc1060p470-v2 esp32-p4-86
 
 jobs:
   build-docs:
@@ -95,8 +96,25 @@ jobs:
           STABLE_RELEASES_JSON=$(printf '%s' "${RELEASES_JSON}" | jq -c '[.[] | select((.draft | not) and (.prerelease | not))][0:5]')
           RELEASE_COUNT=$(printf '%s' "${STABLE_RELEASES_JSON}" | jq 'length')
 
-          if [ "${RELEASE_COUNT}" -eq 0 ]; then
-            echo "::warning::No stable EspDesktop firmware release found yet; retaining the latest EspControl firmware at the compatibility URL"
+          release_set_has_required_assets() {
+            RELEASE_SET="$1"
+            for SLUG in $DEVICE_SLUGS; do
+              if echo " ${OPTIONAL_STABLE_FIRMWARE_SLUGS} " | grep -q " ${SLUG} "; then
+                continue
+              fi
+              if ! printf '%s' "${RELEASE_SET}" | jq -e \
+                --arg manifest "${SLUG}.manifest.json" \
+                --arg ota "${SLUG}.ota.bin" \
+                'any(.[]; (([.assets[]?.name] | index($manifest)) != null) and (([.assets[]?.name] | index($ota)) != null))' \
+                >/dev/null; then
+                return 1
+              fi
+            done
+            return 0
+          }
+
+          if [ "${RELEASE_COUNT}" -eq 0 ] || ! release_set_has_required_assets "${STABLE_RELEASES_JSON}"; then
+            echo "::warning::No complete stable EspDesktop firmware release set found yet; retaining the latest EspControl firmware at the compatibility URL"
             RELEASE_REPOSITORY="${GITHUB_REPOSITORY}"
             RELEASES_JSON=$(curl -fsSL \
               -H "Accept: application/vnd.github+json" \
@@ -217,11 +235,33 @@ jobs:
             "https://api.github.com/repos/${ESPDESKTOP_RELEASE_REPOSITORY}/releases?per_page=20")
           BETA_ASSETS=$(printf '%s' "${RELEASES_JSON}" | jq -c '[.[] | select((.draft | not) and .prerelease)][0].assets // []')
 
-          if [ "${BETA_ASSETS}" = "[]" ]; then
+          asset_list_has_required_firmware() {
+            ASSET_LIST="$1"
+            for SLUG in $DEVICE_SLUGS; do
+              if echo " ${OPTIONAL_STABLE_FIRMWARE_SLUGS} " | grep -q " ${SLUG} "; then
+                continue
+              fi
+              if ! printf '%s' "${ASSET_LIST}" | jq -e \
+                --arg manifest "${SLUG}.manifest.json" \
+                --arg ota "${SLUG}.ota.bin" \
+                '(([.[].name] | index($manifest)) != null) and (([.[].name] | index($ota)) != null)' \
+                >/dev/null; then
+                return 1
+              fi
+            done
+            return 0
+          }
+
+          if ! asset_list_has_required_firmware "${BETA_ASSETS}"; then
             RELEASES_JSON=$(curl -fsSL \
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases?per_page=20")
             BETA_ASSETS=$(printf '%s' "${RELEASES_JSON}" | jq -c '[.[] | select((.draft | not) and .prerelease)][0].assets // []')
+          fi
+
+          if ! asset_list_has_required_firmware "${BETA_ASSETS}"; then
+            echo "::warning::No complete beta firmware release set is available from either repository"
+            BETA_ASSETS='[]'
           fi
 
           if [ "${BETA_ASSETS}" != "[]" ]; then
@@ -249,11 +289,10 @@ jobs:
       - name: Verify firmware assets
         run: |
           MISSING=false
-          OPTIONAL_FIRMWARE_SLUGS="guition-esp32-p4-jc8012p4a1 guition-esp32-p4-jc8012p4a1-v2 guition-esp32-p4-jc1060p470-v2 esp32-p4-86"
           for SLUG in $DEVICE_SLUGS; do
             MANIFEST="firmware/${SLUG}/manifest.json"
             if [ ! -f "$MANIFEST" ]; then
-              if echo " ${OPTIONAL_FIRMWARE_SLUGS} " | grep -q " ${SLUG} "; then
+              if echo " ${OPTIONAL_STABLE_FIRMWARE_SLUGS} " | grep -q " ${SLUG} "; then
                 echo "::warning::No firmware manifest found for ${SLUG} yet — install button will work after the first release asset is published"
               else
                 echo "::error::No firmware manifest found for ${SLUG} — install page will be non-functional"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -85,7 +85,9 @@ jobs:
       - name: Set device slugs
         run: |
           DEVICE_SLUGS=$(jq -r '.devices | keys | join(" ")' devices/manifest.json)
+          RECOVERY_SLUGS=$(jq -r '[.devices | to_entries[] | select(.value.firmware.build.chip == "ESP32-P4") | .key] | join(" ")' devices/manifest.json)
           echo "DEVICE_SLUGS=${DEVICE_SLUGS}" >> "$GITHUB_ENV"
+          echo "RECOVERY_SLUGS=${RECOVERY_SLUGS}" >> "$GITHUB_ENV"
 
       - name: Download firmware from stable releases
         run: |
@@ -102,11 +104,27 @@ jobs:
               if echo " ${OPTIONAL_STABLE_FIRMWARE_SLUGS} " | grep -q " ${SLUG} "; then
                 continue
               fi
-              if ! printf '%s' "${RELEASE_SET}" | jq -e \
+              RELEASE=$(printf '%s' "${RELEASE_SET}" | jq -c \
                 --arg manifest "${SLUG}.manifest.json" \
                 --arg ota "${SLUG}.ota.bin" \
-                'any(.[]; (([.assets[]?.name] | index($manifest)) != null) and (([.assets[]?.name] | index($ota)) != null))' \
-                >/dev/null; then
+                'first(.[] | select(
+                  (([.assets[]?.name] | index($manifest)) != null) and
+                  (([.assets[]?.name] | index($ota)) != null)
+                )) // empty')
+              if [ -z "${RELEASE}" ]; then
+                return 1
+              fi
+              if ! printf '%s' "${RELEASE}" | jq -e \
+                --arg factory "${SLUG}.factory.bin" \
+                '([.assets[]?.name] | index($factory)) != null' >/dev/null; then
+                return 1
+              fi
+              if echo " ${RECOVERY_SLUGS} " | grep -q " ${SLUG} " && \
+                ! printf '%s' "${RELEASE}" | jq -e \
+                  --arg manifest "${SLUG}.recovery.manifest.json" \
+                  --arg image "${SLUG}.recovery.bin" \
+                  '(([.assets[]?.name] | index($manifest)) != null) and
+                   (([.assets[]?.name] | index($image)) != null)' >/dev/null; then
                 return 1
               fi
             done
@@ -233,7 +251,6 @@ jobs:
           RELEASES_JSON=$(curl -fsSL \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${ESPDESKTOP_RELEASE_REPOSITORY}/releases?per_page=20")
-          BETA_ASSETS=$(printf '%s' "${RELEASES_JSON}" | jq -c '[.[] | select((.draft | not) and .prerelease)][0].assets // []')
 
           asset_list_has_required_firmware() {
             ASSET_LIST="$1"
@@ -252,14 +269,31 @@ jobs:
             return 0
           }
 
-          if ! asset_list_has_required_firmware "${BETA_ASSETS}"; then
+          select_complete_beta_assets() {
+            RELEASE_LIST="$1"
+            CANDIDATE_COUNT=$(printf '%s' "${RELEASE_LIST}" | jq '[.[] | select((.draft | not) and .prerelease)] | length')
+            if [ "${CANDIDATE_COUNT}" -eq 0 ]; then
+              return 1
+            fi
+            for IDX in $(seq 0 $((CANDIDATE_COUNT - 1))); do
+              CANDIDATE_ASSETS=$(printf '%s' "${RELEASE_LIST}" | jq -c \
+                "[.[] | select((.draft | not) and .prerelease)][${IDX}].assets // []")
+              if asset_list_has_required_firmware "${CANDIDATE_ASSETS}"; then
+                printf '%s' "${CANDIDATE_ASSETS}"
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          if ! BETA_ASSETS=$(select_complete_beta_assets "${RELEASES_JSON}"); then
             RELEASES_JSON=$(curl -fsSL \
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases?per_page=20")
-            BETA_ASSETS=$(printf '%s' "${RELEASES_JSON}" | jq -c '[.[] | select((.draft | not) and .prerelease)][0].assets // []')
+            BETA_ASSETS=$(select_complete_beta_assets "${RELEASES_JSON}" || true)
           fi
 
-          if ! asset_list_has_required_firmware "${BETA_ASSETS}"; then
+          if [ -z "${BETA_ASSETS}" ]; then
             echo "::warning::No complete beta firmware release set is available from either repository"
             BETA_ASSETS='[]'
           fi


### PR DESCRIPTION
## Summary

- Keep the existing EspControl GitHub Pages firmware URLs working during the move to EspDesktop.
- Mirror stable and beta firmware assets from `jtenniswood/espdesktop` once releases are published there.
- Fall back to the current EspControl releases until EspDesktop has matching release assets.
- Refresh the compatibility mirror every six hours and on manual or existing release triggers.

Replacement product PR: https://github.com/jtenniswood/espdesktop/pull/2
Source feature work: https://github.com/jtenniswood/espcontrol/pull/1855

## Practical impact

- Already-installed panels can discover the first EspDesktop OTA release through the updater URL compiled into their current EspControl firmware.
- New EspDesktop firmware can use the new EspDesktop Pages URL after the bridge update.
- The old Pages address remains a compatibility path rather than stranding existing devices.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- This is an internal OTA compatibility bridge. EspDesktop's renamed public documentation is in its replacement PR.

## Testing

- [x] Automated/local checks passed or were run where practical.
- [x] Device testing is required before merge.
- [ ] Device testing is not required; explain why in Notes for testing.

Affected display/device, if applicable:

- All supported displays using the existing EspControl firmware updater URL.

## Notes for testing

- The workflow YAML parses successfully.
- The public GitHub API currently reports no EspDesktop releases and at least one EspControl release, exercising the intended fallback selection.
- After the first EspDesktop firmware release, run this workflow manually and verify an existing panel discovers and installs that release from the legacy update address.

## PR status

- [x] Checks running or waiting.
- [ ] Needs automated fix.
- [ ] Ready for device test.
- [ ] Device test failed; details below.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.
