### PR TITLE
Improve 4-inch P4 settings and voice control spacing

### DIFF
--- a/devices/esp32-p4-86/device/fonts.yaml
+++ b/devices/esp32-p4-86/device/fonts.yaml
@@ -27,6 +27,13 @@ font:
     bpp: 4
     glyphs: !include ../../../common/assets/network_status_glyphs.yaml
 
+  # Clock-bar icons: match the S3 panel's physical size at 1.5x resolution.
+  - file: '${mdi_font_file}'
+    id: font_icon_clock_bar
+    size: 36
+    bpp: 4
+    glyphs: !include ../../../common/assets/network_status_glyphs.yaml
+
   # Main labels and setup body text
   - file: "gfonts://Roboto"
     id: font_text_body

--- a/devices/esp32-p4-86/device/lvgl.yaml
+++ b/devices/esp32-p4-86/device/lvgl.yaml
@@ -39,7 +39,7 @@ lvgl:
       - obj:
           id: voice_clock_bar_mute_button
           align: top_right
-          x: -68
+          x: -74
           y: 6
           width: 48
           height: 48

--- a/devices/esp32-p4-86/device/lvgl.yaml
+++ b/devices/esp32-p4-86/device/lvgl.yaml
@@ -35,14 +35,14 @@ lvgl:
           text_color: 0xFFFFFF
           hidden: true
 
-      # Network status (tappable, right side of clock bar)
+      # Voice volume (separate touch target beside network/settings)
       - obj:
           id: voice_clock_bar_mute_button
           align: top_right
-          x: -72
-          y: 10
-          width: 44
-          height: 42
+          x: -68
+          y: 6
+          width: 48
+          height: 48
           bg_opa: 0%
           border_width: 0
           pad_all: 0
@@ -54,7 +54,7 @@ lvgl:
             - label:
                 id: voice_clock_bar_mute_icon_label
                 text: "\U000F036C"
-                text_font: font_icon_status
+                text_font: font_icon_clock_bar
                 align: center
                 text_align: center
                 text_color: 0xFFFFFF
@@ -66,10 +66,10 @@ lvgl:
       - obj:
           id: network_status_button
           align: top_right
-          x: -20
-          y: 10
-          width: 44
-          height: 42
+          x: -8
+          y: 6
+          width: 48
+          height: 48
           bg_opa: 0%
           border_width: 0
           pad_all: 0
@@ -81,7 +81,7 @@ lvgl:
             - label:
                 id: network_status_icon_label
                 text: "\U000F0928"
-                text_font: font_icon_status
+                text_font: font_icon_clock_bar
                 align: center
                 text_align: center
                 text_color: 0xFFFFFF
@@ -97,8 +97,8 @@ lvgl:
           align: top_right
           x: 0
           y: 0
-          width: 44
-          height: 42
+          width: 48
+          height: 48
           bg_opa: 0%
           border_width: 0
           pad_all: 0
@@ -110,7 +110,7 @@ lvgl:
             - label:
                 id: night_mode_status_icon_label
                 text: "\U000F00DC"
-                text_font: font_icon_status
+                text_font: font_icon_clock_bar
                 align: center
                 text_align: center
                 text_color: 0xFFFFFF

--- a/devices/esp32-p4-86/packages.yaml
+++ b/devices/esp32-p4-86/packages.yaml
@@ -39,10 +39,17 @@ substitutions:
     lv_obj_add_flag(id(voice_clock_bar_mute_button), LV_OBJ_FLAG_HIDDEN);
   voice_clock_bar_apply_code: |-
     if (id(voice_services_enabled).state) {
+      // These controls open different modals: space their full touch targets,
+      // not just the narrower glyphs, with a 12px gap inside the 60px bar.
+      clock_bar_right_icons = clock_bar_right_icons_begin(clock_bar_right_x, 12);
+      if (show_network) {
+        const int network_box = lv_obj_get_width(id(network_status_button));
+        clock_bar_right_icons_seed(clock_bar_right_icons, network_box, network_box);
+      }
       const int voice_clock_bar_icon_x_box = lv_obj_get_width(id(voice_clock_bar_mute_button));
       const int voice_clock_bar_icon_x = clock_bar_right_icons_next_x(
           clock_bar_right_icons, voice_clock_bar_icon_x_box,
-          clock_bar_glyph_width(id(voice_clock_bar_mute_icon_label), voice_clock_bar_icon_x_box));
+          voice_clock_bar_icon_x_box);
       lv_obj_align(id(voice_clock_bar_mute_button), LV_ALIGN_TOP_RIGHT,
                    voice_clock_bar_icon_x, clock_bar_icon_y);
       lv_obj_clear_flag(id(voice_clock_bar_mute_button), LV_OBJ_FLAG_HIDDEN);

