### PR TITLE
Remove S3 second from flash display list

### DIFF
--- a/.agents/skills/flash-displays/SKILL.md
+++ b/.agents/skills/flash-displays/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flash-displays
-description: Flash EspControl display firmware from this repository using ESPHome. Use when the user invokes /flash-displays with no extra display name, or asks to flash, reflash, update, or upload firmware to all known displays in sequence, or to a specific display such as 7inch, 7-inch P4, 10inch, 10-inch V1, 10-inch V2, P4-86, 4.3-inch P4, 4-inch P4, 4-inch S3, or S3 second, over an explicitly supplied OTA target or USB.
+description: Flash EspControl display firmware from this repository using ESPHome. Use when the user invokes /flash-displays with no extra display name, or asks to flash, reflash, update, or upload firmware to all known displays in sequence, or to a specific display such as 7inch, 7-inch P4, 10inch, 10-inch V1, 10-inch V2, P4-86, 4.3-inch P4, 4-inch P4, or 4-inch S3, over an explicitly supplied OTA target or USB.
 ---
 
 # Flash Displays
@@ -20,7 +20,6 @@ Use the local development ESPHome configs to flash the known EspControl displays
 | `4inch P4`, `4-inch P4`, `P4-86`, `86 Panel`, `Waveshare P4-86`, `esp32-p4-86` | `devices/esp32-p4-86` | `192.168.6.104` |
 | `4.3inch P4`, `4.3-inch P4`, `P4 4.3inch`, `P4 4.3-inch`, `JC4880P443` | `devices/guition-esp32-p4-jc4880p443` | `192.168.6.101` |
 | `4inch S3`, `4-inch S3`, `4848S040` | `devices/guition-esp32-s3-4848s040` | `192.168.6.105` |
-| `S3 second`, `second S3`, `4inch S3 second`, `4-inch S3 second` | `devices/guition-esp32-s3-4848s040` | `192.168.6.100` |
 
 Treat the 7-inch panel at `192.168.6.102`, and an ambiguous or default `7inch` request, as V1 hardware. Always flash that panel with the V1 `JC1060P470` configuration in `devices/guition-esp32-p4-jc1060p470`; never substitute the V2 configuration because that firmware will not work on this panel. Select the V2 directory only when the user explicitly requests the 7-inch V2 panel and supplies a different OTA target or explicitly requests USB.
 
@@ -37,7 +36,6 @@ For `/flash-displays` with no extra target, or for `all`, flash in this sequence
 3. 4-inch P4 / P4-86.
 4. 4.3-inch P4.
 5. 4-inch S3.
-6. S3 second.
 
 ## YAML Selection
 
@@ -154,13 +152,6 @@ python3 ../../scripts/local_esphome.py dev.yaml run --device 192.168.6.105 --no-
 cd /Users/jtenniswood/Git/espcontrol/devices/guition-esp32-s3-4848s040
 python3 ../../scripts/local_esphome.py dev.yaml run --device /dev/cu.usbmodem201301 --no-logs
 
-# S3 second over OTA
-cd /Users/jtenniswood/Git/espcontrol/devices/guition-esp32-s3-4848s040
-python3 ../../scripts/local_esphome.py dev.yaml run --device 192.168.6.100 --no-logs
-
-# S3 second over USB, only when explicitly requested
-cd /Users/jtenniswood/Git/espcontrol/devices/guition-esp32-s3-4848s040
-python3 ../../scripts/local_esphome.py dev.yaml run --device /dev/cu.usbmodem201301 --no-logs
 ```
 
 ## Reporting


### PR DESCRIPTION
## Purpose
Remove the retired `S3 second` target from the `flash-displays` skill.

## Impact
- Removes the S3-second aliases and device-map entry.
- Removes it from the all-displays sequence.
- Removes its OTA and USB command examples.
- Keeps the primary 4-inch S3 target unchanged.

## Checks
- `git diff --check`
- Confirmed no S3-second references remain in the skill file.
- No firmware or runtime code changed; physical-device testing is not required.