### PR TITLE
Name the display at 192.168.6.105 S3 in flash-displays

### DIFF
--- a/.agents/skills/flash-displays/SKILL.md
+++ b/.agents/skills/flash-displays/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flash-displays
-description: Flash EspControl display firmware from this repository using ESPHome. Use when the user invokes /flash-displays with no extra display name, or asks to flash, reflash, update, or upload firmware to all known displays in sequence, or to a specific display such as 7inch, 7-inch P4, 10inch, 10-inch V1, 10-inch V2, P4-86, 4.3-inch P4, or 4-inch P4, over an explicitly supplied OTA target or USB.
+description: Flash EspControl display firmware from this repository using ESPHome. Use when the user invokes /flash-displays with no extra display name, or asks to flash, reflash, update, or upload firmware to all known displays in sequence, or to a specific display such as 7inch, 7-inch P4, 10inch, 10-inch V1, 10-inch V2, P4-86, 4.3-inch P4, 4-inch P4, or S3, over an explicitly supplied OTA target or USB.
 ---
 
 # Flash Displays
@@ -17,8 +17,9 @@ Use the local development ESPHome configs to flash the known EspControl displays
 | `7inch V2`, `7-inch V2`, `JC1060P470 V2` | `devices/guition-esp32-p4-jc1060p470-v2` | Ask for the target |
 | `10inch`, `10-inch`, `10inch P4`, `10-inch P4`, `10inch V1`, `10-inch V1`, `JC8012P4A1` | `devices/guition-esp32-p4-jc8012p4a1` | `192.168.6.103` |
 | `10inch V2`, `10-inch V2`, `JC8012P4A1 V2` | `devices/guition-esp32-p4-jc8012p4a1-v2` | Ask for the target |
-| `4inch`, `4-inch`, `4inch P4`, `4-inch P4`, `P4-86`, `86 Panel`, `Waveshare P4-86`, `esp32-p4-86` | `devices/esp32-p4-86` | `192.168.6.104` |
+| `4inch P4`, `4-inch P4`, `P4-86`, `86 Panel`, `Waveshare P4-86`, `esp32-p4-86` | `devices/esp32-p4-86` | `192.168.6.104` |
 | `4.3inch P4`, `4.3-inch P4`, `P4 4.3inch`, `P4 4.3-inch`, `JC4880P443` | `devices/guition-esp32-p4-jc4880p443` | `192.168.6.101` |
+| `S3`, `4inch S3`, `4-inch S3`, `4848S040` | `devices/guition-esp32-s3-4848s040` | `192.168.6.105` |
 
 Treat the 7-inch panel at `192.168.6.102`, and an ambiguous or default `7inch` request, as V1 hardware. Always flash that panel with the V1 `JC1060P470` configuration in `devices/guition-esp32-p4-jc1060p470`; never substitute the V2 configuration because that firmware will not work on this panel. Select the V2 directory only when the user explicitly requests the 7-inch V2 panel and supplies a different OTA target or explicitly requests USB.
 
@@ -26,7 +27,7 @@ Treat the 10-inch panel at `192.168.6.103`, and an ambiguous or default `10inch`
 
 All screens can also be flashed over USB when explicitly requested. Use the selected screen's config directory and the local serial target, normally `/dev/cu.usbmodem201301`.
 
-If the user says only `4inch` or `4-inch`, use the 4-inch P4 / P4-86 screen.
+If the user says only `4inch` or `4-inch`, ask whether they mean the 4-inch P4 screen or the S3 screen.
 
 For `/flash-displays` with no extra target, or for `all`, flash in this sequence by default over OTA using the default targets above:
 
@@ -34,6 +35,7 @@ For `/flash-displays` with no extra target, or for `all`, flash in this sequence
 2. 10-inch P4 V1.
 3. 4-inch P4 / P4-86.
 4. 4.3-inch P4.
+5. S3.
 
 ## YAML Selection
 
@@ -140,6 +142,14 @@ python3 ../../scripts/local_esphome.py dev.yaml run --device 192.168.6.101 --no-
 
 # 4.3-inch P4 over USB, only when explicitly requested
 cd /Users/jtenniswood/Git/espcontrol/devices/guition-esp32-p4-jc4880p443
