### PR TITLE
Use release Python environment during preflight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
             --disable-pip-version-check \
             --no-cache-dir \
             "PyYAML==6.0.2"
+          echo "PATH=${PYTHON_VENV}/bin:${PATH}" >> "${GITHUB_ENV}"
           echo "${PYTHON_VENV}/bin" >> "${GITHUB_PATH}"
 
       - name: Ensure CMake is available


### PR DESCRIPTION
Exports the PyYAML-enabled release Python environment to the preflight step so CMake firmware tests use the same interpreter.