--- a/devices/esp32-p4-86/packages.yaml
+++ b/devices/esp32-p4-86/packages.yaml
@@ -40,8 +40,8 @@ substitutions:
   voice_clock_bar_apply_code: |-
     if (id(voice_services_enabled).state) {
       // These controls open different modals: space their full touch targets,
-      // not just the narrower glyphs, with a 12px gap inside the 60px bar.
-      clock_bar_right_icons = clock_bar_right_icons_begin(clock_bar_right_x, 12);
+      // not just the narrower glyphs, with an 18px gap inside the 60px bar.
+      clock_bar_right_icons = clock_bar_right_icons_begin(clock_bar_right_x, 18);
       if (show_network) {
         const int network_box = lv_obj_get_width(id(network_status_button));
         clock_bar_right_icons_seed(clock_bar_right_icons, network_box, network_box);

--- a/scripts/generate_device_slots.py
+++ b/scripts/generate_device_slots.py
@@ -109,13 +109,30 @@ def voice_substitution_lines(device: dict) -> list[str]:
             '    ESP_LOGW("navigation", "Voice volume target is not available on this device");',
             '  voice_interaction_active_condition: "false"',
         ]
+    icon_offset_lines = clock_bar_icon_offset_lines(
+        "voice_clock_bar_icon_x", "voice_clock_bar_mute_button",
+        "voice_clock_bar_mute_icon_label",
+    )
+    if device["slug"] == "esp32-p4-86":
+        icon_offset_lines = [
+            "      // These controls open different modals: space their full touch targets,",
+            "      // not just the narrower glyphs, with an 18px gap inside the 60px bar.",
+            "      clock_bar_right_icons = clock_bar_right_icons_begin(clock_bar_right_x, 18);",
+            "      if (show_network) {",
+            "        const int network_box = lv_obj_get_width(id(network_status_button));",
+            "        clock_bar_right_icons_seed(clock_bar_right_icons, network_box, network_box);",
+            "      }",
+            "      const int voice_clock_bar_icon_x_box = lv_obj_get_width(id(voice_clock_bar_mute_button));",
+            "      const int voice_clock_bar_icon_x = clock_bar_right_icons_next_x(",
+            "          clock_bar_right_icons, voice_clock_bar_icon_x_box,",
+            "          voice_clock_bar_icon_x_box);",
+        ]
     return [
         "  voice_clock_bar_hide_code: |-",
         "    lv_obj_add_flag(id(voice_clock_bar_mute_button), LV_OBJ_FLAG_HIDDEN);",
         "  voice_clock_bar_apply_code: |-",
         "    if (id(voice_services_enabled).state) {",
-        *clock_bar_icon_offset_lines("voice_clock_bar_icon_x", "voice_clock_bar_mute_button",
-                                     "voice_clock_bar_mute_icon_label"),
+        *icon_offset_lines,
         "      lv_obj_align(id(voice_clock_bar_mute_button), LV_ALIGN_TOP_RIGHT,",
         "                   voice_clock_bar_icon_x, clock_bar_icon_y);",
         "      lv_obj_clear_flag(id(voice_clock_bar_mute_button), LV_OBJ_FLAG_HIDDEN);",


### PR DESCRIPTION
## Summary

The 4-inch P4 clock bar packed settings/network and voice by their glyph edges, allowing their larger touch targets to overlap. Space these two full touch targets 18px apart so each opens its own modal reliably.

## Practical impact

- Increase clock-bar icons from 26px to 36px, matching the 4-inch S3's 24px icons at the P4's 1.5x resolution.
- Use 48×48px touch targets within the existing 60px bar. The main grid keeps its existing space.
- Keep voice at the right edge when settings/network is hidden and allow the night indicator to follow the visible controls.
- Preserve the 18px touch-target gap when device YAML is regenerated.
- Limit the new font to the P4 clock bar; existing subpage chevrons retain their size.

## Documentation decision

- [x] Updated public docs or release-facing notes for user-visible behavior/configuration.

Docs notes:

This is a visual spacing correction with no setup or configuration changes. The practical change and device testing steps are recorded here for release notes; no separate user guide changes are needed.

## Testing

- [x] ESPHome 2026.8.2 Docker configuration validation passed using placeholder Wi-Fi credentials.
- [x] Configuration-format checks and device-profile cross-checks passed.
- [x] Compiled and ran an isolated check using the existing C++ placement helpers: 18px touch-target gap, right-edge placement with settings hidden, and room for the night icon.
- [x] `python3 scripts/generate_device_slots.py --check` passed; regeneration leaves device files unchanged.
- [x] `git diff --check` passed.
- [ ] Full firmware compile and physical device testing: not performed locally.
- [x] Device testing is required before merge.

Affected display/device:

- **ESP32-P4 86 Panel (4 inches, Square)**.

## Notes for testing

The latest revision increases the gap from the previously flashed 12px to 18px. This wider spacing has not yet been flashed or physically tested.

Build/flash `devices/esp32-p4-86/dev.yaml` from branch `fix-p4-4inch-controls` to the 4-inch P4. Confirm normal boot, larger unclipped icons, and distinct settings/network versus voice-volume tap actions, including near the gap. Check microphone mute, output mute, settings/network hidden, Voice Services disabled, and the night indicator enabled; confirm nothing overlaps the clock or button grid.

## PR status

- [x] Checks running or waiting.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.

## Issue handling

- [x] Do not close related issues until the user confirms the fix works. Keep the PR open until then.

<!-- espcontrol-pr-testing-guidance -->
## Automated testing guidance

Device testing is expected before merge because this change may affect firmware or the on-device experience.

Suggested devices to test:
- ESP32-P4 86 Panel (4 inches, Square)

Suggested checks:
- Confirm the device boots normally and does not restart repeatedly.
- Confirm the affected screen, card, or setting appears correctly.
- Confirm touch/navigation still works where the changed area is interactive.
- Confirm there is no obvious text overlap, clipping, blank screen, or missing icon.

Suggested PR status: Ready for device test once automated checks pass.

Changed files considered:
- `devices/esp32-p4-86/device/fonts.yaml`
- `devices/esp32-p4-86/device/lvgl.yaml`
- `devices/esp32-p4-86/packages.yaml`


