### PR TITLE
Stop publishing disabled battery readings

### DIFF
--- a/devices/guition-esp32-p4-jc8012p4a1/device/battery.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/battery.yaml
@@ -44,7 +44,9 @@ sensor:
     filters:
       - lambda: |-
           if (!id(battery_status_enabled).state) {
-            return NAN;
+            // Drop ADC updates while optional battery support is disabled.
+            // Publishing NAN marks the sensor unavailable and logs it every 30s.
+            return {};
           }
           return min(max((x - ${battery_empty_voltage}f) /
                           (${battery_full_voltage}f - ${battery_empty_voltage}f) * 100.0f,

--- a/devices/guition-esp32-p4-jc8012p4a1/device/battery.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/battery.yaml
@@ -81,5 +81,6 @@ switch:
       - script.execute: clock_bar_apply
       - script.execute: battery_status_refresh
     on_turn_off:
-      - component.update: battery_voltage_raw
+      - lambda: |-
+          id(battery_percent).publish_state(NAN);
       - script.execute: clock_bar_apply


### PR DESCRIPTION
## Purpose
Stop the optional JC8012P4A1 battery sensor from publishing NaN every 30 seconds while battery support is disabled.

## Practical impact
When Screen: Battery Status Icon is off, ADC readings are dropped before publication and no recurring unavailable battery entries appear in logs. When the user enables battery support, the existing percentage calculation, sensor publication, and icon refresh continue unchanged.

## Checks
- ESPHome 2026.8.2 configuration validation passed for the Guition ESP32-P4 JC8012P4A1 development config.
- git diff --check passed.

## Device testing
Physical device testing is still required on the 10-inch P4 display:
1. Leave battery support off and confirm no Battery nan entries appear after several 30-second ADC intervals.
2. Enable battery support and confirm Battery percentage readings appear in logs and the status icon updates.