+python3 ../../scripts/local_esphome.py dev.yaml run --device /dev/cu.usbmodem201301 --no-logs
+
+# S3 over OTA
+cd /Users/jtenniswood/Git/espcontrol/devices/guition-esp32-s3-4848s040
+python3 ../../scripts/local_esphome.py dev.yaml run --device 192.168.6.105 --no-logs
+
+# S3 over USB, only when explicitly requested
+cd /Users/jtenniswood/Git/espcontrol/devices/guition-esp32-s3-4848s040
 python3 ../../scripts/local_esphome.py dev.yaml run --device /dev/cu.usbmodem201301 --no-logs
 
 ```

--- a/.agents/skills/flash-displays/SKILL.md
+++ b/.agents/skills/flash-displays/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flash-displays
-description: Flash EspControl display firmware from this repository using ESPHome. Use when the user invokes /flash-displays with no extra display name, or asks to flash, reflash, update, or upload firmware to all known displays in sequence, or to a specific display such as 7inch, 7-inch P4, 10inch, 10-inch V1, 10-inch V2, P4-86, 4.3-inch P4, 4-inch P4, or 4-inch S3, over an explicitly supplied OTA target or USB.
+description: Flash EspControl display firmware from this repository using ESPHome. Use when the user invokes /flash-displays with no extra display name, or asks to flash, reflash, update, or upload firmware to all known displays in sequence, or to a specific display such as 7inch, 7-inch P4, 10inch, 10-inch V1, 10-inch V2, P4-86, 4.3-inch P4, or 4-inch P4, over an explicitly supplied OTA target or USB.
 ---
 
 # Flash Displays
@@ -17,9 +17,8 @@ Use the local development ESPHome configs to flash the known EspControl displays
 | `7inch V2`, `7-inch V2`, `JC1060P470 V2` | `devices/guition-esp32-p4-jc1060p470-v2` | Ask for the target |
 | `10inch`, `10-inch`, `10inch P4`, `10-inch P4`, `10inch V1`, `10-inch V1`, `JC8012P4A1` | `devices/guition-esp32-p4-jc8012p4a1` | `192.168.6.103` |
 | `10inch V2`, `10-inch V2`, `JC8012P4A1 V2` | `devices/guition-esp32-p4-jc8012p4a1-v2` | Ask for the target |
-| `4inch P4`, `4-inch P4`, `P4-86`, `86 Panel`, `Waveshare P4-86`, `esp32-p4-86` | `devices/esp32-p4-86` | `192.168.6.104` |
+| `4inch`, `4-inch`, `4inch P4`, `4-inch P4`, `P4-86`, `86 Panel`, `Waveshare P4-86`, `esp32-p4-86` | `devices/esp32-p4-86` | `192.168.6.104` |
 | `4.3inch P4`, `4.3-inch P4`, `P4 4.3inch`, `P4 4.3-inch`, `JC4880P443` | `devices/guition-esp32-p4-jc4880p443` | `192.168.6.101` |
-| `4inch S3`, `4-inch S3`, `4848S040` | `devices/guition-esp32-s3-4848s040` | `192.168.6.105` |
 
 Treat the 7-inch panel at `192.168.6.102`, and an ambiguous or default `7inch` request, as V1 hardware. Always flash that panel with the V1 `JC1060P470` configuration in `devices/guition-esp32-p4-jc1060p470`; never substitute the V2 configuration because that firmware will not work on this panel. Select the V2 directory only when the user explicitly requests the 7-inch V2 panel and supplies a different OTA target or explicitly requests USB.
 
@@ -27,7 +26,7 @@ Treat the 10-inch panel at `192.168.6.103`, and an ambiguous or default `10inch`
 
 All screens can also be flashed over USB when explicitly requested. Use the selected screen's config directory and the local serial target, normally `/dev/cu.usbmodem201301`.
 
-If the user says only `4inch` or `4-inch`, ask whether they mean the 4-inch P4 screen or the 4-inch S3 screen.
+If the user says only `4inch` or `4-inch`, use the 4-inch P4 / P4-86 screen.
 
 For `/flash-displays` with no extra target, or for `all`, flash in this sequence by default over OTA using the default targets above:
 
@@ -35,7 +34,6 @@ For `/flash-displays` with no extra target, or for `all`, flash in this sequence
 2. 10-inch P4 V1.
 3. 4-inch P4 / P4-86.
 4. 4.3-inch P4.
-5. 4-inch S3.
 
 ## YAML Selection
 
@@ -142,14 +140,6 @@ python3 ../../scripts/local_esphome.py dev.yaml run --device 192.168.6.101 --no-
 
 # 4.3-inch P4 over USB, only when explicitly requested
 cd /Users/jtenniswood/Git/espcontrol/devices/guition-esp32-p4-jc4880p443
-python3 ../../scripts/local_esphome.py dev.yaml run --device /dev/cu.usbmodem201301 --no-logs
-
-# 4-inch S3 over OTA
-cd /Users/jtenniswood/Git/espcontrol/devices/guition-esp32-s3-4848s040
-python3 ../../scripts/local_esphome.py dev.yaml run --device 192.168.6.105 --no-logs
-
-# 4-inch S3 over USB, only when explicitly requested
-cd /Users/jtenniswood/Git/espcontrol/devices/guition-esp32-s3-4848s040
 python3 ../../scripts/local_esphome.py dev.yaml run --device /dev/cu.usbmodem201301 --no-logs
 
 ```

