### PR TITLE
Recover cover art after failed downloads without a restart

### DIFF
--- a/components/espcontrol/artwork_controller.h
+++ b/components/espcontrol/artwork_controller.h
@@ -7,6 +7,31 @@
 
 namespace espcontrol::artwork {
 
+// Recovery belongs to the failed image, not to the panel's startup window.
+// Keep a deadline even while waiting for Home Assistant to return fresh URLs:
+// a missing attribute reply must not strand recovery either.
+struct DownloadRecovery {
+  uint8_t step{0};
+  uint32_t retry_at{0};
+
+  bool active() const { return step != 0; }
+  uint32_t delay_ms() const {
+    return step >= 6 ? 60000u : (2000u << (step == 0 ? 0 : step - 1));
+  }
+  void failed(uint32_t now) {
+    if (!active()) step = 1;
+    retry_at = now + delay_ms();
+  }
+  bool due(uint32_t now) const {
+    return active() && static_cast<int32_t>(now - retry_at) >= 0;
+  }
+  void retry_started(uint32_t now) {
+    if (step < 6) ++step;
+    retry_at = now + delay_ms();
+  }
+  void reset() { step = 0; retry_at = 0; }
+};
+
 struct SourceSelection {
   std::string primary;
   std::string fallback;
@@ -239,8 +264,9 @@ constexpr bool artwork_timeout_preserves_displayed_image(bool response_window_ex
 // A selected source only needs another download when it differs from the
 // artwork already on screen, except for an explicit recovery refresh.
 constexpr bool artwork_selection_needs_download(bool refresh_forced,
-                                                bool source_matches_current) {
-  return refresh_forced || !source_matches_current;
+                                                bool source_matches_current,
+                                                bool image_ready = true) {
+  return refresh_forced || !source_matches_current || !image_ready;
 }
 
 // Owns the ordering rules for Home Assistant's remote and local artwork URLs.

--- a/components/espcontrol/button_grid_grid.h
+++ b/components/espcontrol/button_grid_grid.h
@@ -425,6 +425,7 @@ inline void setup_media_cover_art(BtnSlot &s, const ParsedCfg &p,
   art->media_artwork_suppressed = espcontrol::cover_art::media_card_artwork_suppressed(
     media_ctx->source_known, media_ctx->external_source);
   art->media_artwork_refresh_forced = false;
+  art->media_artwork_download_recovery.reset();
   art->media_overlay = overlay;
   art->media_overlay_artwork_tint = show_track_details;
   art->media_artwork_applied = [media_ctx]() {

--- a/components/espcontrol/button_grid_image.h
+++ b/components/espcontrol/button_grid_image.h
@@ -82,6 +82,7 @@ struct ImageCardCtx {
   espcontrol::artwork::SourceCandidates media_artwork_sources;
   espcontrol::artwork::RefreshBatch media_artwork_refresh;
   espcontrol::artwork::RefreshTrigger media_artwork_trigger;
+  espcontrol::artwork::DownloadRecovery media_artwork_download_recovery;
   uint8_t media_artwork_retry_mask = 0;
   uint8_t media_artwork_timeout_retries = 0;
   lv_timer_t *media_artwork_trigger_timer = nullptr;
@@ -528,6 +529,7 @@ inline void image_card_clear_media_artwork(ImageCardCtx *ctx) {
   ctx->media_artwork_sources.clear();
   ctx->media_artwork_refresh.reset();
   ctx->media_artwork_trigger.reset();
+  ctx->media_artwork_download_recovery.reset();
   ctx->media_artwork_retry_mask = 0;
   ctx->media_artwork_timeout_retries = 0;
   ctx->media_artwork_refresh_forced = false;
@@ -676,6 +678,7 @@ inline void image_card_apply_downloaded(ImageCardCtx *ctx) {
   image_card_release_download_slot(ctx);
   ctx->last_download_completed_ms = esphome::millis();
   ctx->startup_download_errors = 0;
+  ctx->media_artwork_download_recovery.reset();
   ctx->next_download_retry_ms = 0;
   if (ctx->diagnostics_enabled && ctx->last_tile_request_started_ms != 0) {
     ESP_LOGI("image_card_diag", "Tile image applied for %s after %lu ms",
@@ -702,6 +705,19 @@ inline void image_card_handle_download_error(ImageCardCtx *ctx) {
   ESP_LOGW("image_card", "Image download failed for %s", ctx->entity_id.c_str());
   image_card_log_diagnostics(ctx, "tile-download-error");
   uint32_t now = esphome::millis();
+  if (ctx->active && ctx->media_artwork && !ctx->source_url.empty()) {
+    ctx->media_artwork_download_recovery.failed(now);
+    ctx->next_download_retry_ms = 0;
+    ESP_LOGW("image_card", "Artwork recovery for %s in %lu ms",
+             ctx->entity_id.c_str(),
+             static_cast<unsigned long>(ctx->media_artwork_download_recovery.delay_ms()));
+    if (ctx->image_ready) image_card_hide_loading(ctx);
+    else {
+      image_card_hide(ctx);
+      image_card_set_loading_state(ctx, "Unavailable", true);
+    }
+    return;
+  }
   if (!ctx->image_ready && image_card_startup_retry_active(ctx, now) &&
       ctx->startup_download_errors < IMAGE_CARD_STARTUP_DOWNLOAD_RETRIES) {
     ctx->startup_download_errors++;
@@ -893,6 +909,7 @@ inline void reset_image_card_pool(const GridConfig &cfg) {
     contexts[i].media_artwork_sources.clear();
     contexts[i].media_artwork_refresh.reset();
     contexts[i].media_artwork_trigger.reset();
+    contexts[i].media_artwork_download_recovery.reset();
     contexts[i].media_artwork_retry_mask = 0;
     contexts[i].media_artwork_timeout_retries = 0;
     if (contexts[i].media_artwork_trigger_timer) {
@@ -2230,8 +2247,12 @@ inline void image_card_process_media_artwork(ImageCardCtx *ctx,
     image_card_log_diagnostics(ctx, "media-artwork-timeout-current-preserved");
     return;
   }
-  if (!espcontrol::artwork::artwork_selection_needs_download(
-          refresh_forced, chosen == ctx->source_url)) {
+  // Ordinary repeated notifications must respect a failed image's backoff.
+  // Recovery and track changes explicitly force a new attempt.
+  if ((!refresh_forced && chosen == ctx->source_url &&
+       ctx->media_artwork_download_recovery.active()) ||
+      !espcontrol::artwork::artwork_selection_needs_download(
+          refresh_forced, chosen == ctx->source_url, ctx->image_ready)) {
     image_card_log_diagnostics(ctx, "media-artwork-unchanged");
     return;
   }
@@ -2415,6 +2436,7 @@ inline void image_card_schedule_media_artwork_refresh(ImageCardCtx *ctx,
 
 inline void image_card_refresh_media_artwork_on_metadata_change(ImageCardCtx *ctx) {
   if (!ctx || !ctx->active || !ctx->media_artwork) return;
+  ctx->media_artwork_download_recovery.reset();
   if (espcontrol::artwork::artwork_metadata_refresh_clears_retry(
         ctx->media_artwork_retry_mask)) {
     ctx->media_artwork_retry_mask = 0;
@@ -2512,12 +2534,28 @@ inline void refresh_image_cards() {
   }
 }
 
+inline void image_card_recover_media_artwork(ImageCardCtx *ctx, uint32_t now) {
+  if (!ctx || !ctx->active || !ctx->media_artwork || ctx->entity_id.empty() ||
+      !ctx->media_artwork_download_recovery.due(now) || ctx->download_active ||
+      ctx->media_artwork_refresh.active() || ctx->media_artwork_trigger.pending) return;
+  ctx->media_artwork_download_recovery.retry_started(now);
+  ctx->media_artwork_refresh_forced = true;
+  // A retained read alone would replay the failed URL. Ask HA for fresh
+  // attributes (including any proxy token in the URL) on existing channels.
+  // Their subscription callbacks start the usual paired artwork read.
+  ha_schedule_metadata_refresh(ctx->entity_id,
+      {"entity_picture", "entity_picture_local"}, HA_SUBSCRIPTION_SCOPE_DEFAULT);
+  ESP_LOGI("image_card", "Refreshing Home Assistant artwork for recovery: %s",
+           ctx->entity_id.c_str());
+}
+
 inline void image_card_refresh_due() {
   ImageCardCtx *contexts = image_card_contexts();
   uint32_t now = esphome::millis();
   for (int i = 0; i < IMAGE_CARD_MAX_CONTEXTS; i++) {
     ImageCardCtx *ctx = &contexts[i];
     if (!ctx->active) continue;
+    image_card_recover_media_artwork(ctx, now);
     if (esphome::artwork_image::image_pipeline_completion_needs_recovery(
           ctx->image_ready, ctx->image && ctx->image->has_image(),
           ctx->image && ctx->image->get_url() == ctx->url)) {
@@ -2574,6 +2612,7 @@ inline bool image_card_bind_runtime(BtnSlot &s, const ParsedCfg &p,
   ctx->end_display_takeover = cfg.end_display_takeover;
   ctx->modal_fit = image_card_modal_fit_enabled(p);
   ctx->media_artwork = false;
+  ctx->media_artwork_download_recovery.reset();
   ctx->media_artwork_suppressed = false;
   ctx->media_artwork_refresh_forced = false;
   ctx->media_artwork_refresh.reset();

--- a/docs/card-types/media.md
+++ b/docs/card-types/media.md
@@ -40,6 +40,8 @@ A Media card controls a Home Assistant `media_player`. Choose a small one-job ca
 
 Cover Art is available in square **1×1**, **2×2**, and **3×3** card sizes. It uses one of the panel's shared image slots. ESP32-P4 screens have six slots shared between Camera and Cover Art cards across all pages. If the card shows **Too many**, remove one of those image cards.
 
+If an artwork download fails, the card automatically requests fresh artwork links from Home Assistant and retries, even after the panel has been running overnight. Retry delays increase from 2 seconds to a maximum of 60 seconds. A track change starts a fresh attempt; when Home Assistant reports no artwork, retries stop.
+
 ## Speaker Groups
 
 For speaker groups, first confirm the speakers can join in Home Assistant. EspControl uses the compatible-player list supplied by the configured discovery entity; by default this is `sensor.speaker_group`. The group screen stays hidden when no usable speakers are reported.

--- a/tests/firmware/artwork_recovery_test.cpp
+++ b/tests/firmware/artwork_recovery_test.cpp
@@ -6,8 +6,14 @@
 #include <vector>
 #include "artwork_controller.h"
 
-namespace esphome { using StringRef = std::string; }
+uint32_t current_time = 14u * 60 * 60 * 1000;
+namespace esphome {
+using StringRef = std::string;
+uint32_t millis() { return current_time; }
+}
 #define ESP_LOGD(...) ((void) 0)
+#define ESP_LOGI(...) ((void) 0)
+#define ESP_LOGW(...) ((void) 0)
 struct lv_timer_t { void *user_data; };
 void *lv_timer_get_user_data(lv_timer_t *timer) { return timer->user_data; }
 void lv_timer_del(lv_timer_t *timer) { delete timer; }
@@ -16,11 +22,23 @@ lv_timer_t *lv_timer_create(void (*)(lv_timer_t *), uint32_t, void *data) {
 }
 struct ImageCardCtx {
   bool active = true, media_artwork = true, image_ready = true;
+  bool download_active = false, diagnostics_enabled = false, requested_once = false;
+  void *widget = nullptr, *btn = nullptr, *media_overlay = nullptr;
+  struct Image {
+    std::string url;
+    const std::string &get_url() const { return url; }
+    void release() {}
+  } image_storage;
+  Image *image = &image_storage;
+  std::string url;
+  uint32_t retry_deadline_ms = 45000, next_download_retry_ms = 0;
+  uint32_t last_download_completed_ms = 0, last_tile_request_started_ms = 0;
   std::string entity_id = "media_player.test";
   std::string source_url = "https://ha/artwork/stable.jpg";
   std::string pending_fallback_picture;
   espcontrol::artwork::RefreshBatch media_artwork_refresh;
   espcontrol::artwork::RefreshTrigger media_artwork_trigger;
+  espcontrol::artwork::DownloadRecovery media_artwork_download_recovery;
   espcontrol::artwork::SourceCandidates media_artwork_sources;
   bool media_artwork_refresh_forced = false;
   uint8_t media_artwork_retry_mask = 0, media_artwork_timeout_retries = 0;
@@ -38,12 +56,36 @@ constexpr uint32_t IMAGE_CARD_API_RETRY_INTERVAL_MS = 5000;
 constexpr uint32_t IMAGE_CARD_RETRY_INTERVAL_MS = 5000;
 constexpr uint32_t IMAGE_CARD_MEDIA_ARTWORK_TRIGGER_DEBOUNCE_MS = 100;
 constexpr uint32_t IMAGE_CARD_MEDIA_ARTWORK_RESPONSE_DEBOUNCE_MS = 100;
+constexpr uint8_t IMAGE_CARD_STARTUP_DOWNLOAD_RETRIES = 10;
+constexpr uint32_t HA_SUBSCRIPTION_SCOPE_DEFAULT = 1;
+constexpr int LV_OBJ_FLAG_HIDDEN = 1;
 struct Read {
   std::string attribute;
   std::function<void(esphome::StringRef)> callback;
 };
 std::vector<Read> reads;
 std::vector<std::string> downloads;
+std::vector<std::string> fresh_requests;
+void ha_schedule_metadata_refresh(const std::string &,
+                                  std::initializer_list<const char *> attributes,
+                                  uint32_t) {
+  for (const auto *attribute : attributes) fresh_requests.emplace_back(attribute);
+}
+void image_card_release_download_slot(ImageCardCtx *ctx) { ctx->download_active = false; }
+void image_card_clear_widget_source(void *) {}
+void image_card_hide(ImageCardCtx *) {}
+void image_card_hide_loading(ImageCardCtx *) {}
+void image_card_sync_media_artwork_visibility(ImageCardCtx *) {}
+void image_card_set_widget_source(void *, ImageCardCtx::Image *) {}
+void lv_obj_add_flag(void *, int) {}
+void lv_obj_clear_flag(void *, int) {}
+void lv_obj_move_background(void *) {}
+void lv_obj_invalidate(void *) {}
+void notify_dashboard_content_changed() {}
+bool image_card_startup_retry_active(ImageCardCtx *ctx, uint32_t now) {
+  return ctx->retry_deadline_ms != 0 && int32_t(now - ctx->retry_deadline_ms) < 0;
+}
+bool image_card_modal_active_for(ImageCardCtx *) { return false; }
 bool ha_api_connected() { return true; }
 bool ha_api_state_connected() { return true; }
 uint32_t ha_subscription_generation() { return 1; }
@@ -59,14 +101,6 @@ void image_card_set_loading_state(ImageCardCtx *, const char *, bool) {}
 std::string string_ref_limited(const std::string &value, size_t limit) { return value.substr(0, limit); }
 std::string image_card_base_url(ImageCardCtx *) { return "https://ha"; }
 std::string image_card_join_url(const std::string &, const std::string &value) { return value; }
-void image_card_clear_media_artwork(ImageCardCtx *ctx) {
-  ctx->image_ready = false;
-  ctx->source_url.clear();
-  ctx->media_artwork_sources.clear();
-  ctx->media_artwork_refresh.reset();
-  ctx->media_artwork_trigger.reset();
-  ctx->media_artwork_refresh_forced = false;
-}
 void image_card_handle_picture(ImageCardCtx *ctx, const std::string &url) {
   downloads.push_back(url);
   ctx->source_url = url;
@@ -121,7 +155,102 @@ int main(int argc, char **argv) {
   ImageCardCtx ctx;
   ctx.media_artwork_sources.update(false, ctx.source_url);
   ctx.media_artwork_sources.finish_refresh();
-  if (scenario == "timeout_retry") {
+  if (scenario == "late_download_failure") {
+    ctx.image_ready = false;
+    image_card_handle_download_error(&ctx);
+    assert(ctx.media_artwork_download_recovery.active());
+    assert(!ctx.media_artwork_download_recovery.due(current_time + 1999));
+    image_card_recover_media_artwork(&ctx, current_time + 2000);
+    assert((fresh_requests == std::vector<std::string>{"entity_picture", "entity_picture_local"}));
+    assert(downloads.empty()); // Must obtain fresh HA attributes before retrying.
+  } else if (scenario == "failed_same_url") {
+    ctx.image_ready = false;
+    image_card_schedule_media_artwork_refresh(&ctx);
+    run_trigger(ctx);
+    respond_pair(ctx);
+    assert(downloads.size() == 1); // Missing image is never a successful cache hit.
+  } else if (scenario == "retry_backoff") {
+    ctx.image_ready = false;
+    image_card_handle_download_error(&ctx);
+    for (uint32_t delay : {2000u, 4000u, 8000u, 16000u, 32000u, 60000u, 60000u}) {
+      assert(ctx.media_artwork_download_recovery.retry_at == current_time + delay);
+      current_time += delay;
+      image_card_recover_media_artwork(&ctx, current_time);
+      // No HA reply: recovery must retain its next deadline, with bounded backoff.
+    }
+    assert(fresh_requests.size() == 14);
+  } else if (scenario == "fresh_url_recovery") {
+    ctx.image_ready = false;
+    image_card_handle_download_error(&ctx);
+    // Repeated ordinary notifications must not bypass the backoff.
+    image_card_schedule_media_artwork_refresh(&ctx);
+    run_trigger(ctx);
+    respond_pair(ctx);
+    assert(downloads.empty());
+    image_card_recover_media_artwork(&ctx, current_time + 2000);
+    image_card_schedule_media_artwork_refresh(&ctx); // Fresh subscription notification.
+    run_trigger(ctx);
+    respond("entity_picture", "https://ha/cover?token=renewed");
+    respond("entity_picture_local", "");
+    assert(downloads.size() == 1 && downloads.back() == "https://ha/cover?token=renewed");
+  } else if (scenario == "no_artwork_cancels_recovery") {
+    image_card_handle_download_error(&ctx);
+    image_card_schedule_media_artwork_refresh(&ctx);
+    run_trigger(ctx);
+    respond("entity_picture", "");
+    image_card_recover_media_artwork(&ctx, current_time + 60000);
+    assert(!ctx.media_artwork_download_recovery.active());
+    assert(fresh_requests.empty());
+  } else if (scenario == "track_change_resets_recovery") {
+    image_card_handle_download_error(&ctx);
+    ctx.media_artwork_download_recovery.step = 6;
+    image_card_refresh_media_artwork_on_metadata_change(&ctx);
+    assert(!ctx.media_artwork_download_recovery.active());
+    run_trigger(ctx);
+    respond_pair(ctx);
+    assert(downloads.size() == 1);
+    image_card_handle_download_error(&ctx);
+    assert(ctx.media_artwork_download_recovery.delay_ms() == 2000);
+  } else if (scenario == "success_cancels_recovery") {
+    image_card_handle_download_error(&ctx);
+    ctx.widget = &ctx;
+    ctx.url = ctx.image->url = ctx.source_url;
+    image_card_apply_downloaded(&ctx);
+    assert(ctx.image_ready && !ctx.media_artwork_download_recovery.active());
+    image_card_recover_media_artwork(&ctx, current_time + 60000);
+    assert(fresh_requests.empty());
+  } else if (scenario == "retry_waits_for_download") {
+    image_card_handle_download_error(&ctx);
+    ctx.download_active = true;
+    image_card_recover_media_artwork(&ctx, current_time + 60000);
+    assert(fresh_requests.empty());
+    ctx.download_active = false;
+    image_card_recover_media_artwork(&ctx, current_time + 60000);
+    assert(fresh_requests.size() == 2);
+  } else if (scenario == "retry_clock_wrap") {
+    current_time = UINT32_MAX - 999;
+    image_card_handle_download_error(&ctx);
+    image_card_recover_media_artwork(&ctx, current_time + 1999);
+    assert(fresh_requests.empty());
+    image_card_recover_media_artwork(&ctx, current_time + 2000);
+    assert(fresh_requests.size() == 2);
+  } else if (scenario == "failed_same_url_recovery") {
+    ctx.image_ready = false;
+    image_card_handle_download_error(&ctx);
+    image_card_recover_media_artwork(&ctx, current_time + 2000);
+    image_card_schedule_media_artwork_refresh(&ctx);
+    run_trigger(ctx);
+    respond_pair(ctx);
+    assert(downloads.size() == 1);
+  } else if (scenario == "previous_image_preserved") {
+    image_card_handle_download_error(&ctx);
+    assert(ctx.image_ready && ctx.media_artwork_download_recovery.active());
+    image_card_recover_media_artwork(&ctx, current_time + 2000);
+    image_card_schedule_media_artwork_refresh(&ctx);
+    run_trigger(ctx);
+    respond_pair(ctx);
+    assert(downloads.size() == 1); // Old pixels must not suppress recovery of the failed replacement.
+  } else if (scenario == "timeout_retry") {
     image_card_refresh_media_artwork_on_metadata_change(&ctx);
     run_trigger(ctx);
     timeout(ctx);

--- a/tests/firmware/ha_reconnect_recovery_test.py
+++ b/tests/firmware/ha_reconnect_recovery_test.py
@@ -138,6 +138,10 @@ class ArtworkRecoveryTest(unittest.TestCase):
         directory = Path(cls.directory.name)
         source = (ROOT / "components/espcontrol/button_grid_image.h").read_text()
         names = (
+            "image_card_handle_download_error",
+            "image_card_clear_media_artwork",
+            "image_card_apply_downloaded",
+            "image_card_recover_media_artwork",
             "image_card_request_current_picture",
             "image_card_refresh_current_picture",
             "image_card_process_media_artwork",
@@ -174,6 +178,15 @@ class ArtworkRecoveryTest(unittest.TestCase):
 
     def test_unchanged_artwork_stays_cached(self):
         subprocess.run([self.executable, "unchanged"], check=True)
+
+    def test_download_recovery_after_startup(self):
+        for scenario in ("late_download_failure", "failed_same_url", "retry_backoff",
+                         "fresh_url_recovery", "no_artwork_cancels_recovery",
+                         "track_change_resets_recovery", "success_cancels_recovery",
+                         "retry_waits_for_download", "retry_clock_wrap",
+                         "failed_same_url_recovery", "previous_image_preserved"):
+            with self.subTest(scenario=scenario):
+                subprocess.run([self.executable, scenario], check=True)
 
     def test_missing_companion_does_not_repeat_download(self):
         subprocess.run([self.executable, "missing_companion"], check=True)


### PR DESCRIPTION
## Summary

After a Cover Art card clears its old image, a failed replacement download outside the initial 45-second startup window can leave it blank without a retry. An unchanged artwork URL can also be treated as already handled even when no image loaded successfully.

This change keeps artwork recovery active throughout panel uptime. Failed downloads request fresh `entity_picture` and `entity_picture_local` values from Home Assistant, including renewed tokens in image links. Retries back off from 2 seconds to 60 seconds and continue if Home Assistant does not reply. Track changes reset the delay; successful downloads, empty artwork, and card teardown cancel recovery. Existing images stay visible while a replacement recovers.

## Documentation decision

- [x] Updated public docs for Cover Art recovery behaviour in `docs/card-types/media.md`.

## Testing

- [x] All 54 host firmware tests passed, including artwork recovery regressions. Two sanitizer tests required running outside the local sandbox because LeakSanitizer does not support sandbox tracing.
- [x] Firmware Home Assistant binding checks and diff whitespace checks passed.
- [x] Local ESPHome 2026.8.2 compile for **7-inch P4 V1 / JC1060P470** passed at commit `58052a417`; OTA test firmware built successfully.
- [x] Device testing is required before merge; no device has been flashed or confirmed working with this change yet.

Affected display/device:

- 7-inch P4 V1 / JC1060P470 first; shared Media Cover Art cards on other displays also use this code.

## Notes for testing

Start with the **7-inch P4 V1 / JC1060P470**, using `devices/guition-esp32-p4-jc1060p470/dev.yaml` from branch `fix-artwork-recovery`. Do not use the V2 configuration for this panel. The shared artwork code also affects Media Cover Art cards on other displays.

1. Confirm the panel boots normally, Cover Art shows images, and touch/navigation still works.
2. Wait more than 45 seconds after boot. With artwork initially cleared, temporarily make the artwork URL unavailable while keeping Home Assistant connected, then start playback. Restore the image source: artwork should recover without restarting the panel.
3. Repeat while an old image is already showing: the old image should remain until its replacement loads. An unchanged URL should recover too.
4. During failures, logs should show `Artwork recovery` and `Refreshing Home Assistant artwork for recovery`, with retry delays increasing to 60 seconds. A track change should start a fresh attempt immediately. When Home Assistant reports no artwork, retries should stop.
5. Leave the 7-inch running overnight and confirm artwork still appears when playback resumes the next morning.

Automated testing guidance also recommends checking normal boot, affected card layout, touch/navigation, and absence of blank screens or clipping on affected displays. Build/test results are not a substitute for this physical testing.

## PR status

- [ ] Checks running or waiting.
- [x] Ready for device test; local checks passed, GitHub validation is still queued/running.
- [ ] Device tested successfully.
- [ ] Ready to merge after user confirmation.
## Issue handling

- [x] Do not close related issues until the user confirms the fix works.
