### PR TITLE
Reduce 10-inch media control button sizes

### DIFF
--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -4268,8 +4268,7 @@ inline void media_control_layout_modal(MediaControlCtx *ctx) {
   lv_coord_t text_gap = control_modal_scaled_px(8, layout.short_side);
   if (text_gap < 6) text_gap = 6;
   int transport_button_scale_percent = 100;
-  if ((layout.sw == 1280 && layout.sh == 800) ||
-             (layout.sw == 800 && layout.sh == 1280)) {
+  if (control_modal_uses_large_landscape_tuning(layout)) {
     transport_button_scale_percent = 77;
   }
   const espcontrol::media::MediaTransportLayout transport_layout =

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -4273,7 +4273,7 @@ inline void media_control_layout_modal(MediaControlCtx *ctx) {
     transport_button_scale_percent = 80;
   } else if ((layout.sw == 1280 && layout.sh == 800) ||
              (layout.sw == 800 && layout.sh == 1280)) {
-    transport_button_scale_percent = 75;
+    transport_button_scale_percent = 70;
   }
   const espcontrol::media::MediaTransportLayout transport_layout =
     espcontrol::media::media_transport_layout(

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -4270,7 +4270,7 @@ inline void media_control_layout_modal(MediaControlCtx *ctx) {
   int transport_button_scale_percent = 100;
   if ((layout.sw == 1280 && layout.sh == 800) ||
              (layout.sw == 800 && layout.sh == 1280)) {
-    transport_button_scale_percent = 73;
+    transport_button_scale_percent = 77;
   }
   const espcontrol::media::MediaTransportLayout transport_layout =
     espcontrol::media::media_transport_layout(

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -4267,13 +4267,21 @@ inline void media_control_layout_modal(MediaControlCtx *ctx) {
   lv_coord_t text_w = content_w * 92 / 100;
   lv_coord_t text_gap = control_modal_scaled_px(8, layout.short_side);
   if (text_gap < 6) text_gap = 6;
+  int transport_button_scale_percent = 100;
+  if ((layout.sw == 1024 && layout.sh == 600) ||
+      (layout.sw == 600 && layout.sh == 1024)) {
+    transport_button_scale_percent = 80;
+  } else if ((layout.sw == 1280 && layout.sh == 800) ||
+             (layout.sw == 800 && layout.sh == 1280)) {
+    transport_button_scale_percent = 75;
+  }
   const espcontrol::media::MediaTransportLayout transport_layout =
     espcontrol::media::media_transport_layout(
       content_w, layout.short_side,
       media_control_shuffle_supported(ctx),
       media_control_repeat_supported(ctx),
       control_modal_uses_compact_portrait_tuning(layout) && layout.sh > layout.sw,
-      layout.sw == 1024 && layout.sh == 600);
+      transport_button_scale_percent);
   const lv_coord_t btn_size = transport_layout.button_size;
   lv_coord_t progress_slider_h = content_h * 42 / 100;
   lv_coord_t progress_slider_max_h = control_modal_scaled_px(144, layout.short_side);

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -4273,7 +4273,7 @@ inline void media_control_layout_modal(MediaControlCtx *ctx) {
     transport_button_scale_percent = 80;
   } else if ((layout.sw == 1280 && layout.sh == 800) ||
              (layout.sw == 800 && layout.sh == 1280)) {
-    transport_button_scale_percent = 70;
+    transport_button_scale_percent = 73;
   }
   const espcontrol::media::MediaTransportLayout transport_layout =
     espcontrol::media::media_transport_layout(

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -4272,7 +4272,8 @@ inline void media_control_layout_modal(MediaControlCtx *ctx) {
       content_w, layout.short_side,
       media_control_shuffle_supported(ctx),
       media_control_repeat_supported(ctx),
-      control_modal_uses_compact_portrait_tuning(layout) && layout.sh > layout.sw);
+      control_modal_uses_compact_portrait_tuning(layout) && layout.sh > layout.sw,
+      layout.sw == 1024 && layout.sh == 600);
   const lv_coord_t btn_size = transport_layout.button_size;
   lv_coord_t progress_slider_h = content_h * 42 / 100;
   lv_coord_t progress_slider_max_h = control_modal_scaled_px(144, layout.short_side);

--- a/components/espcontrol/button_grid_media.h
+++ b/components/espcontrol/button_grid_media.h
@@ -4268,10 +4268,7 @@ inline void media_control_layout_modal(MediaControlCtx *ctx) {
   lv_coord_t text_gap = control_modal_scaled_px(8, layout.short_side);
   if (text_gap < 6) text_gap = 6;
   int transport_button_scale_percent = 100;
-  if ((layout.sw == 1024 && layout.sh == 600) ||
-      (layout.sw == 600 && layout.sh == 1024)) {
-    transport_button_scale_percent = 80;
-  } else if ((layout.sw == 1280 && layout.sh == 800) ||
+  if ((layout.sw == 1280 && layout.sh == 800) ||
              (layout.sw == 800 && layout.sh == 1280)) {
     transport_button_scale_percent = 73;
   }

--- a/components/espcontrol/media_playback_modes.h
+++ b/components/espcontrol/media_playback_modes.h
@@ -104,7 +104,8 @@ inline MediaTransportLayout media_transport_layout(int content_width,
                                                     int short_side,
                                                     bool show_shuffle,
                                                     bool show_repeat,
-                                                    bool stack_modes = false) {
+                                                    bool stack_modes = false,
+                                                    bool compact_buttons = false) {
   MediaTransportLayout layout;
   if (content_width < 1) return layout;
   const int mode_count = (show_shuffle ? 1 : 0) + (show_repeat ? 1 : 0);
@@ -121,6 +122,7 @@ inline MediaTransportLayout media_transport_layout(int content_width,
   layout.button_size = media_transport_scaled_px(88, short_side);
   const int minimum_button = media_transport_scaled_px(74, short_side);
   if (layout.button_size < minimum_button) layout.button_size = minimum_button;
+  if (compact_buttons) layout.button_size = layout.button_size * 4 / 5;
 
   const int widest_gaps_width = layout.gap * (widest_row_count - 1);
   const int widest_row_width = layout.button_size * widest_row_count +

--- a/components/espcontrol/media_playback_modes.h
+++ b/components/espcontrol/media_playback_modes.h
@@ -105,7 +105,7 @@ inline MediaTransportLayout media_transport_layout(int content_width,
                                                     bool show_shuffle,
                                                     bool show_repeat,
                                                     bool stack_modes = false,
-                                                    bool compact_buttons = false) {
+                                                    int button_scale_percent = 100) {
   MediaTransportLayout layout;
   if (content_width < 1) return layout;
   const int mode_count = (show_shuffle ? 1 : 0) + (show_repeat ? 1 : 0);
@@ -122,7 +122,9 @@ inline MediaTransportLayout media_transport_layout(int content_width,
   layout.button_size = media_transport_scaled_px(88, short_side);
   const int minimum_button = media_transport_scaled_px(74, short_side);
   if (layout.button_size < minimum_button) layout.button_size = minimum_button;
-  if (compact_buttons) layout.button_size = layout.button_size * 4 / 5;
+  if (button_scale_percent < 1) button_scale_percent = 100;
+  layout.button_size =
+    (layout.button_size * button_scale_percent + 50) / 100;
 
   const int widest_gaps_width = layout.gap * (widest_row_count - 1);
   const int widest_row_width = layout.button_size * widest_row_count +

--- a/tests/firmware/media_playback_modes_test.cpp
+++ b/tests/firmware/media_playback_modes_test.cpp
@@ -67,7 +67,7 @@ int main() {
   const auto seven_inch = media_transport_layout(900, 600, true, true);
   const auto ten_inch = media_transport_layout(1100, 800, true, true);
   const auto ten_inch_compact =
-    media_transport_layout(1100, 800, true, true, false, 73);
+    media_transport_layout(1100, 800, true, true, false, 77);
   assert(portrait.total_width <= 400);
   assert(portrait.modes_on_second_row);
   assert(portrait.first_row_width == portrait.button_size * 3 + portrait.gap * 2);
@@ -80,7 +80,7 @@ int main() {
   assert(!landscape.modes_on_second_row);
   assert(seven_inch.button_size == 110);
   assert(ten_inch.button_size == 146);
-  assert(ten_inch_compact.button_size == 107);
+  assert(ten_inch_compact.button_size == 112);
   assert(ten_inch_compact.total_width < ten_inch.total_width);
 
   return 0;

--- a/tests/firmware/media_playback_modes_test.cpp
+++ b/tests/firmware/media_playback_modes_test.cpp
@@ -69,7 +69,7 @@ int main() {
     media_transport_layout(900, 600, true, true, false, 80);
   const auto ten_inch = media_transport_layout(1100, 800, true, true);
   const auto ten_inch_compact =
-    media_transport_layout(1100, 800, true, true, false, 70);
+    media_transport_layout(1100, 800, true, true, false, 73);
   assert(portrait.total_width <= 400);
   assert(portrait.modes_on_second_row);
   assert(portrait.first_row_width == portrait.button_size * 3 + portrait.gap * 2);
@@ -84,7 +84,7 @@ int main() {
   assert(seven_inch_compact.button_size == 88);
   assert(seven_inch_compact.total_width < seven_inch.total_width);
   assert(ten_inch.button_size == 146);
-  assert(ten_inch_compact.button_size == 102);
+  assert(ten_inch_compact.button_size == 107);
   assert(ten_inch_compact.total_width < ten_inch.total_width);
 
   return 0;

--- a/tests/firmware/media_playback_modes_test.cpp
+++ b/tests/firmware/media_playback_modes_test.cpp
@@ -65,8 +65,6 @@ int main() {
     media_transport_layout(400, 480, true, false, true);
   const auto landscape = media_transport_layout(720, 800, true, true);
   const auto seven_inch = media_transport_layout(900, 600, true, true);
-  const auto seven_inch_compact =
-    media_transport_layout(900, 600, true, true, false, 80);
   const auto ten_inch = media_transport_layout(1100, 800, true, true);
   const auto ten_inch_compact =
     media_transport_layout(1100, 800, true, true, false, 73);
@@ -81,8 +79,6 @@ int main() {
   assert(landscape.total_width <= 720);
   assert(!landscape.modes_on_second_row);
   assert(seven_inch.button_size == 110);
-  assert(seven_inch_compact.button_size == 88);
-  assert(seven_inch_compact.total_width < seven_inch.total_width);
   assert(ten_inch.button_size == 146);
   assert(ten_inch_compact.button_size == 107);
   assert(ten_inch_compact.total_width < ten_inch.total_width);

--- a/tests/firmware/media_playback_modes_test.cpp
+++ b/tests/firmware/media_playback_modes_test.cpp
@@ -66,7 +66,10 @@ int main() {
   const auto landscape = media_transport_layout(720, 800, true, true);
   const auto seven_inch = media_transport_layout(900, 600, true, true);
   const auto seven_inch_compact =
-    media_transport_layout(900, 600, true, true, false, true);
+    media_transport_layout(900, 600, true, true, false, 80);
+  const auto ten_inch = media_transport_layout(1100, 800, true, true);
+  const auto ten_inch_compact =
+    media_transport_layout(1100, 800, true, true, false, 75);
   assert(portrait.total_width <= 400);
   assert(portrait.modes_on_second_row);
   assert(portrait.first_row_width == portrait.button_size * 3 + portrait.gap * 2);
@@ -80,6 +83,9 @@ int main() {
   assert(seven_inch.button_size == 110);
   assert(seven_inch_compact.button_size == 88);
   assert(seven_inch_compact.total_width < seven_inch.total_width);
+  assert(ten_inch.button_size == 146);
+  assert(ten_inch_compact.button_size == 110);
+  assert(ten_inch_compact.total_width < ten_inch.total_width);
 
   return 0;
 }

--- a/tests/firmware/media_playback_modes_test.cpp
+++ b/tests/firmware/media_playback_modes_test.cpp
@@ -69,7 +69,7 @@ int main() {
     media_transport_layout(900, 600, true, true, false, 80);
   const auto ten_inch = media_transport_layout(1100, 800, true, true);
   const auto ten_inch_compact =
-    media_transport_layout(1100, 800, true, true, false, 75);
+    media_transport_layout(1100, 800, true, true, false, 70);
   assert(portrait.total_width <= 400);
   assert(portrait.modes_on_second_row);
   assert(portrait.first_row_width == portrait.button_size * 3 + portrait.gap * 2);
@@ -84,7 +84,7 @@ int main() {
   assert(seven_inch_compact.button_size == 88);
   assert(seven_inch_compact.total_width < seven_inch.total_width);
   assert(ten_inch.button_size == 146);
-  assert(ten_inch_compact.button_size == 110);
+  assert(ten_inch_compact.button_size == 102);
   assert(ten_inch_compact.total_width < ten_inch.total_width);
 
   return 0;

--- a/tests/firmware/media_playback_modes_test.cpp
+++ b/tests/firmware/media_playback_modes_test.cpp
@@ -64,6 +64,9 @@ int main() {
   const auto portrait_shuffle_only =
     media_transport_layout(400, 480, true, false, true);
   const auto landscape = media_transport_layout(720, 800, true, true);
+  const auto seven_inch = media_transport_layout(900, 600, true, true);
+  const auto seven_inch_compact =
+    media_transport_layout(900, 600, true, true, false, true);
   assert(portrait.total_width <= 400);
   assert(portrait.modes_on_second_row);
   assert(portrait.first_row_width == portrait.button_size * 3 + portrait.gap * 2);
@@ -74,6 +77,9 @@ int main() {
   assert(portrait_shuffle_only.second_row_width == portrait_shuffle_only.button_size);
   assert(landscape.total_width <= 720);
   assert(!landscape.modes_on_second_row);
+  assert(seven_inch.button_size == 110);
+  assert(seven_inch_compact.button_size == 88);
+  assert(seven_inch_compact.total_width < seven_inch.total_width);
 
   return 0;
 }


### PR DESCRIPTION
## Purpose
Reduce the five round playback controls in the media modal on the 10-inch display.

## Practical impact
- Reduces the 10-inch button diameter from 146 px to 112 px, approximately 23% smaller.
- Keeps the controls centered and evenly spaced.
- Leaves the 7-inch and other display sizes unchanged.

## Automated checks
- git diff --check
- Firmware unit suite: 45/45 passed with leak detection disabled to accommodate the test environment ptrace limitation.
- Layout assertions cover the restored 7-inch default and resized 10-inch controls.

## Physical device testing
- The latest firmware compiled and flashed successfully to the 7-inch P4 V1 display at 192.168.6.102, restoring its original 110 px media buttons.
- The latest firmware compiled and flashed successfully to the 10-inch P4 V1 display at 192.168.6.103 with 112 px media buttons.
- Both displays returned online after their OTA reboots.
- Visual size, centering, spacing, and tap-target confirmation is awaiting user feedback.