--- a/.agents/skills/flash-displays/agents/openai.yaml
+++ b/.agents/skills/flash-displays/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Flash Displays"
   short_description: "Flash EspControl displays by IP by default, or USB on request."
-  default_prompt: "Use $flash-displays to flash all EspControl displays from main over IP by default, or flash a specific display such as 7inch P4, 10inch P4, or 4inch P4. Say use USB to flash locally over USB instead."
+  default_prompt: "Use $flash-displays to flash all EspControl displays from main over IP by default, or flash a specific display such as 7inch P4, 10inch P4, 4inch P4, or S3. Say use USB to flash locally over USB instead."

--- a/.agents/skills/flash-displays/agents/openai.yaml
+++ b/.agents/skills/flash-displays/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Flash Displays"
   short_description: "Flash EspControl displays by IP by default, or USB on request."
-  default_prompt: "Flash all EspControl displays from main over IP by default, or flash a specific display such as 7inch P4, 10inch P4, 4inch P4, or 4inch S3. Say use USB to flash locally over USB instead."
+  default_prompt: "Use $flash-displays to flash all EspControl displays from main over IP by default, or flash a specific display such as 7inch P4, 10inch P4, or 4inch P4. Say use USB to flash locally over USB instead."


### PR DESCRIPTION
## Summary

Name the display at `192.168.6.105` “S3” in the flash-displays skill, including its device alias, default flashing sequence, command examples, and suggested prompt.

## Practical impact

`/flash-displays S3` selects the S3 at `192.168.6.105`. The default all-display sequence includes the four P4 displays followed by S3. No device at `192.168.6.100` is listed; a search confirmed that target is absent from the skill.

## Documentation decision

- [x] No docs needed because this does not change user-visible behavior/configuration.

Docs notes:

Development skill and prompt metadata only; firmware and public device support are unchanged.

## Testing

- [x] Automated/local checks passed: skill quick validator and `git diff --check`.
- [x] Device testing is not required; only skill instructions and prompt metadata changed.

Affected display/device: S3 at `192.168.6.105`. No firmware flashing performed.

## Notes for testing

Generated testing guidance found no specific device requiring testing. On branch `remove-secondary-s3`, inspect `.agents/skills/flash-displays/SKILL.md`: confirm S3 resolves to `devices/guition-esp32-s3-4848s040` at `192.168.6.105`, appears once in the default sequence, and no target `192.168.6.100` exists. A bare `4inch` request still asks which of the P4 or S3 displays is intended.

## PR status

- [x] Checks running or waiting.

Leave open for user confirmation before merging.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works.
