### PR TITLE
Fix UTF-8 word capitalization

### DIFF
--- a/components/espcontrol/button_grid_config_parser.h
+++ b/components/espcontrol/button_grid_config_parser.h
@@ -1664,6 +1664,163 @@ constexpr size_t HA_TEXT_SENSOR_STATE_MAX_LEN = 256;
 constexpr size_t HA_SHORT_STATE_MAX_LEN = 32;
 constexpr size_t HA_FRIENDLY_NAME_MAX_LEN = 64;
 
+enum class Utf8DecodeStatus : uint8_t {
+  VALID,
+  INVALID,
+  INCOMPLETE,
+};
+
+struct Utf8CasePair {
+  uint32_t upper;
+  uint32_t lower;
+};
+
+inline Utf8DecodeStatus decode_utf8_codepoint(const std::string &text, size_t offset,
+                                               uint32_t &codepoint, size_t &length) {
+  codepoint = 0;
+  length = 0;
+  if (offset >= text.size()) return Utf8DecodeStatus::INCOMPLETE;
+
+  const unsigned char lead = static_cast<unsigned char>(text[offset]);
+  if (lead < 0x80) {
+    codepoint = lead;
+    length = 1;
+    return Utf8DecodeStatus::VALID;
+  }
+
+  size_t expected = 0;
+  uint32_t value = 0;
+  uint32_t minimum = 0;
+  if (lead >= 0xC2 && lead <= 0xDF) {
+    expected = 2;
+    value = lead & 0x1F;
+    minimum = 0x80;
+  } else if (lead >= 0xE0 && lead <= 0xEF) {
+    expected = 3;
+    value = lead & 0x0F;
+    minimum = 0x800;
+  } else if (lead >= 0xF0 && lead <= 0xF4) {
+    expected = 4;
+    value = lead & 0x07;
+    minimum = 0x10000;
+  } else {
+    length = 1;
+    return Utf8DecodeStatus::INVALID;
+  }
+
+  for (size_t i = 1; i < expected; i++) {
+    if (offset + i >= text.size()) return Utf8DecodeStatus::INCOMPLETE;
+    const unsigned char continuation = static_cast<unsigned char>(text[offset + i]);
+    if ((continuation & 0xC0) != 0x80) {
+      length = 1;
+      return Utf8DecodeStatus::INVALID;
+    }
+    value = (value << 6) | (continuation & 0x3F);
+  }
+  if (value < minimum || value > 0x10FFFF || (value >= 0xD800 && value <= 0xDFFF)) {
+    length = 1;
+    return Utf8DecodeStatus::INVALID;
+  }
+
+  codepoint = value;
+  length = expected;
+  return Utf8DecodeStatus::VALID;
+}
+
+inline void append_utf8_codepoint(std::string &out, uint32_t codepoint) {
+  if (codepoint <= 0x7F) {
+    out.push_back(static_cast<char>(codepoint));
+  } else if (codepoint <= 0x7FF) {
+    out.push_back(static_cast<char>(0xC0 | (codepoint >> 6)));
+    out.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+  } else if (codepoint <= 0xFFFF) {
+    out.push_back(static_cast<char>(0xE0 | (codepoint >> 12)));
+    out.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+    out.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+  } else {
+    out.push_back(static_cast<char>(0xF0 | (codepoint >> 18)));
+    out.push_back(static_cast<char>(0x80 | ((codepoint >> 12) & 0x3F)));
+    out.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+    out.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+  }
+}
+
+inline const Utf8CasePair *utf8_latin_case_pairs(size_t &count) {
+  // Locale-dependent Turkish dotted/dotless I are deliberately left unchanged.
+  static const Utf8CasePair pairs[] = {
+    {0x00C0, 0x00E0}, {0x00C1, 0x00E1}, {0x00C2, 0x00E2}, {0x00C3, 0x00E3},
+    {0x00C4, 0x00E4}, {0x00C5, 0x00E5}, {0x00C6, 0x00E6}, {0x00C7, 0x00E7},
+    {0x00C8, 0x00E8}, {0x00C9, 0x00E9}, {0x00CA, 0x00EA}, {0x00CB, 0x00EB},
+    {0x00CC, 0x00EC}, {0x00CD, 0x00ED}, {0x00CE, 0x00EE}, {0x00CF, 0x00EF},
+    {0x00D0, 0x00F0}, {0x00D1, 0x00F1}, {0x00D2, 0x00F2}, {0x00D3, 0x00F3},
+    {0x00D4, 0x00F4}, {0x00D5, 0x00F5}, {0x00D6, 0x00F6}, {0x00D8, 0x00F8},
+    {0x00D9, 0x00F9}, {0x00DA, 0x00FA}, {0x00DB, 0x00FB}, {0x00DC, 0x00FC},
+    {0x00DD, 0x00FD}, {0x00DE, 0x00FE}, {0x0102, 0x0103}, {0x0104, 0x0105},
+    {0x0106, 0x0107}, {0x010C, 0x010D}, {0x010E, 0x010F}, {0x0110, 0x0111},
+    {0x0118, 0x0119}, {0x011A, 0x011B}, {0x011E, 0x011F}, {0x0139, 0x013A}, {0x013D, 0x013E}, {0x0141, 0x0142},
+    {0x0143, 0x0144}, {0x0147, 0x0148}, {0x0150, 0x0151}, {0x0154, 0x0155},
+    {0x0158, 0x0159}, {0x015A, 0x015B}, {0x015E, 0x015F}, {0x0160, 0x0161},
+    {0x0164, 0x0165}, {0x016E, 0x016F}, {0x0170, 0x0171}, {0x0179, 0x017A},
+    {0x017B, 0x017C}, {0x017D, 0x017E}, {0x0218, 0x0219}, {0x021A, 0x021B},
+    {0x1E62, 0x1E63},
+  };
+  count = sizeof(pairs) / sizeof(pairs[0]);
+  return pairs;
+}
+
+inline uint32_t utf8_latin_case(uint32_t codepoint, bool uppercase) {
+  size_t count = 0;
+  const Utf8CasePair *pairs = utf8_latin_case_pairs(count);
+  for (size_t i = 0; i < count; i++) {
+    if (codepoint == pairs[i].upper || codepoint == pairs[i].lower) {
+      return uppercase ? pairs[i].upper : pairs[i].lower;
+    }
+  }
+  return codepoint;
+}
+
+inline bool utf8_letter_like(uint32_t codepoint) {
+  if (codepoint < 0x80) {
+    return std::isalpha(static_cast<unsigned char>(codepoint));
+  }
+  // Latin ranges exclude the multiplication and division symbols.
+  if ((codepoint >= 0x00C0 && codepoint <= 0x00D6) ||
+      (codepoint >= 0x00D8 && codepoint <= 0x00F6) ||
+      (codepoint >= 0x00F8 && codepoint <= 0x02AF) ||
+      (codepoint >= 0x1E00 && codepoint <= 0x1EFF)) {
+    return true;
+  }
+  return (codepoint >= 0x0370 && codepoint <= 0x03FF) ||
+         (codepoint >= 0x0400 && codepoint <= 0x052F) ||
+         (codepoint >= 0x0590 && codepoint <= 0x05FF);
+}
+
+inline bool append_title_case_character(const std::string &text, size_t &offset,
+                                        std::string &out, bool &cap_next) {
+  uint32_t codepoint = 0;
+  size_t length = 0;
+  const Utf8DecodeStatus status = decode_utf8_codepoint(text, offset, codepoint, length);
+  if (status == Utf8DecodeStatus::INCOMPLETE) return false;
+  if (status == Utf8DecodeStatus::INVALID) {
+    out.push_back(text[offset]);
+    offset += length;
+    return true;
+  }
+
+  if (utf8_letter_like(codepoint)) {
+    if (codepoint < 0x80) {
+      const unsigned char ascii = static_cast<unsigned char>(codepoint);
+      codepoint = static_cast<uint32_t>(cap_next ? std::toupper(ascii) : std::tolower(ascii));
+    } else {
+      codepoint = utf8_latin_case(codepoint, cap_next);
+    }
+    cap_next = false;
+  }
+  append_utf8_codepoint(out, codepoint);
+  offset += length;
+  return true;
+}
+
 inline std::string normalized_state_text(esphome::StringRef value,
                                          size_t max_len = HA_SHORT_STATE_MAX_LEN) {
   std::string text = trim_display_unit(string_ref_limited(value, max_len));
@@ -1680,37 +1837,38 @@ inline std::string text_sensor_display_text(esphome::StringRef value,
   out.reserve(raw.size());
   bool cap_next = true;
   bool last_space = false;
-  for (size_t i = 0; i < raw.size(); i++) {
+  for (size_t i = 0; i < raw.size();) {
     char ch = raw[i];
     unsigned char c = static_cast<unsigned char>(ch);
     if (ch == '\r' || ch == '\n') {
-      if (ch == '\r' && i + 1 < raw.size() && raw[i + 1] == '\n') continue;
+      if (ch == '\r' && i + 1 < raw.size() && raw[i + 1] == '\n') {
+        i++;
+        continue;
+      }
       if (!out.empty() && out.back() == ' ') out.pop_back();
       if (!out.empty() && out.back() != '\n') out.push_back('\n');
       cap_next = true;
       last_space = false;
+      i++;
       continue;
     }
     if (ch == '-' && !out.empty() && out.back() != '\n' && out.back() != ' ') {
       out.push_back(ch);
       cap_next = true;
       last_space = false;
+      i++;
       continue;
     }
-    if (ch == '_' || std::isspace(c)) {
+    if (ch == '_' || (c < 0x80 && std::isspace(c))) {
       if (!out.empty() && !last_space && out.back() != '\n') {
         out.push_back(' ');
         last_space = true;
       }
       cap_next = true;
+      i++;
       continue;
     }
-    if (std::isalpha(c)) {
-      out.push_back(static_cast<char>(cap_next ? std::toupper(c) : std::tolower(c)));
-      cap_next = false;
-    } else {
-      out.push_back(ch);
-    }
+    if (!append_title_case_character(raw, i, out, cap_next)) break;
     last_space = false;
   }
   while (!out.empty() && (out.back() == ' ' || out.back() == '\n')) out.pop_back();
@@ -1840,22 +1998,19 @@ inline std::string sentence_cap_text(const std::string &state) {
   out.reserve(state.size());
   bool cap_next = true;
   bool last_space = false;
-  for (char ch : state) {
+  for (size_t i = 0; i < state.size();) {
+    char ch = state[i];
     unsigned char c = static_cast<unsigned char>(ch);
-    if (ch == '_' || ch == '-' || std::isspace(c)) {
+    if (ch == '_' || ch == '-' || (c < 0x80 && std::isspace(c))) {
       if (!out.empty() && !last_space) {
         out.push_back(' ');
         last_space = true;
       }
       cap_next = true;
+      i++;
       continue;
     }
-    if (std::isalpha(c)) {
-      out.push_back(static_cast<char>(cap_next ? std::toupper(c) : std::tolower(c)));
-      cap_next = false;
-    } else {
-      out.push_back(ch);
-    }
+    if (!append_title_case_character(state, i, out, cap_next)) break;
     last_space = false;
   }
   if (!out.empty() && out.back() == ' ') out.pop_back();

--- a/components/espcontrol/button_grid_config_parser.h
+++ b/components/espcontrol/button_grid_config_parser.h
@@ -1790,9 +1790,22 @@ inline bool utf8_letter_like(uint32_t codepoint) {
       (codepoint >= 0x1E00 && codepoint <= 0x1EFF)) {
     return true;
   }
-  return (codepoint >= 0x0370 && codepoint <= 0x03FF) ||
-         (codepoint >= 0x0400 && codepoint <= 0x052F) ||
-         (codepoint >= 0x0590 && codepoint <= 0x05FF);
+  // Unicode 16.0 Letter-category ranges within the supported script blocks.
+  // Punctuation, symbols, combining marks and unassigned positions must not
+  // consume a pending capital letter (for example Greek U+037E or Hebrew U+05BE).
+  return (codepoint >= 0x0370 && codepoint <= 0x0374) ||
+         (codepoint >= 0x0376 && codepoint <= 0x0377) ||
+         (codepoint >= 0x037A && codepoint <= 0x037D) ||
+         codepoint == 0x037F || codepoint == 0x0386 ||
+         (codepoint >= 0x0388 && codepoint <= 0x038A) ||
+         codepoint == 0x038C ||
+         (codepoint >= 0x038E && codepoint <= 0x03A1) ||
+         (codepoint >= 0x03A3 && codepoint <= 0x03F5) ||
+         (codepoint >= 0x03F7 && codepoint <= 0x03FF) ||
+         (codepoint >= 0x0400 && codepoint <= 0x0481) ||
+         (codepoint >= 0x048A && codepoint <= 0x052F) ||
+         (codepoint >= 0x05D0 && codepoint <= 0x05EA) ||
+         (codepoint >= 0x05EF && codepoint <= 0x05F2);
 }
 
 inline bool append_title_case_character(const std::string &text, size_t &offset,

--- a/scripts/check_firmware_parser.py
+++ b/scripts/check_firmware_parser.py
@@ -477,6 +477,15 @@ int main() {
     assert(formatter(u8"ßtest ÿtest Приветtest Ελληνικάtest שלוםtest") ==
            u8"ßtest ÿtest Приветtest Ελληνικάtest שלוםtest");
     assert(formatter(u8"—test 😀test") == u8"—Test 😀Test");
+    // Script punctuation, symbols and combining marks must not consume the first letter.
+    for (const std::string prefix : {u8"\u037E", u8"\u0387", u8"\u0384", u8"\u03F6",
+                                     u8"\u0482", u8"\u0483", u8"\u05BE", u8"\u05C3",
+                                     u8"\u05F3", u8"\u05B0"}) {
+      assert(formatter(prefix + "test") == prefix + "Test");
+      assert(formatter("a" + prefix + "TEST") == "A" + prefix + "test");
+    }
+    assert(formatter(u8"\u037Ftest \u03F7test \u0481test \u048Atest \u05EFtest") ==
+           u8"\u037Ftest \u03F7test \u0481test \u048Atest \u05EFtest");
     assert(formatter(std::string("\xFF") + "test") == std::string("\xFF") + "Test");
     assert(formatter(std::string("\xE2") + "x") == std::string("\xE2") + "X");
     assert(formatter(std::string("\xC0\xAF") + "test") == std::string("\xC0\xAF") + "Test");

--- a/scripts/check_firmware_parser.py
+++ b/scripts/check_firmware_parser.py
@@ -453,6 +453,46 @@ int main() {
   assert(sensor_state_display_text(state_labels, "medium-high") == "Medium-High");
   assert(text_sensor_display_text("pre-wash") == "Pre-Wash");
   assert(text_sensor_display_text("pre_wash") == "Pre Wash");
+  assert(text_sensor_display_text(u8"Übermorgen: Müll") == u8"Übermorgen: Müll");
+  assert(text_sensor_display_text(u8"ätest ötest ütest ætest") == u8"Ätest Ötest Ütest Ætest");
+  assert(text_sensor_display_text(u8"öätest") == u8"Öätest");
+  assert(text_sensor_display_text(u8"ÜBERMORGEN") == u8"Übermorgen");
+  assert(text_sensor_display_text(u8"čESKÝ") == u8"Český");
+  assert(text_sensor_display_text(u8"ßtest ÿtest") == u8"ßtest ÿtest");
+  assert(text_sensor_display_text(u8"Приветtest") == u8"Приветtest");
+  assert(text_sensor_display_text(u8"—test") == u8"—Test");
+  assert(text_sensor_display_text(u8"abä", 3) == "Ab");
+  assert(text_sensor_display_text("first_line\r\nsecond-line") == "First Line\nSecond-Line");
+  assert(sentence_cap_text(u8"über_status-test") == u8"Über Status Test");
+  assert(sentence_cap_text(u8"Приветtest") == u8"Приветtest");
+  assert(sentence_cap_text(u8"—test") == u8"—Test");
+  for (auto formatter : {+[](const std::string &s) { return text_sensor_display_text(s.c_str()); },
+                         +[](const std::string &s) { return sentence_cap_text(s); }}) {
+    assert(formatter("").empty());
+    assert(formatter(u8"Übermorgen: Müll") == u8"Übermorgen: Müll");
+    assert(formatter(u8"ätest ötest ütest ætest") == u8"Ätest Ötest Ütest Ætest");
+    assert(formatter(u8"öätest ÜBERMORGEN čESKÝ") == u8"Öätest Übermorgen Český");
+    assert(formatter(u8"ṣTEST ṢTEST") == u8"Ṣtest Ṣtest");
+    assert(formatter(u8"İTEST ıTEST iTEST ITEST") == u8"İtest ıtest Itest Itest");
+    assert(formatter(u8"ßtest ÿtest Приветtest Ελληνικάtest שלוםtest") ==
+           u8"ßtest ÿtest Приветtest Ελληνικάtest שלוםtest");
+    assert(formatter(u8"—test 😀test") == u8"—Test 😀Test");
+    assert(formatter(std::string("\xFF") + "test") == std::string("\xFF") + "Test");
+    assert(formatter(std::string("\xE2") + "x") == std::string("\xE2") + "X");
+    assert(formatter(std::string("\xC0\xAF") + "test") == std::string("\xC0\xAF") + "Test");
+    assert(formatter(std::string("\xED\xA0\x80") + "test") == std::string("\xED\xA0\x80") + "Test");
+    assert(formatter(std::string("\xF4\x90\x80\x80") + "test") == std::string("\xF4\x90\x80\x80") + "Test");
+    assert(formatter(std::string("ab\xE2\x82")) == "Ab");
+  }
+  assert(text_sensor_display_text(" \r\nfirst__line\n\nsecond-line \r\n") == "First Line\nSecond-Line");
+  assert(sentence_cap_text(" \r\nfirst__line\n\nsecond-line \r\n") == "First Line Second Line");
+  for (const std::string s : {u8"ä", u8"Ṣ", u8"😀"}) {
+    for (size_t limit = 1; limit < s.size(); limit++) {
+      assert(text_sensor_display_text(s.c_str(), limit).empty());
+      assert(text_sensor_display_text(("ab" + s).c_str(), 2 + limit) == "Ab");
+    }
+    assert(text_sensor_display_text(s.c_str(), s.size()) == (s == u8"ä" ? u8"Ä" : s));
+  }
   auto legacy_state_labels = parse_cfg(";;;;sensor.bin_level;;sensor;text;state_labels,state_high_label=Please%20empty");
   assert(legacy_state_labels.options == "state_labels,state_input=high,state_output=Please empty");
   auto numeric_state_labels = parse_cfg(";;;;sensor.bin_level;;sensor;0;state_labels,state_high_label=Please%20empty");


### PR DESCRIPTION
## Summary

Fix accented letters at the start of words in shared firmware text formatters. A Home Assistant text sensor containing `Übermorgen: Müll` now stays `Übermorgen: Müll` instead of becoming `ÜBermorgen: Müll`; `ätest ötest ütest ætest` becomes `Ätest Ötest Ütest Ætest`.

Both formatters now read complete UTF-8 characters, retain existing word capitalization and separator behavior, preserve unsupported characters, and omit incomplete trailing UTF-8 sequences. Turkish dotted/dotless I remain unchanged. No settings or saved configuration changes.

Related to #1937. Adapts the approach from closed, unmerged #1699.

## Automated checks

Review follow-up `6cf8ecc`: parser checks passed with new regression coverage for Greek/Hebrew punctuation, Cyrillic symbols and combining marks in both formatters. The new tests fail on the prior revision and pass with the fix. Full `npm test` and the three firmware builds below passed on `f35541c`; they were not repeated for this focused follow-up.

- `python3 scripts/check_firmware_parser.py` — passed, including accented letters, mixed scripts, Turkish I, malformed UTF-8, newline handling and multibyte truncation.
- `npm test` — passed, including all 54 firmware unit tests.

- ESPHome 2026.8.2 factory build: Guition JC1060P470 — passed.
- ESPHome 2026.8.2 factory build: Guition JC4880P443 — passed.
- ESPHome 2026.8.2 factory build: Guition 4848S040 — passed.

## Device testing required

Shared firmware change affecting all supported displays: ESP32-P4 86 Panel, Guition JC1060P470 (including V2), JC4880P443, JC8012P4A1 (including V2), and 4848S040. Automated testing guidance recommends boot, affected-screen, navigation and layout checks.

Flash the `fix-utf8-capitalization` branch onto one representative display, such as Guition JC1060P470 (7-inch), and use a live Home Assistant text sensor to verify:

- `Übermorgen: Müll` stays unchanged.
- `ätest ötest ütest ætest` displays as `Ätest Ötest Ütest Ætest`.
- `öätest` displays as `Öätest`; `ÜBERMORGEN` displays as `Übermorgen`.
- Punctuation, hyphens, underscores, whitespace and multiline values retain their existing behavior.
- The display boots normally without repeated restarts; touch/navigation works; text has no clipping, overlap or missing glyphs.

Physical device testing has not been performed. Keep this PR and issue open until the user confirms the fix works.
